### PR TITLE
Update Llama notebook to include 8B SFT

### DIFF
--- a/notebooks/LeMa - Tuning Llama.ipynb
+++ b/notebooks/LeMa - Tuning Llama.ipynb
@@ -61,17 +61,6 @@
     "lema-launch -p $LEMA_CONFIG_PATH envs.HF_TOKEN=$HF_TOKEN user=$ALCF_USER\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Towards OPE-145

While we have configs for 70B LoRA, there's currently issues getting it to train.