### PR TITLE
Support llama2b with lema trainer

### DIFF
--- a/configs/lema/llama2b.pt.yaml
+++ b/configs/lema/llama2b.pt.yaml
@@ -5,7 +5,6 @@ model:
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "flash_attention_2"
-  compile: False # TODO: Try with compilation enabled.
   load_pretrained_weights: False
   trust_remote_code: True
   model_kwargs:

--- a/src/lema/builders/optimizers.py
+++ b/src/lema/builders/optimizers.py
@@ -58,7 +58,7 @@ def build_optimizer(
             lr=config.learning_rate,
             beta1=config.adam_beta1,
             weight_decay=config.weight_decay,
-            eps=config.adam_epsilon,
+            relative_step=False,
         )
     else:
         raise ValueError(f"Unsupported optimizer: {optimizer_name}")


### PR DESCRIPTION
- Adafactor epsilon needs to be a tuple of floats, not a single one, so I'm removing the param. https://huggingface.co/docs/transformers/en/main_classes/optimizer_schedules#transformers.Adafactor
- We can't enable both `relative_step` and `lr`

With these changes, I get 13.5k tok/s on 1 A100-80GB in GCP for the Lema trainer using the current settings. In contrast, we get 15k tok/s with the TRL_SFT trainer.

Towards OPE-257