### PR TITLE
Switch from nightly to stable version of SkyPilot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",
 ]
-# TODO: Switch to stable build "skypilot[gcp,lambda,runpod]"
-# once RunPod multi-GPU bugfix is included (>0.5.0)
-# https://github.com/skypilot-org/skypilot/pull/3291/files
+
 dependencies = [
     "fabric",
     "patchwork",


### PR DESCRIPTION
We were waiting for version `>0.5.0` to include RunPod multi-gpu bugfix https://github.com/skypilot-org/skypilot/pull/3291/files

The current stable version is `0.6.1`:

```
sky --version
skypilot, version 0.6.1
```

nightly was introduced in https://github.com/openlema/lema/pull/33