### PR TITLE
Allow gradient clipping to be optional

### DIFF
--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -513,7 +513,7 @@ class TrainingParams(BaseParams):
     """Maximum gradient norm (for gradient clipping) to avoid exploding gradients which
     can destabilize training.
 
-    Defaults to 1.0.
+    Defaults to 1.0. When set to 0.0 or None gradient clipping will not be applied.
     """
 
     trainer_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -677,6 +677,9 @@ class TrainingParams(BaseParams):
 
         if self.gradient_accumulation_steps < 1:
             raise ValueError("gradient_accumulation_steps must be >= 1.")
+
+        if self.max_grad_norm is not None and self.max_grad_norm < 0:
+            raise ValueError("max_grad_norm must be >= 0.")
 
         if self.logging_dir is None and self.output_dir:
             # Push the logging_dir inside the output_dir.

--- a/src/oumi/core/trainers/oumi_trainer.py
+++ b/src/oumi/core/trainers/oumi_trainer.py
@@ -289,7 +289,7 @@ class Trainer(BaseTrainer):
                 if end_of_global_step or stop_on_max_steps_limit:
                     with self._telemetry_block("optimizer step"):
                         self.scaler.unscale_(self.optimizer)
-                        if self.max_norm is not None:
+                        if self.max_norm is not None and self.max_norm > 0:
                             torch.nn.utils.clip_grad_norm_(
                                 self.model.parameters(), max_norm=self.max_norm
                             )


### PR DESCRIPTION
There are cases where the user won't need to do gradient clipping. This simple PR promotes that by making the `max_grad_norm` an optional parameter. 

Note: 
1. HF, generic [Trainer](https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/trainer.py#L2422C64-L2422C77) checks for both None and for the parameter to be bigger than zero to do gradient clipping (so here we could opt by asking the user to set the value to 0.0).  
2. HF-PPO [Trainer](https://github.com/huggingface/trl/blob/23bf9d4b58bd7640f2f2964bc2638a8afa02a21e/trl/trainer/ppo_trainer.py#L1063) **only** checks for the parameter to be None.
3. An example case where we do **not** want to do gradient clipping is Llama3.1-full-SFT per torch-tune [recipes](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_full.yaml)

