### PR TITLE
Fix `apply_chat_template` issue in `VisionLanguageSftDataset`

### DIFF
--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -194,20 +194,8 @@ class VisionLanguageSftDataset(BaseLMSftDataset, ABC):
         # including image placeholders for each image in the conversation
         texts = []
         for turn in conversation.messages:
-            if turn.is_text():
-                texts.append(
-                    {
-                        "content": [{"type": "text", "text": turn.content}],
-                        "role": str(turn.role),
-                    }
-                )
-
-            elif turn.is_image():
-                image_placeholder = {
-                    "content": [{"type": "image"}],
-                    "role": str(turn.role),
-                }
-                texts.append(image_placeholder)
+            if turn.is_text() or turn.is_image():
+                texts.append(turn)
             else:
                 raise ValueError(f"Unsupported message type: {turn.type}")
 

--- a/src/oumi/datasets/chat_templates/llava.jinja
+++ b/src/oumi/datasets/chat_templates/llava.jinja
@@ -1,8 +1,7 @@
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.
+{{ ' ' }}
 {% for message in messages %}
     {% if message['role'] == 'user' %}USER: {% else %}ASSISTANT: {% endif %}
-    {% for item in message['content'] %}
-        {% if item['type'] == 'text' %}{{ item['text'] }}{% elif item['type'] == 'image' %}<image>{% endif %}
-    {% endfor %}
+    {% if message['type'] == 'text' %}{{ message['content'] + ' ' }}{% elif message['type'] in ('image_path','image_url','image_binary') %}<image>{% endif %}
     {% if message['role'] == 'user' %} {% else %}{{eos_token}}{% endif %}
 {% endfor %}


### PR DESCRIPTION
-- Update LLAVA jinja template to match the latest `Message` structure 
-- Removed `image_placeholder` dict . Let' use `Message` everywhere for consistency.

This is a quick fix, a more robust longer term solution may be needed. 

Towards OPE-545
Fixes OPE-561