### PR TITLE
[VLLM Engine] Enabling BitsAndBytes quantization

### DIFF
--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -78,25 +78,19 @@ class VLLMInferenceEngine(BaseInferenceEngine):
                 f"{gpu_memory_utilization}."
             )
 
-        # Check if BitsAndBytes quantization was requested.
-        bitsandbytes_quantization = False
+        # Check if any quantization keys are set.
+        quantization_keys_set = False
         if model_params.model_kwargs:
-            bitsandbytes_quantization_kwargs = ["load_in_4bit", "load_in_8bit"]
-            for key in bitsandbytes_quantization_kwargs:
+            quantization_kwargs = ["load_in_4bit", "load_in_8bit"]
+            for key in quantization_kwargs:
                 if model_params.model_kwargs.get(key):
-                    bitsandbytes_quantization = True
+                    quantization_keys_set = True
 
         vllm_kwargs = {}
 
-        # Ensure BitsAndBytes keys for vllm.LLM are properly set.
-        if bitsandbytes_quantization:
-            if quantization and quantization != "bitsandbytes":
-                raise ValueError(
-                    "The model kwargs include `bitsandbytes` quantization keys "
-                    f"(such as {', '.join(bitsandbytes_quantization_kwargs)}), but a "
-                    "different quantization method was requested: `{quantization}`."
-                )
-            else:
+        # If quantization requested but undefined, default to BitsAndBytes.
+        if quantization_keys_set:
+            if not quantization or quantization == "bitsandbytes":
                 quantization = "bitsandbytes"
                 vllm_kwargs["load_format"] = "bitsandbytes"
                 logger.info("VLLM engine loading a `bitsandbytes` quantized model.")


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
VLLM Engine: Enabling BitsAndBytes quantization

2 different scenarios tested:
(original model weights for `meta-llama/Llama-3.2-1B-Instruct`: **_2.3185 GB_**; expectation was 1B --> 1 GB* 2 bytes = 2GB)

1) Loading a **_pre-quantized checkpoint_** (`unsloth/Llama-3.2-1B-Instruct-bnb-4bit`)
- [requires](https://docs.vllm.ai/en/latest/features/quantization/bnb.html):  quantization = "bitsandbytes", load_format" = "bitsandbytes"
- quantization (4bit or 8bit) depends on the model itself; it is 4bit by default in this case. 
- most bitsandbytes models [discussed in HF](https://huggingface.co/models?other=bitsandbytes) do NOT work as expected, but I validated that this one does.
- model weights reduction 2.37x (**_2.3185 GB --> 0.9786 GB_**), expectation was ~4x (going from 16 bits to 4 bits)
```
WARNING 01-24 00:39:48 config.py:321] bitsandbytes quantization is not fully optimized yet. The speed can be slower than non-quantized models.
INFO 01-24 00:39:50 loader.py:1051] Loading weights with BitsAndBytes quantization.  May take a while ...
INFO 01-24 00:39:51 model_runner.py:1067] Loading model weights took 0.9786 GB
```

2) Leveraging **_Inflight quantization_** (`meta-llama/Llama-3.2-1B-Instruct`)
- [requires](https://docs.vllm.ai/en/latest/features/quantization/bnb.html):  quantization = "bitsandbytes", load_format" = "bitsandbytes"
- quantization can ONLY be 4bit (no option for 8bit, so Oumi's flag `load_in_8bit` will still load in 4 bit)
- model weights reduction 2.37 (**_2.3185 GB --> 0.9785 GB_**), expectation was ~4x (going from 16 bits to 4 bits)
```
WARNING 01-24 00:46:16 config.py:321] bitsandbytes quantization is not fully optimized yet. The speed can be slower than non-quantized models.
INFO 01-24 00:46:18 loader.py:1051] Loading weights with BitsAndBytes quantization.  May take a while ...
INFO 01-24 00:46:19 model_runner.py:1067] Loading model weights took 0.9785 GB
```

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
