### PR TITLE
Replacing `EvaluationConfig`'s `DataParams` with `DatasetSplitParams`

### DIFF
--- a/configs/lema/gpt2.asynceval.nvidia.yaml
+++ b/configs/lema/gpt2.asynceval.nvidia.yaml
@@ -11,10 +11,9 @@ evaluation:
     trust_remote_code: True
 
   data:
-    validation:
-      datasets:
-        - dataset_name: "hellaswag"
-        #  - dataset_name: "mmlu"
+    datasets:
+      - dataset_name: "hellaswag"
+      #  - dataset_name: "mmlu"
 
   generation:
     batch_size: 32

--- a/configs/lema/phi3.eval.lema.mac.yaml
+++ b/configs/lema/phi3.eval.lema.mac.yaml
@@ -5,9 +5,8 @@ model:
   trust_remote_code: True
 
 data:
-  validation:
-    datasets:
-      - dataset_name: "cais/mmlu"
+  datasets:
+    - dataset_name: "cais/mmlu"
 
 generation:
   batch_size: 2

--- a/configs/lema/phi3.eval.lema.nvidia.yaml
+++ b/configs/lema/phi3.eval.lema.nvidia.yaml
@@ -5,9 +5,8 @@ model:
   trust_remote_code: True
 
 data:
-  validation:
-    datasets:
-      - dataset_name: "cais/mmlu"
+  datasets:
+    - dataset_name: "cais/mmlu"
 
 generation:
   batch_size: 32

--- a/configs/lema/phi3.eval.lm_harness.mac.yaml
+++ b/configs/lema/phi3.eval.lm_harness.mac.yaml
@@ -3,9 +3,8 @@ model:
   trust_remote_code: True
 
 data:
-  validation:
-    datasets:
-      - dataset_name: "mmlu"
+  datasets:
+    - dataset_name: "mmlu"
 
 generation:
   batch_size: 2

--- a/configs/lema/zephyr.7b/sft/eval_mmlu.yaml
+++ b/configs/lema/zephyr.7b/sft/eval_mmlu.yaml
@@ -10,10 +10,9 @@ model:
   attn_implementation: "flash_attention_2"
 
 data:
-  validation:
-    datasets:
-      - dataset_name: "mmlu"
-        split: "test"
+  datasets:
+    - dataset_name: "mmlu"
+      split: "test"
 
 generation:
   batch_size: 32

--- a/src/lema/core/types/configs.py
+++ b/src/lema/core/types/configs.py
@@ -5,7 +5,7 @@ from typing import Optional
 from omegaconf import MISSING
 
 from lema.core.types.base_config import BaseConfig
-from lema.core.types.params.data_params import DataParams
+from lema.core.types.params.data_params import DataParams, DatasetSplitParams
 from lema.core.types.params.model_params import ModelParams
 from lema.core.types.params.peft_params import PeftParams
 from lema.core.types.params.training_params import TrainerType, TrainingParams
@@ -95,7 +95,7 @@ class InferenceConfig(BaseConfig):
 
 @dataclass
 class EvaluationConfig(BaseConfig):
-    data: DataParams = field(default_factory=DataParams)
+    data: DatasetSplitParams = field(default_factory=DatasetSplitParams)
     model: ModelParams = field(default_factory=ModelParams)
     generation: GenerationConfig = field(default_factory=GenerationConfig)
     evaluation_framework: EvaluationFramework = EvaluationFramework.LM_HARNESS

--- a/src/lema/evaluate.py
+++ b/src/lema/evaluate.py
@@ -82,7 +82,7 @@ def evaluate_lema(config: EvaluationConfig) -> None:
         None for now, we will return a relevant class in the future.
     """
     # Load the dataset from HuggingFace or a local repository.
-    if config.data.validation.datasets[0].dataset_name == "cais/mmlu":
+    if config.data.datasets[0].dataset_name == "cais/mmlu":
         mmlu_dataset = MmluDataset(subject="all", num_shots=config.num_shots)
         dataset = mmlu_dataset.get_test_split(num_entries=config.num_samples)
         answer_indices = mmlu_dataset.get_test_labels(num_entries=config.num_samples)
@@ -139,7 +139,7 @@ def evaluate_lm_harness(config: EvaluationConfig) -> None:
     Returns:
         None.
     """
-    benchmarks = [dataset.dataset_name for dataset in config.data.validation.datasets]
+    benchmarks = [dataset.dataset_name for dataset in config.data.datasets]
     if torch.cuda.is_available():
         device = "cuda:0"
     elif torch.backends.mps.is_available():

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -4,7 +4,6 @@ import tempfile
 
 from lema import evaluate_lema, evaluate_lm_harness
 from lema.core.types import (
-    DataParams,
     DatasetParams,
     DatasetSplitParams,
     EvaluationConfig,
@@ -21,15 +20,13 @@ def test_evaluate_lema():
 
         config: EvaluationConfig = EvaluationConfig(
             output_dir=nested_output_dir,
-            data=DataParams(
-                validation=DatasetSplitParams(
-                    datasets=[
-                        DatasetParams(
-                            dataset_name="cais/mmlu",
-                        )
-                    ],
-                    target_col="text",
-                ),
+            data=DatasetSplitParams(
+                datasets=[
+                    DatasetParams(
+                        dataset_name="cais/mmlu",
+                    )
+                ],
+                target_col="text",
             ),
             model=ModelParams(
                 model_name="openai-community/gpt2",
@@ -54,14 +51,12 @@ def test_evaluate_lm_harness():
 
         config: EvaluationConfig = EvaluationConfig(
             output_dir=nested_output_dir,
-            data=DataParams(
-                validation=DatasetSplitParams(
-                    datasets=[
-                        DatasetParams(
-                            dataset_name="mmlu",
-                        )
-                    ],
-                ),
+            data=DatasetSplitParams(
+                datasets=[
+                    DatasetParams(
+                        dataset_name="mmlu",
+                    )
+                ],
             ),
             model=ModelParams(
                 model_name="openai-community/gpt2",

--- a/tests/test_evaluate_async.py
+++ b/tests/test_evaluate_async.py
@@ -4,7 +4,6 @@ import tempfile
 from lema import evaluate_async
 from lema.core.types import (
     AsyncEvaluationConfig,
-    DataParams,
     DatasetParams,
     DatasetSplitParams,
     EvaluationConfig,
@@ -18,15 +17,13 @@ def test_evaluate_async_polling_interval():
         config: AsyncEvaluationConfig = AsyncEvaluationConfig(
             evaluation=EvaluationConfig(
                 output_dir=output_temp_dir,
-                data=DataParams(
-                    validation=DatasetSplitParams(
-                        datasets=[
-                            DatasetParams(
-                                dataset_name="cais/mmlu",
-                            )
-                        ],
-                        target_col="text",
-                    ),
+                data=DatasetSplitParams(
+                    datasets=[
+                        DatasetParams(
+                            dataset_name="cais/mmlu",
+                        )
+                    ],
+                    target_col="text",
                 ),
                 model=ModelParams(
                     model_name="openai-community/gpt2",


### PR DESCRIPTION
Initially it seemed that this flexibility (being able to define multiple dataset splits for evaluation) is useful BUT it may create more confusion than help (Yes, Matt warned me and I didn't listen). For instance, when running experiments with LM Harness, users might think that they are using the **validation** dataset of the benchmark (since they are adding the `validation` term at `config.data.validation.datasets[..]` but they are actually NOT! LM harness is choosing the relevant split for evals. So, I am dropping the `validation` field to make things cleaner (until we really need this, which we might not). 