### PR TITLE
[docs] Include cli reference

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,5 +1,42 @@
 # CLI Reference
 
-```{attention}
-Section under construction. Contributions welcome!
+## Training
+
+```{typer} oumi.core.cli.main.app.train
+  :prog: oumi train
+  :make-sections:
+  :preferred: svg
+  :theme: monokai
+  :width: 80
+```
+
+## Evaluation
+
+```{typer} oumi.core.cli.main.app.evaluate
+  :prog: oumi evaluate
+  :make-sections:
+  :preferred: svg
+  :theme: monokai
+  :width: 80
+```
+
+## Inference
+
+```{typer} oumi.core.cli.main.app.infer
+  :prog: oumi infer
+  :make-sections:
+  :preferred: svg
+  :theme: monokai
+  :width: 80
+```
+
+## Launch
+
+```{typer} oumi.core.cli.main.app.launch
+  :prog: oumi launch
+  :make-sections:
+  :show-nested:
+  :preferred: svg
+  :theme: monokai
+  :width: 80
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.typer",
 ]
 
 source_suffix = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ docs = [
     "sphinx-rtd-theme>=3.0.1", # Readthedocs theme for Sphinx
     "sphinx",                  # Used to build the docs
     "sphinxcontrib-bibtex",    # Allows us to cite bibtex references in the docs
+    "sphinxcontrib-typer",     # Allows us to include typer CLI in the docs
 ]
 # Dependencies that require a GPU to install
 gpu = ["liger-kernel", "nvidia-ml-py", "vllm>=0.6.2,<0.7.0"]


### PR DESCRIPTION
**Changes**
- Include CLI reference in the documentation  using `sphinxcontrib-typer`

Towards OPE-589

Note: Merged directly to unblock. This PR has no doc content change to review and does not impact the package runtime.