### PR TITLE
Handling Gradient Checkpointing 

### DIFF
--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -109,9 +109,11 @@ def train(config: TrainingConfig, **kwargs) -> None:
     if config.training.log_model_summary:
         log_model_summary(model)
 
-    # Enable gradients for input embeddings
+    # Enable gradient checkpointing
     if config.training.enable_gradient_checkpointing:
-        model.enable_input_require_grads()
+        model.gradient_checkpointing_enable(
+            config.training.gradient_checkpointing_kwargs
+        )
 
     # Load data & preprocessing
     dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)


### PR DESCRIPTION
This is a small PR where I am proposing that we do not use `model.enable_input_require_grads()` whenever the user requests doing gradient checkpointing, and make the code more fine-grained. 

First, my current understanding is that for both LoRA/PEFT and full models, when they are finetuned: 
- finetuning (also) their input embeddings is *optional* (despite that in most cases doing so esp. if new vocab symbols are used is beneficial).
- for LoRA models, in particular, if `gradient checkpointing` is requested it is recommended (by HF, see: https://huggingface.co/docs/transformers/en/main_classes/model ) to activate the training of the input embeddings, and in fact, if such LoRA models are downloaded directly from HF they will enable gradients on the input-embs _by default_ (see: https://github.com/huggingface/transformers/blob/74a207404e8d4524d1fdc4aa23789694f9eef347/src/transformers/modeling_utils.py#L2273C27-L2273C49).
- However, the above action is not *necessary* for LoRA/PEFT as long as the kwargs_arg `use_reentrant` of the gradient_accumulation is set to False (which is now the recommended default of HF, See: https://pytorch.org/docs/stable/checkpoint.html). In that case; the comp. graph will be able to flow the gradient even in layers (such as the input embs.) where the `requires_grad` variable is set to False. 

Proposed solution - to *extend* this PR:
- add a separate TrainingParam controlling the training or not of the input embeddings _explicitly_ (default to False).
- Add `use_reentrant`  in our `config.training.gradient_checkpointing_kwargs` with a default of False.

Contributes to OPE-34