### PR TITLE
Define `GenerationParams.input_image_filepath_for_infer_interactive`

### DIFF
--- a/src/oumi/core/configs/params/generation_params.py
+++ b/src/oumi/core/configs/params/generation_params.py
@@ -31,7 +31,7 @@ class GenerationParams(BaseParams):
     output_filepath: Optional[str] = None
     """Path where the generated text will be saved."""
 
-    input_image_filepath_for_infer_interactive: Optional[str] = None
+    interactive_input_image_filepath: Optional[str] = None
     """Path to the input image to exercise LLMs with image and text inputs.
 
     Only used in interactive mode (`infer_interactive`).


### PR DESCRIPTION
-- The param is used to configure input image for interactive mode
-- User can ask text questions interactively given the image.

Towards OPE-401