### PR TITLE
Disable `sdpa` for `blip2`

### DIFF
--- a/configs/oumi/blip2_opt_2.7b.sft.yaml
+++ b/configs/oumi/blip2_opt_2.7b.sft.yaml
@@ -3,7 +3,6 @@ model:
   torch_dtype_str: "bfloat16"
   model_max_length: 256
   trust_remote_code: True
-  attn_implementation: "sdpa"
   freeze_layers:
     - "vision_model"
 


### PR DESCRIPTION
Error:  

```
ValueError: Blip2ForConditionalGeneration does not support an attention implementation through torch.nn.functional.scaled_dot_product_attention yet. Please request the support for this architecture: https://github.com/huggingface/transformers/issues/28005. If you believe this error is a bug, please open an issue in Transformers GitHub repository and load your model with the argument `attn_implementation="eager"` meanwhile. Example: `model = AutoModel.from_pretrained("openai/whisper-tiny", attn_implementation="eager")`
```

Enabled `sdpa` at the last moment yesterday, but it doesn't actually work for this model.

 https://github.com/huggingface/transformers/issues/28005

Towards OPE-353
Fixes OPE-233