### PR TITLE
Ensure that jobs are queued on existing clusters when users call UP

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -117,6 +117,47 @@ def test_launch_launch_job(mock_launcher, mock_printer):
         mock_cluster.get_job.assert_called_once_with("job_id")
 
 
+def test_launch_launch_job_existing_cluster(mock_launcher, mock_printer):
+    with tempfile.TemporaryDirectory() as output_temp_dir:
+        train_yaml_path = str(pathlib.Path(output_temp_dir) / "train.yaml")
+        config: TrainingConfig = _create_training_config()
+        config.to_yaml(train_yaml_path)
+        job_yaml_path = str(pathlib.Path(output_temp_dir) / "job.yaml")
+        job_config = _create_job_config(train_yaml_path)
+        job_config.to_yaml(job_yaml_path)
+        mock_launcher.JobConfig = JobConfig
+        mock_cluster = Mock()
+        mock_cluster.name.return_value = "cluster_id"
+        job_status = JobStatus(
+            id="job_id",
+            cluster="cluster_id",
+            name="job_name",
+            status="running",
+            metadata="",
+            done=False,
+        )
+        mock_launcher.run.return_value = job_status
+        mock_cluster.get_job.return_value = JobStatus(
+            id="job_id",
+            cluster="cluster_id",
+            name="job_name",
+            status="done",
+            metadata="",
+            done=True,
+        )
+        mock_cloud = Mock()
+        mock_launcher.get_cloud.return_value = mock_cloud
+        mock_cloud.get_cluster.return_value = mock_cluster
+        launch(
+            _LaunchArgs(
+                job=job_yaml_path, action=_LauncherAction.UP, cluster="cluster_id"
+            )
+        )
+        mock_launcher.run.assert_called_once_with(job_config, "cluster_id")
+        mock_printer.assert_called_once_with("Running job job_id", ANY)
+        mock_cluster.get_job.assert_called_once_with("job_id")
+
+
 def test_launch_launch_job_detach(mock_launcher, mock_printer):
     with tempfile.TemporaryDirectory() as output_temp_dir:
         train_yaml_path = str(pathlib.Path(output_temp_dir) / "train.yaml")


### PR DESCRIPTION
If the user specifies a cluster in their UP command, we should reuse existing clusters if the names match.

Note that this ignores the resources in their job config for the new job, but this is simply a nicety via our CLI. The user can work around this by switching cluster names.

Fixes OPE-323