### PR TITLE
[Draft] Example changes to support 70B single-node inference

### DIFF
--- a/configs/lema/jobs/polaris/vllm.yaml
+++ b/configs/lema/jobs/polaris/vllm.yaml
@@ -1,7 +1,7 @@
 name: vllm
 # NOTE: Replace with your username.
 user: your_username
-num_nodes: 2
+num_nodes: 1
 
 resources:
   cloud: polaris
@@ -15,7 +15,7 @@ envs:
   MODEL: Meta-Llama-3.1-70B-Instruct  # HF model name.
   LEMA_VLLM_INPUT_FILEPATH: your_input_filepath  # Path to input data file.
   LEMA_VLLM_OUTPUT_DIR: your_output_dir  # Output dir.
-  LEMA_VLLM_NUM_WORKERS: 10  # Samples will be divided amongst workers
+  LEMA_VLLM_NUM_WORKERS: 100  # Samples will be divided amongst workers
   LEMA_VLLM_WORKERS_SPAWNED_PER_SECOND: 10
 
 # `setup` will always be executed before `run`. It's strongly suggested to set any PBS

--- a/scripts/polaris/jobs/vllm_job.sh
+++ b/scripts/polaris/jobs/vllm_job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l select=2:system=polaris
+#PBS -l select=1:system=polaris
 #PBS -l place=scatter
 #PBS -l walltime=00:40:00
 #PBS -l filesystems=home:eagle

--- a/scripts/polaris/jobs/vllm_worker.sh
+++ b/scripts/polaris/jobs/vllm_worker.sh
@@ -97,6 +97,9 @@ if [ "${POLARIS_NODE_RANK}" == "0" ]; then
         --disable-custom-all-reduce \
         --enforce-eager \
         --disable-log-requests \
+        --enable-chunked-prefill=True \
+        --gpu-memory-utilization=0.95 \
+        --max-model-len=8192 \
         ${LORA_MODULES} \
         2>&1 | tee "${SERVER_LOG_PATH}" &
 


### PR DESCRIPTION
Can hit 2.87 req/s on one node with this:

{
"Total tok/s": 1317.37,
"Total tokens": 455445,
"Input tok/s": 789.24,
"Input tokens": 272858,
"Output tok/s": 528.13,
"Output tokens": 182587,
"Requests/s": 2.89,
"Request count": 1000,
"Elapsed Time": "00:05:45",
"Elapsed Time (seconds)": 345.72
}