### PR TITLE
Add another `bareer()` call before train()

### DIFF
--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -325,18 +325,15 @@ def train(config: TrainingConfig, **kwargs) -> None:
 
         verify_torch_distributed_initialized_if_needed()
 
+        checkpoint_location = _find_checkpoint_to_resume_from(
+            config.training.resume_from_checkpoint,
+            config.training.try_resume_from_last_checkpoint,
+            config.training.output_dir,
+        )
         # Make sure all workers start training at the same time.
         barrier()
 
-        trainer.train(
-            resume_from_checkpoint=(
-                _find_checkpoint_to_resume_from(
-                    config.training.resume_from_checkpoint,
-                    config.training.try_resume_from_last_checkpoint,
-                    config.training.output_dir,
-                )
-            )
-        )
+        trainer.train(resume_from_checkpoint=checkpoint_location)
     logger.info("Training is Complete.")
 
     log_nvidia_gpu_memory_utilization(log_prefix="Max Memory Usage After Training:")


### PR DESCRIPTION
-- Making sure all workers start training at the same time approximately