### PR TITLE
[tiny] Enable D104 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ select = [
 ignore = [
     "D100",   # Missing docstring in public module, temporary, OPE-326
     "D101",   # Missing docstring in public class, temporary, OPE-326
-    "D104",   # Missing docstring in public package, temporary, OPE-326
     "NPY002", # Replace legacy numpy aliases
 ]
 


### PR DESCRIPTION
**Changes**
- Adding docstrings for packages is now required going forward
- PR #415 fixed docs for all current packages

Towards OPE-326