### PR TITLE
Minor tuning of llama8b configs

### DIFF
--- a/configs/lema/llama8b.lora.yaml
+++ b/configs/lema/llama8b.lora.yaml
@@ -29,9 +29,9 @@ data:
 training:
   trainer_type: TRL_SFT
   use_peft: True
-  save_steps: 100
-  per_device_train_batch_size: 3  # torchtune uses bs=2x32, but we can fit bs=3
-  gradient_accumulation_steps: 21
+  save_steps: 200
+  per_device_train_batch_size: 2 # torchtune uses bs=2x32
+  gradient_accumulation_steps: 32
 
   enable_gradient_checkpointing: False
   ddp_find_unused_parameters: False
@@ -59,5 +59,5 @@ peft:
   lora_r: 8
   lora_alpha: 16
   lora_target_modules:
-  - "q_proj"
-  - "v_proj"
+    - "q_proj"
+    - "v_proj"

--- a/configs/lema/llama8b.sft.yaml
+++ b/configs/lema/llama8b.sft.yaml
@@ -28,7 +28,7 @@ data:
 
 training:
   trainer_type: TRL_SFT
-  save_steps: 100
+  save_steps: 200
   per_device_train_batch_size: 2
   gradient_accumulation_steps: 1
 


### PR DESCRIPTION
-- Reduce LoRA batch size from 3 to 2.  3 is still flakey: still fails sometimes on GCP but works OK on Polaris (?). Also, for consistency with `torchtune`'s  `bs=2x32`
-- Increase `save_steps` from `100` to `200`
-- Auto-formatting 

Towards OPE-313, OPE-312