### PR TITLE
Update skypilot/sky_gpt2.yaml to include an example how to mount GCS dir

### DIFF
--- a/configs/skypilot/sky_gpt2.yaml
+++ b/configs/skypilot/sky_gpt2.yaml
@@ -13,7 +13,7 @@ resources:
 
   disk_size: 200      # Disk size in GB
   # disk_tier: medium # medium is the default.
-  # region: us-central1  # Uncomment this line to only consider a specific region.
+  # region: us-central1  # Uncomment this line to only consider a specific GCP region.
 
 # Upload a working directory to remote ~/sky_workdir.
 workdir: .
@@ -25,7 +25,7 @@ file_mounts:
   #   name: lema-dev-private # Not available on lambda
   #   mode: MOUNT
 
-  # Uncomment to mount GCS dir as "training.output_dir=/output_dir_gcs/gpt2.pt/"
+  # Uncomment to mount GCS dir (then use as e.g., "training.output_dir=/output_dir_gcs/gpt2.pt/")
   # /output_dir_gcs:
   #  source: gs://lema-dev-us-central1
   #  store: gcs


### PR DESCRIPTION
-- add some other changes for consistency with `sky.yaml`

Contributes to OPE-61, OPE-64, OPE-57