### PR TITLE
Initial notebook for llama 8b LoRa tuning.

### DIFF
--- a/notebooks/LeMa - Tuning Llama.ipynb
+++ b/notebooks/LeMa - Tuning Llama.ipynb
@@ -26,7 +26,7 @@
     "- You have a valid ALCF account with access to Polaris\n",
     "- You're familiar with our tuning flow\n",
     "- You're familiar with how to launch lema workflows on Polaris. [Here's a relevant tutorial](https://github.com/openlema/lema/blob/main/notebooks/LeMa%20-%20Deploying%20a%20Job.ipynb)\n",
-    "- You've signed [Llama's agreement on HuggingFace](https://huggingface.co/meta-llama/Meta-Llama-3-8B)"
+    "- You've signed [Llama's agreement on HuggingFace](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B)"
    ]
   },
   {


### PR DESCRIPTION
Add a brief notebook with a description on how to run Llama 8b LoRA tuning.

This notebook will be updated as folks finalize the best configurations for each flavor of Llama given our experiments.

Towards OPE-145