### PR TITLE
Add bool param to  resume training from the last known checkpoint (if exists)

### DIFF
--- a/src/lema/core/types.py
+++ b/src/lema/core/types.py
@@ -102,7 +102,7 @@ class TrainingParams:
     # w/o loading any intermediate checkpoints.
     # NOTE: if `resume_from_checkpoint` is specified and contains a non-empty path,
     # then this parameter has no effect.
-    resume_from_last_checkpoint_if_exists: bool = False
+    try_resume_from_last_checkpoint: bool = False
 
     def to_hf(self):
         """Converts LeMa config to HuggingFace's TrainingArguments."""

--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -65,13 +65,14 @@ def main() -> None:
 
 def _find_checkpoint_to_resume_from(
     resume_from_checkpoint: Optional[str],
-    resume_from_last_checkpoint_if_exists: bool,
+    try_resume_from_last_checkpoint: bool,
     output_dir: str,
 ) -> Optional[str]:
+    """Finds and returns the last checkpoint path to be passed to Trainer."""
     checkpoint_path = None
     if resume_from_checkpoint:
         checkpoint_path = resume_from_checkpoint
-    elif resume_from_last_checkpoint_if_exists:
+    elif try_resume_from_last_checkpoint:
         checkpoint_path = get_last_checkpoint(output_dir)
         if not checkpoint_path:
             logger.warning(f"No checkpoints found under {output_dir}")
@@ -133,7 +134,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
         resume_from_checkpoint=(
             _find_checkpoint_to_resume_from(
                 config.training.resume_from_checkpoint,
-                config.training.resume_from_last_checkpoint_if_exists,
+                config.training.try_resume_from_last_checkpoint,
                 config.training.output_dir,
             )
         )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -31,7 +31,7 @@ def test_train_basic():
                 enable_wandb=False,
                 enable_tensorboard=False,
                 output_dir=output_temp_dir,
-                resume_from_last_checkpoint_if_exists=True,
+                try_resume_from_last_checkpoint=True,
             ),
         )
 


### PR DESCRIPTION
-- also replace  `logger.warn()` (deprecated) with  `logger.warning()`

Towards OPE-57