### PR TITLE
Remove bitsandbytes from train dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,7 @@ dev = [
 ]
 # TODO: train target will be removed in a future release
 train = [
-    "openai",       # TODO: remove this dependency, only used in scripts/polaris/jobs/python/vllm_inference.py
-    "bitsandbytes", # Used for QLora, and PagedAdam implemenation
-    # "llama-cpp-python",             # for local cpu inference. TODO: resolve install issues
+    "openai", # TODO: remove this dependency, only used in scripts/polaris/jobs/python/vllm_inference.py
 ]
 docs = [
     "myst_parser",             # Allows us to write docs in markdown
@@ -109,7 +107,10 @@ cambrian = [ # Consider merging into "train"
     "diffusers[torch]",
     "einops==0.6.1",
 ]
-
+optional = [
+    "bitsandbytes",     # Used for QLora, and PagedAdam implemenation
+    "llama-cpp-python", # for local cpu/gpu inference. TODO: resolve install issues
+]
 # TODO: Deprecated, will be removed in a future release
 all = ["oumi[dev,train,azure,gcp,lambda,runpod,docs]"]
 

--- a/src/oumi/builders/optimizers.py
+++ b/src/oumi/builders/optimizers.py
@@ -50,7 +50,7 @@ def build_optimizer(
         "paged_adamw_32bit",
     ):
         try:
-            import bitsandbytes
+            import bitsandbytes  # pyright: ignore[reportMissingImports]
         except ImportError:
             raise ImportError(
                 "bitsandbytes is not installed. "


### PR DESCRIPTION
**Changes**
- Make sure the code can be used if `bitsandbytes` is not installed
- Remove from `train` dependencies. Whenever a user needs to use a functionality from `bnb`, they will get an error message with instructions to install.
- As a bonus, this removes a warning we've been getting on Mac:
```python
UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
```

Towards  OPE-493