### PR TITLE
explicitly specify the model's dtype in LMH

### DIFF
--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -178,6 +178,16 @@ class ModelParams(BaseParams):
             model_args_dict["peft"] = self.adapter_model
         if self.attn_implementation:
             model_args_dict["attn_implementation"] = self.attn_implementation
+
+        # Handle extra model_kwargs (construction arguments).
+        # Towards OPE-564.
+        if self.model_kwargs:
+            relevant_for_lm = ["load_in_4bit", "load_in_8bit"]
+            for key in relevant_for_lm:
+                if key in self.model_kwargs:
+                    model_args_dict[key] = self.model_kwargs[key]
+            # TODO: load_in_8bit, load_in_4bit are deprecated and will be removed in
+            # future versions of HF. Integrate via PeftConfig.
         return model_args_dict
 
     def __validate__(self):


### PR DESCRIPTION
Update some basic parameters when utilizing LMH via Oumi:
1.  Explicitly specify the torch.dtype of the neural model that will be instantiated with LMH. 
2. Enabling the loading of quantized model in 4 or 8 bits.

Towards OPE-564.

Note (future todo). We will revisit the interoperability between the two libraries. For instance, there might exist parameters in the [model_kwargs](https://github.com/oumi-ai/oumi/pull/607/files#diff-5d668620d9ee30efe51708c9716b83a3cfdf73c1760020fe689218e9a00aeacfR184
) that are not relevant for LMH but are relevant for Oumi. Also, shortly we should directly pass the PeftConfig instead of using the ``load_in_4bit``, etc.