### PR TITLE
Add config example for long context fine-tuning

### DIFF
--- a/configs/oumi/llama3.8b.sft.longctx.yaml
+++ b/configs/oumi/llama3.8b.sft.longctx.yaml
@@ -8,7 +8,7 @@
 #     --dynamo_backend inductor \
 #     --mixed_precision no \
 #     -m oumi.train \
-#     -c "configs/oumi/llama3.8b.sft.longctx"
+#     -c "configs/oumi/llama3.8b.sft.longctx.yaml"
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"


### PR DESCRIPTION
**Changes**
This PR adds a config optimized to fine-tune llama8b with 32K context.

**Usage**
This was tested on `8xA100-40GB` using the latest `oumi` version.

```bash
accelerate launch \
    --config_file configs/accelerate/llama8b.fsdp.yaml \
    --use_fsdp \
    --num_processes 8 \
    --dynamo_backend inductor \
    --mixed_precision no \
    -m oumi.train \
    -c "configs/oumi/llama3.8b.sft.longctx.yaml"
```