### PR TITLE
Switch from writing individual conversations to all conversations

### DIFF
--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import jsonlines
+from tqdm import tqdm
 
 from oumi.core.configs import GenerationParams, InferenceConfig
 from oumi.core.types.conversation import Conversation
@@ -109,7 +110,7 @@ class BaseInferenceEngine(ABC):
         # Make the directory if it doesn't exist.
         Path(output_filepath).parent.mkdir(parents=True, exist_ok=True)
         with jsonlines.open(output_filepath, mode="w") as writer:
-            for conversation in conversations:
+            for conversation in tqdm(conversations, desc="Saving conversations"):
                 json_obj = conversation.to_dict()
                 writer.write(json_obj)
 

--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -190,11 +190,11 @@ class VLLMInferenceEngine(BaseInferenceEngine):
             )
             output_conversations.append(new_conversation)
 
-            if inference_config.output_path:
-                self._save_conversation(
-                    new_conversation,
-                    inference_config.output_path,
-                )
+        if inference_config.output_path:
+            self._save_conversations(
+                output_conversations,
+                inference_config.output_path,
+            )
         return output_conversations
 
     def infer_online(


### PR DESCRIPTION
# Describe your change
VLLM inference currently waits until inference is complete, then runs a for-loop which repeatedly opens the file and writes one conversation. This is seemingly causing a massive slowdown when using a mounted drive (i.e. GCS bucket), likely due to repeatedly needing to sync?

This change switches to opening the file once and writing all conversations at once.
<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->

Fixes # (issue)


## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?


## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
