### PR TITLE
Increase llama2b batch size from 2 to 3

### DIFF
--- a/configs/skypilot/sky_llama2b.yaml
+++ b/configs/skypilot/sky_llama2b.yaml
@@ -50,8 +50,8 @@ run: |
       "training.max_steps=20" \
       "training.save_steps=100" \
       "training.save_final_model=true" \
-      "training.per_device_train_batch_size=2" \
-      "training.gradient_accumulation_steps=128" \
+      "training.per_device_train_batch_size=3" \
+      "training.gradient_accumulation_steps=86" \
       "training.dataloader_num_workers=2" \
       "training.dataloader_prefetch_factor=4" \
       "training.include_performance_metrics=true" \

--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -77,7 +77,7 @@ if [ "$TRAINING_MODE" == "ddp" ]; then
         "training.save_steps=0" \
         "training.save_final_model=False" \
         "training.per_device_train_batch_size=3" \
-        "training.gradient_accumulation_steps=128" \
+        "training.gradient_accumulation_steps=86" \
         "training.output_dir=output/llama2b.pt/" \
         "training.dataloader_num_workers=2" \
         "training.dataloader_prefetch_factor=4" \


### PR DESCRIPTION
-- Enable model compilation in https://github.com/openlema/lema/pull/224  reduced memory requirements (ops fusion?), which allows larger batch size
-- reduce `gradient_accumulation_steps` to `86` to keep effective global batch size `~256`

Polaris 
1 node: 30.151 samples/s,  15437 tokens/s/gpu  Train Step MFU': 0.541  https://wandb.ai/lema-train-test/huggingface/runs/gp8dni4b
2 nodes:   55.726 samples/s,  14265 tokens/s/gpu, Train Step MFU: 0.499  https://wandb.ai/lema-train-test/huggingface/runs/pw387vgh

Towards OPE-122, OPE-133