### PR TITLE
Rename `training.save_model` param to `training.save_final_model` for clarity

### DIFF
--- a/src/lema/core/types/params/training_params.py
+++ b/src/lema/core/types/params/training_params.py
@@ -34,11 +34,13 @@ class TrainingParams:
     save_epoch: bool = False
     # Save a checkpoint every `save_steps`. If both `save_steps` and
     # `save_epoch` are set, then `save_steps` takes precedence.
+    # To disable saving checkpoints during training,
+    # set `save_steps` to `0` and `save_epoch` to `False`.
     save_steps: int = 100
     # Whether to save model at the end of training. Should normally be `True`
     # but in some cases you may want to disable it e.g., if saving a large model
     # takes a long time, and you want to quickly test training speed/metrics.
-    save_model: bool = True
+    save_final_model: bool = True
 
     run_name: str = "default"
 

--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -195,7 +195,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
 
     # Save final checkpoint & training state.
     trainer.save_state()
-    if config.training.save_model:
+    if config.training.save_final_model:
         trainer.save_model(config=config)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -44,7 +44,7 @@ def test_train_basic():
                 enable_tensorboard=False,
                 output_dir=output_training_dir,
                 try_resume_from_last_checkpoint=True,
-                save_model=True,
+                save_final_model=True,
             ),
         )
 
@@ -82,7 +82,7 @@ def test_train_unregistered_metrics_function():
                     enable_tensorboard=False,
                     output_dir=output_training_dir,
                     try_resume_from_last_checkpoint=True,
-                    save_model=False,
+                    save_final_model=False,
                 ),
             )
 


### PR DESCRIPTION
-- Update some checkpointing-related comments.

Towards OPE-202