### PR TITLE
Rename build_dataset -> build_dataset_mixture

### DIFF
--- a/notebooks/build_zephyr7b.ipynb
+++ b/notebooks/build_zephyr7b.ipynb
@@ -12,7 +12,7 @@
     "from omegaconf import OmegaConf\n",
     "\n",
     "from lema.builders import (\n",
-    "    build_dataset,\n",
+    "    build_dataset_mixture,\n",
     "    build_model,\n",
     "    build_peft_model,\n",
     "    build_tokenizer,\n",
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "# Load data & preprocessing\n",
-    "dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)\n",
+    "dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)\n",
     "\n",
     "\n",
     "if not config.data.train.stream:\n",

--- a/scripts/benchmarks/benchmark_dataloader.py
+++ b/scripts/benchmarks/benchmark_dataloader.py
@@ -13,7 +13,7 @@ from torch.utils.data import IterableDataset as TorchIterableDataset
 from torch.utils.data.distributed import DistributedSampler
 from tqdm.auto import tqdm
 
-from lema.builders import build_dataset, build_tokenizer
+from lema.builders import build_dataset_mixture, build_tokenizer
 from lema.core.distributed import (
     cleanup_distributed,
     init_distributed,
@@ -70,7 +70,7 @@ def main(args):
 
         tokenizer = build_tokenizer(config.model)
         init_time, dataset = _load_dataset(
-            build_dataset, config, tokenizer, DatasetSplit.TRAIN
+            build_dataset_mixture, config, tokenizer, DatasetSplit.TRAIN
         )
 
         # Anything that's useful for debugging / slicing plots.

--- a/src/lema/builders/__init__.py
+++ b/src/lema/builders/__init__.py
@@ -9,7 +9,7 @@ allowing for easier setup and configuration of machine learning experiments.
 """
 
 from lema.builders.callbacks import build_training_callbacks
-from lema.builders.data import build_dataset
+from lema.builders.data import build_dataset_mixture
 from lema.builders.metrics import build_metrics_function
 from lema.builders.models import (
     build_chat_template,
@@ -21,7 +21,7 @@ from lema.builders.optimizers import build_optimizer
 from lema.builders.training import build_trainer
 
 __all__ = [
-    "build_dataset",
+    "build_dataset_mixture",
     "build_metrics_function",
     "build_model",
     "build_optimizer",

--- a/src/lema/builders/data.py
+++ b/src/lema/builders/data.py
@@ -72,7 +72,7 @@ def build_prompt_generation_fn(
     raise ValueError(f"Unknown prompt generation function: {function_name}")
 
 
-def build_dataset(
+def build_dataset_mixture(
     config: TrainingConfig,
     tokenizer: BaseTokenizer,
     dataset_split: DatasetSplit,
@@ -94,7 +94,7 @@ def build_dataset(
     dataset_split_params: DatasetSplitParams = config.data.get_split(dataset_split)
 
     if dataset_split_params.experimental_use_torch_datapipes:
-        from lema.builders.lema_data import build_dataset as build_lema_dataset
+        from lema.builders.lema_data import build_dataset_mixture as build_lema_dataset
 
         logger.warning(
             "Using experimental torch datapipes preprocessing pipeline. "

--- a/src/lema/builders/lema_data.py
+++ b/src/lema/builders/lema_data.py
@@ -20,7 +20,7 @@ from lema.core.registry import REGISTRY
 from lema.core.tokenizers import BaseTokenizer
 
 
-def build_dataset(
+def build_dataset_mixture(
     config: TrainingConfig,
     tokenizer: BaseTokenizer,
     dataset_split: DatasetSplit,

--- a/src/lema/train.py
+++ b/src/lema/train.py
@@ -9,7 +9,7 @@ import torch
 from transformers.trainer_utils import get_last_checkpoint
 
 from lema.builders import (
-    build_dataset,
+    build_dataset_mixture,
     build_metrics_function,
     build_model,
     build_peft_model,
@@ -256,11 +256,11 @@ def train(config: TrainingConfig, **kwargs) -> None:
         )
 
     # Load data & preprocessing
-    dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
 
     eval_dataset = None
     if len(config.data.get_split(DatasetSplit.VALIDATION).datasets) != 0:
-        eval_dataset = build_dataset(config, tokenizer, DatasetSplit.VALIDATION)
+        eval_dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
 
     # Train model
     create_trainer_fn: Callable[..., BaseTrainer] = build_trainer(

--- a/tests/integration/builders/test_data.py
+++ b/tests/integration/builders/test_data.py
@@ -4,7 +4,7 @@ import pytest
 from datasets import Dataset, IterableDataset
 from trl.trainer import ConstantLengthDataset
 
-from lema.builders import build_dataset, build_tokenizer
+from lema.builders import build_dataset_mixture, build_tokenizer
 from lema.core.configs import (
     DataParams,
     DatasetParams,
@@ -88,7 +88,7 @@ def test_data_single_dataset(stream: bool):
         DatasetSplit.TRAIN,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
     assert _get_dataset_size(dataset, stream) == 100
 
 
@@ -110,7 +110,7 @@ def test_data_multiple_datasets(stream: bool):
         DatasetSplit.TEST,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.TEST)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TEST)
     assert _get_dataset_size(dataset, stream) == 100 * 2  # Duplicated dataset
 
 
@@ -134,7 +134,7 @@ def test_data_multiple_datasets_local_sample(stream: bool):
         DatasetSplit.VALIDATION,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.VALIDATION)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
     assert _get_dataset_size(dataset, stream) == 5 + 201
 
 
@@ -174,7 +174,7 @@ def test_data_multiple_datasets_shuffle_different_seeds(stream: bool):
         DatasetSplit.VALIDATION,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.VALIDATION)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
     assert _get_dataset_size(dataset, stream) == 20
     # Read all the data to handle streaming / nonstreaming in a unified manner.
     data = []
@@ -223,7 +223,7 @@ def test_data_multiple_datasets_local_mixed(stream: bool):
     config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "first_exhausted"
     config.data.get_split(DatasetSplit.TRAIN).seed = 1
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
     # The dataset size should be small. We stop merging when the smallest dataset is
     # exhausted.
     assert _get_dataset_size(dataset, stream) == 9
@@ -263,7 +263,7 @@ def test_data_multiple_datasets_local_mixed_all_exhausted(stream: bool):
     config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "all_exhausted"
     config.data.get_split(DatasetSplit.TRAIN).seed = 1
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
     # The dataset size should be larger. We stop merging when all datasets have been
     # exhausted.
     assert _get_dataset_size(dataset, stream) == 124
@@ -335,7 +335,7 @@ def test_data_multiple_datasets_different_mix_seeds(stream: bool):
         config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "first_exhausted"
         config.data.get_split(DatasetSplit.TRAIN).seed = seed
         tokenizer = build_tokenizer(config.model)
-        datasets.append(build_dataset(config, tokenizer, DatasetSplit.TRAIN))
+        datasets.append(build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN))
     dataset_a = datasets[0]
     dataset_b = datasets[1]
     assert _get_dataset_size(dataset_a, stream) != _get_dataset_size(dataset_b, stream)
@@ -374,7 +374,7 @@ def test_data_multiple_datasets_packing(stream: bool):
         config.data.get_split(DatasetSplit.TEST).mixture_strategy = "first_exhausted"
         config.data.get_split(DatasetSplit.TEST).seed = 1
         tokenizer = build_tokenizer(config.model)
-        dataset = build_dataset(config, tokenizer, DatasetSplit.TEST)
+        dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TEST)
         # The packed dataset should be even smaller.
         assert _get_dataset_size(dataset, stream, pack=True) == 3
     else:

--- a/tests/integration/train/test_custom_models.py
+++ b/tests/integration/train/test_custom_models.py
@@ -4,7 +4,7 @@ import unittest
 from transformers import Trainer
 
 from lema import train
-from lema.builders.data import build_dataset
+from lema.builders.data import build_dataset_mixture
 from lema.builders.models import build_model, build_tokenizer
 from lema.core.configs import (
     DataParams,
@@ -63,7 +63,7 @@ def test_train_native_pt_model_from_api():
 
         tokenizer = build_tokenizer(config.model)
 
-        dataset = build_dataset(config, tokenizer, DatasetSplit.TRAIN)
+        dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
 
         model = build_model(model_params=config.model)
 


### PR DESCRIPTION
This PR contains no logic change, and just renames our `build_dataset` function into `build_dataset_mixture` to better reflect it's usage and functionality