### PR TITLE
Disallow using `DatasetParams` field names as keys in `DatasetParams.dataset_kwargs`

### DIFF
--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any, Literal, Optional, Union
 
@@ -163,6 +163,17 @@ class DatasetParams(BaseParams):
                 raise ValueError(
                     "Non-positive value of transform_num_workers: "
                     f"{self.transform_num_workers}."
+                )
+
+        if len(self.dataset_kwargs) > 0:
+            conflicting_keys = {f.name for f in fields(self)}.intersection(
+                self.dataset_kwargs.keys()
+            )
+            if len(conflicting_keys) > 0:
+                raise ValueError(
+                    "dataset_kwargs attempts to override the following "
+                    f"reserved fields: {conflicting_keys}. "
+                    "Use properties of DatasetParams instead."
                 )
 
 

--- a/tests/unit/core/configs/params/test_data_params.py
+++ b/tests/unit/core/configs/params/test_data_params.py
@@ -1,0 +1,35 @@
+import dataclasses
+
+import pytest
+
+from oumi.core.configs.params.data_params import DatasetParams
+
+
+def _get_invalid_field_name_lists() -> list[list[str]]:
+    all_fields: set[str] = {f.name for f in dataclasses.fields(DatasetParams())}
+    result = [[field_name] for field_name in all_fields]
+    result.extend([["valid_kwarg", field_name] for field_name in all_fields][:3])
+    return result
+
+
+def _get_test_name_for_invalid_field_name_list(x):
+    assert isinstance(x, list)
+    return "--".join(x)
+
+
+@pytest.mark.parametrize(
+    "field_names",
+    _get_invalid_field_name_lists(),
+    ids=_get_test_name_for_invalid_field_name_list,
+)
+def test_dataset_params_reserved_kwargs(field_names: list[str]):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "dataset_kwargs attempts to override the following " "reserved fields: "
+        ),
+    ):
+        DatasetParams(
+            dataset_name="DUMMY-NON-EXISTENT",
+            dataset_kwargs={field_name: "foo_value" for field_name in field_names},
+        )

--- a/tests/unit/core/configs/params/test_data_params.py
+++ b/tests/unit/core/configs/params/test_data_params.py
@@ -23,10 +23,14 @@ def _get_test_name_for_invalid_field_name_list(x):
     ids=_get_test_name_for_invalid_field_name_list,
 )
 def test_dataset_params_reserved_kwargs(field_names: list[str]):
+    invalid_names = {f.name for f in dataclasses.fields(DatasetParams())}.intersection(
+        field_names
+    )
     with pytest.raises(
         ValueError,
         match=(
-            "dataset_kwargs attempts to override the following " "reserved fields: "
+            "dataset_kwargs attempts to override the following reserved fields: "
+            f"{invalid_names}"
         ),
     ):
         DatasetParams(


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

-- This may lead to obscure Python kwarg resolution error (function call with duplicate keyed arguments). Better to block it from the start.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes OPE-916

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [X] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [X] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
