### PR TITLE
Update Trainer.save_model to start using the public HF save_model() method (except for PEFT)

### DIFF
--- a/src/lema/builders/training.py
+++ b/src/lema/builders/training.py
@@ -44,7 +44,6 @@ class HuggingFaceTrainer(BaseTrainer):
                 # FIXME: Can we replace the private method `_save()` with
                 # `Trainer.save_model()`?
                 # https://github.com/huggingface/transformers/blob/0f67ba1d741d65b07d549daf4ee157609ce4f9c1/src/transformers/trainer.py#L3384
-                # FIXME: Add conditional saving logic for multi-node runs.
                 self._hf_trainer._save(output_dir, state_dict=state_dict)
             else:
                 self._hf_trainer.save_model(output_dir)


### PR DESCRIPTION
-- From a quick look, the methods seem mostly equivalent for our purposes but better to use public methods when possible (vs private HF._save())
-- Tested OK for pretraining 