### PR TITLE
FSDP config updates

### DIFF
--- a/configs/lema/llama2b.pt.yaml
+++ b/configs/lema/llama2b.pt.yaml
@@ -39,6 +39,6 @@ training:
   compile: True
 
   logging_steps: 10
-  log_model_summary: True
+  log_model_summary: False
   output_dir: "output/llama2b.pt"
   include_performance_metrics: True

--- a/configs/skypilot/sky_llama2b_fsdp.yaml
+++ b/configs/skypilot/sky_llama2b_fsdp.yaml
@@ -67,32 +67,3 @@ run: |
       "training.enable_wandb=true"
 
   echo "Node ${SKYPILOT_NODE_RANK} is all done!"
-
-
-# ----
-# Bassline (main)
-# No gradient checkpointing
-# sky launch --cloud GCP -i 10 --env LEMA_RUN_NAME=llama2b.pt.FSDP.HYBRID.1node.4xA10040GB.20steps.bs12.gas16.tc.v600 --num-nodes 1 --gpus "A100:4" --use-spot --cluster xrdaukar-1node4gpu-01-lema-cluster  configs/skypilot/sky_llama2b_fsdp.yaml
-# 'Train Step MFU': 0.4926110953741452, 'Train MFU': 0.49200319771761136
-#                    total_flos 7.600297676583731e+16
-#                   train/epoch 1.0
-#             train/global_step 20
-#               train/grad_norm 1.19966
-#           train/learning_rate 0.0
-#                    train/loss 8.5737
-#   train/num_input_tokens_seen 31457280
-# train/train_tokens_per_second 12821.295
-#                    train_loss 9.28232
-#                 train_runtime 613.3796
-#      train_samples_per_second 25.042
-#        train_steps_per_second 0.033
-# https://wandb.ai/lema-train-test/lema-train-test/runs/81h0bxuv
-
-# sky launch --cloud GCP -i 10 --env LEMA_RUN_NAME=llama2b.pt.FSDP.HYBRID.1node.4xA10040GB.20steps.bs12.gas16.tc.gckpt.v601 --num-nodes 1 --gpus "A100:4" --use-spot --cluster xrdaukar-1node4gpu-01-lema-cluster  configs/skypilot/sky_llama2b_fsdp.yaml
-
-# sky launch --cloud GCP -i 10 --env LEMA_RUN_NAME=llama2b.pt.FSDP.HYBRID.1node.4xA10040GB.20steps.bs16.gas16.tc.gckpt.v602 --num-nodes 1 --gpus "A100:4" --use-spot --cluster xrdaukar-1node4gpu-02-lema-cluster  configs/skypilot/sky_llama2b_fsdp.yaml
-
-
-# sky launch --cloud GCP -i 10 --env LEMA_RUN_NAME=llama2b.pt.FSDP.HYBRID.1node.4xA10040GB.20steps.bs16.gas16.tc.gckpt.newbase.v603 --num-nodes 1 --gpus "A100:4" --use-spot --cluster xrdaukar-1node4gpu-01-lema-cluster  configs/skypilot/sky_llama2b_fsdp.yaml
-
-# sky launch --cloud GCP -i 10 --env LEMA_RUN_NAME=llama2b.pt.FSDP.HYBRID.1node.4xA10040GB.20steps.bs14.gas19.tc.gckpt.newbase.v604 --num-nodes 1 --gpus "A100:4" --use-spot --cluster xrdaukar-1node4gpu-02-lema-cluster  configs/skypilot/sky_llama2b_fsdp.yaml

--- a/scripts/polaris/jobs/multinode_example_job.sh
+++ b/scripts/polaris/jobs/multinode_example_job.sh
@@ -43,6 +43,6 @@ NDEPTH=64 # Number of hardware threads per rank (Polaris has 64 CPU cores per no
 set -x  # Print "mpiexec" command with expanded variables
 mpiexec --verbose \
     --np $LEMA_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind depth \
-    ./scripts/polaris/jobs/multinode_example_worker.sh -m ddp
+    ./scripts/polaris/jobs/multinode_example_worker.sh -m fsdp
 
 echo "Polaris job is all done!"

--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -107,8 +107,8 @@ else
       "training.save_steps=0" \
       "training.save_final_model=false" \
       "training.optimizer='adafactor'" \
-      "training.per_device_train_batch_size=16" \
-      "training.gradient_accumulation_steps=16" \
+      "training.per_device_train_batch_size=14" \
+      "training.gradient_accumulation_steps=19" \
       "training.dataloader_num_workers=2" \
       "training.dataloader_prefetch_factor=4" \
       "training.log_model_summary=false" \

--- a/src/lema/builders/models.py
+++ b/src/lema/builders/models.py
@@ -168,7 +168,7 @@ def build_huggingface_model(
         )
 
     # FIXME You may have to uncomment the following line in FSDP mode:
-    model.config.use_cache = False
+    # model.config.use_cache = False
     #
     # Context:
     # https://github.com/huggingface/transformers/issues/28499


### PR DESCRIPTION
-- Enabled "adafactor" optimizer
-- `data.train.experimental_use_async_dataset=true`
-- Tweaked batch size and grad accumulation steps
-- Updated Polaris multi-node launcher script to run `-m fsdp` by default (helps with the current FSDP/DeepSpeed experiments)
-- `log_model_summary: False` for llama model to reduce noise in logs (we already know LLama architecture)

Towards OPE-122, OPE-133