### PR TITLE
Pass `split` param to `datasets.load_dataset()`

### DIFF
--- a/src/oumi/core/datasets/base_dataset.py
+++ b/src/oumi/core/datasets/base_dataset.py
@@ -145,6 +145,7 @@ class BaseMapDataset(MapDataPipe, ABC):
         splits_or_dataset = datasets.load_dataset(
             path=path,
             name=self.dataset_subset,
+            split=self.split,
             trust_remote_code=self.trust_remote_code,
         )
 


### PR DESCRIPTION
- It enables additional features like Slicing (`--split="train[:20%]"`) https://huggingface.co/docs/datasets/v1.10.1/splits.html#slicing-api
- Allows optimization e.g., not reading all splits if not needed 