### PR TITLE
Increase the default value of `ProfilerParams.row_limit` from 20 to 50

### DIFF
--- a/src/lema/core/types/params/profiler_params.py
+++ b/src/lema/core/types/params/profiler_params.py
@@ -68,7 +68,7 @@ class ProfilerParams(BaseParams):
         },
     )
     row_limit: int = field(
-        default=20,
+        default=50,
         metadata={
             "help": (
                 "Max number of rows to include into profiling report tables."


### PR DESCRIPTION
-- `20` can be too little

Towards OPE-136