### PR TITLE
Remove special case for saving PEFT models

### DIFF
--- a/src/lema/core/trainers/hf_trainer.py
+++ b/src/lema/core/trainers/hf_trainer.py
@@ -37,17 +37,7 @@ class HuggingFaceTrainer(BaseTrainer):
         if is_world_process_zero():
             # TODO: OPE-311 - Save full state dict for FSDP training.
             output_dir = config.training.output_dir
-            if config.training.use_peft:
-                state_dict = {
-                    k: t
-                    for k, t in self._hf_trainer.model.named_parameters()
-                    if "lora_" in k
-                }
-                # FIXME: Can we replace the private method `_save()` with
-                # `Trainer.save_model()`?
-                # https://github.com/huggingface/transformers/blob/0f67ba1d741d65b07d549daf4ee157609ce4f9c1/src/transformers/trainer.py#L3384
-                self._hf_trainer._save(output_dir, state_dict=state_dict)
-            else:
-                self._hf_trainer.save_model(output_dir)
+
+            self._hf_trainer.save_model(output_dir)
 
             logger.info(f"Model has been saved at {output_dir}.")


### PR DESCRIPTION
-- Switch to using  `_hf_trainer.save_model(output_dir)` in HF trainer path
-- In my test, both variants produce files of same size in output directory, so I think it's best to use a public method `save_model()` (?)

Towards OPE-213
Fixes OPE-313

BEFORE:
```
"-rw-r--r-- 1 community_ai     662 Aug 23 21:29 adapter_config.json
-rw-r--r-- 1 community_ai 6832728 Aug 23 21:29 adapter_model.safetensors
drwxr-sr-x 2 community_ai    4096 Aug 23 21:28 logs
drwxr-sr-x 3 community_ai    4096 Aug 23 21:28 profiler
-rw-r--r-- 1 community_ai    5111 Aug 23 21:29 README.md
-rw-r--r-- 1 community_ai     325 Aug 23 21:29 special_tokens_map.json
-rw-r--r-- 1 community_ai   55380 Aug 23 21:29 tokenizer_config.json
-rw-r--r-- 1 community_ai 9085657 Aug 23 21:29 tokenizer.json
-rw-r--r-- 1 community_ai    1108 Aug 23 21:29 trainer_state.json
-rw-r--r-- 1 community_ai    5560 Aug 23 21:29 training_args.bin"
```

AFTER:
```
"-rw-r--r-- 1 community_ai     662 Aug 23 21:38 adapter_config.json
-rw-r--r-- 1 community_ai 6832728 Aug 23 21:38 adapter_model.safetensors
drwxr-sr-x 2 community_ai    4096 Aug 23 21:36 logs
drwxr-sr-x 3 community_ai    4096 Aug 23 21:37 profiler
-rw-r--r-- 1 community_ai    5111 Aug 23 21:38 README.md
-rw-r--r-- 1 community_ai     325 Aug 23 21:38 special_tokens_map.json
-rw-r--r-- 1 community_ai   55380 Aug 23 21:38 tokenizer_config.json
-rw-r--r-- 1 community_ai 9085657 Aug 23 21:38 tokenizer.json
-rw-r--r-- 1 community_ai    1108 Aug 23 21:38 trainer_state.json
-rw-r--r-- 1 community_ai    5560 Aug 23 21:38 training_args.bin"
```

