### PR TITLE
Update accelerate version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "torchfix",
 ]
 train = [
-    "accelerate==1.0.0",
+    "accelerate>=1.0.0",
     "aiohttp",
     "aioresponses",
     "asyncio",


### PR DESCRIPTION
Fixes OPE-496

1.0.0 just released today. I tested that it still solves the FSDP model saving option, but should fix the issue Jeremy encountered with AdamW: https://linear.app/oumi/issue/OPE-496#comment-6b7c2880