### PR TITLE
Update sample commands to point to the preemptable queue

### DIFF
--- a/configs/lema/jobs/polaris/llama8b_lora.yaml
+++ b/configs/lema/jobs/polaris/llama8b_lora.yaml
@@ -1,6 +1,6 @@
 # Config to LoRA tune Llama 3.1 8B Instruct on 1 Polaris node.
 # Example command:
-# lema-launch -p configs/lema/jobs/polaris/llama8b_lora.yaml -c debug-scaling.$ALCF_USER user=$ALCF_USER
+# lema-launch -p configs/lema/jobs/polaris/llama8b_lora.yaml -c preemptable.$ALCF_USER user=$ALCF_USER
 name: llama8b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/lema/jobs/polaris/llama8b_sft.yaml
+++ b/configs/lema/jobs/polaris/llama8b_sft.yaml
@@ -1,6 +1,6 @@
 # Config for Llama 3.1 8B Instruct SFT on 1 Polaris node.
 # Example command:
-# lema-launch -p configs/lema/jobs/polaris/llama8b_sft.yaml -c debug-scaling.$ALCF_USER user=$ALCF_USER
+# lema-launch -p configs/lema/jobs/polaris/llama8b_sft.yaml -c preemptable.$ALCF_USER user=$ALCF_USER
 name: llama8b-sft
 # NOTE: Replace with your username.
 user: your_username


### PR DESCRIPTION
8b models should not be run on the debug queue if they require more than 1hr walltime.


Reference on walltimes: https://docs.alcf.anl.gov/polaris/running-jobs/