### PR TITLE
[Tiny] update missing dataset import

### DIFF
--- a/src/oumi/datasets/__init__.py
+++ b/src/oumi/datasets/__init__.py
@@ -27,6 +27,7 @@ from oumi.datasets.chatrag_bench import ChatRAGBenchDataset
 from oumi.datasets.debug import DebugClassificationDataset, DebugPretrainingDataset
 from oumi.datasets.dolly import ArgillaDollyDataset
 from oumi.datasets.magpie import ArgillaMagpieUltraDataset, MagpieProDataset
+from oumi.datasets.sft_jsonlines import TextSftJsonLinesDataset
 from oumi.datasets.vision_language.coco_captions import COCOCaptionsDataset
 from oumi.datasets.vision_language.flickr30k import Flickr30kDataset
 from oumi.datasets.vision_language.vision_jsonlines import JsonlinesDataset
@@ -43,4 +44,5 @@ __all__ = [
     "ArgillaDollyDataset",
     "ArgillaMagpieUltraDataset",
     "MagpieProDataset",
+    "TextSftJsonLinesDataset",
 ]


### PR DESCRIPTION
- SftJson dataset was not being imported in `oumi.datasets`, causing the dataset not to be registered at runtime