### PR TITLE
Add `pip install -U uv;` to `make setup` for existing envs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -105,7 +105,7 @@
             "module": "oumi.infer",
             "args": [
                 "--interactive",
-                "model.model_name=nyu-visionx/cambrian-phi3-3b",
+                "model.model_name=openai-community/gpt2",
                 "model.trust_remote_code=true",
                 "generation.max_new_tokens=16"
             ],


### PR DESCRIPTION
-- Otherwise, it failed for my existing env (`uv` was not previously installed).
-- Overhead should be minimal if `uv` already xists