### PR TITLE
Configure max file size in precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-added-large-files
+        args: ['--maxkb=500']
       - id: check-ast
       - id: check-case-conflict
       - id: check-docstring-first


### PR DESCRIPTION
Explicitly configure max file size for clarity (500K is the current default limit)