### PR TITLE
Update train path to save meta-info as files under `telemetry` sub-dir

### DIFF
--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -287,13 +287,9 @@ def train(config: TrainingConfig, **kwargs) -> None:
     config = _finalize_training_config(config)
 
     if is_local_process_zero():
-        # Only write the config file once from rank 0 for telemetry.
-        training_config_filename = (
-            telemetry_dir / "training_config.txt"
-            if telemetry_dir and is_world_process_zero()
-            else None
-        )
-        log_training_config(config, training_config_filename)
+        log_training_config(config)
+        if telemetry_dir and is_world_process_zero():
+            config.to_yaml(str(telemetry_dir / "training_config.yaml"))
 
     # Initialize model and tokenizer.
     tokenizer = build_tokenizer(config.model)

--- a/src/lema/utils/torch_utils.py
+++ b/src/lema/utils/torch_utils.py
@@ -38,16 +38,9 @@ def limit_per_process_memory(percent: float = 0.95) -> None:
         torch.cuda.set_per_process_memory_fraction(percent)
 
 
-def log_training_config(
-    config: TrainingConfig, filepath: Optional[Path] = None
-) -> None:
+def log_training_config(config: TrainingConfig) -> None:
     """Logs training config."""
-    config_text = pformat(config)
-    logger.info(f"TrainingConfig: {config_text}")
-
-    if filepath:
-        with filepath.open("w", encoding="utf-8") as f:
-            f.write(config_text)
+    logger.info(f"TrainingConfig: {pformat(config)}")
 
 
 def log_versioning_info() -> None:


### PR DESCRIPTION
-- Modifying logging logic to also save relevant info  (world size, model summary, training config, etc) as separate files for easier future reference.
 
Towards OPE-349