### PR TITLE
Update final lema references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Open Unified Machine Intelligence (OUMI)
 
-[![PyPI version](https://badge.fury.io/py/lema.svg)](https://badge.fury.io/py/lema)
+[![PyPI version](https://badge.fury.io/py/oumi.svg)](https://badge.fury.io/py/oumi)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Pre-review Tests](https://github.com/oumi-ai/oumi/actions/workflows/pretest.yaml/badge.svg?branch=main)](https://github.com/oumi-ai/oumi/actions/workflows/pretest.yaml)
-[![Documentation](https://img.shields.io/badge/docs-lema-blue.svg)](https://learning-machines.ai/docs/latest/index.html)
+[![Documentation](https://img.shields.io/badge/docs-oumi-blue.svg)](https://learning-machines.ai/docs/latest/index.html)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 

--- a/configs/oumi/jobs/gcp/llama70b_lora.yaml
+++ b/configs/oumi/jobs/gcp/llama70b_lora.yaml
@@ -35,7 +35,7 @@ setup: |
   # Download model from GCS, which is faster than downloading during training.
   # At the moment, you need to run this manually after ssh-ing into the cluster
   # because it requires manual authentication.
-  # gsutil -m cp -R gs://lema-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
+  # gsutil -m cp -R gs://oumi-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/oumi/jobs/gcp/llama70b_sft.yaml
+++ b/configs/oumi/jobs/gcp/llama70b_sft.yaml
@@ -35,7 +35,7 @@ setup: |
   # Download model from GCS, which is faster than downloading during training.
   # At the moment, you need to run this manually after ssh-ing into the cluster
   # because it requires manual authentication.
-  # gsutil -m cp -R gs://lema-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
+  # gsutil -m cp -R gs://oumi-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/oumi/jobs/gcp/llama8b_eval.yaml
+++ b/configs/oumi/jobs/gcp/llama8b_eval.yaml
@@ -23,7 +23,7 @@ storage_mounts:
   # See https://github.com/oumi-ai/oumi/wiki/Clouds-Setup#mounting-gcs-buckets
   # for documentation on using GCS buckets.
   /output_dir_gcs:
-    source: gs://lema-dev-us-central1
+    source: gs://oumi-dev-us-central1
     store: gcs
 
 envs:

--- a/configs/skypilot/sky_gpt2_eval.yaml
+++ b/configs/skypilot/sky_gpt2_eval.yaml
@@ -16,7 +16,7 @@ file_mounts:
   # See https://github.com/oumi-ai/oumi/wiki/Clouds-Setup#mounting-gcs-buckets
   # for documentation on using GCS buckets.
   /output_dir_gcs:
-    source: gs://lema-dev-us-central1
+    source: gs://oumi-dev-us-central1
     store: gcs
     mode: MOUNT
 

--- a/configs/skypilot/sky_llama70b_lora.yaml
+++ b/configs/skypilot/sky_llama70b_lora.yaml
@@ -32,7 +32,7 @@ setup: |
   # Download model from GCS, which is faster than downloading during training.
   # At the moment, you need to run this manually after ssh-ing into the cluster
   # because it requires manual authentication.
-  # gsutil -m cp -R gs://lema-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
+  # gsutil -m cp -R gs://oumi-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/skypilot/sky_llama70b_sft.yaml
+++ b/configs/skypilot/sky_llama70b_sft.yaml
@@ -29,7 +29,7 @@ setup: |
   # Download model from GCS, which is faster than downloading during training.
   # At the moment, you need to run this manually after ssh-ing into the cluster
   # because it requires manual authentication.
-  # gsutil -m cp -R gs://lema-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
+  # gsutil -m cp -R gs://oumi-dev-us-central1/wizeng/models/models--meta-llama--Meta-Llama-3.1-70B-Instruct ~/.cache/huggingface/hub
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/skypilot/sky_phi3_eval.yaml
+++ b/configs/skypilot/sky_phi3_eval.yaml
@@ -18,7 +18,7 @@ file_mounts:
   # See https://github.com/oumi-ai/oumi/wiki/Clouds-Setup#mounting-gcs-buckets
   # for documentation on using GCS buckets.
   /output_dir_gcs:
-    source: gs://lema-dev-us-central1
+    source: gs://oumi-dev-us-central1
     store: gcs
     mode: MOUNT
 

--- a/configs/skypilot/sky_zephyr_7b_qlora_sft.yaml
+++ b/configs/skypilot/sky_zephyr_7b_qlora_sft.yaml
@@ -22,7 +22,7 @@ file_mounts:
   # See https://github.com/oumi-ai/oumi/wiki/Clouds-Setup#mounting-gcs-buckets
   # for documentation on using GCS buckets.
   /output_dir_gcs:
-    source: gs://lema-dev-us-central1
+    source: gs://oumi-dev-us-central1
     store: gcs
     mode: MOUNT
 

--- a/configs/skypilot/sky_zephyr_7b_sft.yaml
+++ b/configs/skypilot/sky_zephyr_7b_sft.yaml
@@ -22,7 +22,7 @@ file_mounts:
   # See https://github.com/oumi-ai/oumi/wiki/Clouds-Setup#mounting-gcs-buckets
   # for documentation on using GCS buckets.
   /output_dir_gcs:
-    source: gs://lema-dev-us-central1
+    source: gs://oumi-dev-us-central1
     store: gcs
     mode: MOUNT
 

--- a/src/experimental/pretokenize/sky.yaml
+++ b/src/experimental/pretokenize/sky.yaml
@@ -20,7 +20,7 @@ file_mounts:
   ~/.netrc: ~/.netrc # WandB credentials
 
   /dataset_parent_dir:
-    source: gs://lema-dev-europe-west4/
+    source: gs://oumi-dev-europe-west4/
     store: gcs
     mode: MOUNT
 


### PR DESCRIPTION
Towards OPE-364

This PR updates our README badges and our GCS bucket names. I copied over the contents of the old buckets into the new ones, and will delete the old buckets a few days after this PR is merged.

The only two lema references left after this refactor are our GCP project id `lema-dev` and our email `contact@openlema.com`.

