### PR TITLE
[tiny] sphinx conf update

### DIFF
--- a/docs/.sphinx/conf.py
+++ b/docs/.sphinx/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.duration",
     "myst_parser",
     "nbsphinx",
 ]
@@ -41,6 +42,7 @@ source_suffix = {
 
 nbsphinx_execute = "never"
 nbsphinx_allow_errors = True
+napoleon_include_special_with_doc = True
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]


### PR DESCRIPTION
**Changes**
- Include magic function in documentation: we use a few magic functions as part of our regular code paths (e.g. `__getitem__` for datasets), which are excluded by default. This change enables docstring generation for magic functions
- Add logging for docstring generation (not very informative now, but will be useful when doctests are enabled in a future PR)