### PR TITLE
Add integration tests that verify all configs load properly.

### DIFF
--- a/configs/lema/gpt2.pt.yaml
+++ b/configs/lema/gpt2.pt.yaml
@@ -17,9 +17,9 @@ data:
       - dataset_name: "HuggingFaceFW/fineweb-edu"
         dataset_config: "sample-10BT"
         split: "train"
-  stream: True
-  pack: True
-  target_col: "text"
+    stream: True
+    pack: True
+    target_col: "text"
 
 training:
   trainer_type: TRL_SFT

--- a/configs/lema/llama2b.pt.yaml
+++ b/configs/lema/llama2b.pt.yaml
@@ -8,7 +8,7 @@ model:
 
 data:
   train:
-    dataset:
+    datasets:
       - dataset_name: "HuggingFaceFW/fineweb"
         split: "train"
     stream: True

--- a/src/lema/core/types.py
+++ b/src/lema/core/types.py
@@ -25,6 +25,12 @@ from transformers.utils import is_flash_attn_2_available
 from lema.logging import logger
 
 
+class HardwareException(Exception):
+    """An exception thrown for invalid hardware configurations."""
+
+    pass
+
+
 #
 # Training Params
 #
@@ -376,7 +382,7 @@ class ModelParams:
         if (self.attn_implementation == "flash_attention_2") and (
             not is_flash_attn_2_available()
         ):
-            raise ValueError(
+            raise HardwareException(
                 "Flash attention 2 was requested but it is not "
                 "supported. Confirm that your hardware is compatible and then "
                 "consider installing it: pip install -U flash-attn --no-build-isolation"

--- a/tests/integration/configs/test_parse_configs.py
+++ b/tests/integration/configs/test_parse_configs.py
@@ -1,9 +1,10 @@
+import glob
 import os
 from typing import List
 
 import pytest
 
-from lema.core.types import EvaluationConfig, TrainingConfig
+from lema.core.types import EvaluationConfig, HardwareException, TrainingConfig
 
 
 def _is_config_file(path: str) -> bool:
@@ -23,13 +24,8 @@ def _get_all_config_paths() -> List[str]:
     """Recursively returns all configs in the /configs/lema/ dir of the repo."""
     path_to_current_file = os.path.realpath(__file__)
     repo_root = _backtrack_on_path(path_to_current_file, 4)
-    config_dir = os.path.join(repo_root, "configs", "lema")
-    return [
-        os.path.join(directory, file_name)
-        for directory, _, files in os.walk(config_dir)
-        for file_name in files
-        if _is_config_file(os.path.join(directory, file_name))
-    ]
+    yaml_pattern = os.path.join(repo_root, "configs", "lema", "**", "*.yaml")
+    return glob.glob(yaml_pattern, recursive=True)
 
 
 @pytest.mark.parametrize("config_path", _get_all_config_paths())
@@ -38,25 +34,17 @@ def test_parse_configs(config_path: str):
     eval_config_error = ""
     try:
         _ = TrainingConfig.from_yaml(config_path)
-        return
-    except Exception as exception:
-        # Somes checks involve inspecting the user's hardware. Ignore configs that
-        # fail for that reason.
-        if "Flash attention 2" in str(exception):
-            return
-        training_config_error = str(exception)
-
+    except (HardwareException, Exception) as exception:
+        # Ignore HardwareExceptions.
+        if not isinstance(exception, HardwareException):
+            training_config_error = str(exception)
     try:
         _ = EvaluationConfig.from_yaml(config_path)
-        return
-    except Exception as exception:
-        # Somes checks involve inspecting the user's hardware. Ignore configs that
-        # fail for that reason.
-        if "Flash attention 2" in str(exception):
-            return
-        eval_config_error = str(exception)
-    raise Exception(
-        f"Failed to parse `{config_path}`.\n Training config error: "
-        f"{training_config_error} .\n Evaluation config error: "
+    except (HardwareException, Exception) as exception:
+        # Ignore HardwareExceptions.
+        if not isinstance(exception, HardwareException):
+            eval_config_error = str(exception)
+    assert (len(training_config_error) == 0) or (len(eval_config_error) == 0), (
+        f"Training config error: {training_config_error} . Evaluation config error: "
         f"{eval_config_error} ."
     )


### PR DESCRIPTION
This test helps prevent breaking changes when config formats change.

I've put this in an "integration" folder as in the future it shouldn't stop code submission but should be flagged quickly.

Note: this tests parses all test under /configs/lema. The test will pass if each config can either be parsed as a `TrainingConfig` or an `EvaluationConfig`