### PR TITLE
Export top level launcher functions and instantiate a default launcher.

### DIFF
--- a/src/lema/launcher/__init__.py
+++ b/src/lema/launcher/__init__.py
@@ -1,7 +1,7 @@
 import lema.launcher.clouds as clouds  # Ensure that the clouds are registered
 from lema.core.types.configs import JobConfig
 from lema.core.types.params.job_resources import JobResources, StorageMount
-from lema.launcher.launcher import Launcher
+from lema.launcher.launcher import Launcher, down, get_cloud, run, status, stop, up
 from lema.utils import logging
 
 logging.configure_dependency_warnings()
@@ -9,8 +9,14 @@ logging.configure_dependency_warnings()
 
 __all__ = [
     "clouds",
+    "down",
+    "get_cloud",
     "JobConfig",
     "JobResources",
     "Launcher",
     "StorageMount",
+    "run",
+    "status",
+    "stop",
+    "up",
 ]

--- a/tests/launcher/test_launcher.py
+++ b/tests/launcher/test_launcher.py
@@ -6,7 +6,16 @@ from lema.core.types.base_cloud import BaseCloud
 from lema.core.types.base_cluster import BaseCluster, JobStatus
 from lema.core.types.configs import JobConfig
 from lema.core.types.params.job_resources import JobResources, StorageMount
-from lema.launcher.launcher import Launcher
+from lema.launcher.launcher import (
+    LAUNCHER,
+    Launcher,
+    down,
+    get_cloud,
+    run,
+    status,
+    stop,
+    up,
+)
 
 
 #
@@ -119,7 +128,7 @@ def test_launcher_get_cloud_by_name_missing_value(mock_registry):
         }
         mock_registry.get.return_value = None
         launcher = Launcher()
-        _ = launcher.get_cloud_by_name("lambda")
+        _ = launcher.get_cloud("lambda")
     assert "not found in the registry." in str(exception_info.value)
 
 
@@ -128,7 +137,7 @@ def test_launcher_get_cloud_by_name_empty(mock_registry):
         mock_registry.get_all.return_value = {}
         mock_registry.get.return_value = None
         launcher = Launcher()
-        _ = launcher.get_cloud_by_name("lambda")
+        _ = launcher.get_cloud("lambda")
     assert "not found in the registry." in str(exception_info.value)
 
 
@@ -568,3 +577,12 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             metadata="bar",
         ),
     ]
+
+
+def test_launcher_export_methods(mock_registry):
+    assert LAUNCHER.up == up
+    assert LAUNCHER.run == run
+    assert LAUNCHER.stop == stop
+    assert LAUNCHER.down == down
+    assert LAUNCHER.status == status
+    assert LAUNCHER.get_cloud == get_cloud


### PR DESCRIPTION
Minor cleanup to help make our tutorials simpler.

Similar to `REGISTRY`, I've instantiated a top-level launcher instance. I've also exported all default methods of this instance so they can be used as the module level.

Previously:
```python
from lema.launcher import Launcher
launcher = Launcher()
launcher.up(...)
```

Now:
```python
import lema.launcher as launcher
launcher.up(...)
```

Towards OPE-242