### PR TITLE
[bug] enable logger propagation so that pytest can capture them

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,12 @@ def root_testdata_dir():
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_logging():
-    """Fixture to set up logging for all tests."""
-    # We want to propagate to the root logger
-    # so that we can test captured logging with caplog fixture
+    """Fixture to set up logging for all tests.
+
+    We want to propagate to the root logger so that
+    pytest caplog can capture logs, and we can test
+    logging for the default oumi logger.
+    """
     logger = get_logger("oumi")
     logger.propagate = True
     return logger


### PR DESCRIPTION
# Describe your change

- The `caplog` fixture is very useful to test logging, but was always empty because we don't propagate the oumi logger
- This PR adds a fixture that enables logger propagation during testing 

## Related issues

Fixes # (issue)
Closes OPE-636

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

