### PR TITLE
Switch to using official UV action with dependency caching

### DIFF
--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -28,7 +28,7 @@ jobs:
       run: |
         # Install in system python as we're in a sandbox env
         # Install in verbose mode to see what's going on
-        uv pip install -e '.[all]' --system -v
+        uv pip install -e '.[all]' --system
 
     - name: Cache pre-commit
       uses: actions/cache@v4


### PR DESCRIPTION
**Changes**
- Switch to using official UV action with dependency caching
- Reduces build time by 1-2 minutes with a cache hit
- No need to manually install uv in the setup section