### PR TITLE
Minor fixes in DISTRIBUTED_TRAINING.md

### DIFF
--- a/docs/DISTRIBUTED_TRAINING.md
+++ b/docs/DISTRIBUTED_TRAINING.md
@@ -30,7 +30,7 @@ For example, for Phi3 DPO model, there are two related sample configs provided:
 - SkyPilot config: [configs/skypilot/sky_phi3_dpo_fsdp.yaml](../configs/skypilot/sky_phi3_dpo_fsdp.yaml)
   - Set the `accelerators:` section as follows: `accelerators: {"A40": N}`, where `N` is the number of GPUs to use e.g., `2`.
 - [`accelerate`](https://github.com/huggingface/accelerate) config: [configs/accelerate/phi3.fsdp.dpo.yaml](../configs/accelerate/phi3.fsdp.dpo.yaml)
-  - Set `num_processes: N`, where `N` is the number of GPUs. NOTE: This step is normally optional as the value is overridden in SkyPilot config `--num_processes ${TOTAL_NUM_GPUS}`)
+  - Set `num_processes: N`, where `N` is the number of GPUs. NOTE: This step can be optional as the value is overridden in SkyPilot config as: `--num_processes ${TOTAL_NUM_GPUS}`)
   - Update `fsdp_transformer_layer_cls_to_wrap` to match transformer layer class name in your model.
   - Review and tune other parameters in the config, as described in [FSDP Configuration](https://huggingface.co/docs/transformers/main/en/fsdp#fsdp-configuration) and in [accelerate FSDP usage guide](https://huggingface.co/docs/accelerate/en/usage_guides/fsdp). They control various performance trade-offs.
 


### PR DESCRIPTION
-- Correct few FSDP links to reflect the new directory structure (`docs` sub-dir)
-- Remove the instruction (`Set num_processes: N where N is the number of GPUs.`) . No longer necessary