### PR TITLE
Replace `logger.exception()` in `TextCollatorWithPadding` with `logger.error()`

### DIFF
--- a/src/oumi/core/collators/text_collator_with_padding.py
+++ b/src/oumi/core/collators/text_collator_with_padding.py
@@ -72,7 +72,7 @@ class TextCollatorWithPadding:
         try:
             result = self._default_collator({_INPUT_IDS_KEY: inputs})  # type: ignore
         except ValueError:
-            logger.exception(
+            logger.error(
                 "Failed to collate! "
                 f"Batch maximum length: {batch_max_length}. "
                 f"Maximum allowed length: {self._max_length}. "
@@ -192,7 +192,7 @@ class TextCollatorWithPadding:
                 "Input sequence exceeded max length"
                 + (" and truncated! " if self._truncation else ". ")
                 + (
-                    f"Max length: {self._max_length}. "
+                    f"Max allowed length: {self._max_length}. "
                     f"'input_ids' length: {self._max_input_ids_length}. "
                     f"'labels' length: {self._max_labels_length}."
                 )


### PR DESCRIPTION
-- Reduce noise in test logs
-- `logger.exception` looks like a false positive in test logs 