### PR TITLE
Remove logger propagation

### DIFF
--- a/src/lema/logging.py
+++ b/src/lema/logging.py
@@ -29,6 +29,7 @@ def get_logger(name: str, level: str = "info") -> logging.Logger:
         console_handler.setLevel(level.upper())
 
         logger.addHandler(console_handler)
+        logger.propagate = False
     else:
         logger = logging.getLogger(name)
 

--- a/src/lema/utils/torch_utils.py
+++ b/src/lema/utils/torch_utils.py
@@ -69,7 +69,6 @@ def log_devices_info() -> None:
     if not is_world_process_zero():
         return
     if not torch.cuda.is_available():
-        logger.info("CUDA is not available!")
         return
 
     num_devices = torch.cuda.device_count()


### PR DESCRIPTION
Towards OPE-114

Otherwise, we're double logging each log line, as the message gets propagated up to the root logger's handler:

```
[2024-07-15 19:34:52,354][lema][INFO][torch_utils.py:50] Torch version: 2.4.0.dev20240612. NumPy version: 1.26.4
2024-07-15:19:34:52,354 INFO     [torch_utils.py:50] Torch version: 2.4.0.dev20240612. NumPy version: 1.26.4
```

Example of another module doing this: https://github.com/huggingface/transformers/blob/6fbea6d237cbdfc3c229cdadfa3c968cfb2d5142/src/transformers/utils/logging.py#L104