### PR TITLE
Add `empty_device_cache_steps` param and configure it for Llama8b model

### DIFF
--- a/configs/lema/llama8b.lora.yaml
+++ b/configs/lema/llama8b.lora.yaml
@@ -49,6 +49,7 @@ training:
 
   logging_steps: 100
   log_model_summary: False
+  empty_device_cache_steps: 50
   output_dir: "output/llama8b.lora"
   include_performance_metrics: True
   enable_wandb: True

--- a/src/lema/core/configs/params/training_params.py
+++ b/src/lema/core/configs/params/training_params.py
@@ -212,6 +212,10 @@ class TrainingParams(BaseParams):
     #: Parameters for performance profiling.
     profiler: ProfilerParams = field(default_factory=ProfilerParams)
 
+    #: Number of steps to wait before calling `torch.<device>.empty_cache()`.
+    #: If left unset, cache will not be emptied.
+    empty_device_cache_steps: Optional[int] = None
+
     def to_hf(self):
         """Converts LeMa config to HuggingFace's TrainingArguments."""
         save_strategy: str = "no"
@@ -273,6 +277,7 @@ class TrainingParams(BaseParams):
             save_steps=self.save_steps,
             save_strategy=save_strategy,
             logging_first_step=self.logging_first_step,
+            torch_empty_cache_steps=self.empty_device_cache_steps,
             resume_from_checkpoint=self.resume_from_checkpoint,
             eval_strategy=self.eval_strategy,
             eval_steps=self.eval_steps,


### PR DESCRIPTION
-- It helps to keep VRAM usage under control.
-- Otherwise, mem usage slowly grows for the model and leads to CUDA OOM after ~140 steps with bs=3.


Tested: https://wandb.ai/lema-train-test/lema-train-test/runs/7osxgqb4?nw=nwuserxrdaukar
![EmptyCacheEffect_Capture](https://github.com/user-attachments/assets/8c0738e1-2343-4da1-a112-2c2148135e2f)

The periodic drops in memory usage correspond to `torch.cuda.empty_cache()` calls

Towards OPE-149, OPE-312