### PR TITLE
Update LEMA training loop to count tokens on CPU

### DIFF
--- a/src/lema/core/trainers/lema_trainer.py
+++ b/src/lema/core/trainers/lema_trainer.py
@@ -227,17 +227,21 @@ class Trainer(BaseTrainer):
                     self.log("End of epoch")
                     break
 
+            # Count tokens on CPU.
+            with self._telemetry_block("computing tokens"):
+                num_tokens = (
+                    batch["input_ids"]
+                    .to("cpu", non_blocking=True)
+                    .ne(self.tokenizer.pad_token_id)
+                    .sum()
+                    .item()
+                )
+                self.state.total_tokens_seen += num_tokens
+
             with self._telemetry_block("moving batch to device"):
                 batch = {
                     k: v.to(self.device, non_blocking=True) for k, v in batch.items()
                 }
-
-            with self._telemetry_block("computing tokens"):
-                num_tokens = batch["input_ids"].ne(self.tokenizer.pad_token_id).sum()
-
-            with self._telemetry_block("syncing to cpu"):
-                num_tokens = num_tokens.item()
-                self.state.total_tokens_seen += num_tokens
 
             with self.mixed_precision_ctx, self._telemetry_block("model forward"):
                 self.model.require_backward_grad_sync = (  # type: ignore


### PR DESCRIPTION
-- Counting tokens on CPU is fast (`~330us`),  and saves one GPU-to-CPU transfer

Towards OPE-296