### PR TITLE
Rename 'NodeParams' -> 'JobResources'

### DIFF
--- a/src/lema/core/types/__init__.py
+++ b/src/lema/core/types/__init__.py
@@ -19,6 +19,7 @@ from lema.core.types.params.data_params import (
     DatasetSplitParams,
     MixtureStrategy,
 )
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.core.types.params.model_params import ModelParams
 from lema.core.types.params.peft_params import PeftParams
 from lema.core.types.params.profiler_params import ProfilerParams
@@ -44,12 +45,14 @@ __all__ = [
     "HardwareException",
     "InferenceConfig",
     "JobConfig",
+    "JobResources",
     "JobStatus",
     "MixtureStrategy",
     "ModelParams",
     "PeftParams",
     "ProfilerParams",
     "SchedulerType",
+    "StorageMount",
     "TrainerType",
     "TrainingConfig",
     "TrainingParams",

--- a/src/lema/core/types/configs.py
+++ b/src/lema/core/types/configs.py
@@ -6,8 +6,8 @@ from omegaconf import MISSING
 
 from lema.core.types.base_config import BaseConfig
 from lema.core.types.params.data_params import DataParams, DatasetSplitParams
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.core.types.params.model_params import ModelParams
-from lema.core.types.params.node_params import NodeParams, StorageMount
 from lema.core.types.params.peft_params import PeftParams
 from lema.core.types.params.training_params import TrainerType, TrainingParams
 from lema.utils.logging import logger
@@ -175,7 +175,7 @@ class JobConfig(BaseConfig):
     num_nodes: int = 1
 
     # The resources required for each node in the job.
-    resources: NodeParams = field(default_factory=NodeParams)
+    resources: JobResources = field(default_factory=JobResources)
 
     # The environment variables to set on the node.
     envs: Dict[str, str] = field(default_factory=dict)

--- a/src/lema/core/types/params/job_resources.py
+++ b/src/lema/core/types/params/job_resources.py
@@ -17,7 +17,7 @@ class StorageMount:
 
 
 @dataclass
-class NodeParams:
+class JobResources:
     """Resources required for a single node in a job."""
 
     # The cloud used to run the job (required).

--- a/src/lema/launcher/__init__.py
+++ b/src/lema/launcher/__init__.py
@@ -1,5 +1,6 @@
 import lema.launcher.clouds as clouds  # Ensure that the clouds are registered
 from lema.core.types.configs import JobConfig
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.launcher import Launcher
 from lema.utils import logging
 
@@ -9,5 +10,7 @@ logging.configure_dependency_warnings()
 __all__ = [
     "clouds",
     "JobConfig",
+    "JobResources",
     "Launcher",
+    "StorageMount",
 ]

--- a/tests/launcher/clients/test_sky_client.py
+++ b/tests/launcher/clients/test_sky_client.py
@@ -4,7 +4,7 @@ import pytest
 
 from lema.core.types.base_cluster import JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.clients.sky_client import SkyClient
 
 
@@ -18,7 +18,7 @@ def mock_sky_data_storage():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,

--- a/tests/launcher/clouds/test_polaris_cloud.py
+++ b/tests/launcher/clouds/test_polaris_cloud.py
@@ -5,7 +5,7 @@ import pytest
 from lema.core.registry import REGISTRY, RegistryType
 from lema.core.types.base_cluster import JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.clients.polaris_client import PolarisClient
 from lema.launcher.clouds.polaris_cloud import PolarisCloud
 from lema.launcher.clusters.polaris_cluster import PolarisCluster
@@ -28,7 +28,7 @@ def mock_polaris_cluster():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,

--- a/tests/launcher/clouds/test_sky_cloud.py
+++ b/tests/launcher/clouds/test_sky_cloud.py
@@ -6,7 +6,7 @@ import sky
 from lema.core.registry import REGISTRY, RegistryType
 from lema.core.types.base_cluster import JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.clients.sky_client import SkyClient
 from lema.launcher.clouds.sky_cloud import SkyCloud
 from lema.launcher.clusters.sky_cluster import SkyCluster
@@ -27,7 +27,7 @@ def mock_sky_cluster():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,

--- a/tests/launcher/clusters/test_polaris_cluster.py
+++ b/tests/launcher/clusters/test_polaris_cluster.py
@@ -4,7 +4,7 @@ import pytest
 
 from lema.core.types.base_cluster import JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.clients.polaris_client import PolarisClient
 from lema.launcher.clusters.polaris_cluster import PolarisCluster
 
@@ -18,7 +18,7 @@ def mock_polaris_client():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,

--- a/tests/launcher/clusters/test_sky_cluster.py
+++ b/tests/launcher/clusters/test_sky_cluster.py
@@ -4,7 +4,7 @@ import pytest
 
 from lema.core.types.base_cluster import JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.clients.sky_client import SkyClient
 from lema.launcher.clusters.sky_cluster import SkyCluster
 
@@ -18,7 +18,7 @@ def mock_sky_client():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,

--- a/tests/launcher/test_launcher.py
+++ b/tests/launcher/test_launcher.py
@@ -5,7 +5,7 @@ import pytest
 from lema.core.types.base_cloud import BaseCloud
 from lema.core.types.base_cluster import BaseCluster, JobStatus
 from lema.core.types.configs import JobConfig
-from lema.core.types.params.node_params import NodeParams, StorageMount
+from lema.core.types.params.job_resources import JobResources, StorageMount
 from lema.launcher.launcher import Launcher
 
 
@@ -19,7 +19,7 @@ def mock_registry():
 
 
 def _get_default_job(cloud: str) -> JobConfig:
-    resources = NodeParams(
+    resources = JobResources(
         cloud=cloud,
         region="us-central1",
         zone=None,


### PR DESCRIPTION
Minor naming change to make it clearer what each field is doing in a LeMa Job. I'm consuming this downstream in our tutorial.

Note that this deviates from our "FooParams" naming scheme, but I think this is much more useful for our end users.

Towards OPE-241