### PR TITLE
fix(docs): "interested by joining" to "interested in joining"

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Oumi is a community-first effort. Whether you are a developer, a researcher, or 
 
 - To contribute to the `oumi` repository, please check the [`CONTRIBUTING.md`](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) for guidance on how to contribute to send your first Pull Request.
 - Make sure to join our [Discord community](https://discord.gg/oumi) to get help, share your experiences, and contribute to the project!
-- If you are interested by joining one of the community's open-science efforts, check out our [open collaboration](https://oumi.ai/community) page.
+- If you are interested in joining one of the community's open-science efforts, check out our [open collaboration](https://oumi.ai/community) page.
 
 ## 🙏 Acknowledgements
 


### PR DESCRIPTION
Incorrect preposition “by” instead of “in.”
Apologies for the tiny one-word fix, but this was the only typo spotted! Kudos to the team for keeping everything else pristine.

---

# Description

This PR fixes a small documentation typo where the phrase “interested by joining” was used instead of “interested **in** joining.” Everything else looks great! Thank you for maintaining such high-quality documentation.

## Before submitting

- [X] This PR only changes documentation. (You can ignore the following checks in that case)