### PR TITLE
Fix a minor bug in `TelemetryCallback.on_train_end`

### DIFF
--- a/configs/accelerate/llama.fsdp.yaml
+++ b/configs/accelerate/llama.fsdp.yaml
@@ -24,7 +24,7 @@ fsdp_config:
   fsdp_forward_prefetch: true
   fsdp_limit_all_gathers: true
   fsdp_offload_params: false
-  fsdp_sharding_strategy: HYBRID_SHARD_ZERO2
+  fsdp_sharding_strategy: HYBRID_SHARD
   fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_sync_module_states: true
   fsdp_transformer_layer_cls_to_wrap: LlamaDecoderLayer

--- a/src/lema/core/callbacks/telemetry_callback.py
+++ b/src/lema/core/callbacks/telemetry_callback.py
@@ -158,10 +158,8 @@ class TelemetryCallback(transformers.TrainerCallback):
         if self._callback_disabled():
             return
 
-        logger.info("on_train_end()")
-
         summary = self._telemetry.get_summary()
-        if not ("timers" in summary and _LOGS_KWARG in kwargs):
+        if "timers" not in summary:
             return
 
         device_rank_info = get_device_rank_info()


### PR DESCRIPTION
-- Remove one irrelevant condition, which is always false

Towards OPE-254, OPE-293