### PR TITLE
[tiny] enable ruff format on save with notebooks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     },
     "[markdown]": {
         "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
-    }
+    },
+    "notebook.formatOnSave.enabled": true
 }


### PR DESCRIPTION
- Update default `vscode` config to enable notebook cell formatting using the default formatter