### PR TITLE
Update TOTAL_NUM_GPUS compare commands in SkyPilot configs

### DIFF
--- a/configs/skypilot/sky_llama2b_ddp.yaml
+++ b/configs/skypilot/sky_llama2b_ddp.yaml
@@ -24,12 +24,12 @@ setup: |
   pip install '.[gpu]'
 
 run: |
-  set -xe  # Exit if any command failed.
+  set -e  # Exit if any command failed.
   source ./configs/skypilot/sky_init.sh
 
   TOTAL_NUM_GPUS=$((${OUMI_NUM_NODES} * ${SKYPILOT_NUM_GPUS_PER_NODE}))
   ACCELERATE_MULTI_GPU_OPTION=
-  if [${TOTAL_NUM_GPUS} -gt 1]; then
+  if test ${TOTAL_NUM_GPUS} -gt 1; then
     ACCELERATE_MULTI_GPU_OPTION="--multi_gpu"
   fi
 

--- a/configs/skypilot/sky_llama2b_deepspeed.yaml
+++ b/configs/skypilot/sky_llama2b_deepspeed.yaml
@@ -31,6 +31,10 @@ run: |
   source ./configs/skypilot/sky_init.sh
 
   TOTAL_NUM_GPUS=$((${OUMI_NUM_NODES} * ${SKYPILOT_NUM_GPUS_PER_NODE}))
+  if test ${TOTAL_NUM_GPUS} -lt 2; then
+    echo "Using DeepSpeed with only 1 GPU may lead to errors. Multiple GPUs are expected."
+  fi
+
   set -x  # Print "accelerate launch" command with expanded variables
   accelerate launch \
       --num_machines ${OUMI_NUM_NODES} \

--- a/configs/skypilot/sky_llama70b_lora.yaml
+++ b/configs/skypilot/sky_llama70b_lora.yaml
@@ -39,6 +39,10 @@ run: |
   source ./configs/skypilot/sky_init.sh
 
   TOTAL_NUM_GPUS=$((${OUMI_NUM_NODES} * ${SKYPILOT_NUM_GPUS_PER_NODE}))
+  if test ${TOTAL_NUM_GPUS} -lt 2; then
+    echo "Using FSDP with only 1 GPU may lead to errors. Multiple GPUs are expected."
+  fi
+
   set -x  # Print "accelerate launch" command with expanded variables
   accelerate launch \
       --num_machines ${OUMI_NUM_NODES} \

--- a/configs/skypilot/sky_llama8b_lora.yaml
+++ b/configs/skypilot/sky_llama8b_lora.yaml
@@ -39,7 +39,7 @@ run: |
 
   TOTAL_NUM_GPUS=$((${OUMI_NUM_NODES} * ${SKYPILOT_NUM_GPUS_PER_NODE}))
   ACCELERATE_MULTI_GPU_OPTION=
-  if [${TOTAL_NUM_GPUS} -gt 1]; then
+  if test ${TOTAL_NUM_GPUS} -gt 1; then
     ACCELERATE_MULTI_GPU_OPTION="--multi_gpu"
   fi
 


### PR DESCRIPTION
-- The current syntax leads to errors on GCP => switch to `test $X -lt $Y`
-- Add more warnings if FSDP is used with 1 GPU