### PR TITLE
Add makefile with common local commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ infer:
 	$(CONDA_RUN) python -m lema.infer $(ARGS)
 
 skyssh:
-	$(CONDA_RUN) sky launch $(ARGS) --no-setup -c "${USERNAME}-dev" --cloud gcp configs/skypilot/sky_ssh.yaml
+	$(CONDA_RUN) sky launch $(ARGS) -y --no-setup -c "${USERNAME}-dev" --cloud gcp configs/skypilot/sky_ssh.yaml
 	ssh "${USERNAME}-dev"
 
 skycode:
-	$(CONDA_RUN) sky launch $(ARGS) --no-setup -c "${USERNAME}-dev" --cloud gcp configs/skypilot/sky_ssh.yaml
+	$(CONDA_RUN) sky launch $(ARGS) -y --no-setup -c "${USERNAME}-dev" --cloud gcp configs/skypilot/sky_ssh.yaml
 	code --new-window --folder-uri=vscode-remote://ssh-remote+"${USERNAME}-dev/home/gcpuser/sky_workdir/"
 
 .PHONY: help setup upgrade clean check format test train evaluate infer skyssh skycode


### PR DESCRIPTION
This pull request introduces a Makefile, to help with common development tasks (e.g. launching a remove vscode/ssh session, running tests, ruff, pre-commit hooks, upgrade dependencies)

## Usage

**Running tests  and code quality checks**
```shell
make test
make check
make lint
```

**Opening a VSCode remote session on a cloud VM**
```shell
# both commands will launch a new cluster with the sky-ssh.yaml config, or use an existing cluster if found
make skycode 
make skyssh ARGS="--gpus=A100:4"
```

**Running train/evaluate/infer**
```shell
make train ARGS="-c configs/lema/gpt2.pt.mac.yaml"
```

**Setting up the project**
```shell
make setup  # init a new conda env with dependencies. Skips if already exists
make upgrade  # upgrade depenencies
```


