### PR TITLE
Log peak gpu memory at the end of training

### DIFF
--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -52,6 +52,7 @@ from oumi.utils.torch_utils import (
     limit_per_process_memory,
     log_devices_info,
     log_model_summary,
+    log_peak_gpu_memory,
     log_versioning_info,
 )
 
@@ -330,6 +331,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
     logger.info("Training is Complete.")
 
     log_nvidia_gpu_runtime_info(log_prefix="GPU Metrics After Training:")
+    log_peak_gpu_memory()
 
     # Save final checkpoint & training state.
     if config.training.save_final_model:

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -90,6 +90,13 @@ def log_devices_info(filepath: Optional[Path] = None) -> None:
             f.write(all_text)
 
 
+def log_peak_gpu_memory():
+    """Log the peak GPU memory usage."""
+    if torch.cuda.is_available():
+        peak_memory = torch.cuda.max_memory_allocated() / 1024**3  # Convert to GB
+        logger.info(f"Peak GPU memory usage: {peak_memory:.2f} GB")
+
+
 def create_model_summary(model: Any) -> str:
     """Creates a model summary as a free-formed string."""
     lines = ["Model summary:", repr(model), ""]


### PR DESCRIPTION
# Log peak gpu memory at the end of training
- Log peak gpu memory at the end of training

Fixes OPE-583

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

