### PR TITLE
Cap TRL library version to <0.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "torchdata>=0.8.0",             # Used by data pipes loader
     "tqdm",
     "transformers>=4.45.2,<4.46",
-    "trl>=0.9.0",
+    "trl>=0.9.0,<0.12.2",
     "typer",                        # Used by CLI
     "typing_extensions",            # Backports of typing updates to python 3.9
     "wandb==0.18.4",                # Logging to Weights and Biases. # TODO: Un-pin version when lm-eval is updated to include https://github.com/EleutherAI/lm-evaluation-harness/pull/2484


### PR DESCRIPTION
In case anyone runs into this error:

TypeError: Trainer.__init__() got an unexpected keyword argument 'processing_class'

TRL's latest update breaks us:
https://github.com/huggingface/trl/releases

The fix is to prevent TRL from upgrading:
"trl>=0.9.0,<0.12.2",

# Description:

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->


<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?


## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
