### PR TITLE
Add Llama 3B configs

### DIFF
--- a/configs/oumi/llama3b.lora.yaml
+++ b/configs/oumi/llama3b.lora.yaml
@@ -1,0 +1,69 @@
+# Lora config for Llama 3.2 3B.
+# Borrows param values from:
+# https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_lora.yaml
+
+model:
+  # Vocab size: 128256
+  # Hidden size: 3072
+  # MLP intermediate size: 8192
+  # Num layers: 28
+  # Num attention heads: 24
+  # Num KV heads: 8
+  # Weight tying: True
+  # Model max length: 131072 (initially trained with 8192)
+  model_name: "meta-llama/Llama-3.2-3B-Instruct"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  load_pretrained_weights: True
+  trust_remote_code: True
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+        preprocessing_function_name: "alpaca"
+    target_col: "prompt"
+    experimental_use_async_dataset: True
+
+training:
+  trainer_type: TRL_SFT
+  use_peft: True
+  save_steps: 800
+  num_train_epochs: 1
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 4
+
+  enable_gradient_checkpointing: True
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 3.0e-04
+  lr_scheduler_type: "cosine"
+  warmup_steps: 100
+  weight_decay: 0.01
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/llama3b.lora"
+  include_performance_metrics: True
+  enable_wandb: True
+
+peft:
+  q_lora: False
+  lora_r: 64
+  lora_alpha: 128
+  lora_dropout: 0.0
+  lora_target_modules:
+    - "q_proj"
+    - "v_proj"
+    - "o_proj"
+    - "gate_proj"
+    - "up_proj"
+    - "down_proj"

--- a/configs/oumi/llama3b.qlora.yaml
+++ b/configs/oumi/llama3b.qlora.yaml
@@ -1,0 +1,71 @@
+# QLora config for Llama 3.2 3B.
+# Borrows param values from:
+# https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_qlora_single_device.yaml
+
+model:
+  # Vocab size: 128256
+  # Hidden size: 3072
+  # MLP intermediate size: 8192
+  # Num layers: 28
+  # Num attention heads: 24
+  # Num KV heads: 8
+  # Weight tying: True
+  # Model max length: 131072 (initially trained with 8192)
+  model_name: "meta-llama/Llama-3.2-3B-Instruct"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  load_pretrained_weights: True
+  trust_remote_code: True
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+        preprocessing_function_name: "alpaca"
+    target_col: "prompt"
+    experimental_use_async_dataset: True
+
+training:
+  trainer_type: TRL_SFT
+  use_peft: True
+  save_steps: 800
+  num_train_epochs: 1
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 4
+
+  enable_gradient_checkpointing: True
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 3.0e-04
+  lr_scheduler_type: "cosine"
+  warmup_steps: 100
+  weight_decay: 0.01
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/llama3b.qlora"
+  include_performance_metrics: True
+  enable_wandb: True
+
+peft:
+  q_lora: True
+  # https://github.com/pytorch/torchtune/blob/37337f71677da69f0967a9cde34b96ad7fec3cb6/torchtune/modules/peft/lora.py#L95
+  bnb_4bit_quant_type: "nf4"
+  lora_r: 64
+  lora_alpha: 128
+  lora_dropout: 0.0
+  lora_target_modules:
+    - "q_proj"
+    - "v_proj"
+    - "o_proj"
+    - "gate_proj"
+    - "up_proj"
+    - "down_proj"

--- a/configs/oumi/llama3b.sft.yaml
+++ b/configs/oumi/llama3b.sft.yaml
@@ -1,0 +1,52 @@
+# SFT config for Llama 3.2 3B.
+# Borrows param values from:
+# https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_full.yaml
+
+model:
+  # Vocab size: 128256
+  # Hidden size: 3072
+  # MLP intermediate size: 8192
+  # Num layers: 28
+  # Num attention heads: 24
+  # Num KV heads: 8
+  # Weight tying: True
+  # Model max length: 131072 (initially trained with 8192)
+  model_name: "meta-llama/Llama-3.2-3B-Instruct"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  load_pretrained_weights: True
+  trust_remote_code: True
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+        preprocessing_function_name: "alpaca"
+    target_col: "prompt"
+    experimental_use_async_dataset: True
+
+training:
+  trainer_type: TRL_SFT
+  save_steps: 800
+  num_train_epochs: 3
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 4
+
+  enable_gradient_checkpointing: True
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 2.0e-05
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/llama3b.sft"
+  include_performance_metrics: True
+  enable_wandb: True

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -327,7 +327,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
             barrier()
 
         with torch.profiler.record_function("train"):
-            logger.info(f"Training init time: {time.time() - _START_TIME}s")
+            logger.info(f"Training init time: {time.time() - _START_TIME:.3f}s")
             logger.info("Starting training...")
             trainer.train(resume_from_checkpoint=checkpoint_location)
 


### PR DESCRIPTION
Towards OPE-547

We can run these configs directly on mac, ex. `oumi-train -c configs/oumi/llama3b.sft.yaml "training.optimizer=adamw_torch" "training.max_steps=10" "model.model_max_length=128"`