### PR TITLE
Fix infer examples in OUMI Tour notebook

### DIFF
--- a/notebooks/OUMI - A Tour.ipynb
+++ b/notebooks/OUMI - A Tour.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,9 +195,9 @@
     "    \"Remember that we didn't train for long, so the results might not be great.\"\n",
     ")\n",
     "\n",
-    "results = infer(config.model, config.generation, [[input_text]])\n",
+    "results = infer(config.model, config.generation, [input_text])\n",
     "\n",
-    "print(results[0][0])"
+    "print(results[0])"
    ]
   },
   {
@@ -213,9 +220,9 @@
     "\n",
     "input_text = \"Input for the pretrained model: What is your name? \"\n",
     "\n",
-    "results = infer(pretrained_config.model, pretrained_config.generation, [[input_text]])\n",
+    "results = infer(pretrained_config.model, pretrained_config.generation, [input_text])\n",
     "\n",
-    "print(results[0][0])"
+    "print(results[0])"
    ]
   },
   {


### PR DESCRIPTION
-- It should be `infer(... [input_text])` (not `infer(... [[input_text]])`) to match https://github.com/oumi-ai/oumi/blob/1157def8a219dc3063053f83a77124556d7ea4ee/src/oumi/infer.py#L64
-- Similarly for `result[0]` (vs `result[0][0]`)