### PR TITLE
Add more detailed comment headers to YAML configs

### DIFF
--- a/configs/examples/bulk_inference/gcp_job.yaml
+++ b/configs/examples/bulk_inference/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/examples/bulk_inference/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/bulk_inference/gcp_job.yaml
+++ b/configs/examples/bulk_inference/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: oumi-bulk-inference
 

--- a/configs/examples/bulk_inference/gcp_job.yaml
+++ b/configs/examples/bulk_inference/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/fineweb_ablation_pretraining/ddp/gcp_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/gcp_job.yaml
@@ -1,8 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
 #
-# Example command:
-# oumi launch up -c configs/examples/fineweb_ablation_pretraining/ddp/gcp_job.yaml --cluster fineweb-ddp
+# Usage:
+#   oumi launch up -c configs/examples/fineweb_ablation_pretraining/ddp/gcp_job.yaml --cluster fineweb-ddp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: fineweb-ddp
 

--- a/configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to DDP pretrain the FineWeb ablation model on Polaris.
+# Job config to DDP pretrain the FineWeb ablation model on Polaris.
 #
 # Usage:
 #   oumi launch up -c configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER

--- a/configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to DDP pretrain the FineWeb ablation model on Polaris.
-# Example command:
-# oumi launch up -c configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/examples/fineweb_ablation_pretraining/ddp/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: fineweb-pt-ddp
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "HuggingFaceFW/ablation-model-fineweb-v1"

--- a/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml
@@ -1,8 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
 #
-# Example command:
-# oumi launch up -c configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml --cluster fineweb-fsdp
+# Usage:
+#   oumi launch up -c configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml --cluster fineweb-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: fineweb-fsdp
 

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP pretrain the FineWeb ablation model on Polaris.
+# Job config to FSDP pretrain the FineWeb ablation model on Polaris.
 #
 # Usage:
 #   oumi launch up -c configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml --cluster debug-scaling.$ALCF_USER --user $ALCF_USER --num_nodes 2 --log-level DEBUG

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP pretrain the FineWeb ablation model on Polaris.
-# Example command:
-# oumi launch up -c configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml --cluster debug-scaling.$ALCF_USER --user $ALCF_USER --num_nodes 2 --log-level DEBUG
+#
+# Usage:
+#   oumi launch up -c configs/examples/fineweb_ablation_pretraining/fsdp/polaris_job.yaml --cluster debug-scaling.$ALCF_USER --user $ALCF_USER --num_nodes 2 --log-level DEBUG
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: fineweb-pt-fsdp
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "HuggingFaceFW/ablation-model-fineweb-v1"

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/examples/misc/dev_gcp_job.yaml
+++ b/configs/examples/misc/dev_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Config used by our Makefile to launch a bare-bones GCP VM for development.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/dev_gcp_job.yaml
+++ b/configs/examples/misc/dev_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Config used by our Makefile to launch a bare-bones GCP VM for development.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/examples/misc/dev_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/dev_gcp_job.yaml
+++ b/configs/examples/misc/dev_gcp_job.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config used by our Makefile to launch a bare-bones GCP VM for development.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: oumi-ssh
 
 num_nodes: 1

--- a/configs/examples/misc/dev_gcp_job.yaml
+++ b/configs/examples/misc/dev_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config used by our Makefile to launch a bare-bones GCP VM for development.
+# Job config used by our Makefile to launch a bare-bones GCP VM for development.
 #
 # Usage:
 #   oumi launch up -c configs/examples/misc/dev_gcp_job.yaml --cluster my-oumi-cluster

--- a/configs/examples/misc/hello_world_gcp_job.yaml
+++ b/configs/examples/misc/hello_world_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/examples/misc/hello_world_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/hello_world_gcp_job.yaml
+++ b/configs/examples/misc/hello_world_gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: hello-world
 resources:

--- a/configs/examples/misc/hello_world_gcp_job.yaml
+++ b/configs/examples/misc/hello_world_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/hello_world_polaris_job.yaml
+++ b/configs/examples/misc/hello_world_polaris_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: hello-world
 # NOTE: Replace with your username.

--- a/configs/examples/misc/hello_world_polaris_job.yaml
+++ b/configs/examples/misc/hello_world_polaris_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/hello_world_polaris_job.yaml
+++ b/configs/examples/misc/hello_world_polaris_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/examples/misc/hello_world_polaris_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/vllm_polaris_job.yaml
+++ b/configs/examples/misc/vllm_polaris_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: vllm
 # NOTE: Replace with your username.

--- a/configs/examples/misc/vllm_polaris_job.yaml
+++ b/configs/examples/misc/vllm_polaris_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/examples/misc/vllm_polaris_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/examples/misc/vllm_polaris_job.yaml
+++ b/configs/examples/misc/vllm_polaris_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/aya/evaluation/eval.yaml
+++ b/configs/projects/aya/evaluation/eval.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+# Eval config for Aya.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/projects/aya/evaluation/eval.yaml
+++ b/configs/projects/aya/evaluation/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Aya.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/projects/aya/evaluation/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/projects/aya/evaluation/gcp_job.yaml
+++ b/configs/projects/aya/evaluation/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: llama3-8b-aya-sft
 

--- a/configs/projects/aya/evaluation/gcp_job.yaml
+++ b/configs/projects/aya/evaluation/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/projects/aya/evaluation/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/aya/evaluation/gcp_job.yaml
+++ b/configs/projects/aya/evaluation/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: llama3-8b-aya-sft
 

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/projects/aya/sft/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/aya/sft/train.yaml
+++ b/configs/projects/aya/sft/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/projects/aya/sft/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/projects/aya/sft/train.yaml
+++ b/configs/projects/aya/sft/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/projects/chatqa/chatqa_stage1_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage1_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/projects/chatqa/chatqa_stage1_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/projects/chatqa/chatqa_stage1_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage1_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   # model_name: "openai-community/gpt2"

--- a/configs/projects/chatqa/chatqa_stage2_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage2_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   # model_name: "openai-community/gpt2"

--- a/configs/projects/chatqa/chatqa_stage2_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage2_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/projects/chatqa/chatqa_stage2_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/projects/chatqa/gcp_job.yaml
+++ b/configs/projects/chatqa/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/projects/chatqa/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/chatqa/gcp_job.yaml
+++ b/configs/projects/chatqa/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/projects/chatqa/gcp_job.yaml
+++ b/configs/projects/chatqa/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: chatqa-stage2-nopack
 

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Deepseek R1 Distill Llama 3.3 70B.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Deepseek R1 Distill Llama 3.3 70B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml --cluster deepseek-r1-llama70b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml --cluster deepseek-r1-llama70b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama70b-eval
 
 resources:

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Deepseek R1 Distill Llama 3.3 70B.
+# Job config to eval Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml --cluster deepseek-r1-llama70b-eval

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Deepseek R1 Distill Llama 3.1 8B.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Deepseek R1 Distill Llama 3.3 8B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml --cluster deepseek-r1-llama8b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml --cluster deepseek-r1-llama8b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama8b-eval
 
 resources:

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Deepseek R1 Distill Llama 3.3 8B.
+# Job config to eval Deepseek R1 Distill Llama 3.3 8B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml --cluster deepseek-r1-llama8b-eval

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Deepseek R1 Distill Qwen2.5 1.5B.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Deepseek R1 Distill Qwen2.5 1.5B.
+# Job config to eval Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml --cluster deepseek-r1-qwen1-5b-eval

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Deepseek R1 Distill Qwen2.5 1.5B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml --cluster deepseek-r1-qwen1-5b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/gcp_job.yaml --cluster deepseek-r1-qwen1-5b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-qwen1-5b-eval
 
 resources:

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Deepseek R1 Distill Qwen2.5 32B.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Deepseek R1 Distill Qwen2.5 32B.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Deepseek R1 Distill Qwen2.5 32B.
+# Job config to eval Deepseek R1 Distill Qwen2.5 32B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml --cluster deepseek-r1-qwen32b-eval

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Deepseek R1 Distill Qwen2.5 32B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml --cluster deepseek-r1-qwen32b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml --cluster deepseek-r1-qwen32b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-qwen32b-eval
 
 resources:

--- a/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
@@ -1,10 +1,16 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Deepseek R1 671B.
-# NOTE: Set the `TOGETHER_API_KEY` env var to your Together API key.
-# Example command:
-# oumi infer -i -c configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
+#
+# Requirements:
+#   - Set the `TOGETHER_API_KEY` env var to your Together API key.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1"

--- a/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
@@ -4,7 +4,7 @@
 #   - Set the `TOGETHER_API_KEY` env var to your Together API key.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/671b_together_infer.yaml
@@ -10,7 +10,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1"

--- a/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Deepseek R1 Distill Llama 3.3 70B.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/deepseek_r1/inference/distill_llama_70b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Deepseek R1 Distill Llama 3.1 8B.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_llama_8b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Deepseek R1 Distill Qwen2.5 1.5B.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/deepseek_r1/inference/distill_qwen_1_5b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Deepseek R1 Distill Qwen2.5 32B.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"

--- a/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
+++ b/configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Deepseek R1 Distill Qwen2.5 32B.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/deepseek_r1/inference/distill_qwen_32b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to full fine-tune Deepseek R1 Distill Llama 3.3 70B.
+# Job config to full fine-tune Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml --cluster deepseek-r1-llama70b-fft

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to full fine-tune Deepseek R1 Distill Llama 3.3 70B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml --cluster deepseek-r1-llama70b-fft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml --cluster deepseek-r1-llama70b-fft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama70b-fft
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
@@ -1,7 +1,7 @@
 # FFT config for Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FFT config for Deepseek R1 Distill Llama 3.3 70B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Deepseek R1 Distill Llama 3.3 70B.
+# Job config to LoRA tune Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml --cluster deepseek-r1-llama70b-lora

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Deepseek R1 Distill Llama 3.3 70B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml --cluster deepseek-r1-llama70b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml --cluster deepseek-r1-llama70b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama70b-lora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
@@ -1,7 +1,7 @@
 # LoRA config for Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # LoRA config for Deepseek R1 Distill Llama 3.3 70B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to QLoRA tune Deepseek R1 Distill Llama 3.3 70B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml --cluster deepseek-r1-llama70b-qlora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml --cluster deepseek-r1-llama70b-qlora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama70b-qlora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to QLoRA tune Deepseek R1 Distill Llama 3.3 70B.
+# Job config to QLoRA tune Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml --cluster deepseek-r1-llama70b-qlora

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
@@ -1,7 +1,7 @@
 # QLoRA config for Deepseek R1 Distill Llama 3.3 70B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLoRA config for Deepseek R1 Distill Llama 3.3 70B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to full fine-tune Deepseek R1 Distill Llama 3.1 8B.
+# Job config to full fine-tune Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml --cluster deepseek-r1-llama8b-fft

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to full fine-tune Deepseek R1 Distill Llama 3.1 8B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml --cluster deepseek-r1-llama8b-fft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml --cluster deepseek-r1-llama8b-fft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-llama8b-fft
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FFT config for Deepseek R1 Distill Llama 3.1 8B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
@@ -1,7 +1,7 @@
 # FFT config for Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Deepseek R1 Distill Llama 3.1 8B.
+# Job config to LoRA tune Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml --cluster deepseek-r1-llama8b-lora

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Deepseek R1 Distill Llama 3.1 8B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml --cluster deepseek-r1-llama8b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml --cluster deepseek-r1-llama8b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-lora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # LoRA config for Deepseek R1 Distill Llama 3.1 8B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
@@ -1,7 +1,7 @@
 # LoRA config for Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to QLoRA tune Deepseek R1 Distill Llama 3.1 8B.
+# Job config to QLoRA tune Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml --cluster deepseek-r1-llama8b-qlora

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to QLoRA tune Deepseek R1 Distill Llama 3.1 8B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml --cluster deepseek-r1-llama8b-qlora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml --cluster deepseek-r1-llama8b-qlora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-qlora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
@@ -1,7 +1,7 @@
 # QLoRA config for Deepseek R1 Distill Llama 3.1 8B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLoRA config for Deepseek R1 Distill Llama 3.1 8B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to full fine-tune tune Deepseek R1 Distill Qwen2.5 1.5B.
+# Job config to full fine-tune tune Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-fft

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to full fine-tune tune Deepseek R1 Distill Qwen2.5 1.5B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-fft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-fft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-qwen1-5b-fft
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FFT config for Deepseek R1 Distill Qwen2.5 1.5B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
@@ -1,7 +1,7 @@
 # FFT config for Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Deepseek R1 Distill Qwen2.5 1.5B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-qwen1-5b-lora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Deepseek R1 Distill Qwen2.5 1.5B.
+# Job config to LoRA tune Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_gcp_job.yaml --cluster deepseek-r1-qwen1-5b-lora

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # LoRA config for Deepseek R1 Distill Qwen2.5 1.5B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
@@ -1,7 +1,7 @@
 # LoRA config for Deepseek R1 Distill Qwen2.5 1.5B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Deepseek R1 Distill Qwen2.5 32B.
+# Job config to LoRA tune Deepseek R1 Distill Qwen2.5 32B.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml --cluster deepseek-r1-qwen32b-lora

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Deepseek R1 Distill Qwen2.5 32B.
-# Example command:
-# oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml --cluster deepseek-r1-qwen32b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml --cluster deepseek-r1-qwen32b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: deepseek-r1-distill-qwen32b-lora
 
 resources:

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
@@ -1,7 +1,7 @@
 # LoRA config for Deepseek R1 Distill Qwen2.5 32B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # LoRA config for Deepseek R1 Distill Qwen2.5 32B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"

--- a/configs/recipes/gpt2/evaluation/async_eval.yaml
+++ b/configs/recipes/gpt2/evaluation/async_eval.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+# Async eval config for GPT2.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 evaluation:
   output_dir: "output/gpt2.pt" # NOTE: Update to your output directory.

--- a/configs/recipes/gpt2/evaluation/async_eval.yaml
+++ b/configs/recipes/gpt2/evaluation/async_eval.yaml
@@ -1,7 +1,7 @@
 # Async eval config for GPT2.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/gpt2/evaluation/async_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
+++ b/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: gpt2-eval
 

--- a/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
+++ b/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/recipes/gpt2/evaluation/async_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
+++ b/configs/recipes/gpt2/evaluation/async_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/gpt2/inference/infer.yaml
+++ b/configs/recipes/gpt2/inference/infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "openai-community/gpt2"

--- a/configs/recipes/gpt2/inference/infer.yaml
+++ b/configs/recipes/gpt2/inference/infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/gpt2/inference/infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/gpt2/inference/infer.yaml
+++ b/configs/recipes/gpt2/inference/infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "openai-community/gpt2"

--- a/configs/recipes/gpt2/pretraining/gcp_job.yaml
+++ b/configs/recipes/gpt2/pretraining/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: gpt2-pt
 

--- a/configs/recipes/gpt2/pretraining/gcp_job.yaml
+++ b/configs/recipes/gpt2/pretraining/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/gpt2/pretraining/gcp_job.yaml
+++ b/configs/recipes/gpt2/pretraining/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/recipes/gpt2/pretraining/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/gpt2/pretraining/mac_train.yaml
+++ b/configs/recipes/gpt2/pretraining/mac_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Simplified GPT-2 config for local testing on Mac.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 # Model automatically uses weight tying
 model:

--- a/configs/recipes/gpt2/pretraining/mac_train.yaml
+++ b/configs/recipes/gpt2/pretraining/mac_train.yaml
@@ -1,7 +1,7 @@
 # Simplified GPT-2 config for local testing on Mac.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/gpt2/pretraining/mac_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/gpt2/pretraining/train.yaml
+++ b/configs/recipes/gpt2/pretraining/train.yaml
@@ -1,7 +1,7 @@
 # GPT-2's implementation in nanoGPT: https://github.com/karpathy/build-nanogpt
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/gpt2/pretraining/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/gpt2/pretraining/train.yaml
+++ b/configs/recipes/gpt2/pretraining/train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # GPT-2's implementation in nanoGPT: https://github.com/karpathy/build-nanogpt
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 # Model automatically uses weight tying
 model:

--- a/configs/recipes/llama3_1/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for Llama 70B Instruct.
+# Eval config for Llama 3.1 70B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.1 70B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/llama3_1/evaluation/70b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.1 70B Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml --cluster llama70b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml --cluster llama70b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-eval
 
 resources:

--- a/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.1 70B Instruct on GCP.
+# Job config to eval Llama 3.1 70B Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml --cluster llama70b-eval

--- a/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.1 70B Instruct on Polaris.
+# Job config to eval Llama 3.1 70B Instruct on Polaris.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.1 70B Instruct on Polaris.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-eval
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/evaluation/8b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.1 8B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/llama3_1/evaluation/8b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/llama3_1/evaluation/8b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for Llama 8B Instruct.
+# Eval config for Llama 3.1 8B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.1 8B Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml --cluster llama8b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml --cluster llama8b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-eval
 
 resources:

--- a/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.1 8B Instruct on GCP.
+# Job config to eval Llama 3.1 8B Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml --cluster llama8b-eval

--- a/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.1 8B Instruct on Polaris.
+# Job config to eval Llama 3.1 8B Instruct on Polaris.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.1 8B Instruct on Polaris.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-eval
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/70b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/70b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 70B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/70b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 70B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_1/inference/70b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_1/inference/8b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 8B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_1/inference/8b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_1/inference/8b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 8B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -23,7 +23,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -1,7 +1,8 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 8B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start vLLM server:
 # python -u -m vllm.entrypoints.openai.api_server \
 #   --port 6864 \
@@ -17,6 +18,12 @@
 #   --enable-chunked-prefill=false \
 #   --gpu-memory-utilization=0.95 \
 #   --tensor-parallel-size 1
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 8B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
 #
 # Sample command to start vLLM server:
 # python -u -m vllm.entrypoints.openai.api_server \

--- a/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
@@ -1,11 +1,18 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 8B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
 #     --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
 #     --port 6864 --disable-cuda-graph --mem-fraction-static=0.99
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
@@ -12,7 +12,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 8B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \

--- a/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to HSDP (FSDP HYBRID_SHARD) pre-training of Llama 3.1 8B on 1 GCP node.
+# Job config to HSDP (FSDP HYBRID_SHARD) pre-training of Llama 3.1 8B on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml --cluster llama8b-pretrain-hsdp

--- a/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to HSDP (FSDP HYBRID_SHARD) pre-training of Llama 3.1 8B on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml --cluster llama8b-pretrain-hsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml --cluster llama8b-pretrain-hsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3.1_8B_hsdp
 
 num_nodes: 1

--- a/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config for Llama 3.1 8B pre-training on 1 Polaris node.
+# Job config for Llama 3.1 8B pre-training on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up --cluster preemptable.$ALCF_USER --detach --user $ALCF_USER -c configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml

--- a/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
@@ -1,11 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config for Llama 3.1 8B pre-training on 1 Polaris node.
-# Example command:
-# oumi launch up --cluster preemptable.$ALCF_USER --detach --user $ALCF_USER -c configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
-# Example command to run on 2 nodes:
-# oumi launch up --cluster debug-scaling.$ALCF_USER --detach --user $ALCF_USER -c configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml --num_nodes 2
+#
+# Usage:
+#   oumi launch up --cluster preemptable.$ALCF_USER --detach --user $ALCF_USER -c configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-pretrain
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/pretraining/8b/train.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B"

--- a/configs/recipes/llama3_1/pretraining/8b/train.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/pretraining/8b/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Llama 3.1 405B Instruct FFT config
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml --cluster prod.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml --cluster prod.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama405b-fft
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -1,7 +1,7 @@
 # FFT config for Llama 405B.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/405b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FFT config for Llama 405B.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"

--- a/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP LoRA tune Llama 3.1 405B Instruct.
+# Job config to FSDP LoRA tune Llama 3.1 405B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml --cluster llama405b-lora-fsdp

--- a/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP LoRA tune Llama 3.1 405B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml --cluster llama405b-lora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml --cluster llama405b-lora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama405b-lora-fsdp
 
 num_nodes: 2

--- a/configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # LoRA tune Llama 3.1 405B Instruct config
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama405b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Lora config for Llama 405B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/405b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP QLoRA tune Llama 3.1 405B Instruct.
+# Job config to FSDP QLoRA tune Llama 3.1 405B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml --cluster llama405b-qlora-fsdp

--- a/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP QLoRA tune Llama 3.1 405B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml --cluster llama405b-qlora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml --cluster llama405b-qlora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama405b-qlora-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # QLoRA tune Llama 3.1 405B Instruct config
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama405b-qlora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLora config for Llama 405B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/405b_qlora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP full fine-tune Llama 3.1 70B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-sft-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP full fine-tune Llama 3.1 70B Instruct.
+# Job config to FSDP full fine-tune Llama 3.1 70B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp

--- a/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config for Llama 3.1 70B Instruct SFT on 4 Polaris nodes.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-sft
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config for Llama 3.1 70B Instruct SFT on 4 Polaris nodes.
+# Job config for Llama 3.1 70B Instruct SFT on 4 Polaris nodes.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -1,14 +1,21 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for Llama 70B.
+# FFT config for Llama 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_full.yaml
-# Command to run locally on a single-node 8xA100-80GB machine:
-# oumi distributed torchrun -m oumi train -c configs/recipes/llama3_1/sft/70b_full/train.yaml
 #
 # Strongly recommend downloading the model first:
 # HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# Command to run locally on a single-node 8xA100-80GB machine:
+#   oumi distributed torchrun -m oumi train -c configs/recipes/llama3_1/sft/70b_full/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -6,7 +6,7 @@
 # HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/70b_full/train.yaml
 #
 # Command to run locally on a single-node 8xA100-80GB machine:
 #   oumi distributed torchrun -m oumi train -c configs/recipes/llama3_1/sft/70b_full/train.yaml

--- a/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP LoRA tune Llama 3.1 70B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-lora-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP LoRA tune Llama 3.1 70B Instruct.
+# Job config to FSDP LoRA tune Llama 3.1 70B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp

--- a/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
+# Job config to LoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/70b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Lora config for Llama 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP QLoRA tune Llama 3.1 70B Instruct.
+# Job config to FSDP QLoRA tune Llama 3.1 70B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp

--- a/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP QLoRA tune Llama 3.1 70B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-qlora-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to QLoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-qlora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to QLoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
+# Job config to QLoRA tune Llama 3.1 70B Instruct on 2 Polaris nodes.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -4,7 +4,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/70b_qlora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -1,10 +1,16 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLora config for Llama 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_lora.yaml
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to full fine-tune Llama 3.1 8B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml --cluster llama8b-sft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml --cluster llama8b-sft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-sft
 
 num_nodes: 1

--- a/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to full fine-tune Llama 3.1 8B Instruct on 1 GCP node.
+# Job config to full fine-tune Llama 3.1 8B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml --cluster llama8b-sft

--- a/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
@@ -1,4 +1,4 @@
-# Configuration for fine-tuning Llama 3.8B model with long context.
+# Config for fine-tuning Llama 3.8B model with long context.
 #
 # Usage (for 8xA100-40GB GPUs):
 #   accelerate launch \

--- a/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
@@ -1,10 +1,7 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# Configuration for fine-tuning Llama 3.8B model with long context
+# Configuration for fine-tuning Llama 3.8B model with long context.
 #
-# Run command for 8x40GB A100 GPUs
-# accelerate launch \
+# Usage (for 8xA100-40GB GPUs):
+#   accelerate launch \
 #     --config_file configs/recipes/llama3_1/sft/8b_full/accelerate.yaml \
 #     --use_fsdp \
 #     --num_processes 8 \
@@ -12,6 +9,12 @@
 #     --mixed_precision no \
 #     -m oumi train \
 #     -c "configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml"
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config for Llama 3.1 8B Instruct SFT on 1 Polaris node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-sft
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config for Llama 3.1 8B Instruct SFT on 1 Polaris node.
+# Job config for Llama 3.1 8B Instruct SFT on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_full.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/8b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for Llama 8B.
+# FFT config for Llama 8B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_full.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
+# Job config to FSDP LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml --cluster llama8b-lora-fsdp

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml --cluster llama8b-lora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml --cluster llama8b-lora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-lora-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FSDP Lora config for Llama 8B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
+# Job config to LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml --cluster llama8b-lora

--- a/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Llama 3.1 8B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml --cluster llama8b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml --cluster llama8b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-lora
 
 resources:

--- a/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Llama 3.1 8B Instruct on 1 Polaris node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Llama 3.1 8B Instruct on 1 Polaris node.
+# Job config to LoRA tune Llama 3.1 8B Instruct on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml --cluster preemptable.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/8b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Lora config for Llama 8B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP QLoRA tune Llama 3.1 8B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml --cluster llama8b-qlora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml --cluster llama8b-qlora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama8b-qlora-fsdp
 
 resources:

--- a/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP QLoRA tune Llama 3.1 8B Instruct on 1 GCP node.
+# Job config to FSDP QLoRA tune Llama 3.1 8B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml --cluster llama8b-qlora-fsdp

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLora config for Llama 8B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_qlora_single_device.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/8B_qlora_single_device.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_1/sft/8b_qlora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/evaluation/1b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/1b_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for Llama 1B Instruct.
+# Eval config for Llama 3.2 1B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/evaluation/1b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/1b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.2 1B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/llama3_2/evaluation/1b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/llama3_2/evaluation/3b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/3b_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for Llama 3B Instruct.
+# Eval config for Llama 3.2 3B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/evaluation/3b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/3b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.2 3B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/llama3_2/evaluation/3b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/llama3_2/inference/1b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 1B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 1B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/1b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
@@ -12,7 +12,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
@@ -1,11 +1,18 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 1B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
 #     --model-path meta-llama/Llama-3.2-1B-Instruct \
 #     --port 6864 --disable-cuda-graph --mem-fraction-static=0.99
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 1B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \

--- a/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 1B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 1B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_2/inference/3b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 3B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/3b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
@@ -12,7 +12,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
@@ -1,11 +1,18 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 3B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
 #     --model-path meta-llama/Llama-3.2-3B-Instruct \
 #     --port 6864 --disable-cuda-graph --mem-fraction-static=0.99
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \

--- a/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for Llama 3B Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3B Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_2/sft/1b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/1b_full/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/1B_full.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/1b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/1b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/1b_full/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for Llama 3.2 1B Instruct.
+# FFT config for Llama 3.2 1B Instruct.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/1B_full.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml --cluster llama3b-sft-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml --cluster llama3b-sft-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-sft-fsdp
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to FSDP full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml --cluster llama3b-sft-fsdp

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# FSDP SFT config for Llama 3.2 3B.
+# FSDP FFT config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_full.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_full.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml --cluster llama3b-sft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml --cluster llama3b-sft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-sft
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to full fine-tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml --cluster llama3b-sft

--- a/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config for Llama 3.2 3B Instruct SFT on 1 Polaris node.
+# Job config for Llama 3.2 3B Instruct SFT on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config for Llama 3.2 3B Instruct SFT on 1 Polaris node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-sft
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_2/sft/3b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_full.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/3b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for Llama 3.2 3B.
+# FFT config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_full.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to FSDP LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml --cluster llama3b-lora-fsdp

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml --cluster llama3b-lora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml --cluster llama3b-lora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-lora-fsdp
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FSDP Lora config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml --cluster llama3b-lora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml --cluster llama3b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-lora
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to LoRA tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml --cluster llama3b-lora

--- a/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to LoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to LoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
+# Job config to LoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Lora config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml --cluster llama3b-qlora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml --cluster llama3b-qlora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-qlora-fsdp
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to FSDP QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml --cluster llama3b-qlora-fsdp

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_qlora_single_device.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # FSDP QLora config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_qlora_single_device.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
+# Job config to QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml --cluster llama3b-qlora

--- a/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to QLoRA tune Llama 3.2 3B Instruct on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml --cluster llama3b-qlora
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml --cluster llama3b-qlora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-qlora
 
 resources:

--- a/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to QLoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama3b-lora
 # NOTE: Replace with your username.
 user: your_username

--- a/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
@@ -1,4 +1,4 @@
-# Config to QLoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
+# Job config to QLoRA tune Llama 3.2 3B Instruct on 1 Polaris node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml --cluster debug.$ALCF_USER --user $ALCF_USER

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLora config for Llama 3.2 3B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_qlora_single_device.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-3B-Instruct"

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_2/3B_qlora_single_device.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_2/sft/3b_qlora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_3/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for Llama 3.3v 70B Instruct.
+# Eval config for Llama 3.3 70B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.3 70B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/llama3_3/evaluation/70b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.3 70B Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml --cluster llama70b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml --cluster llama70b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-eval
 
 resources:

--- a/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.JobConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 
-# Config to eval Llama 3.3v 70B Instruct on GCP.
+# Config to eval Llama 3.3 70B Instruct on GCP.
 # Example command:
 # oumi launch up -c configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml --cluster llama70b-eval
 name: llama70b-eval

--- a/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.3 70B Instruct on GCP.
+# Job config to eval Llama 3.3 70B Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml --cluster llama70b-eval

--- a/configs/recipes/llama3_3/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
-# Inference config for Llama 3.3v 70B Instruct with a NATIVE engine.
+# Inference config for Llama 3.3 70B Instruct with a NATIVE engine.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3.3 70B Instruct with a NATIVE engine.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_3/inference/70b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_3/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
-# Inference config for Llama 3.3v 70B Instruct with VLLM.
+# Inference config for Llama 3.3 70B Instruct with VLLM.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3.3 70B Instruct with VLLM.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.JobConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 
-# Config to FSDP full fine-tune Llama 3.3v 70B Instruct on a single GCP node.
+# Config to FSDP full fine-tune Llama 3.3 70B Instruct on a single GCP node.
 # Example command:
 # oumi launch up -c configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp
 name: llama70b-sft-fsdp

--- a/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP full fine-tune Llama 3.3 70B Instruct on a single GCP node.
+# Job config to FSDP full fine-tune Llama 3.3 70B Instruct on a single GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp

--- a/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP full fine-tune Llama 3.3 70B Instruct on a single GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml --cluster llama70b-sft-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-sft-fsdp
 
 resources:

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for Llama 3.3 70B.
+# FFT config for Llama 3.3 70B.
 # Some param values are inspired by the following recipe:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_full.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.TrainingConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
 
-# SFT config for Llama 3.3v 70B.
+# SFT config for Llama 3.3 70B.
 # Some param values are inspired by the following recipe:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_full.yaml
 

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_full.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_3/sft/70b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP LoRA tune Llama 3.3 70B Instruct.
+# Job config to FSDP LoRA tune Llama 3.3 70B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp

--- a/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP LoRA tune Llama 3.3 70B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-lora-fsdp
 
 resources:

--- a/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.JobConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 
-# Config to FSDP LoRA tune Llama 3.3v 70B Instruct.
+# Config to FSDP LoRA tune Llama 3.3 70B Instruct.
 # Example command:
 # oumi launch up -c configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml --cluster llama70b-lora-fsdp
 name: llama70b-lora-fsdp

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -1,9 +1,15 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # Lora config for Llama 3.3 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_lora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_lora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_3/sft/70b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.TrainingConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
 
-# Lora config for Llama 3.3v 70B.
+# Lora config for Llama 3.3 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_lora.yaml
 

--- a/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to FSDP QLoRA tune Llama 3.3 70B Instruct.
-# Example command:
-# oumi launch up -c configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp
+#
+# Usage:
+#   oumi launch up -c configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama70b-qlora-fsdp
 
 resources:

--- a/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.JobConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 
-# Config to FSDP QLoRA tune Llama 3.3v 70B Instruct.
+# Config to FSDP QLoRA tune Llama 3.3 70B Instruct.
 # Example command:
 # oumi launch up -c configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp
 name: llama70b-qlora-fsdp

--- a/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to FSDP QLoRA tune Llama 3.3 70B Instruct.
+# Job config to FSDP QLoRA tune Llama 3.3 70B Instruct.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml --cluster llama70b-qlora-fsdp

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -1,10 +1,16 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
 # QLora config for Llama 3.3 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_lora.yaml
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.3-70B-Instruct"

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -4,7 +4,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/llama3_3/sft/70b_qlora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -1,7 +1,7 @@
 # Class: oumi.core.configs.TrainingConfig
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
 
-# QLora config for Llama 3.3v 70B.
+# QLora config for Llama 3.3 70B.
 # Borrows param values from:
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_3/70B_lora.yaml
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/405B_qlora.yaml

--- a/configs/recipes/phi3/dpo/gcp_job.yaml
+++ b/configs/recipes/phi3/dpo/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c configs/recipes/phi3/dpo/gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/phi3/dpo/gcp_job.yaml
+++ b/configs/recipes/phi3/dpo/gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: phi3-dpo
 

--- a/configs/recipes/phi3/dpo/gcp_job.yaml
+++ b/configs/recipes/phi3/dpo/gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/configs/recipes/phi3/dpo/mac_train.yaml
+++ b/configs/recipes/phi3/dpo/mac_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/dpo/mac_train.yaml
+++ b/configs/recipes/phi3/dpo/mac_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/dpo/mac_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/dpo/nvidia_24g_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/dpo/nvidia_80g_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/dpo/train.yaml
+++ b/configs/recipes/phi3/dpo/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/dpo/train.yaml
+++ b/configs/recipes/phi3/dpo/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/dpo/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/phi3/evaluation/eval.yaml
+++ b/configs/recipes/phi3/evaluation/eval.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+# Eval config for Phi3.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/evaluation/eval.yaml
+++ b/configs/recipes/phi3/evaluation/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Phi3.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/phi3/evaluation/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/phi3/evaluation/gcp_job.yaml
+++ b/configs/recipes/phi3/evaluation/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Phi3 Instruct on GCP.
+# Job config to eval Phi3 Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/phi3/evaluation/gcp_job.yaml --cluster phi3-eval

--- a/configs/recipes/phi3/evaluation/gcp_job.yaml
+++ b/configs/recipes/phi3/evaluation/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Phi3 Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/phi3/evaluation/gcp_job.yaml --cluster phi3-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/phi3/evaluation/gcp_job.yaml --cluster phi3-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 
 name: phi3-eval
 

--- a/configs/recipes/phi3/sft/lora_train.yaml
+++ b/configs/recipes/phi3/sft/lora_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/sft/lora_train.yaml
+++ b/configs/recipes/phi3/sft/lora_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/sft/lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/phi3/sft/mac_lora_train.yaml
+++ b/configs/recipes/phi3/sft/mac_lora_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/configs/recipes/phi3/sft/mac_lora_train.yaml
+++ b/configs/recipes/phi3/sft/mac_lora_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/phi3/sft/mac_lora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/smollm/evaluation/135m/eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/smollm/evaluation/135m/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/smollm/evaluation/135m/eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/evaluation/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to evaluate smollm 135M on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/smollm/evaluation/135m/gcp_job.yaml --cluster smollm-135m-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/evaluation/135m/gcp_job.yaml --cluster smollm-135m-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-eval
 
 resources:

--- a/configs/recipes/smollm/evaluation/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to evaluate smollm 135M on 1 GCP node.
+# Job config to evaluate smollm 135M on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/smollm/evaluation/135m/gcp_job.yaml --cluster smollm-135m-eval

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+# HuggingFace Leaderboard V1 eval config.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
@@ -1,7 +1,7 @@
 # HuggingFace Leaderboard V1 eval config.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to evaluate smollm 135M on HuggingFace's Leaderboard V1 (1 GCP node).
-# Example command:
-# oumi launch up -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job_eval.yaml --cluster smollm-135m-lb-v1-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job_eval.yaml --cluster smollm-135m-lb-v1-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-lb-v1-eval
 
 resources:

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to evaluate smollm 135M on HuggingFace's Leaderboard V1 (1 GCP node).
+# Job config to evaluate smollm 135M on HuggingFace's Leaderboard V1 (1 GCP node).
 #
 # Usage:
 #   oumi launch up -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job_eval.yaml --cluster smollm-135m-lb-v1-eval

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
@@ -1,8 +1,17 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# NOTE: Your must first request access to the GPQA dataset here:
-# https://huggingface.co/datasets/Idavidrein/gpqa
+# HuggingFace Leaderboard V2 eval config.
+#
+# Requirements:
+#   - You must first request access to the GPQA dataset here:
+#     https://huggingface.co/datasets/Idavidrein/gpqa
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
@@ -5,7 +5,7 @@
 #     https://huggingface.co/datasets/Idavidrein/gpqa
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
@@ -1,11 +1,17 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
-# NOTE: Your must first request access to the GPQA dataset here:
-# https://huggingface.co/datasets/Idavidrein/gpqa
 # Config to evaluate smollm 135M on HuggingFace's Leaderboard V2 (1 GCP node).
-# Example command:
-# oumi launch up -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job_eval.yaml --cluster smollm-135m-lb-v2-eval
+#
+# Requirements:
+#   - Request access to the GPQA dataset: https://huggingface.co/datasets/Idavidrein/gpqa
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job_eval.yaml --cluster smollm-135m-lb-v2-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-lb-v2-eval
 
 resources:

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to evaluate smollm 135M on HuggingFace's Leaderboard V2 (1 GCP node).
+# Job config to evaluate smollm 135M on HuggingFace's Leaderboard V2 (1 GCP node).
 #
 # Requirements:
 #   - Request access to the GPQA dataset: https://huggingface.co/datasets/Idavidrein/gpqa

--- a/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for SmolLM 135M Instruct.
+# Quickstart Alpaca v2 eval config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
@@ -1,7 +1,7 @@
 # Quickstart Alpaca v2 eval config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
-# Eval config for SmolLM 135M Instruct.
+# Quickstart eval config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
@@ -1,7 +1,7 @@
 # Quickstart eval config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to evaluate smollm 135M on 1 GCP node.
+# Job config to evaluate smollm 135M on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml --cluster smollm-135m-eval

--- a/configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to evaluate smollm 135M on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml --cluster smollm-135m-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/evaluation/135m/quickstart_gcp_job.yaml --cluster smollm-135m-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-eval
 
 resources:

--- a/configs/recipes/smollm/inference/135m_infer.yaml
+++ b/configs/recipes/smollm/inference/135m_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/smollm/inference/135m_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/smollm/inference/135m_infer.yaml
+++ b/configs/recipes/smollm/inference/135m_infer.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
 # Inference config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/inference/135m_infer.yaml
+++ b/configs/recipes/smollm/inference/135m_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/sft/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to tune smollm 135M on 1 GCP node.
+# Job config to tune smollm 135M on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/smollm/sft/135m/gcp_job.yaml --cluster smollm-135m-fft

--- a/configs/recipes/smollm/sft/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to tune smollm 135M on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/smollm/sft/135m/gcp_job.yaml --cluster smollm-135m-fft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/sft/135m/gcp_job.yaml --cluster smollm-135m-fft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-sft
 
 resources:

--- a/configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to tune smollm 135M on 1 GCP node.
+# Job config to tune smollm 135M on 1 GCP node.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --cluster smollm-135m-fft

--- a/configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to tune smollm 135M on 1 GCP node.
-# Example command:
-# oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --cluster smollm-135m-fft
+#
+# Usage:
+#   oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --cluster smollm-135m-fft
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: smollm-135m-sft
 
 resources:

--- a/configs/recipes/smollm/sft/135m/quickstart_train.yaml
+++ b/configs/recipes/smollm/sft/135m/quickstart_train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for SmolLM 135M Instruct.
+# FFT config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/sft/135m/quickstart_train.yaml
+++ b/configs/recipes/smollm/sft/135m/quickstart_train.yaml
@@ -1,7 +1,7 @@
 # FFT config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/smollm/sft/135m/quickstart_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/smollm/sft/135m/train.yaml
+++ b/configs/recipes/smollm/sft/135m/train.yaml
@@ -1,7 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-# SFT config for SmolLM 135M Instruct.
+# FFT config for SmolLM 135M Instruct.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"

--- a/configs/recipes/smollm/sft/135m/train.yaml
+++ b/configs/recipes/smollm/sft/135m/train.yaml
@@ -1,7 +1,7 @@
 # FFT config for SmolLM 135M Instruct.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/smollm/sft/135m/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Llama 3.2 11B Vision Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
+
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"
   model_max_length: 1024

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Llama 3.2 11B Vision Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Llama 3.2 Vision 11B Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml --cluster llama32v-11b-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml --cluster llama32v-11b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: llama32v-11b-eval
 
 resources:

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Llama 3.2 Vision 11B Instruct on GCP.
+# Job config to eval Llama 3.2 Vision 11B Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml --cluster llama32v-11b-eval

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
@@ -28,7 +28,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
@@ -1,6 +1,8 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample python command to start vLLM server:
 #
 # Note, for models that vLLM supports LoRA-adapters adapt below line
@@ -21,6 +23,12 @@
 #   --gpu-memory-utilization=0.95 \
 #   --tensor-parallel-size 1 \
 #   ${USE_LORA}
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
 #
 # Sample python command to start vLLM server:
 #

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
@@ -1,11 +1,20 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
 #     --model-path meta-llama/Llama-3.2-11B-Vision-Instruct \
 #     --tokenizer-path meta-llama/Llama-3.2-11B-Vision-Instruct \
 #     --port 6864 --disable-cuda-graph --mem-fraction-static=0.99
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
+
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
@@ -13,7 +13,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml --cluster llama3-2-vision
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml --cluster llama3-2-vision
 name: llama32v-11b-sft-train
 
 resources:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml --cluster llama3-2-vision
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml --cluster llama3-2-vision
 name: llama32v-11b-sft-lora-train
 
 resources:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -1,7 +1,7 @@
 # LoRA config for Llama 11B Vision with the vqav2-small dataset.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -1,9 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-##
-# LoRA config for sft-training Llama-11B-Vision with the vqav2-small dataset.
-##
+# LoRA config for Llama 11B Vision with the vqav2-small dataset.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-11B-Vision-Instruct"

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml --cluster llama3-2-vision-90b
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml --cluster llama3-2-vision-90b
 name: llama32v-90b-sft-train
 
 resources:

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -1,7 +1,7 @@
 # FFT config for Llama- 90B Vision with the vqav2-small dataset.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -1,9 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-##
-# Full SFT-training config for Llama-90B-Vision with the vqav2-small dataset.
-##
+# FFT config for Llama- 90B Vision with the vqav2-small dataset.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "meta-llama/Llama-3.2-90B-Vision-Instruct"

--- a/configs/recipes/vision/llava_7b/inference/infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "llava-hf/llava-1.5-7b-hf"

--- a/configs/recipes/vision/llava_7b/inference/infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "llava-hf/llava-1.5-7b-hf"

--- a/configs/recipes/vision/llava_7b/inference/infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llava_7b/inference/infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "llava-hf/llava-1.5-7b-hf"

--- a/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "llava-hf/llava-1.5-7b-hf"

--- a/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml --cluster my-oumi-cluster
 name: llava-7b-sft-oumi-train
 
 resources:

--- a/configs/recipes/vision/llava_7b/sft/train.yaml
+++ b/configs/recipes/vision/llava_7b/sft/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/llava_7b/sft/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/llava_7b/sft/train.yaml
+++ b/configs/recipes/vision/llava_7b/sft/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "llava-hf/llava-1.5-7b-hf"

--- a/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml --cluster my-oumi-cluster
 name: llava-7b-sft
 
 num_nodes: 1 # Set it to N for multi-node training.

--- a/configs/recipes/vision/phi3/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/phi3/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/phi3/inference/vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/phi3/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/phi3/inference/vllm_infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "microsoft/Phi-3-vision-128k-instruct"

--- a/configs/recipes/vision/phi3/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/phi3/inference/vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "microsoft/Phi-3-vision-128k-instruct"

--- a/configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml --cluster my-oumi-cluster
 name: phi3-sft-oumi-train
 
 resources:

--- a/configs/recipes/vision/phi3/sft/train.yaml
+++ b/configs/recipes/vision/phi3/sft/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-vision-128k-instruct"

--- a/configs/recipes/vision/phi3/sft/train.yaml
+++ b/configs/recipes/vision/phi3/sft/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/phi3/sft/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/phi3/sft/trl_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/trl_gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/phi3/sft/trl_gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/phi3/sft/trl_gcp_job.yaml --cluster my-oumi-cluster
 name: phi3-sft-trl-train
 
 resources:

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
@@ -1,7 +1,14 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
-
 # Eval config for Qwen2 VL 2B Instruct.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
+
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"
   model_max_length: 1024

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Qwen2 VL 2B Instruct.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
@@ -1,4 +1,4 @@
-# Config to eval Qwen2 VL 2B Instruct on GCP.
+# Job config to eval Qwen2 VL 2B Instruct on GCP.
 #
 # Usage:
 #   oumi launch up -c configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml --cluster qwen2-vl-eval

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
@@ -1,9 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
-
 # Config to eval Qwen2 VL 2B Instruct on GCP.
-# Example command:
-# oumi launch up -c configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml --cluster qwen2-vl-eval
+#
+# Usage:
+#   oumi launch up -c configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml --cluster qwen2-vl-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
 name: qwen2-vl-eval
 
 resources:

--- a/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
@@ -15,7 +15,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \

--- a/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml
@@ -1,6 +1,8 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
 #   --model-path Qwen/Qwen2-VL-2B-Instruct \
@@ -8,6 +10,12 @@
 #   --disable-cuda-graph \
 #   --mem-fraction-static=0.99 \
 #   --trust-remote-code
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
@@ -7,7 +7,7 @@
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
 #   - Config class: oumi.core.configs.InferenceConfig
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
-#   - Other eval configs: configs/**/inference/
+#   - Other inference configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.InferenceConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+# Inference config.
+#
+# Usage:
+#   oumi infer -i -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other eval configs: configs/**/inference/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config.
 #
 # Usage:
-#   oumi infer -i -c <config_path>
+#   oumi infer -i -c configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml --cluster my-oumi-cluster
 name: qwen2-vl-sft-oumi-train
 
 resources:

--- a/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "Qwen/Qwen2-VL-2B-Instruct"

--- a/configs/recipes/vision/smolvlm/sft/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/gcp_job.yaml
@@ -1,8 +1,14 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up --config configs/recipes/vision/smolvlm/sft/gcp_job.yaml --cluster my-oumi-cluster
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
-# Sample command:
-# oumi launch up --config configs/recipes/vision/smolvlm/sft/gcp_job.yaml --cluster my-oumi-cluster
 name: smolvlm-sft-trl-train
 
 resources:

--- a/configs/recipes/vision/smolvlm/sft/train.yaml
+++ b/configs/recipes/vision/smolvlm/sft/train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c configs/recipes/vision/smolvlm/sft/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/configs/recipes/vision/smolvlm/sft/train.yaml
+++ b/configs/recipes/vision/smolvlm/sft/train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "HuggingFaceTB/SmolVLM-Instruct"

--- a/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
+++ b/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
@@ -1,7 +1,7 @@
 # Eval config for Zephyr.
 #
 # Usage:
-#   oumi evaluate -c <config_path>
+#   oumi evaluate -c src/experimental/configs/projects/zephyr/evaluation/eval.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html

--- a/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
+++ b/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.EvaluationConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+# Eval config for Zephyr.
+#
+# Usage:
+#   oumi evaluate -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
 
 model:
   # Note: update model_name or adapter_model with your checkpoint directories

--- a/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: zephyr-7b-fft
 

--- a/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/projects/zephyr/sft/full_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_train.yaml
@@ -5,7 +5,7 @@
 # Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c src/experimental/configs/projects/zephyr/sft/full_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/src/experimental/configs/projects/zephyr/sft/full_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_train.yaml
@@ -1,11 +1,17 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-## Recipe and HPs used for Zephyr.7B:
-## https://huggingface.co/alignment-handbook/zephyr-7b-sft-full
-
-## Setup for training with 8, 80GB A100, GPUS.
-## Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
+# FFT config for Zephyr 7B:
+# https://huggingface.co/alignment-handbook/zephyr-7b-sft-full
+#
+# Setup for training with 8 A100-80GB GPUS.
+# Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "mistralai/Mistral-7B-v0.1"

--- a/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: zephyr-7b-qlora
 

--- a/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
@@ -5,7 +5,7 @@
 # Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html

--- a/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
@@ -1,11 +1,17 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
-
-## Recipe and HPs used for Quantized Zephyr.7B:
-## https://huggingface.co/alignment-handbook/zephyr-7b-sft-qlora
-
-## Setup for training with 8, A100, GPUS.
-## Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
+# QLoRA config for Zephyr 7B:
+# https://huggingface.co/alignment-handbook/zephyr-7b-sft-qlora
+#
+# Setup for training with 8 A100 GPUS.
+# Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "mistralai/Mistral-7B-v0.1"

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.JobConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+# Job config.
+#
+# Usage:
+#   oumi launch up -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
 
 name: phi3-dpo-fsdp
 

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path> --cluster my-oumi-cluster
+#   oumi launch up -c src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
@@ -1,7 +1,7 @@
 # Job config.
 #
 # Usage:
-#   oumi launch up -c <config_path>
+#   oumi launch up -c <config_path> --cluster my-oumi-cluster
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_nvidia_24g_train.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_nvidia_24g_train.yaml
@@ -1,5 +1,13 @@
-# Class: oumi.core.configs.TrainingConfig
-# https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+# Training config.
+#
+# Usage:
+#   oumi train -c <config_path>
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
   model_name: "microsoft/Phi-3-mini-4k-instruct"

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_nvidia_24g_train.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_nvidia_24g_train.yaml
@@ -1,7 +1,7 @@
 # Training config.
 #
 # Usage:
-#   oumi train -c <config_path>
+#   oumi train -c src/experimental/configs/recipes/phi3/dpo/fsdp_nvidia_24g_train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html


### PR DESCRIPTION
# Description

All configs will now have detailed information including the class they're loaded in, a link to documentation, and an example command to run.

This PR only modifies the comment headers of YAML config files. I double checked this is true for all files. I wouldn't recommend reviewing each line as it's a large PR, but instead to review an example header for one of each type of config (train/eval/infer/job.yaml) for its contents.

## Related issues

Towards OPE-894

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

