### PR TITLE
[tiny] add gpt2 chat template, and update tests to use it

### DIFF
--- a/src/oumi/datasets/chat_templates/gpt2.jinja
+++ b/src/oumi/datasets/chat_templates/gpt2.jinja
@@ -1,0 +1,1 @@
+{% for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}

--- a/tests/integration/infer/test_infer.py
+++ b/tests/integration/infer/test_infer.py
@@ -12,6 +12,7 @@ def test_infer_basic_interactive(monkeypatch: pytest.MonkeyPatch):
         model=ModelParams(
             model_name="openai-community/gpt2",
             trust_remote_code=True,
+            chat_template="gpt2",
         ),
         generation=GenerationParams(max_new_tokens=5, temperature=0.0, seed=42),
     )
@@ -24,7 +25,9 @@ def test_infer_basic_interactive(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.parametrize("num_batches,batch_size", [(1, 1), (1, 2), (2, 1), (2, 2)])
 def test_infer_basic_non_interactive(num_batches, batch_size):
     model_params = ModelParams(
-        model_name="openai-community/gpt2", trust_remote_code=True
+        model_name="openai-community/gpt2",
+        trust_remote_code=True,
+        chat_template="gpt2",
     )
     generation_params = GenerationParams(
         max_new_tokens=5, temperature=0.0, seed=42, batch_size=batch_size

--- a/tests/integration/infer/test_native_text_inference_engine.py
+++ b/tests/integration/infer/test_native_text_inference_engine.py
@@ -13,6 +13,7 @@ def _get_default_model_params() -> ModelParams:
     return ModelParams(
         model_name="openai-community/gpt2",
         trust_remote_code=True,
+        chat_template="gpt2",
     )
 
 


### PR DESCRIPTION
**Changes**
- Add a dummy template for gpt2. This template ignores all the roles and just concatenates all the inputs, and is similar to what was used in `transformers <4.45.0`
- Update tests that relied on hardcoded gpt2 responses to use the template

Closes OPE-115
Towards OPE-490