### PR TITLE
Add  pytorch profiler (`-p`) option to `multinode_example_worker.sh` script

### DIFF
--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -63,6 +63,7 @@ fi
 
 MAX_STEPS=20
 if "${ENABLE_PYTORCH_PROFILER}"; then
+   # Use a smaller number of steps with Profiler to keep traces usable.
    MAX_STEPS=5
    PROFILER_TRAINING_PARAMS="training.output_dir=/eagle/community_ai/${USER}/${PBS_JOBID}
    training.profiler.enable_cpu_profiling=true


### PR DESCRIPTION
-- Makes it easier to enable PyTorch profiler 

Towards OPE-254, OPE-136