### PR TITLE
Remove device_map for model init from config

### DIFF
--- a/src/lema/builders/models.py
+++ b/src/lema/builders/models.py
@@ -188,7 +188,6 @@ def build_huggingface_model(
         model = transformers_model_class.from_config(
             config=hf_config,
             torch_dtype=model_params.torch_dtype(),
-            device_map=device_map,
             trust_remote_code=model_params.trust_remote_code,
             **kwargs,
         )


### PR DESCRIPTION
Received this error for Llama 2B PT jobs: `LlamaForCausalLM.__init__() got an unexpected keyword argument 'device_map'`. Was introduced in #459.