### PR TITLE
Upload sample configs for running async evals on GPT2

### DIFF
--- a/configs/lema/gpt2.asynceval.nvidia.yaml
+++ b/configs/lema/gpt2.asynceval.nvidia.yaml
@@ -7,7 +7,6 @@ evaluation:
     model_max_length: 1024
     torch_dtype_str: "bfloat16"
     attn_implementation: "flash_attention_2"
-    load_pretrained_weights: False
     trust_remote_code: True
 
   data:

--- a/configs/skypilot/sky_gpt2_eval.yaml
+++ b/configs/skypilot/sky_gpt2_eval.yaml
@@ -4,7 +4,7 @@ resources:
   # Use 1 of the following GPUs depending on availability. No preference.
   # To view other GPU types use the following commands:
   # `sky show-gpus`, `sky show-gpus -a`
-  accelerators: {"A100-80GB"}  # "A100-80GB-SXM", "H100-80GB-SXM", "A100-80GB", "H100-80GB"
+  accelerators: {"A100"}  # "A100-80GB-SXM", "H100-80GB-SXM", "A100-80GB", "H100-80GB"
   # To configure single-node, multi-gpu (N GPUs) training, set `accelerators:` above to
   # something like this: {"A40": N}
   any_of:


### PR DESCRIPTION
Add several configs as PoCs for async eval.

Note: our vanilla MMLU evaluation runs are currently taking 5+ hours. We need to dig in further to understand how we can better improve inference during evaluation.

Towards OPE-68