### PR TITLE
Update package structure for the launcher

### DIFF
--- a/src/lema/core/types/__init__.py
+++ b/src/lema/core/types/__init__.py
@@ -1,3 +1,5 @@
+from lema.core.types.base_cloud import BaseCloud
+from lema.core.types.base_cluster import BaseCluster, JobStatus
 from lema.core.types.base_model import BaseModel
 from lema.core.types.base_trainer import BaseTrainer
 from lema.core.types.configs import (
@@ -22,6 +24,8 @@ from lema.core.types.params.training_params import TrainerType, TrainingParams
 
 __all__ = [
     "AsyncEvaluationConfig",
+    "BaseCloud",
+    "BaseCluster",
     "BaseModel",
     "BaseTrainer",
     "DataParams",
@@ -32,6 +36,7 @@ __all__ = [
     "GenerationConfig",
     "HardwareException",
     "InferenceConfig",
+    "JobStatus",
     "MixtureStrategy",
     "ModelParams",
     "PeftParams",

--- a/src/lema/launcher/__init__.py
+++ b/src/lema/launcher/__init__.py
@@ -1,0 +1,11 @@
+import lema.launcher.clouds as clouds  # Ensure that the clouds are registered
+from lema.launcher.launcher import Launcher
+from lema.utils import logging
+
+logging.configure_dependency_warnings()
+
+
+__all__ = [
+    "clouds",
+    "Launcher",
+]

--- a/src/lema/launcher/clouds/__init__.py
+++ b/src/lema/launcher/clouds/__init__.py
@@ -1,0 +1,11 @@
+from lema.launcher.clouds.polaris_cloud import PolarisCloud
+from lema.launcher.clouds.sky_cloud import SkyCloud
+from lema.utils import logging
+
+logging.configure_dependency_warnings()
+
+
+__all__ = [
+    "PolarisCloud",
+    "SkyCloud",
+]


### PR DESCRIPTION
Updating various __init__.py's to ensure our package structure is up to date.

By re-exporting the `cloud` module we also ensure that the proper clouds are registered in our Registry when the Launcher is used.

Towards OPE-201