### PR TITLE
Enable more ruff rules

### DIFF
--- a/notebooks/Oumi - A Tour.ipynb
+++ b/notebooks/Oumi - A Tour.ipynb
@@ -360,7 +360,7 @@
     "logs_dir = Path(tutorial_dir) / \"logs\"\n",
     "for log_file in logs_dir.iterdir():\n",
     "    print(f\"Log file: {log_file}\")\n",
-    "    with open(log_file, \"r\") as f:\n",
+    "    with open(log_file) as f:\n",
     "        print(f.read())"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,8 @@ optional = [
 all = ["oumi[dev,train,azure,gcp,lambda,runpod,docs]"]
 
 quant = [
-    "bitsandbytes",     # Used for QLora, and PagedAdam implemenation
-]                       # TODO: consider augmenting with more quantization frameworks
+    "bitsandbytes", # Used for QLora, and PagedAdam implemenation
+]
 
 [project.scripts]
 oumi = "oumi.core.cli.main:run"
@@ -131,13 +131,22 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
-    "F",   # pyflakes: detect various errors
-    "E",   # pycodestyle: errors
-    "W",   # pycodestyle: warnings
-    "I",   # isort: check import order
-    "D",   # pydocstyle: check docstring style
-    "TID", # flake8-tidy-imports: check import tidiness
-    "NPY", # NumPy-specific rules
+    "F",     # pyflakes: detect various errors
+    "E",     # pycodestyle: errors
+    "W",     # pycodestyle: warnings
+    "I",     # isort: check import order
+    "D",     # pydocstyle: check docstring style
+    "TID",   # flake8-tidy-imports: check import tidiness
+    "NPY",   # NumPy-specific rules
+    "UP",    # pyupgrade: check for Python syntax updates
+    "ASYNC", # flake8-async: check for async/await syntax
+    "ICN",   # flake-8 import conventions,
+    "LOG",   # flake8-logging-format: check for logging format,
+    "Q",     # flake8-quotes
+    "RSE",   # flake8-raise, use raise statements instead of return statements
+    "TID",   # flake8-tidy-imports: check for import tidiness
+    "INT",   # flake8-gettext,
+    "PD",    # pandas vet
 ]
 ignore = [
     "D100",   # Missing docstring in public module, temporary, OPE-326

--- a/scripts/llm-as-judge/generate_prompts.py
+++ b/scripts/llm-as-judge/generate_prompts.py
@@ -98,7 +98,7 @@ def generate_judge_prompt(
     content = prompt_template[-1]["content"]
     content = content.replace("$user_input_request", row[request_col_name])
     content = content.replace("$ai_response", str(row[response_col_name]))
-    if not context_col_name or row.isnull()[context_col_name]:
+    if not context_col_name or row.isna()[context_col_name]:
         content = content.replace("\n\n$optional_context", "")
     else:
         content = content.replace("$optional_context", str(row[context_col_name]))

--- a/src/oumi/models/experimental/cambrian/model/multimodal_projector/projectors.py
+++ b/src/oumi/models/experimental/cambrian/model/multimodal_projector/projectors.py
@@ -46,10 +46,10 @@ class Projector(nn.Module):
         self.build_net()
 
     def build_net(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _forward(self, x):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Args:

--- a/src/oumi/utils/saver.py
+++ b/src/oumi/utils/saver.py
@@ -29,7 +29,7 @@ def load_infer_prob(input_filepath: str) -> List[List[List[float]]]:
         return probs_list
 
     df_probs = pd.read_parquet(f"{input_filepath}{PARQUET_EXTENSION}")
-    probabilities = df_probs.values.tolist()
+    probabilities = df_probs.to_numpy().tolist()
     probabilities = [[to_list(probs) for probs in batch] for batch in probabilities]
     return probabilities
 


### PR DESCRIPTION
# Enable more ruff rules

- Add a few ruff rules to check for more lint cases on documentation, import, log format, pandas and async usage
  - We're doing pretty good already. Fixed a couple minor updates
- Almost no impact on `make check` runtime, < 100ms extra ms. 
  - Pyright is still the slowest step, taking ~70% of the total time 


## Related issues

Closes OPE-613

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [X] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

