### PR TITLE
Fix a circular dependency when invoking the oumi src directory via Python.

### DIFF
--- a/src/oumi/__main__.py
+++ b/src/oumi/__main__.py
@@ -5,6 +5,12 @@ from oumi.cli.main import run
 if __name__ == "__main__":
     import sys
 
-    # move the current working directory to the end position
-    sys.path = sys.path[1:] + sys.path[:1]
+    # Per https://docs.python.org/3/library/sys_path_init.html , the first entry in
+    # sys.path is the directory containing the input script.
+    # This means `python ./src/oumi` will result in `import datasets` resolving to
+    # `oumi.datasets` instead of the installed `datasets` package.
+    # Moving the first entry of sys.path to the end will ensure that the installed
+    # packages are found first.
+    if len(sys.path) > 1:
+        sys.path = sys.path[1:] + sys.path[:1]
     run()


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
You will get a circular dependency error if you run the simple command:
```
python ./src/oumi
```

The reason here is a nuance of the import system. When running the above command, `/src/oumi` becomes the default directory from which packages are imported. Therefore running `import datasets` imports our `oumi.datasets` package instead of the global `datasets` 3rd party package we have installed. This leads to a circular dependency.

The simple solution is to move the first system path to the end of the system list when we detect oumi is being called in such a fashion.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes OPE-881

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
