### PR TITLE
Align pyright checks with latest Pylance version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=500"]
@@ -41,12 +41,11 @@ repos:
     hooks:
       - id: pyright
         name: pyright
-        entry: pyright
+        entry: env PYRIGHT_PYTHON_PYLANCE_VERSION=latest-release pyright
         language: node
         types: [python]
         pass_filenames: false
         args: [--warnings]
-        additional_dependencies: ["pyright@1.1.368"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.16.0
     hooks:

--- a/src/oumi/core/configs/base_config.py
+++ b/src/oumi/core/configs/base_config.py
@@ -64,7 +64,7 @@ class BaseConfig:
         config = OmegaConf.to_object(OmegaConf.merge(schema, file_config))
         if not isinstance(config, cls):
             raise TypeError(f"config is not {cls}")
-        return cast(cls, config)
+        return cast(T, config)
 
     @classmethod
     def from_yaml_and_arg_list(
@@ -118,7 +118,7 @@ class BaseConfig:
         if not isinstance(config, cls):
             raise TypeError(f"config {type(config)} is not {type(cls)}")
 
-        return cast(cls, config)
+        return cast(T, config)
 
     def validate(self) -> None:
         """Validates the top level params objects."""

--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -245,7 +245,7 @@ class VisionLanguageSftDataset(BaseLMSftDataset, ABC):
             except requests.exceptions.RequestException as e:
                 logger.exception(f"Failed to download image: '{image.content}'")
                 raise e
-            image_bin = Image.open(response.raw).convert("RGB")
+            image_bin = Image.open(io.BytesIO(response.content)).convert("RGB")
 
         elif image.type == Type.IMAGE_BINARY:
             if image.binary is None:


### PR DESCRIPTION
**Changes**
- Change pyright pre-commit checks to use the same version as the latest release Pylance in vscode
  - Without this, users will see different errors in their editor vs 
  - This also allows pyright to be always updated 
- New version of pyright & Pylance seem to catch more typing bugs, this PR also fixes the newly discovered issues  