### PR TITLE
Update training_params.py so HF trainer uses num_train_epochs

### DIFF
--- a/src/lema/core/types/params/training_params.py
+++ b/src/lema/core/types/params/training_params.py
@@ -99,6 +99,7 @@ class TrainingParams:
             logging_steps=self.logging_steps,
             logging_strategy=self.logging_strategy,
             max_steps=self.max_steps,
+            num_train_epochs=self.num_train_epochs,
             output_dir=self.output_dir,
             per_device_eval_batch_size=self.per_device_eval_batch_size,
             per_device_train_batch_size=self.per_device_train_batch_size,


### PR DESCRIPTION
Export the `num_train_epochs` via the to_hf(). Without this, the HF trainer is using its default (num_train_epochs=3), affecting the underlying learning-rate-scheduler, etc.