### PR TITLE
Add support for `add_generation_prompt` in LLAVA chat template

### DIFF
--- a/src/oumi/datasets/chat_templates/llava.jinja
+++ b/src/oumi/datasets/chat_templates/llava.jinja
@@ -5,3 +5,4 @@ A chat between a curious user and an artificial intelligence assistant. The assi
     {% if message['type'] == 'text' %}{{ message['content'] + ' ' }}{% elif message['type'] in ('image_path','image_url','image_binary') %}<image>{% endif %}
     {% if message['role'] == 'user' %} {% else %}{{eos_token}}{% endif %}
 {% endfor %}
+{% if add_generation_prompt %}ASSISTANT: {% endif %}


### PR DESCRIPTION
-- Leads to better infer responses
-- Consistent with the original LLAVA template: https://linear.app/oumi/issue/OPE-561#comment-ddfde552

Towards OPE-401