### PR TITLE
Add param to customize NCCL timeout

### DIFF
--- a/src/lema/core/configs/params/training_params.py
+++ b/src/lema/core/configs/params/training_params.py
@@ -216,11 +216,11 @@ class TrainingParams(BaseParams):
     #: If left unset, cache will not be emptied.
     empty_device_cache_steps: Optional[int] = None
 
-    #: Default timeout for NCCL operations in seconds.
+    #: Default timeout for NCCL operations in minutes.
     #: See: https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group
     #: If unset, will use the default value of `torch.distributed.init_process_group`
     #: which is 10min.
-    nccl_default_timeout: Optional[float] = None
+    nccl_default_timeout_minutes: Optional[float] = None
 
     def to_hf(self):
         """Converts LeMa config to HuggingFace's TrainingArguments."""

--- a/src/lema/core/distributed.py
+++ b/src/lema/core/distributed.py
@@ -196,11 +196,15 @@ def global_leader_first(*args, **kwargs):
 #
 # Distributed Initialization
 #
-def init_distributed(backend: str = "nccl", timeout: Optional[float] = None) -> None:
+def init_distributed(
+    backend: str = "nccl", timeout_minutes: Optional[float] = None
+) -> None:
     """Initialize the distributed environment."""
     device_rank_info: DeviceRankInfo = get_device_rank_info()
-    timeout_delta = timedelta(seconds=timeout) if timeout is not None else None
-    dist.init_process_group(backend=backend, timeout=timeout_delta)
+    timeout = (
+        timedelta(minutes=timeout_minutes) if timeout_minutes is not None else None
+    )
+    dist.init_process_group(backend=backend, timeout=timeout)
     torch.cuda.set_device(int(device_rank_info.local_rank))
 
 

--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -244,7 +244,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
     _START_TIME = time.time()
 
     if is_distributed():
-        init_distributed(timeout=config.training.nccl_default_timeout)
+        init_distributed(timeout_minutes=config.training.nccl_default_timeout_minutes)
 
     if is_local_process_zero():
         log_versioning_info()


### PR DESCRIPTION
**Changes**
- Add params to customize NCCL default timeout (used for all nccl operations)
- The default value is 10min. This can be increased as needed for larger models