### PR TITLE
[ALCF] Reverse Polaris GPU order to match CPU/GPU affinities

### DIFF
--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -2,7 +2,8 @@
 
 POLARIS_NODE_RANK=${PMI_RANK:=0}
 POLARIS_GPUS_PER_NODE=4
-# Reversing GPUs order to match Polaris CPU affinities
+# Reversing GPUs order to match Polaris CPU affinities:
+# https://docs.alcf.anl.gov/polaris/hardware-overview/machine-overview/#polaris-device-affinity-information
 export CUDA_VISIBLE_DEVICES=3,2,1,0
 LOG_PREFIX="Node: ${POLARIS_NODE_RANK}:"
 


### PR DESCRIPTION
Polaris docs recommend reversing GPU order (CUDA_VISIBLE_DEVICES=3,2,1,0) to match CPU/GPU affinities:

- https://github.com/argonne-lcf/GettingStarted/blob/498550dd942a0a5188065e6131c285380419585e/Examples/Polaris/affinity_gpu/set_affinity_gpu_polaris.sh#L5
- https://docs.alcf.anl.gov/polaris/hardware-overview/machine-overview/#polaris-device-affinity-information

In my initial tests, the change makes minor difference e.g., MFU 0.503 ->0.505/0.509 for 4 node DDP, [data](https://docs.google.com/spreadsheets/d/11GfKfjjWaNypDWgXYJ4Kgo6wrJlxVr_sMaWIJNjYeLQ/edit?gid=109378257#gid=109378257 ). More tests enqueued. Regardless, the change should make no harm, let's follow the recommendation.

Towards OPE-231, OPE-252