### PR TITLE
Fix dataclass strings to be parsable by our docs generator.

### DIFF
--- a/src/lema/core/types/base_cluster.py
+++ b/src/lema/core/types/base_cluster.py
@@ -9,23 +9,24 @@ from lema.core.types.configs import JobConfig
 class JobStatus:
     """Dataclass to hold the status of a job."""
 
-    # The display name of the job.
+    #: The display name of the job.
     name: str
 
-    # The unique identifier of the job on the cluster
+    #: The unique identifier of the job on the cluster
     id: str
 
-    # The status of the job.
+    #: The status of the job.
     status: str
 
-    # The cluster to which the job belongs.
+    #: The cluster to which the job belongs.
     cluster: str
 
-    # Miscellaneous metadata about the job.
+    #: Miscellaneous metadata about the job.
     metadata: str
 
-    # A flag indicating whether the job is done.
-    # True only if the job is in a terminal state (e.g. completed, failed, or canceled).
+    #: A flag indicating whether the job is done.
+    #: True only if the job is in a terminal state (e.g. completed, failed, or
+    #: canceled).
     done: bool
 
 

--- a/src/lema/core/types/configs.py
+++ b/src/lema/core/types/configs.py
@@ -123,16 +123,16 @@ class EvaluationConfig(BaseConfig):
     model: ModelParams = field(default_factory=ModelParams)
     generation: GenerationConfig = field(default_factory=GenerationConfig)
     evaluation_framework: EvaluationFramework = EvaluationFramework.LM_HARNESS
-    # Number of few-shot examples (with responses) to add in the prompt, in order to
-    # teach the model how to respond to the specific dataset's prompts.
-    # If not set (None): LM Harness will decide the value.
-    # If set to 0: no few-shot examples will be added in the prompt.
+    #: Number of few-shot examples (with responses) to add in the prompt, in order to
+    #: teach the model how to respond to the specific dataset's prompts.
+    #: If not set (None): LM Harness will decide the value.
+    #: If set to 0: no few-shot examples will be added in the prompt.
     num_shots: Optional[int] = None
-    # Number of samples/examples to evaluate from this dataset. Mostly for debugging, in
-    # order to reduce the runtime. If not set (None): the entire dataset is evaluated.
-    # If set, this must be a positive integer.
+    #: Number of samples/examples to evaluate from this dataset. Mostly for debugging,
+    #: in order to reduce the runtime. If not set (None): the entire dataset is
+    #: evaluated. If set, this must be a positive integer.
     num_samples: Optional[int] = None
-    # Where to write computed evaluations.
+    #: Where to write computed evaluations.
     output_dir: str = "output"
 
     def __post_init__(self):
@@ -155,16 +155,16 @@ class EvaluationConfig(BaseConfig):
 class AsyncEvaluationConfig(BaseConfig):
     evaluation: EvaluationConfig = field(default_factory=EvaluationConfig)
 
-    # The directory to poll for new checkpoints.
+    #: The directory to poll for new checkpoints.
     checkpoints_dir: str = MISSING
 
-    # The time in seconds between the end of the previous evaluation and the start of
-    # the next polling attempt. Cannot be negative.
+    #: The time in seconds between the end of the previous evaluation and the start of
+    #: the next polling attempt. Cannot be negative.
     polling_interval: float = MISSING
 
-    # The number of times to retry polling before exiting the current job.
-    # A retry occurs when the job reads the target directory but cannot find a new
-    # model checkpoint to evaluate. Defaults to 5. Cannot be negative.
+    #: The number of times to retry polling before exiting the current job.
+    #: A retry occurs when the job reads the target directory but cannot find a new
+    #: model checkpoint to evaluate. Defaults to 5. Cannot be negative.
     num_retries: int = 5
 
     def __post_init__(self):
@@ -179,41 +179,41 @@ class AsyncEvaluationConfig(BaseConfig):
 class JobConfig(BaseConfig):
     """Configuration for launching jobs on a cluster."""
 
-    # Job name (optional). Only used for display purposes.
+    #: Job name (optional). Only used for display purposes.
     name: Optional[str] = None
 
-    # The user that the job will run as (optional). Required only for Polaris.
+    #: The user that the job will run as (optional). Required only for Polaris.
     user: Optional[str] = None
 
-    # The local directory containing the scripts required to execute this job.
-    # This directory will be copied to the remote node before the job is executed.
+    #: The local directory containing the scripts required to execute this job.
+    #: This directory will be copied to the remote node before the job is executed.
     working_dir: str = MISSING
 
-    # The number of nodes to use for the job. Defaults to 1.
+    #: The number of nodes to use for the job. Defaults to 1.
     num_nodes: int = 1
 
-    # The resources required for each node in the job.
+    #: The resources required for each node in the job.
     resources: JobResources = field(default_factory=JobResources)
 
-    # The environment variables to set on the node.
+    #: The environment variables to set on the node.
     envs: Dict[str, str] = field(default_factory=dict)
 
-    # File mounts to attach to the node.
-    # For mounting (copying) local directories, the key is the file path on the remote
-    # and the value is the local path.
-    # The keys of `file_mounts` cannot be shared with `storage_mounts`.
+    #: File mounts to attach to the node.
+    #: For mounting (copying) local directories, the key is the file path on the remote
+    #: and the value is the local path.
+    #: The keys of `file_mounts` cannot be shared with `storage_mounts`.
     file_mounts: Dict[str, str] = field(default_factory=dict)
 
-    # Storage system mounts to attach to the node.
-    # For mounting remote storage solutions, the key is the file path on the remote
-    # and the value is a StorageMount.
-    # The keys of `storage_mounts` cannot be shared with `file_mounts`.
+    #: Storage system mounts to attach to the node.
+    #: For mounting remote storage solutions, the key is the file path on the remote
+    #: and the value is a StorageMount.
+    #: The keys of `storage_mounts` cannot be shared with `file_mounts`.
     storage_mounts: Dict[str, StorageMount] = field(default_factory=dict)
 
-    # The setup script to run on every node. Optional.
-    # `setup` will always be executed before `run`.
-    # ex) pip install -r requirements.txt
+    #: The setup script to run on every node. Optional.
+    #: `setup` will always be executed before `run`.
+    #: ex) pip install -r requirements.txt
     setup: Optional[str] = None
 
-    # The script to run on every node. Required. Runs after `setup`.
+    #: The script to run on every node. Required. Runs after `setup`.
     run: str = MISSING

--- a/src/lema/core/types/params/data_params.py
+++ b/src/lema/core/types/params/data_params.py
@@ -39,31 +39,32 @@ class MixtureStrategy(str, Enum):
 
 @dataclass
 class DatasetParams(BaseParams):
-    # Parameters for `datasets.load_dataset()`
+    #: Parameters for `datasets.load_dataset()`
     dataset_name: str = MISSING
-    # The subset of the dataset to load, usually a subfolder within the dataset root.
+    #: The subset of the dataset to load, usually a subfolder within the dataset root.
     subset: Optional[str] = None
-    # The split of the dataset to load, usually "train", "test", or "validation".
+    #: The split of the dataset to load, usually "train", "test", or "validation".
     split: str = "train"
-    # Keyword arguments to pass to the dataset constructor.
+    #: Keyword arguments to pass to the dataset constructor.
     dataset_kwargs: Dict[str, Any] = field(default_factory=dict)
 
-    # The number of examples to sample from the dataset. Must be non-negative. If
-    # `sample_count` is larger than the size of the dataset then the required additional
-    # examples are sampled by looping over the original dataset. Defaults to None.
+    #: The number of examples to sample from the dataset. Must be non-negative. If
+    #: `sample_count` is larger than the size of the dataset then the required
+    #: additional examples are sampled by looping over the original dataset.
+    #: Defaults to None.
     sample_count: Optional[int] = None
-    # The proportion of examples from this dataset relative to other datasets in the
-    # mixture. If specified, all datasets must supply this value. Must be a float in
-    # the range [0, 1.0]. The `mixture_proportion` for all input datasets must sum to 1.
-    # Examples are sampled after the dataset has been sampled using `sample_count` if
-    # specified. Defaults to None.
+    #: The proportion of examples from this dataset relative to other datasets in the
+    #: mixture. If specified, all datasets must supply this value. Must be a float in
+    #: the range [0, 1.0]. The `mixture_proportion` for all input datasets must sum to
+    #: 1. Examples are sampled after the dataset has been sampled using `sample_count`
+    #: if specified. Defaults to None.
     mixture_proportion: Optional[float] = None
-    # If specified, the dataset is shuffled before any sampling occurs.
+    #: If specified, the dataset is shuffled before any sampling occurs.
     shuffle: bool = False
-    # The random seed used for shuffling the dataset before sampling, if specified.
-    # If set to `None` shuffling will be non-deterministic.
+    #: The random seed used for shuffling the dataset before sampling, if specified.
+    #: If set to `None` shuffling will be non-deterministic.
     seed: Optional[int] = None
-    # The size of the shuffle buffer used for shuffling the dataset before sampling.
+    #: The size of the shuffle buffer used for shuffling the dataset before sampling.
     shuffle_buffer_size: int = 1000
 
     @staticmethod
@@ -96,19 +97,19 @@ class DatasetParams(BaseParams):
 
 @dataclass
 class DatasetSplitParams(BaseParams):
-    # The input datasets used for training. This will later be split into train, test,
-    # and validation.
+    #: The input datasets used for training. This will later be split into train, test,
+    #: and validation.
     datasets: List[DatasetParams] = field(default_factory=list)
-    # Whether to pack the text into constant-length chunks,
-    # each the size of the model's max input length.
-    # This will stream the dataset, and tokenize on the fly
-    # if the dataset isn't already tokenized (i.e. has an `input_ids` column).
-    # Requires `stream` to be set to True.
+    #: Whether to pack the text into constant-length chunks,
+    #: each the size of the model's max input length.
+    #: This will stream the dataset, and tokenize on the fly
+    #: if the dataset isn't already tokenized (i.e. has an `input_ids` column).
+    #: Requires `stream` to be set to True.
     pack: bool = False
     stream: bool = False
-    # The dataset column name containing the input for training/testing/validation.
-    # Required for SFTTrainer. If specified, all datasets in this split must contain a
-    # column with this name.
+    #: The dataset column name containing the input for training/testing/validation.
+    #: Required for SFTTrainer. If specified, all datasets in this split must contain a
+    #: column with this name.
     target_col: Optional[str] = None
     mixture_strategy: str = field(
         default=MixtureStrategy.FIRST_EXHAUSTED.value,
@@ -123,14 +124,14 @@ class DatasetSplitParams(BaseParams):
             f"`{MixtureStrategy.FIRST_EXHAUSTED.value}`."
         },
     )
-    # The random seed used for mixing this dataset split, if specified.
-    # If set to `None` mixing will be non-deterministic.
+    #: The random seed used for mixing this dataset split, if specified.
+    #: If set to `None` mixing will be non-deterministic.
     seed: Optional[int] = None
 
-    # EXPERIMENTAL PARAMS -------------------------
-    # Whether to use the PretrainingAsyncTextDataset instead of ConstantLengthDataset.
+    #: EXPERIMENTAL PARAMS -------------------------
+    #: Whether to use the PretrainingAsyncTextDataset instead of ConstantLengthDataset.
     experimental_use_async_dataset: bool = False
-    # END EXPERIMENTAL PARAMS --------------------
+    #: END EXPERIMENTAL PARAMS --------------------
 
     def __post_init__(self):
         """Verifies params."""
@@ -190,13 +191,13 @@ class DatasetSplitParams(BaseParams):
 
 @dataclass
 class DataParams(BaseParams):
-    # The input datasets used for training.
+    #: The input datasets used for training.
     train: DatasetSplitParams = field(default_factory=DatasetSplitParams)
 
-    # The input datasets used for testing.
+    #: The input datasets used for testing.
     test: DatasetSplitParams = field(default_factory=DatasetSplitParams)
 
-    # The input datasets used for validation.
+    #: The input datasets used for validation.
     validation: DatasetSplitParams = field(default_factory=DatasetSplitParams)
 
     def get_split(self, split: DatasetSplit) -> DatasetSplitParams:

--- a/src/lema/core/types/params/job_resources.py
+++ b/src/lema/core/types/params/job_resources.py
@@ -8,11 +8,12 @@ from omegaconf import MISSING
 class StorageMount:
     """A storage system mount to attach to a node."""
 
-    # The remote path to mount the local path to (Required).
-    # e.g. 'gs://bucket/path' for GCS, 's3://bucket/path' for S3, or 'r2://path' for R2.
+    #: The remote path to mount the local path to (Required).
+    #: e.g. 'gs://bucket/path' for GCS, 's3://bucket/path' for S3, or 'r2://path' for
+    #: R2.
     source: str = MISSING
 
-    # The remote storage solution (Required). Must be one of 's3', 'gcs' or 'r2'.
+    #: The remote storage solution (Required). Must be one of 's3', 'gcs' or 'r2'.
     store: str = MISSING
 
 
@@ -20,39 +21,39 @@ class StorageMount:
 class JobResources:
     """Resources required for a single node in a job."""
 
-    # The cloud used to run the job (required).
+    #: The cloud used to run the job (required).
     cloud: str = MISSING
 
-    # The region to use (optional). Supported values vary by environment.
+    #: The region to use (optional). Supported values vary by environment.
     region: Optional[str] = None
 
-    # The zone to use (optional). Supported values vary by environment.
+    #: The zone to use (optional). Supported values vary by environment.
     zone: Optional[str] = None
 
-    # Accelerator type (optional). Supported values vary by environment.
-    # For GCP you may specify the accelerator name and count, e.g. "V100:4".
+    #: Accelerator type (optional). Supported values vary by environment.
+    #: For GCP you may specify the accelerator name and count, e.g. "V100:4".
     accelerators: Optional[str] = None
 
-    # Number of vCPUs to use per node (optional). Sky-based clouds support strings with
-    # modifiers, e.g. "2+" to indicate at least 2 vCPUs.
+    #: Number of vCPUs to use per node (optional). Sky-based clouds support strings with
+    #: modifiers, e.g. "2+" to indicate at least 2 vCPUs.
     cpus: Optional[str] = None
 
-    # Memory to allocate per node in GiB (optional). Sky-based clouds support strings
-    # with modifiers, e.g. "256+" to indicate at least 256 GB.
+    #: Memory to allocate per node in GiB (optional). Sky-based clouds support strings
+    #: with modifiers, e.g. "256+" to indicate at least 256 GB.
     memory: Optional[str] = None
 
-    # Instance type to use (optional). Supported values vary by environment.
-    # The instance type is automatically inferred if `accelerators` is specified.
+    #: Instance type to use (optional). Supported values vary by environment.
+    #: The instance type is automatically inferred if `accelerators` is specified.
     instance_type: Optional[str] = None
 
-    # Whether the cluster should use spot instances (optional).
-    # If unspecified, defaults to False (on-demand instances).
+    #: Whether the cluster should use spot instances (optional).
+    #: If unspecified, defaults to False (on-demand instances).
     use_spot: bool = False
 
-    # Disk size in GiB to allocate for OS (mounted at /). Ignored by Polaris. Optional.
+    #: Disk size in GiB to allocate for OS (mounted at /). Ignored by Polaris. Optional.
     disk_size: Optional[int] = None
 
-    # Disk tier to use for OS (optional).
-    # For sky-based clouds this Could be one of 'low', 'medium', 'high' or 'best'
-    # (default: 'medium').
+    #: Disk tier to use for OS (optional).
+    #: For sky-based clouds this Could be one of 'low', 'medium', 'high' or 'best'
+    #: (default: 'medium').
     disk_tier: Optional[str] = "medium"

--- a/src/lema/core/types/params/model_params.py
+++ b/src/lema/core/types/params/model_params.py
@@ -16,13 +16,13 @@ class ModelParams(BaseParams):
     adapter_model: Optional[str] = None
     tokenizer_name: Optional[str] = None
     model_max_length: Optional[int] = None
-    # Whether to load the pretrained model's weights. Else, the model will be
-    # initialized from the pretrained config.
+    #: Whether to load the pretrained model's weights. Else, the model will be
+    #: initialized from the pretrained config.
     load_pretrained_weights: bool = True
     trust_remote_code: bool = False
     torch_dtype_str: str = "float32"
-    # Whether to JIT compile the model. For training, do not set this param, and instead
-    # set `TrainingParams.compile`.
+    #: Whether to JIT compile the model. For training, do not set this param, and
+    #: instead set `TrainingParams.compile`.
     compile: bool = False
     chat_template: Optional[str] = None
     attn_implementation: Optional[str] = None

--- a/src/lema/core/types/params/profiler_params.py
+++ b/src/lema/core/types/params/profiler_params.py
@@ -6,6 +6,9 @@ from lema.core.types.params.base_params import BaseParams
 
 @dataclass
 class ProfilerScheduleParams(BaseParams):
+    #: Whether profiling schedule is enabled.
+    #: If `False`, then profiling is enabled for the entire process
+    #: duration, and all schedule parameters below will be ignored.
     enable_schedule: bool = field(
         default=False,
         metadata={
@@ -17,6 +20,9 @@ class ProfilerScheduleParams(BaseParams):
         },
     )
 
+    #: The number of training steps to skip at the beginning of
+    #: each profiling cycle (`ProfilerAction.NONE`).
+    #: Each cycle includes `wait + warmup + active` steps.
     wait: int = field(
         default=0,
         metadata={
@@ -27,6 +33,9 @@ class ProfilerScheduleParams(BaseParams):
             )
         },
     )
+
+    #: The number of training steps to do profiling warmup
+    #: (`ProfilerAction.WARMUP`) in each profiling cycle.
     warmup: int = field(
         default=1,
         metadata={
@@ -36,6 +45,9 @@ class ProfilerScheduleParams(BaseParams):
             )
         },
     )
+
+    #: The number of training steps to do active recording
+    #: (`ProfilerAction.RECORD`) in each profiling cycle.
     active: int = field(
         default=3,
         metadata={
@@ -45,6 +57,11 @@ class ProfilerScheduleParams(BaseParams):
             )
         },
     )
+
+    #: The optional number of profiling cycles.
+    #: Each cycle includes `wait + warmup + active` steps.
+    #: The zero value means that the cycles will continue
+    #: until the profiling is finished.
     repeat: int = field(
         default=1,
         metadata={
@@ -56,6 +73,9 @@ class ProfilerScheduleParams(BaseParams):
             )
         },
     )
+
+    #: The number of initial training steps to skip at the beginning of
+    #: profiling session (`ProfilerAction.NONE`).
     skip_first: int = field(
         default=1,
         metadata={
@@ -89,6 +109,9 @@ class ProfilerScheduleParams(BaseParams):
 
 @dataclass
 class ProfilerParams(BaseParams):
+    #: Directory where the profiling data will be saved to.
+    #: If not specified and profiling is enabled, then
+    #: the `profiler` sub-dir will be used under `output_dir`.
     save_dir: Optional[str] = field(
         default=None,
         metadata={
@@ -99,6 +122,9 @@ class ProfilerParams(BaseParams):
             )
         },
     )
+
+    #: Whether to profile CPU activity.
+    #: Corresponds to `torch.profiler.ProfilerActivity.CPU`.
     enable_cpu_profiling: bool = field(
         default=False,
         metadata={
@@ -108,6 +134,9 @@ class ProfilerParams(BaseParams):
             )
         },
     )
+
+    #: Whether to profile CUDA.
+    #: Corresponds to `torch.profiler.ProfilerActivity.CUDA`.
     enable_cuda_profiling: bool = field(
         default=False,
         metadata={
@@ -126,12 +155,17 @@ class ProfilerParams(BaseParams):
         default=False,
         metadata={"help": "Track tensor memory allocation/deallocation."},
     )
+
+    #: Record source information (file and line number) for the ops.
     with_stack: bool = field(
         default=False,
         metadata={
             "help": "Record source information (file and line number) for the ops."
         },
     )
+
+    #: Record module hierarchy (including function names) corresponding to
+    #: the callstack of the op.
     with_flops: bool = field(
         default=False,
         metadata={
@@ -141,6 +175,9 @@ class ProfilerParams(BaseParams):
             )
         },
     )
+
+    #: Use formula to estimate the FLOPs (floating point operations) of
+    #: specific operators (matrix multiplication and 2D convolution).
     with_modules: bool = field(
         default=False,
         metadata={
@@ -150,6 +187,9 @@ class ProfilerParams(BaseParams):
             )
         },
     )
+
+    #: Max number of rows to include into profiling report tables.
+    #: Set to -1 to make it unlimited.
     row_limit: int = field(
         default=50,
         metadata={

--- a/src/lema/core/types/params/training_params.py
+++ b/src/lema/core/types/params/training_params.py
@@ -79,26 +79,26 @@ class TrainingParams(BaseParams):
     gradient_accumulation_steps: int = 1
     max_steps: int = -1
     num_train_epochs: int = 3
-    # Save a checkpoint at the end of every epoch.
+    #: Save a checkpoint at the end of every epoch.
     save_epoch: bool = False
-    # Save a checkpoint every `save_steps`. If both `save_steps` and
-    # `save_epoch` are set, then `save_steps` takes precedence.
-    # To disable saving checkpoints during training,
-    # set `save_steps` to `0` and `save_epoch` to `False`.
+    #: Save a checkpoint every `save_steps`. If both `save_steps` and
+    #: `save_epoch` are set, then `save_steps` takes precedence.
+    #: To disable saving checkpoints during training,
+    #: set `save_steps` to `0` and `save_epoch` to `False`.
     save_steps: int = 100
-    # Whether to save model at the end of training. Should normally be `True`
-    # but in some cases you may want to disable it e.g., if saving a large model
-    # takes a long time, and you want to quickly test training speed/metrics.
+    #: Whether to save model at the end of training. Should normally be `True`
+    #: but in some cases you may want to disable it e.g., if saving a large model
+    #: takes a long time, and you want to quickly test training speed/metrics.
     save_final_model: bool = True
-    # Random seed, passed to the trainer and to all downstream dependencies
+    #: Random seed, passed to the trainer and to all downstream dependencies
     seed: int = 42
 
     run_name: str = "default"
 
-    # The name of the metrics function in the LeMa registry to use for evaluation
-    # during training. The method must accept as input a HuggingFace EvalPrediction and
-    # return a dictionary of metrics, with string keys mapping to metric values. A
-    # single metrics_function may compute multiple metrics.
+    #: The name of the metrics function in the LeMa registry to use for evaluation
+    #: during training. The method must accept as input a HuggingFace EvalPrediction and
+    #: return a dictionary of metrics, with string keys mapping to metric values. A
+    #: single metrics_function may compute multiple metrics.
     metrics_function: Optional[str] = None
 
     log_level: str = "info"
@@ -107,7 +107,7 @@ class TrainingParams(BaseParams):
     enable_wandb: bool = False
     enable_tensorboard: bool = True
 
-    logging_strategy: str = "steps"  # possible values: "steps", "epoch", "no"
+    logging_strategy: str = "steps"  #: possible values: "steps", "epoch", "no"
     logging_dir: str = "output/runs"
     logging_steps: int = 50
 
@@ -117,19 +117,19 @@ class TrainingParams(BaseParams):
         metadata={"help": "Whether to log and evaluate the first global_step or not."},
     )
 
-    eval_strategy: str = "no"  # possible values: "steps", "epoch", "no"
+    eval_strategy: str = "no"  #: possible values: "steps", "epoch", "no"
     eval_steps: int = 50
 
-    # Learning rate schedule.
+    #: Learning rate schedule.
     learning_rate: float = 5e-05
-    # See possible scheduler types here:
-    # https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_utils.py#L408-L418
+    #: See possible scheduler types here:
+    #: https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_utils.py#L408-L418
     lr_scheduler_type: str = "cosine"
     lr_scheduler_kwargs: Dict[str, Any] = field(default_factory=dict)
     warmup_ratio: Optional[float] = None
     warmup_steps: Optional[int] = None
 
-    # Optimizer params.
+    #: Optimizer params.
     optimizer: str = "adamw_torch"
     weight_decay: float = 0.0
     adam_beta1: float = 0.9
@@ -137,74 +137,74 @@ class TrainingParams(BaseParams):
     adam_epsilon: float = 1e-08
     sgd_momentum: float = 0.9
 
-    # `use_reentrant` is a required parameter and is recommended to be set to False.
-    # See: https://pytorch.org/docs/stable/checkpoint.html
+    #: `use_reentrant` is a required parameter and is recommended to be set to False.
+    #: See: https://pytorch.org/docs/stable/checkpoint.html
     gradient_checkpointing_kwargs: Dict[str, Any] = field(default_factory=dict)
 
     mixed_precision_dtype: MixedPrecisionDtype = MixedPrecisionDtype.NONE
 
-    # Whether to JIT compile the model. This param should be used instead of
-    # `ModelParams.compile` for training.
+    #: Whether to JIT compile the model. This param should be used instead of
+    #: `ModelParams.compile` for training.
     compile: bool = False
 
-    # Whether to include performance metrics e.g., tokens stats
+    #: Whether to include performance metrics e.g., tokens stats
     include_performance_metrics: Optional[bool] = None
 
-    # Whether to print model summary e.g., layer names, for informational purposes.
+    #: Whether to print model summary e.g., layer names, for informational purposes.
     log_model_summary: bool = False
 
-    # Whether to resume training by loading first the pointed model from this folder.
+    #: Whether to resume training by loading first the pointed model from this folder.
     resume_from_checkpoint: Optional[str] = None
 
-    # If True, try to find the last checkpoint in "output_dir".
-    # If present, training will resume from the model/optimizer/scheduler states loaded
-    # here. Otherwise (if checkpoint is not present), then training will continue
-    # w/o loading any intermediate checkpoints.
-    # NOTE: if `resume_from_checkpoint` is specified and contains a non-empty path,
-    # then this parameter has no effect.
+    #: If True, try to find the last checkpoint in "output_dir".
+    #: If present, training will resume from the model/optimizer/scheduler states loaded
+    #: here. Otherwise (if checkpoint is not present), then training will continue
+    #: w/o loading any intermediate checkpoints.
+    #: NOTE: if `resume_from_checkpoint` is specified and contains a non-empty path,
+    #: then this parameter has no effect.
     try_resume_from_last_checkpoint: bool = False
 
-    # Number of subprocesses to use for data loading (PyTorch only).
-    # 0 means that the data will be loaded in the main process.
-    #
-    # You can also use the special value "auto" to select the number
-    # of dataloader workers using a simple heuristic based on the number of CPU-s and
-    # GPU-s per node. Note that the accurate estimation of workers is difficult and
-    # depends on many factors (the properties of a model, dataset, VM, network, etc)
-    # so you can start with "auto" then experimentally tune the exact number to make it
-    # more optimal for your specific case. If "auto" is requested,
-    # then at minumum 1 worker is guaranteed to be assigned.
+    #: Number of subprocesses to use for data loading (PyTorch only).
+    #: 0 means that the data will be loaded in the main process.
+    #:
+    #: You can also use the special value "auto" to select the number
+    #: of dataloader workers using a simple heuristic based on the number of CPU-s and
+    #: GPU-s per node. Note that the accurate estimation of workers is difficult and
+    #: depends on many factors (the properties of a model, dataset, VM, network, etc)
+    #: so you can start with "auto" then experimentally tune the exact number to make it
+    #: more optimal for your specific case. If "auto" is requested,
+    #: then at minumum 1 worker is guaranteed to be assigned.
     dataloader_num_workers: Union[int, str] = 0
 
-    # Number of batches loaded in advance by each worker. 2 means there will be
-    # a total of 2 * num_workers batches prefetched across all workers.
-    # Can only be set if dataloader_num_workers >= 1.
+    #: Number of batches loaded in advance by each worker. 2 means there will be
+    #: a total of 2 * num_workers batches prefetched across all workers.
+    #: Can only be set if dataloader_num_workers >= 1.
     dataloader_prefetch_factor: Optional[int] = None
 
-    # If set to `True`, the dataloader is only iterated through on the main process
-    # (rank 0), then the batches are split and broadcast to each process.
-    # This can reduce the number of requests to the dataset, and helps ensure
-    # that each example is seen by max one GPU per epoch, but may become a performance
-    # bottleneck if a large number of GPUs is used.
-    # If set to `False`, the dataloader is iterated through on each
-    # GPU process.
-    # If set to `None` (*default*), then `True` or `False` is auto-selected based on
-    # heuristics (properties of dataset, the number of nodes and/or GPUs, etc).
-    # NOTE: We recommend to benchmark your setup, and configure `True` or `False`.
+    #: If set to `True`, the dataloader is only iterated through on the main process
+    #: (rank 0), then the batches are split and broadcast to each process.
+    #: This can reduce the number of requests to the dataset, and helps ensure
+    #: that each example is seen by max one GPU per epoch, but may become a performance
+    #: bottleneck if a large number of GPUs is used.
+    #: If set to `False`, the dataloader is iterated through on each
+    #: GPU process.
+    #: If set to `None` (*default*), then `True` or `False` is auto-selected based on
+    #: heuristics (properties of dataset, the number of nodes and/or GPUs, etc).
+    #: NOTE: We recommend to benchmark your setup, and configure `True` or `False`.
     dataloader_main_process_only: Optional[bool] = None
 
-    # When using distributed training, the value of the flag `find_unused_parameters`
-    # passed to `DistributedDataParallel`. Will default to `False` if gradient
-    # checkpointing is used, `True` otherwise.
+    #: When using distributed training, the value of the flag `find_unused_parameters`
+    #: passed to `DistributedDataParallel`. Will default to `False` if gradient
+    #: checkpointing is used, `True` otherwise.
     ddp_find_unused_parameters: Optional[bool] = None
 
-    # Maximum gradient norm (for gradient clipping) to avoid exploding gradients which
-    # can destabilize training.
+    #: Maximum gradient norm (for gradient clipping) to avoid exploding gradients which
+    #: can destabilize training.
     max_grad_norm: float = 1.0
 
     trainer_kwargs: Dict[str, Any] = field(default_factory=dict)
 
-    # Parameters for performance profiling.
+    #: Parameters for performance profiling.
     profiler: ProfilerParams = field(default_factory=ProfilerParams)
 
     def to_hf(self):


### PR DESCRIPTION
Comments will be explicitly picked up if prefaced with `#:`

Samples of when docstrings will be picked up:

```python
class Foo:
    """Docstring for class Foo."""

    #: Doc comment for class attribute Foo.bar.
    #: It can have multiple lines.
    bar = 1

    flox = 1.5   #: Doc comment for Foo.flox. One line only.

    baz = 2
    """Docstring for class attribute Foo.baz."""

    def __init__(self):
        #: Doc comment for instance attribute qux.
        self.qux = 3

        self.spam = 4
        """Docstring for instance attribute spam."""
```
(source: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute)
Towards OPE-300