### PR TITLE
Update SkyPilot cconfig to start using torchrun

### DIFF
--- a/configs/skypilot/sky.yaml
+++ b/configs/skypilot/sky.yaml
@@ -34,5 +34,4 @@ run: |
       "training.output_dir=train/" \
       "training.enable_wandb=true" \
       "training.enable_tensorboard=true" \
-      "training.max_steps=10" \
       "training.logging_steps=10"


### PR DESCRIPTION
it's required for distributed training. For now, it still runs on 1 GPUs (no change)