### PR TITLE
Fix interpolation when loading lema configs.

### DIFF
--- a/configs/lema/jobs/gcp/llama2b_fsdp.yaml
+++ b/configs/lema/jobs/gcp/llama2b_fsdp.yaml
@@ -36,17 +36,17 @@ run: |
 
   set -x  # Print "accelerate launch" command with expanded variables
   accelerate launch \
-      --num_machines \${LEMA_NUM_NODES} \
-      --machine_rank \${SKYPILOT_NODE_RANK} \
-      --num_processes $((\${LEMA_NUM_NODES} * \${SKYPILOT_NUM_GPUS_PER_NODE})) \
-      --main_process_ip \${LEMA_MASTER_ADDR} \
+      --num_machines ${LEMA_NUM_NODES} \
+      --machine_rank ${SKYPILOT_NODE_RANK} \
+      --num_processes $((${LEMA_NUM_NODES} * ${SKYPILOT_NUM_GPUS_PER_NODE})) \
+      --main_process_ip ${LEMA_MASTER_ADDR} \
       --main_process_port 8007 \
       --use_fsdp \
       --config_file configs/accelerate/llama.fsdp.yaml \
       -m lema.train \
       -c configs/lema/llama2b.pt.yaml \
       "data.train.experimental_use_async_dataset=true" \
-      "training.run_name='\${LEMA_RUN_NAME}.\${SKYPILOT_TASK_ID}'" \
+      "training.run_name='${LEMA_RUN_NAME}.${SKYPILOT_TASK_ID}'" \
       "training.max_steps=20" \
       "training.save_steps=0" \
       "training.save_final_model=false" \
@@ -60,4 +60,4 @@ run: |
       "training.try_resume_from_last_checkpoint=false" \
       "training.enable_wandb=true"
 
-  echo "Node \${SKYPILOT_NODE_RANK} is all done!"
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/lema/jobs/polaris/hello_world.yaml
+++ b/configs/lema/jobs/polaris/hello_world.yaml
@@ -26,8 +26,6 @@ setup: |
   #PBS -o /eagle/community_ai/jobs/logs/
   #PBS -e /eagle/community_ai/jobs/logs/
 
-# Note that in the `run` and `setup` sections remote interpolations must be escaped with
-# a backslash. e.g. ${LEMA_NUM_NODES} -> \${LEMA_NUM_NODES}
 run: |
   set -e  # Exit if any command failed.
 

--- a/configs/lema/jobs/polaris/multinode_example.yaml
+++ b/configs/lema/jobs/polaris/multinode_example.yaml
@@ -19,14 +19,12 @@ setup: |
   #PBS -o /eagle/community_ai/jobs/logs/
   #PBS -e /eagle/community_ai/jobs/logs/
 
-# Note that in the `run` section remote interpolations must be escaped with a backslash.
-# e.g. ${LEMA_NUM_NODES} -> \${LEMA_NUM_NODES}
 run: |
   set -e
 
   # Change to the directory where the job was submitted.
-  echo "Changing directory to \${PBS_O_WORKDIR} ..."
-  cd \${PBS_O_WORKDIR}
+  echo "Changing directory to ${PBS_O_WORKDIR} ..."
+  cd ${PBS_O_WORKDIR}
 
   # Run several checks and export "LEMA_*" env vars.
   source ./scripts/polaris/polaris_init.sh
@@ -40,7 +38,7 @@ run: |
   # Activate the LeMa Conda environment.
   conda activate /home/$USER/miniconda3/envs/lema
 
-  echo "Starting torchrun with \${LEMA_NUM_NODES} node(s)..."
+  echo "Starting torchrun with ${LEMA_NUM_NODES} node(s)..."
 
   # NCCL settings:
   # https://docs.alcf.anl.gov/polaris/data-science-workflows/frameworks/pytorch/#multi-gpu-multi-node-scale-up
@@ -55,7 +53,7 @@ run: |
   #FIXME Should we set --envall, --noenvall, or only pass specific env vars?
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
-      --np $LEMA_NUM_NODES -ppn \${NRANKS} -d \${NDEPTH} --cpu-bind depth \
+      --np $LEMA_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind depth \
       ./scripts/polaris/jobs/multinode_example_worker.sh -m fsdp
 
   echo "Polaris job is all done!"


### PR DESCRIPTION
Omegaconf would throw an error if the `setup` for `run` fields in a lema job config contained variable interpolation ( ${myvar}).

We can circumvent this by reading the file and manually replacing these instances with a delimited version.

Note that in the final config, the fields will NOT have the delimiter. OmegaConf removes it after initial parsing.



Fixes OPE-285