### PR TITLE
Update default idle_minutes_to_autostop to 1 hour.

### DIFF
--- a/docs/user_guides/launch/launch.md
+++ b/docs/user_guides/launch/launch.md
@@ -539,7 +539,7 @@ To stop the cluster when you are done to avoid extra charges, run:
 oumi launch stop --cluster my-cluster
 ```
 
-In addition, the Oumi launcher automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 30, i.e. clusters will stop automatically after 30 minutes of no jobs running.
+In addition, the Oumi launcher automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running.
 
 Stopped clusters preserve their disk, and are quicker to initialize than turning up a brand new cluster. Stopped clusters can be automatically restarted by specifying them in an `oumi launch up` command.
 
@@ -560,7 +560,7 @@ import oumi.launcher as launcher
 launcher.stop(cloud_name="gcp", cluster_name="my-cluster")
 ```
 
-In addition, Oumi automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 30, i.e. clusters will stop automatically after 30 minutes of no jobs running.
+In addition, Oumi automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running.
 
 Stopped clusters preserve their disk, and are quicker to initialize than turning up a brand new cluster. Stopped clusters can be automatically restarted by specifying them in a `launcher.up(...)` command.
 

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -90,8 +90,8 @@ class SkyClient:
             A JobStatus with only `id` and `cluster` populated.
         """
         autostop_kw = "idle_minutes_to_autostop"
-        # Default to 30 minutes.
-        idle_minutes_to_autostop = 30
+        # Default to 60 minutes.
+        idle_minutes_to_autostop = 60
         if autostop_kw in kwargs:
             idle_minutes_to_autostop = kwargs.get(autostop_kw)
         else:

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -96,7 +96,7 @@ def test_sky_client_launch(mock_sky_data_storage):
             ANY,
             cluster_name=None,
             detach_run=True,
-            idle_minutes_to_autostop=30,
+            idle_minutes_to_autostop=60,
         )
 
 
@@ -171,7 +171,7 @@ def test_sky_client_launch_unused_kwarg(mock_sky_data_storage):
             ANY,
             cluster_name=None,
             detach_run=True,
-            idle_minutes_to_autostop=30,
+            idle_minutes_to_autostop=60,
         )
 
 
@@ -196,7 +196,7 @@ def test_sky_client_launch_with_cluster_name(mock_sky_data_storage):
             ANY,
             cluster_name="cluster_name",
             detach_run=True,
-            idle_minutes_to_autostop=30,
+            idle_minutes_to_autostop=60,
         )
 
 


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Update `idle_minutes_to_autostop` for sky-based clusters to default to a value of 60 minutes. Users can always override this value with kwargs.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->


<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
