### PR TITLE
MFU Improvements for Llama 2B on Polaris

### DIFF
--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -71,7 +71,7 @@ if [ "$TRAINING_MODE" == "ddp" ]; then
         --master-port=8007 \
         -m lema.train \
         -c configs/lema/llama2b.pt.yaml \
-        "data.train.use_async_dataset_experimental=true" \
+        "data.train.experimental_use_async_dataset=true" \
         "$TRAIN_DATASETS" \
         "training.run_name='polaris.llama2b.ddp.${PBS_JOBID}'" \
         "training.max_steps=20" \

--- a/src/lema/builders/data.py
+++ b/src/lema/builders/data.py
@@ -125,7 +125,7 @@ def build_dataset(
         if config.model.model_max_length:
             dataset_kwargs["seq_length"] = config.model.model_max_length
 
-        if dataset_split_params.use_async_dataset_experimental:
+        if dataset_split_params.experimental_use_async_dataset:
             dataset = PretrainingAsyncTextDataset(
                 tokenizer,
                 dataset,

--- a/src/lema/core/types/params/data_params.py
+++ b/src/lema/core/types/params/data_params.py
@@ -122,7 +122,7 @@ class DatasetSplitParams:
 
     # EXPERIMENTAL PARAMS -------------------------
     # Whether to use the PretrainingAsyncTextDataset instead of ConstantLengthDataset.
-    use_async_dataset_experimental: bool = False
+    experimental_use_async_dataset: bool = False
     # END EXPERIMENTAL PARAMS --------------------
 
     def __post_init__(self):


### PR DESCRIPTION
Add configurable option for experimental async dataset, change optimizer to adafactor, and increase batch size to 4.

Towards OPE-127