### PR TITLE
Update model dtype for DeepSpeed to make it work with SkyPilot and Polaris

### DIFF
--- a/configs/accelerate/llama.fsdp.yaml
+++ b/configs/accelerate/llama.fsdp.yaml
@@ -19,8 +19,6 @@ enable_cpu_affinity: false
 fsdp_config:
   fsdp_activation_checkpointing: true
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
-  # fsdp_auto_wrap_policy: SIZE_BASED_WRAP
-  # fsdp_min_num_params: 100000000
   fsdp_backward_prefetch: BACKWARD_PRE
   fsdp_cpu_ram_efficient_loading: true
   fsdp_forward_prefetch: true

--- a/scripts/polaris/jobs/multinode_example_worker.sh
+++ b/scripts/polaris/jobs/multinode_example_worker.sh
@@ -134,6 +134,7 @@ elif [ "$TRAINING_MODE" == "deepspeed" ]; then
       "training.enable_gradient_checkpointing=false" \
       "training.per_device_train_batch_size=4" \
       "training.gradient_accumulation_steps=64" \
+      "model.torch_dtype_str=float32" \
       "training.mixed_precision_dtype=BF16"
 else
     set -x  # Print "accelerate" command with expanded variables


### PR DESCRIPTION
Note that DeepSpeed uses mixed_precision, which makes MFU calculation incorrect (it's based on `float32`, not on mixed precision dtype `bf16`):  OPE-304

Towards OPE-304
Fixes OPE-76