### PR TITLE
[tiny] Fix lema loop performance gap 

### DIFF
--- a/src/lema/core/trainers/lema_trainer.py
+++ b/src/lema/core/trainers/lema_trainer.py
@@ -115,12 +115,12 @@ class Trainer(BaseTrainer):
         if is_distributed():
             # Wrap model for distributed training
             with self._telemetry_block("wrap model for distributed"):
-                self.model = prepare_model_for_distributed(model, use_fsdp=False)
+                self.model = prepare_model_for_distributed(self.model, use_fsdp=False)
 
         if self.params.compile:
             self.log("Compiling model...")
             with self._telemetry_block("compile model"):
-                self.model = cast(torch.nn.Module, torch.compile(model))
+                self.model = cast(torch.nn.Module, torch.compile(self.model))
 
         self.callbacks = callbacks if callbacks is not None else []
 


### PR DESCRIPTION
This is by far the silliest bug I've at lema so far 🥲: we we're compiling the model, but not using the compiled version 🤦 

With this change, tokens/s/gpu on an A100 go from `11665` -> `13583` on the tested config, in-line with `TRL_SFT` 