### PR TITLE
Misc updates to Polaris launcher scripts

### DIFF
--- a/configs/oumi/jobs/polaris/llama70b_sft.yaml
+++ b/configs/oumi/jobs/polaris/llama70b_sft.yaml
@@ -33,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 70b -t
+      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 70b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama8b_sft.yaml
+++ b/configs/oumi/jobs/polaris/llama8b_sft.yaml
@@ -1,7 +1,6 @@
 # Config for Llama 3.1 8B Instruct SFT on 1 Polaris node.
 # Example command:
 # oumi-launch -p configs/oumi/jobs/polaris/llama8b_sft.yaml -c preemptable.$ALCF_USER user=$ALCF_USER
-# oumi-launch -p configs/oumi/jobs/polaris/llama8b_sft.yaml -c debug.$ALCF_USER user=$ALCF_USER num_nodes=1
 name: llama8b-sft
 # NOTE: Replace with your username.
 user: your_username
@@ -18,7 +17,7 @@ working_dir: .
 # PBS directives.
 setup: |
   #PBS -l place=scatter
-  #PBS -l walltime=01:00:00
+  #PBS -l walltime=02:00:00
   #PBS -l filesystems=home:eagle
   #PBS -A community_ai
   #PBS -o /eagle/community_ai/jobs/logs/
@@ -34,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 8b -t
+      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 8b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ train = [
     "asyncio",
     "bitsandbytes",                 # for quantization
     "datasets",
-    # "llama-cpp-python",             # for local cpu inference
+    "llama-cpp-python",             # for local cpu inference
     "lm-eval==0.4.3",               # OPE-390
     "nvidia-ml-py",
     "omegaconf",

--- a/scripts/polaris/jobs/llama_tune.sh
+++ b/scripts/polaris/jobs/llama_tune.sh
@@ -84,9 +84,6 @@ export TOKENIZERS_PARALLELISM=false
 # don't need to be modified during experimentation.
 SHARED_TRAINING_PARAMS="training.run_name='polaris.llama${MODEL_SIZE}.${TRAINING_MODE}.${OUMI_JOBNUM}'
 training.output_dir=/eagle/community_ai/${USER}/runs/llama${MODEL_SIZE}.${TRAINING_MODE}.${OUMI_JOBNUM}
-training.max_steps=200
-training.save_steps=0
-training.save_final_model=false
 ${OUMI_TELEMETRY_PARAMS}"
 
 # Our config is set to train for one epoch. Each section lists the number of steps


### PR DESCRIPTION
-- Add `-t` (telemetry) option to `scripts/polaris/jobs/llama_tune.sh`
--  Move `OUMI_JOBNUM` computation to `polaris_init.sh` for reusability
-- Define `$SHARED_TRAINING_PARAMS` in `llama_tune.sh`

Towards OPE-413