### PR TITLE
Enable markdown docs

### DIFF
--- a/docs/.sphinx/conf.py
+++ b/docs/.sphinx/conf.py
@@ -29,7 +29,13 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "myst_parser",
 ]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,14 @@ dev = [
     "pyright",
     "pytest",
     "ruff",
-    "sphinx",               # for documentation
-    "sphinx-rtd-theme",     # for documentation
+    "sphinx",           # for documentation
+    "sphinx-rtd-theme", # for documentation
     "torchfix",
+    "myst_parser",
 ]
 train = [
-    "accelerate",           # for quantization
-    "bitsandbytes",         # for quantization
+    "accelerate",                   # for quantization
+    "bitsandbytes",                 # for quantization
     "datasets",
     "deepspeed",
     "lm-eval",
@@ -64,7 +65,7 @@ train = [
     "pydantic>=2",
     "pynvml",
     "safetensors",
-    "sentencepiece",        # for phi-3
+    "sentencepiece",                # for phi-3
     "tensorboard",
     "torchdata>=0.8.0",
     "transformers>=4.43.1,<4.44.0",


### PR DESCRIPTION
Enable importing markdown files when generating the documentation with sphinx. Markdown is enabled in addition to rest 