### PR TITLE
Raise `NOT_IMPLEMENTED` if `adapter_model` is configured for `LM_HARNESS` eval

### DIFF
--- a/src/lema/evaluate.py
+++ b/src/lema/evaluate.py
@@ -163,7 +163,7 @@ def evaluate_lm_harness(config: EvaluationConfig) -> None:
 
     if config.model.adapter_model:
         raise NotImplementedError(
-            f"Adapter model {config.model.adapter_model} is not yet supported "
+            f"Adapter models ('{config.model.adapter_model}') are not yet supported "
             "by LM_HARNESS evaluation method in LeMa."
         )
 


### PR DESCRIPTION


Towards OPE-313