### PR TITLE
Fix broken pyright hook.

### DIFF
--- a/src/lema/builders/optimizers.py
+++ b/src/lema/builders/optimizers.py
@@ -50,7 +50,6 @@ def build_optimizer(
             lr=config.learning_rate,
             momentum=config.sgd_momentum,
             weight_decay=config.weight_decay,
-            fused=fused_available,
         )
     elif optimizer_name == "adafactor":
         return Adafactor(


### PR DESCRIPTION
The SGD optimizer does not support the `fused` param. This breaks pyright.