### PR TITLE
Add distribution mode flag to llama_tune

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,7 +86,7 @@
                 "8",
                 "--use_fsdp",
                 "--config_file",
-                "configs/accelerate/llama8b.fsdp.yaml",
+                "configs/accelerate/llama.fsdp.yaml",
                 "-m",
                 "oumi.train",
                 "-c",

--- a/configs/accelerate/llama.fsdp.mixedprec.yaml
+++ b/configs/accelerate/llama.fsdp.mixedprec.yaml
@@ -1,4 +1,7 @@
+# Accelerate FSDP config for Llama models <8B in size with mixed precision.
+# The only difference compared to llama.fsdp.yaml is `mixed_precision: 'bf16'`.
 # Intended node: 4xA100-40GB GPUs
+
 compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: FSDP
@@ -19,6 +22,7 @@ fsdp_config:
   fsdp_use_orig_params: true
 machine_rank: 0
 main_training_function: main
+mixed_precision: 'bf16'
 num_machines: 1
 num_processes: 4
 rdzv_backend: static

--- a/configs/accelerate/llama.fsdp.yaml
+++ b/configs/accelerate/llama.fsdp.yaml
@@ -1,16 +1,5 @@
-# Sample command:
-# accelerate launch \
-#   --use_fsdp \
-#   --config_file configs/accelerate/llama.fsdp.yaml \
-#   -m oumi.train \
-#   -c configs/oumi/llama3.8b.aya.sft.yaml \
-#   "training.output_dir=/tmp/train/" \
-#   "training.enable_wandb=false" \
-#   "training.enable_tensorboard=false" \
-#   "training.include_performance_metrics=true" \
-#   "training.max_steps=100" \
-#   "training.logging_steps=10"
-
+# Accelerate FSDP config for Llama models <8B in size.
+# Intended node: 4xA100-40GB GPUs
 compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: FSDP
@@ -31,7 +20,6 @@ fsdp_config:
   fsdp_use_orig_params: true
 machine_rank: 0
 main_training_function: main
-mixed_precision: 'bf16'
 num_machines: 1
 num_processes: 4
 rdzv_backend: static

--- a/configs/accelerate/llama70b.fsdp.yaml
+++ b/configs/accelerate/llama70b.fsdp.yaml
@@ -1,3 +1,4 @@
+# Accelerate FSDP config for Llama 70B.
 # Intended node: 4xA100-40GB GPUs
 # Referencing this config:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_full.yaml

--- a/configs/accelerate/llama70b.lora.yaml
+++ b/configs/accelerate/llama70b.lora.yaml
@@ -1,6 +1,10 @@
+# Accelerate FSDP config for Llama 70B Lora/QLora.
 # Intended node: 4xA100-40GB GPUs
 # Referencing this config:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_lora.yaml
+# The differences compared to llama70b.fsdp.yaml is:
+# - `fsdp_offload_params: false`
+# - `fsdp_state_dict_type: FULL_STATE_DICT`
 compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: FSDP

--- a/configs/oumi/jobs/gcp/llama2b_fsdp_trl.yaml
+++ b/configs/oumi/jobs/gcp/llama2b_fsdp_trl.yaml
@@ -39,7 +39,7 @@ run: |
       --main_process_ip ${OUMI_MASTER_ADDR} \
       --main_process_port 8007 \
       --use_fsdp \
-      --config_file configs/accelerate/llama.fsdp.yaml \
+      --config_file configs/accelerate/llama.fsdp.mixedprec.yaml \
       -m oumi.train \
       -c configs/oumi/llama2b.pt.fsdp.trl.yaml \
       "training.run_name='${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}'" \

--- a/configs/oumi/jobs/gcp/llama8b_sft.yaml
+++ b/configs/oumi/jobs/gcp/llama8b_sft.yaml
@@ -49,7 +49,7 @@ run: |
       --main_process_ip ${OUMI_MASTER_ADDR} \
       --main_process_port 8007 \
       --use_fsdp \
-      --config_file configs/accelerate/llama8b.fsdp.yaml \
+      --config_file configs/accelerate/llama.fsdp.yaml \
       -m oumi.train \
       -c configs/oumi/llama8b.sft.yaml \
       "training.run_name='${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}'" \

--- a/configs/oumi/jobs/polaris/llama3b_lora.yaml
+++ b/configs/oumi/jobs/polaris/llama3b_lora.yaml
@@ -29,7 +29,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m lora -s 3b
+      ./scripts/polaris/jobs/llama_tune.sh -m lora -d ddp -s 3b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama3b_qlora.yaml
+++ b/configs/oumi/jobs/polaris/llama3b_qlora.yaml
@@ -29,7 +29,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m qlora -s 3b
+      ./scripts/polaris/jobs/llama_tune.sh -m qlora -d ddp -s 3b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama3b_sft.yaml
+++ b/configs/oumi/jobs/polaris/llama3b_sft.yaml
@@ -29,7 +29,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 3b
+      ./scripts/polaris/jobs/llama_tune.sh -m sft -d ddp -s 3b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama70b_lora.yaml
+++ b/configs/oumi/jobs/polaris/llama70b_lora.yaml
@@ -33,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m lora -s 70b
+      ./scripts/polaris/jobs/llama_tune.sh -m lora -d fsdp -s 70b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama70b_sft.yaml
+++ b/configs/oumi/jobs/polaris/llama70b_sft.yaml
@@ -33,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 70b
+      ./scripts/polaris/jobs/llama_tune.sh -m sft -d fsdp -s 70b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama8b_lora.yaml
+++ b/configs/oumi/jobs/polaris/llama8b_lora.yaml
@@ -33,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m lora -s 8b
+      ./scripts/polaris/jobs/llama_tune.sh -m lora -d ddp -s 8b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/jobs/polaris/llama8b_sft.yaml
+++ b/configs/oumi/jobs/polaris/llama8b_sft.yaml
@@ -33,7 +33,7 @@ run: |
   set -x  # Print "mpiexec" command with expanded variables
   mpiexec --verbose \
       --np $OUMI_NUM_NODES -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind ${CPU_BIND} \
-      ./scripts/polaris/jobs/llama_tune.sh -m sft -s 8b
+      ./scripts/polaris/jobs/llama_tune.sh -m sft -d fsdp -s 8b
 
   echo -e "Finished training on ${OUMI_NUM_NODES} node(s):\n$(cat $PBS_NODEFILE)"
   echo "Polaris job is all done!"

--- a/configs/oumi/llama2b.pt.fsdp.trl.yaml
+++ b/configs/oumi/llama2b.pt.fsdp.trl.yaml
@@ -1,5 +1,5 @@
 # FSDP pretraining (PT) config for Llama 2B.
-# Accelerate config: configs/accelerate/llama.fsdp.yaml
+# Accelerate config: configs/accelerate/llama.fsdp.mixedprec.yaml
 
 model:
   # Vocab size: 50272

--- a/configs/skypilot/sky_llama2b_fsdp.yaml
+++ b/configs/skypilot/sky_llama2b_fsdp.yaml
@@ -41,7 +41,7 @@ run: |
       --main_process_ip ${OUMI_MASTER_ADDR} \
       --main_process_port 8007 \
       --use_fsdp \
-      --config_file configs/accelerate/llama.fsdp.yaml \
+      --config_file configs/accelerate/llama.fsdp.mixedprec.yaml \
       -m oumi.train \
       -c configs/oumi/llama2b.pt.fsdp.trl.yaml \
       "training.run_name='${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}'" \

--- a/configs/skypilot/sky_llama8b_sft.yaml
+++ b/configs/skypilot/sky_llama8b_sft.yaml
@@ -47,7 +47,7 @@ run: |
       --main_process_ip ${OUMI_MASTER_ADDR} \
       --main_process_port 8007 \
       --use_fsdp \
-      --config_file configs/accelerate/llama8b.fsdp.yaml \
+      --config_file configs/accelerate/llama.fsdp.yaml \
       -m oumi.train \
       -c configs/oumi/llama8b.sft.yaml \
       "training.run_name='${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}'" \

--- a/notebooks/Oumi - Running Jobs Remotely.ipynb
+++ b/notebooks/Oumi - Running Jobs Remotely.ipynb
@@ -398,7 +398,7 @@
     "    --main_process_ip \\\\${OUMI_MASTER_ADDR} \\\n",
     "    --main_process_port 8007 \\\n",
     "    --use_fsdp \\\n",
-    "    --config_file configs/accelerate/llama.fsdp.yaml \\\n",
+    "    --config_file configs/accelerate/llama.fsdp.mixedprec.yaml \\\n",
     "    -m oumi.train \\\n",
     "    -c configs/oumi/llama2b.pt.fsdp.trl.yaml \\\n",
     "    \"training.run_name='\\\\${OUMI_RUN_NAME}.\\\\${SKYPILOT_TASK_ID}'\" \\\n",

--- a/scripts/polaris/jobs/llama2b_pt_worker.sh
+++ b/scripts/polaris/jobs/llama2b_pt_worker.sh
@@ -167,7 +167,7 @@ else       # FSDP
         --main_process_ip ${OUMI_MASTER_ADDR} \
         --main_process_port 8007 \
         --use_fsdp \
-        --config_file configs/accelerate/llama.fsdp.yaml \
+        --config_file configs/accelerate/llama.fsdp.mixedprec.yaml \
         -m oumi.train \
         -c configs/oumi/llama2b.pt.fsdp.trl.yaml \
         "$TRAIN_DATASETS" \


### PR DESCRIPTION
Towards OPE-547

- Rename `llama8b.fsdp.yaml` to `llama.fsdp.yaml` since it's also the config for llama 3B
- Rename `llama.fsdp.yaml` to `llama.fsdp.mixedprec.yaml` to make clear the only difference is mixed precision
- Add a distribution mode flag to `llama_tune.sh` so we can control whether we run ddp/fsdp

Tested existing configs on Polaris