### PR TITLE
Set accelerate version to fix FSDP model saving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "torchfix",
 ]
 train = [
-    "accelerate==0.33.0",
+    "accelerate==0.33.0",           # OPE-496. Don't use 0.34.*.
     "aiohttp",
     "aioresponses",
     "asyncio",


### PR DESCRIPTION
Fixes OPE-496

Would recommend everyone to rerun pip-install after pulling this change to resolve the issue on their machines.

Current version is 0.34.2, which doesn't properly unwrap the FSDP model for saving (specifically the embedding and LM head). Reverting back to 0.33.0, which doesn't have this issue. 0.34.0 doesn't work because it has a different unrelated error.

The pre-release 1.0.0rc0 version fixes this, but we may not want to depend on this in our codebase. However, this likely means Accelerate fixed the issue, so we don't need to flag this to them.

Tested this on GCP with `oumi-launch -p configs/oumi/jobs/gcp/llama8b_sft.yaml -c fix`, and successfully loaded the trained model.