### PR TITLE
Freeze `lm-eval` and `torch` versions as a workaround for  OPE-390

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ train = [
     "asyncio",
     "bitsandbytes",                 # for quantization
     "datasets",
-    "lm-eval==0.4.3",
+    "lm-eval==0.4.3",               # OPE-390
     "nvidia-ml-py",
     "omegaconf",
     "peft",
@@ -76,7 +76,7 @@ train = [
     "safetensors",
     "sentencepiece",                # for phi-3
     "tensorboard",
-    "torch==2.4.0",
+    "torch==2.4.0",                 # OPE-390
     "torchdata>=0.8.0",
     "transformers>=4.43.1,<4.44.0",
     "trl>=0.9.0",


### PR DESCRIPTION
-- Otherwise, training jobs fail to start on GCP 

Towards  OPE-390