### PR TITLE
Fix saving merged lora model

### DIFF
--- a/src/oumi/core/configs/params/peft_params.py
+++ b/src/oumi/core/configs/params/peft_params.py
@@ -34,8 +34,8 @@ class PeftSaveMode(Enum):
     """Merge the adapter and base model's weights and save as a single model.
 
     Note that the resulting model is a standard HF Transformers model, and is no longer
-    a PEFT model. This means that it's no longer possible to continue fine-tuning the
-    adapter on its own.
+    a PEFT model. A copy of the adapter before merging is saved in the "adapter/"
+    subdirectory.
     """
 
 

--- a/src/oumi/core/trainers/hf_trainer.py
+++ b/src/oumi/core/trainers/hf_trainer.py
@@ -69,13 +69,18 @@ class HuggingFaceTrainer(BaseTrainer):
                 # Saving the merged model only saves the model weights, not the
                 # tokenizer files and training args. To ensure we're saving all relevant
                 # files, we save the PEFT model first, delete the adapter files, then
-                # save the merged model. The adapter files are deleted so that the model
-                # will be loaded correctly as a non-PEFT model.
+                # save the merged model.
+                # The adapter files are moved to the "adapter/" subdirectory to not
+                # interfere with the other saved model files.
+
                 self._hf_trainer.save_model(output_dir)
+                output_dir_path = pathlib.Path(output_dir)
+                adapter_dir = output_dir_path / "adapter"
+                adapter_dir.mkdir(parents=True, exist_ok=True)
                 for filename in ["adapter_config.json", "adapter_model.safetensors"]:
-                    file_path = pathlib.Path(output_dir) / filename
+                    file_path = output_dir_path / filename
                     if file_path.exists():
-                        file_path.unlink()
+                        file_path.rename(adapter_dir / filename)
                     else:
                         logger.warning(
                             f"{filename} not found in {output_dir} when "


### PR DESCRIPTION
# Description

Saving the merged LoRA model wasn't saving the tokenizer and training args.

This approach saves the PEFT model and deletes the adapter model files before saving the merged model. This way, I don't need to replicate HF's code for saving the tokenizer/training args, and make our approach more future-proof in case HF updates their saving logic or add more files to save. The downside is trying to delete the adapter model files is a bit hacky.

## Related issues

Fixes OPE-711

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
