### PR TITLE
Enable Liger for Llama 8B SFT

### DIFF
--- a/configs/lema/llama70b.lora.yaml
+++ b/configs/lema/llama70b.lora.yaml
@@ -17,7 +17,6 @@ model:
   attn_implementation: "flash_attention_2"
   load_pretrained_weights: True
   trust_remote_code: True
-  enable_liger_kernel: True
 
 data:
   train:

--- a/configs/lema/llama70b.sft.yaml
+++ b/configs/lema/llama70b.sft.yaml
@@ -17,7 +17,6 @@ model:
   attn_implementation: "flash_attention_2"
   load_pretrained_weights: True
   trust_remote_code: True
-  enable_liger_kernel: True
 
 data:
   train:

--- a/configs/lema/llama8b.lora.yaml
+++ b/configs/lema/llama8b.lora.yaml
@@ -17,8 +17,8 @@ model:
   attn_implementation: "flash_attention_2"
   load_pretrained_weights: True
   trust_remote_code: True
-  # Enabling Liger actually slows Lora training.
-  enable_liger_kernel: True
+  # Enabling Liger slows down training.
+  enable_liger_kernel: False
 
 data:
   train:
@@ -31,7 +31,7 @@ data:
 training:
   trainer_type: TRL_SFT
   use_peft: True
-  save_steps: 10000 # 50
+  save_steps: 50
   num_train_epochs: 1
   per_device_train_batch_size: 2
   gradient_accumulation_steps: 32

--- a/configs/lema/llama8b.sft.yaml
+++ b/configs/lema/llama8b.sft.yaml
@@ -17,6 +17,7 @@ model:
   attn_implementation: "flash_attention_2"
   load_pretrained_weights: True
   trust_remote_code: True
+  # Improves training speed by 20% with default config.
   enable_liger_kernel: True
 
 data:
@@ -29,7 +30,7 @@ data:
 
 training:
   trainer_type: TRL_SFT
-  save_steps: 200
+  save_steps: 800
   num_train_epochs: 1
   per_device_train_batch_size: 2
   gradient_accumulation_steps: 1

--- a/scripts/polaris/jobs/llama_tune.sh
+++ b/scripts/polaris/jobs/llama_tune.sh
@@ -105,7 +105,7 @@ if [ "$MODEL_SIZE" == "8b" ]; then
         # Batch size per GPU: 2
         # Gradient accumulation steps (GAS): 1
         # Examples per step: 1 node * 4 GPUs/node * 2 bs * 1 GAS  = 8
-        # Num steps for 1 epoch: 51,760 / 8 = 6,475
+        # Num steps for 1 epoch: 51,760 / 8 = 6,470
         set -x  # Print "accelerate" command with expanded variables
         accelerate launch \
             --num_machines ${LEMA_NUM_NODES} \
@@ -129,7 +129,7 @@ else  # 70B
         # Batch size per GPU: 2
         # Gradient accumulation steps (GAS): 1
         # Examples per step: 2 nodes * 4 GPUs/node * 2 bs * 1 GAS  = 16
-        # Num steps for 1 epoch: 51,760 / 16 = 3,238
+        # Num steps for 1 epoch: 51,760 / 16 = 3,235
         set -x  # Print "accelerate" command with expanded variables
         accelerate launch \
             --num_machines ${LEMA_NUM_NODES} \


### PR DESCRIPTION
Towards OPE-331

With our default config, enabling Liger for 8B SFT has a noticeable improvement to training speed, which is not the case for other configs.

Also switched to explicitly training for 1 epoch instead of putting the calculated steps needed. Also adjusted the save steps for the 8B configs to be more reasonable given the total number of steps and training speed.