### PR TITLE
Minor changes in `scripts/benchmarks/minimal_multimodal_training.py`

### DIFF
--- a/scripts/benchmarks/minimal_multimodal_training.py
+++ b/scripts/benchmarks/minimal_multimodal_training.py
@@ -12,8 +12,8 @@ For multi-GPU training, use torchrun:
 Working configs:
     --model-name Salesforce/blip2-opt-2.7b --dataset-name coco_captions
     --model-name Salesforce/blip2-opt-2.7b --dataset-name nlphuji/flickr30k
-    --model-name llava-hf/llava-1.5-7b-hf --dataset-name coco_captions --test_fsdp
-    --model-name llava-hf/llava-1.5-7b-hf --dataset-name nlphuji/flickr30k --test_fsdp
+    --model-name llava-hf/llava-1.5-7b-hf --dataset-name coco_captions --test-fsdp
+    --model-name llava-hf/llava-1.5-7b-hf --dataset-name nlphuji/flickr30k --test-fsdp
 """
 
 from enum import Enum


### PR DESCRIPTION
-- Use full name of Flickr dataset
-- Support configurable `split`, and change default split of `nlphuji/flickr30k` to `test` (the only split available there)
-- Update separator in `--test-fsdp` in sample commands

Towards OPE-353
