### PR TITLE
[tiny] Add datasets import to enable registry discovery

### DIFF
--- a/src/oumi/__init__.py
+++ b/src/oumi/__init__.py
@@ -58,7 +58,7 @@ See Also:
     - :mod:`oumi.core.configs`: For configuration classes used in Oumi
 """
 
-from oumi import judges, models
+from oumi import datasets, judges, models
 from oumi.evaluate import evaluate, evaluate_lm_harness
 from oumi.evaluate_async import evaluate_async
 from oumi.infer import infer, infer_interactive
@@ -70,6 +70,7 @@ logging.configure_dependency_warnings()
 
 
 __all__ = [
+    "datasets",
     "evaluate_async",
     "evaluate_lm_harness",
     "evaluate",


### PR DESCRIPTION
# Describe your change

- I we don't import the `datasets` module at the root, datasets risk not being registered in certain code paths.

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

