### PR TITLE
Use "cluster_name" instead of "name" in the Sky client.

### DIFF
--- a/src/lema/launcher/clients/sky_client.py
+++ b/src/lema/launcher/clients/sky_client.py
@@ -81,7 +81,7 @@ class SkyClient:
         _, resource_handle = sky.launch(
             _convert_job_to_task(job), cluster_name=cluster_name
         )
-        return resource_handle.name
+        return resource_handle.cluster_name
 
     def status(self) -> List[Dict[str, Any]]:
         """Gets a list of cluster statuses.

--- a/tests/launcher/clients/test_sky_client.py
+++ b/tests/launcher/clients/test_sky_client.py
@@ -69,7 +69,7 @@ def test_sky_client_launch(mock_sky_data_storage):
     with patch("sky.launch") as mock_launch:
         job = _get_default_job("gcp")
         mock_resource_handle = Mock()
-        mock_resource_handle.name = "mycluster"
+        mock_resource_handle.cluster_name = "mycluster"
         mock_launch.return_value = (1, mock_resource_handle)
         client = SkyClient()
         cluster_name = client.launch(job)
@@ -81,7 +81,7 @@ def test_sky_client_launch_with_cluster_name(mock_sky_data_storage):
     with patch("sky.launch") as mock_launch:
         job = _get_default_job("gcp")
         mock_resource_handle = Mock()
-        mock_resource_handle.name = "cluster_name"
+        mock_resource_handle.cluster_name = "cluster_name"
         mock_launch.return_value = (1, mock_resource_handle)
         client = SkyClient()
         cluster_name = client.launch(job, "cluster_name")


### PR DESCRIPTION
A small bugfix for the Sky client. We should use the "cluster_name" field to identify clusters.

Towards OPE-134