### PR TITLE
Update our dev set up instructions to not conflict with the new CLI

### DIFF
--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -96,12 +96,12 @@ Section under construction. Contributions welcome!
 ## 4. [optional] Add an Oumi shortcut in your environment {.zshrc or .bashrc}
 
    ```shell
-   alias oumi="cd ~/<YOUR_PATH>/oumi && conda activate oumi"
+   alias oumi-conda="cd ~/<YOUR_PATH>/oumi && conda activate oumi"
    ```
 
    Ensure that this works with:
 
    ```shell
    source ~/{.zshrc or .bashrc}
-   oumi
+   oumi-conda
    ```


### PR DESCRIPTION
Any devs who set up an `oumi` shortcut in their .zshrc will hit a naming collision when trying to use the new `oumi` CLI.