### PR TITLE
Fix precommit issues

### DIFF
--- a/src/oumi/utils/saver.py
+++ b/src/oumi/utils/saver.py
@@ -1,5 +1,6 @@
 import csv
 
+import numpy as np
 import pandas as pd
 
 PARQUET_EXTENSION = ".parquet"
@@ -15,9 +16,9 @@ def load_infer_prob(input_filepath: str) -> list[list[list[float]]]:
     """Retrieve batched probabilities from a parquet file."""
     probs_count_in_first_batch = None
 
-    def to_list(probs):
+    def to_list(probs: np.ndarray) -> list[float]:
         """Ensure number of probabilities is the same for all entries."""
-        probs_list = list(probs)
+        probs_list = [float(prob) for prob in probs]
         nonlocal probs_count_in_first_batch
         probs_count_in_first_batch = probs_count_in_first_batch or len(probs_list)
         if probs_count_in_first_batch != len(probs_list):
@@ -28,9 +29,8 @@ def load_infer_prob(input_filepath: str) -> list[list[list[float]]]:
         return probs_list
 
     df_probs = pd.read_parquet(f"{input_filepath}{PARQUET_EXTENSION}")
-    probabilities = df_probs.to_numpy().tolist()
-    probabilities = [[to_list(probs) for probs in batch] for batch in probabilities]
-    return probabilities
+    probabilities: list[list[np.ndarray]] = df_probs.to_numpy().tolist()  # type: ignore
+    return [[to_list(probs) for probs in batch] for batch in probabilities]
 
 
 #  The inference probabilities (`probabilities`) are structured as follows:

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -239,7 +239,7 @@ def get_torch_dtype(torch_dtype_str: str) -> torch.dtype:
 
 
 def get_dtype_size_in_bytes(
-    dtype: Union[str, torch.dtype, numpy.typing.DTypeLike],
+    dtype: Union[str, torch.dtype, numpy.typing.DTypeLike],  # type: ignore
 ) -> int:
     """Returns size of this dtype in bytes."""
     if isinstance(dtype, torch.dtype):


### PR DESCRIPTION
# Description:

```
/Users/wizeng/Documents/oumi/src/oumi/utils/saver.py
  /Users/wizeng/Documents/oumi/src/oumi/utils/saver.py:33:12 - error: Type "list[list[list[str]]]" is not assignable to return type "list[list[list[float]]]"
    "list[list[list[str]]]" is not assignable to "list[list[list[float]]]"
      Type parameter "_T@list" is invariant, but "list[list[str]]" is not the same as "list[list[float]]"
      Consider switching from "list" to "Sequence" which is covariant (reportReturnType)
/Users/wizeng/Documents/oumi/src/oumi/utils/torch_utils.py
  /Users/wizeng/Documents/oumi/src/oumi/utils/torch_utils.py:242:36 - error: Variable not allowed in type expression (reportInvalidTypeForm)
2 errors, 0 warnings, 0 informations
```

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?