### PR TITLE
Submit config to create Custom IAM role for SkyPilot Service Accounts on GCP

### DIFF
--- a/configs/clouds/gcp/lema_dev_iam_custom_role.yaml
+++ b/configs/clouds/gcp/lema_dev_iam_custom_role.yaml
@@ -1,5 +1,5 @@
 title: "LeMa Core Developer"
-description: "Custom IAM role for LeMa core team developers"
+description: "Custom IAM role for SkyPilot Service Accounts used by LeMa core team developers"
 stage: "ALPHA"
 includedPermissions:
 - compute.disks.create


### PR DESCRIPTION
Based on IAM permissions listed in https://skypilot.readthedocs.io/en/latest/cloud-setup/cloud-permissions/gcp.html

Towards OPE-64