### PR TITLE
Support HuggingFaceM4/Docmatix dataset

### DIFF
--- a/configs/recipes/vision/llava_7b/sft/train.yaml
+++ b/configs/recipes/vision/llava_7b/sft/train.yaml
@@ -34,6 +34,15 @@ data:
           # limit: 8192 # Uncomment to limit dataset size!
           return_tensors: True
 
+      - dataset_name: "HuggingFaceM4/Docmatix"
+        split: "train"
+        shuffle: True
+        seed: 42
+        transform_num_workers: "auto"
+        dataset_kwargs:
+          processor_name: "llava-hf/llava-1.5-7b-hf"
+          return_tensors: True
+
       # Below are examples of other vision SFT datasets
       # - dataset_name: "HuggingFaceH4/llava-instruct-mix-vsft"
       #   split: "train"

--- a/configs/recipes/vision/phi3/sft/train.yaml
+++ b/configs/recipes/vision/phi3/sft/train.yaml
@@ -33,6 +33,14 @@ data:
         dataset_kwargs:
           processor_name: "microsoft/Phi-3-vision-128k-instruct"
           return_tensors: True
+      - dataset_name: "HuggingFaceM4/Docmatix"
+        split: "train"
+        shuffle: True
+        seed: 42
+        transform_num_workers: "auto"
+        dataset_kwargs:
+          processor_name: "microsoft/Phi-3-vision-128k-instruct"
+          return_tensors: True
       # - dataset_name: "HuggingFaceH4/llava-instruct-mix-vsft"
       #   split: "train"
       #   shuffle: True

--- a/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/train.yaml
@@ -33,6 +33,14 @@ data:
           processor_name: "Qwen/Qwen2-VL-2B-Instruct"
           # limit: 4096 # Uncomment to limit dataset size!
           return_tensors: True
+      - dataset_name: "HuggingFaceM4/Docmatix"
+        split: "train"
+        shuffle: True
+        seed: 42
+        transform_num_workers: "auto"
+        dataset_kwargs:
+          processor_name: "Qwen/Qwen2-VL-2B-Instruct"
+          return_tensors: True
       # - dataset_name: "HuggingFaceH4/llava-instruct-mix-vsft"
       #   split: "train"
       #   shuffle: True

--- a/configs/recipes/vision/smolvlm/sft/train.yaml
+++ b/configs/recipes/vision/smolvlm/sft/train.yaml
@@ -34,6 +34,14 @@ data:
           processor_name: "HuggingFaceTB/SmolVLM-Instruct"
           # limit: 4096 # Uncomment to limit dataset size!
           return_tensors: True
+      - dataset_name: "HuggingFaceM4/Docmatix"
+        split: "train"
+        shuffle: True
+        seed: 42
+        transform_num_workers: "auto"
+        dataset_kwargs:
+          processor_name: "HuggingFaceTB/SmolVLM-Instruct"
+          return_tensors: True
 
 training:
   output_dir: "output/vlm_finetuned"

--- a/src/oumi/datasets/vision_language/docmatix.py
+++ b/src/oumi/datasets/vision_language/docmatix.py
@@ -1,0 +1,70 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing_extensions import override
+
+from oumi.core.datasets import VisionLanguageSftDataset
+from oumi.core.registry import register_dataset
+from oumi.core.types.conversation import (
+    ContentItem,
+    Conversation,
+    Message,
+    Role,
+    Type,
+)
+
+
+@register_dataset("HuggingFaceM4/Docmatix")
+class DocmatixDataset(VisionLanguageSftDataset):
+    """Dataset class for the `HuggingFaceM4/Docmatix` dataset."""
+
+    default_dataset = "HuggingFaceM4/Docmatix"
+
+    @override
+    def transform_conversation(self, example: dict) -> Conversation:
+        """Transform a single conversation example into a Conversation object."""
+        input_text = example["question"]
+        output_text = example["answer"]
+
+        user_items: list[ContentItem] = []
+
+        if "image_bytes" in example:
+            user_items.append(
+                ContentItem(
+                    binary=example["image_bytes"],
+                    type=Type.IMAGE_BINARY,
+                )
+            )
+        elif "image_path" in example:
+            user_items.append(
+                ContentItem(
+                    content=example["image_path"],
+                    type=Type.IMAGE_PATH,
+                )
+            )
+        else:
+            raise ValueError(
+                "Training example contains none of required keys: "
+                "'image_bytes', 'image_path'. "
+                f"Available keys: {example.keys()}."
+            )
+
+        user_items.append(ContentItem(type=Type.TEXT, content=input_text))
+
+        return Conversation(
+            messages=[
+                Message(role=Role.USER, content=user_items),
+                Message(role=Role.ASSISTANT, content=output_text),
+            ]
+        )


### PR DESCRIPTION
Related to #915

Add support for the HuggingFaceM4/Docmatix dataset for Document Visual Question Answering.

* **New Dataset Class**
  - Add `DocmatixDataset` class in `src/oumi/datasets/vision_language/docmatix.py` to handle the HuggingFaceM4/Docmatix dataset.
  - Implement `transform_conversation` method to convert raw data into a `Conversation` object.
  - Register the dataset using the `register_dataset` decorator.

* **Configuration Updates**
  - Update `configs/recipes/vision/llava_7b/sft/train.yaml` to include the HuggingFaceM4/Docmatix dataset under `data.train.datasets`.
  - Update `configs/recipes/vision/phi3/sft/train.yaml` to include the HuggingFaceM4/Docmatix dataset under `data.train.datasets`.
  - Update `configs/recipes/vision/qwen2_vl_2b/sft/train.yaml` to include the HuggingFaceM4/Docmatix dataset under `data.train.datasets`.
  - Update `configs/recipes/vision/smolvlm/sft/train.yaml` to include the HuggingFaceM4/Docmatix dataset under `data.train.datasets`.

