### PR TITLE
fix trl version as 0.8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 ]
 train = [
     "transformers",
-    "trl",
+    "trl==0.8.6",
     "peft",
     "datasets",
     "omegaconf",


### PR DESCRIPTION
trl==0.9.3 leads to errors during training:
 " test_train.py::test_basic_train - AttributeError: 'TrainingArguments' object has no attribute 'packing'"
and for many other attributes... 

TODO: Figure out how to resolve it better