### PR TITLE
Check ignored docstring rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,10 @@ select = [
     "NPY", # NumPy-specific rules
 ]
 ignore = [
-    # "D100",   # Missing docstring in public module, temporary, OPE-326
-    # "D101",   # Missing docstring in public class, temporary, OPE-326
-    # "D104",   # Missing docstring in public package, temporary, OPE-326
-    # "NPY002", # Replace legacy numpy aliases
+    "D100",   # Missing docstring in public module, temporary, OPE-326
+    "D101",   # Missing docstring in public class, temporary, OPE-326
+    "D104",   # Missing docstring in public package, temporary, OPE-326
+    "NPY002", # Replace legacy numpy aliases
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]


### PR DESCRIPTION
Our auto-generated docstrings are fairly bare. We have several rules that are ignored that we need to iteratively fix: D100, D101, D104. 

Our codebase contains 130 violations total.

Towards OPE-326