### PR TITLE
[Polaris] Move venv creation from worker to launcher.

### DIFF
--- a/scripts/polaris/jobs/example_job.sh
+++ b/scripts/polaris/jobs/example_job.sh
@@ -24,12 +24,8 @@ module use /soft/modulefiles
 module load conda
 conda activate base
 
-# Set up a virtual python environment.
-mkdir -p ./worker_venv/example_environment
-python3 -m venv ./worker_venv/example_environment --system-site-packages
+# Activate the virtual python environment with LeMa installed.
 source ./worker_venv/example_environment/bin/activate
-
-python3 -m pip install -e '.[train]'
 
 # Using torch.distributed.launch instead of torchrun as there
 # is a known issue with torchrun and virtual python environments.

--- a/scripts/polaris/launcher.sh
+++ b/scripts/polaris/launcher.sh
@@ -42,5 +42,12 @@ rsync -e "ssh -S ~/.ssh/control-%h-%p-%r" -avz --delete ${SOURCE_DIRECTORY} ${PO
 # Submit a job on Polaris over the same SSH tunnel.
 ssh -S ~/.ssh/control-%h-%p-%r ${POLARIS_USER}@polaris.alcf.anl.gov << EOF
   cd ${COPY_DIRECTORY}
+  module use /soft/modulefiles
+  module load conda
+  conda activate base
+  mkdir -p ./worker_venv/example_environment
+  python3 -m venv ./worker_venv/example_environment --system-site-packages
+  source ./worker_venv/example_environment/bin/activate
+  python3 -m pip install -e '.[train]'
   qsub ${JOB_PATH}
 EOF


### PR DESCRIPTION
Moved the creation of a virtual environment from each worker to the launcher. This way there will not be contention for venv creation when multiple workers are used.

Towards OPE-121