### PR TITLE
Increase `llava.7b.sft` max length from 512 to 1024

### DIFF
--- a/configs/oumi/llava.7b.sft.yaml
+++ b/configs/oumi/llava.7b.sft.yaml
@@ -20,7 +20,7 @@ data:
         seed: 42
         dataset_kwargs:
           processor_name: "llava-hf/llava-1.5-7b-hf"
-      #   limit: 1024
+          limit: 1024
           return_tensors: True
       # - dataset_name: "coco_captions"
       #   split: "train"

--- a/configs/skypilot/sky_llava.7b.sft.yaml
+++ b/configs/skypilot/sky_llava.7b.sft.yaml
@@ -44,7 +44,7 @@ run: |
       -m oumi.train \
       -c configs/oumi/llava.7b.sft.yaml \
       "training.run_name='${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}'" \
-      "training.max_steps=1000" \
+      "training.max_steps=10" \
       "training.save_steps=0" \
       "training.save_final_model=false"
 

--- a/src/oumi/core/collators/text_collator_with_padding.py
+++ b/src/oumi/core/collators/text_collator_with_padding.py
@@ -189,7 +189,7 @@ class TextCollatorWithPadding:
 
         if log_max_lengths:
             logger.warning(
-                "Input sequences exceeded max length"
+                "Input sequence exceeded max length"
                 + (" and truncated! " if self._truncation else ". ")
                 + (
                     f"Max length: {self._max_length}. "


### PR DESCRIPTION
-- This eliminates almost all truncations.
-- Minor logging improvements

Towards OPE-467