### PR TITLE
A hack for running jobs on Polaris.

### DIFF
--- a/scripts/polaris/jobs/example_job.sh
+++ b/scripts/polaris/jobs/example_job.sh
@@ -31,6 +31,8 @@ source ./worker_venv/example_environment/bin/activate
 
 python3 -m pip install -e '.[train]'
 
+# Using torch.distributed.launch instead of torchrun as there
+# is a known issue with torchrun and virtual python environments.
 python3 -m torch.distributed.launch \
     --nnodes=${LEMA_NUM_NODES} \
     --node-rank=${PBS_NODENUM} \
@@ -45,3 +47,4 @@ python3 -m torch.distributed.launch \
     "training.ddp_find_unused_parameters=false" \
     "training.dataloader_num_workers=2" \
     "training.dataloader_prefetch_factor=4" \
+    "training.per_device_train_batch_size=32" \

--- a/src/lema/core/types/base_config.py
+++ b/src/lema/core/types/base_config.py
@@ -9,6 +9,15 @@ T = TypeVar("T", bound="BaseConfig")
 _CLI_IGNORED_PREFIXES = ["--local-rank"]
 
 
+def _filter_ignored_args(arg_list: List[str]) -> List[str]:
+    """Filters out ignored CLI arguments."""
+    return [
+        arg
+        for arg in arg_list
+        if not any(arg.startswith(prefix) for prefix in _CLI_IGNORED_PREFIXES)
+    ]
+
+
 @dataclass
 class BaseConfig:
     def to_yaml(self, config_path: str) -> None:
@@ -61,11 +70,7 @@ class BaseConfig:
             all_configs.append(cls.from_yaml(config_path))
 
         # Filter out CLI arguments that should be ignored.
-        arg_list = [
-            arg
-            for arg in arg_list
-            if not any(arg.startswith(prefix) for prefix in _CLI_IGNORED_PREFIXES)
-        ]
+        arg_list = _filter_ignored_args(arg_list)
 
         # Override with CLI arguments.
         all_configs.append(OmegaConf.from_cli(arg_list))


### PR DESCRIPTION
There's apparently a known issue with torchrun: https://github.com/pytorch/pytorch/issues/77737
It does not work with virtual environments.

Trying the workaround of specifying 
```
python3 -m torch.distributed.launch
```

almost does the trick. However, this command silently adds an argument to the command line which causes our config parsing to fail: --local-rank

After updating our config parsing logic to ignore this arg, I finally hit another terminal failure. Need to verify if this is expected with only 40GB RAM:
```
 torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.50 GiB. GPU  has a total capacity of 39.39 GiB of which 723.00 MiB is free. Process 2518572 has 414.00 MiB memory in use. Including non-PyTorch memory, this process has 38.27 GiB memory in use. Of the allocated memory 36.55 GiB is allocated by PyTorch, and 53.25 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```
Towards OPE-107, OPE-121