### PR TITLE
Add a source directory to the Polaris launcher and clean up rsync copies.

### DIFF
--- a/scripts/polaris/launcher.sh
+++ b/scripts/polaris/launcher.sh
@@ -5,11 +5,14 @@ helpFunction()
    echo ""
    echo "Usage: $0 -u username -s . -d /home/username/copylocation/ -j ./local/path/to/your_job.sh"
    echo -e "\t-u The username on Polaris."
-   echo -e "\t-s The source directory to copy."
+   echo -e "\t-s The source directory to copy. Defaults to the current directory."
    echo -e "\t-d The destination directory on Polaris to copy local files."
    echo -e "\t-j The local path to your job."
    exit 1 # Exit script after printing help
 }
+
+# Default values.
+SOURCE_DIRECTORY="."
 
 while getopts "u:s:d:j:" opt
 do
@@ -23,7 +26,7 @@ do
 done
 
 # Print a help message if parameters are empty.
-if [ -z "$POLARIS_USER" ] || [ -z "$COPY_DIRECTORY" ] || [ -z "$JOB_PATH" ]
+if [ -z "$POLARIS_USER" ] || [ -z "$COPY_DIRECTORY" ] || [ -z "$JOB_PATH" ] || [ -z "$SOURCE_DIRECTORY" ]
 then
    echo "Some or all required parameters are empty";
    helpFunction
@@ -34,6 +37,7 @@ fi
 ssh -f -N -M -S ~/.ssh/control-%h-%p-%r -o "ControlPersist 5m" ${POLARIS_USER}@polaris.alcf.anl.gov
 
 # Copy files to Polaris over the same SSH tunnel.
+# --filter='- .*/' excludes folders starting with a dot.
 rsync -e "ssh -S ~/.ssh/control-%h-%p-%r" -avz --delete ${SOURCE_DIRECTORY} ${POLARIS_USER}@polaris.alcf.anl.gov:${COPY_DIRECTORY} --filter='- .*/'
 
 # Submit a job on Polaris over the same SSH tunnel.


### PR DESCRIPTION
Add a -s flag for the source directory to copy.

Updates rsync to ignore folders with a leading "." like ".git/".

Towards OPE-107