### PR TITLE
Update the polaris client to automatically set execute permissions for copied files.

### DIFF
--- a/src/lema/launcher/clients/polaris_client.py
+++ b/src/lema/launcher/clients/polaris_client.py
@@ -341,7 +341,7 @@ class PolarisClient:
         self._fs.put(source, destination, recursive=True)
         # Ensure all copied files are executable as `put` does not propagate
         # permissions.
-        self._connection.run(f"chmod -R a+x {destination}", warn=True)
+        self._connection.run(f"chmod -R +x {destination}", warn=True)
 
     @retry_auth
     def put(self, file_contents: str, destination: str) -> None:

--- a/tests/launcher/clients/test_polaris_client.py
+++ b/tests/launcher/clients/test_polaris_client.py
@@ -696,7 +696,7 @@ def test_polaris_client_put_recursive_success(
         "destination",
         recursive=True,
     )
-    mock_connection.run.assert_called_once_with("chmod -R a+x destination", warn=True)
+    mock_connection.run.assert_called_once_with("chmod -R +x destination", warn=True)
 
 
 def test_polaris_client_put_recursive_failure(


### PR DESCRIPTION
This is a hack as sftp copy operations don't persist chmod permissions. Setting execute permissions recursively after we copy to polaris to ensure all dependent job scripts can run.

Fixes OPE-201