### PR TITLE
Resolve circular dependencies in Oumi

### DIFF
--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -7,7 +7,6 @@ import torch
 from PIL import Image
 from typing_extensions import override
 
-from oumi.builders.processors import build_processor
 from oumi.core.configs.internal.internal_model_config import (
     InternalFeatureFirstDimAction,
     InternalModelConfig,
@@ -78,6 +77,8 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
     ) -> None:
         """Initializes a new instance of the VisionLanguageDataset class."""
         super().__init__(tokenizer=tokenizer, **kwargs)
+        # Importing these here to avoid circular dependencies
+        from oumi.builders.processors import build_processor
 
         if tokenizer is None:
             raise ValueError(

--- a/src/oumi/core/trainers/oumi_trainer.py
+++ b/src/oumi/core/trainers/oumi_trainer.py
@@ -24,8 +24,6 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm.auto import tqdm
 from transformers import TrainerCallback
 
-from oumi.builders.lr_schedules import build_lr_scheduler
-from oumi.builders.optimizers import build_optimizer
 from oumi.core.configs import MixedPrecisionDtype, TrainingConfig, TrainingParams
 from oumi.core.configs.params.fsdp_params import FSDPParams, StateDictType
 from oumi.core.distributed import (
@@ -75,6 +73,10 @@ class Trainer(BaseTrainer):
         **kwargs,
     ):
         """Initializes the Oumi trainer."""
+        # Importing these here to avoid circular dependencies
+        from oumi.builders.lr_schedules import build_lr_scheduler
+        from oumi.builders.optimizers import build_optimizer
+
         self.telemetry = TelemetryTracker()
         self.start_time = time.perf_counter()
         self.collator_fn = data_collator


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
The long-term fix here is to move each builder into the directory of the noun upon which it operates (dataset_builder should be in the `datasets` package, etc)

For now, we can simply delay these imports in each file's init. This is a quick fix so folks can test a working version of Oumi ASAP.

Test results after my change:
```
tests/integration/deps/test_circular_deps.py ......................................................................................................................................................... [ 84%]
............................                                                                                                                                                                           [100%]

============================================================================================== warnings summary ==============================================================================================
../../miniconda3/envs/oumi/lib/python3.11/site-packages/_pytest/config/__init__.py:1441
  /Users/matthewpersons/miniconda3/envs/oumi/lib/python3.11/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 181 passed, 1 warning in 287.59s (0:04:47) =================================================================================
```

See #1030 for previous failures.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards OPE-836

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
