### PR TITLE
Adopt new Llama 3.1 HF names

### DIFF
--- a/configs/examples/misc/vllm_polaris_job.yaml
+++ b/configs/examples/misc/vllm_polaris_job.yaml
@@ -23,7 +23,7 @@ working_dir: .
 # NOTE: Replace with your input/output paths, and adjust other parameters as needed.
 envs:
   REPO: meta-llama  # HF model repo.
-  MODEL: Meta-Llama-3.1-70B-Instruct  # HF model name.
+  MODEL: Llama-3.3-70B-Instruct  # HF model name.
   OUMI_VLLM_INPUT_FILEPATH: your_input_filepath  # Path to input data file.
   OUMI_VLLM_OUTPUT_DIR: your_output_dir  # Output dir.
   OUMI_VLLM_NUM_WORKERS: 100  # Samples will be divided amongst workers

--- a/configs/projects/aya/evaluation/eval.yaml
+++ b/configs/projects/aya/evaluation/eval.yaml
@@ -10,7 +10,7 @@
 #   - Other eval configs: configs/**/evaluation/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 4096
   torch_dtype_str: "bfloat16"
   trust_remote_code: True

--- a/configs/projects/aya/sft/train.yaml
+++ b/configs/projects/aya/sft/train.yaml
@@ -10,7 +10,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 4096
   torch_dtype_str: "bfloat16"
   trust_remote_code: True

--- a/configs/projects/chatqa/chatqa_stage1_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage1_train.yaml
@@ -14,7 +14,7 @@ model:
   # torch_dtype_str: "float16"
   # model_max_length: 1024
 
-  # model_name: "meta-llama/Meta-Llama-3-8B-Instruct"
+  # model_name: "meta-llama/Llama-3-8B-Instruct"
   # torch_dtype_str: "bfloat16"
   # model_max_length: 4096
 

--- a/configs/projects/chatqa/chatqa_stage1_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage1_train.yaml
@@ -14,7 +14,7 @@ model:
   # torch_dtype_str: "float16"
   # model_max_length: 1024
 
-  # model_name: "meta-llama/Llama-3-8B-Instruct"
+  # model_name: "meta-llama/Llama-3.1-8B-Instruct"
   # torch_dtype_str: "bfloat16"
   # model_max_length: 4096
 

--- a/configs/recipes/llama3_1/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_eval.yaml
@@ -10,7 +10,7 @@
 #   - Other eval configs: configs/**/evaluation/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"
+  model_name: "meta-llama/Llama-3.1-70B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 131072
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
@@ -31,7 +31,7 @@ envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
   # NOTE: For LoRA, instead update this to point to your LoRA adapter.
   #       The base model will be inferred automatically.
-  MODEL_CHECKPOINT_DIR: meta-llama/Meta-Llama-3.1-70B-Instruct
+  MODEL_CHECKPOINT_DIR: meta-llama/Llama-3.1-70B-Instruct
   WANDB_PROJECT: oumi-eval
   OUMI_RUN_NAME: llama70b.eval
 
@@ -40,7 +40,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
@@ -23,7 +23,7 @@ envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
   # NOTE: For LoRA, instead update this to point to your LoRA adapter.
   #       The base model will be inferred automatically.
-  MODEL_CHECKPOINT_DIR: meta-llama/Meta-Llama-3.1-70B-Instruct
+  MODEL_CHECKPOINT_DIR: meta-llama/Llama-3.1-70B-Instruct
   WANDB_PROJECT: oumi-eval
 
 # `setup` will always be executed before `run`. It's strongly suggested to set any PBS

--- a/configs/recipes/llama3_1/evaluation/8b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_eval.yaml
@@ -10,7 +10,7 @@
 #   - Other eval configs: configs/**/evaluation/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 131072
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
@@ -30,7 +30,7 @@ envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
   # NOTE: For LoRA, instead update this to point to your LoRA adapter.
   #       The base model will be inferred automatically.
-  MODEL_CHECKPOINT_DIR: meta-llama/Meta-Llama-3.1-8B-Instruct
+  MODEL_CHECKPOINT_DIR: meta-llama/Llama-3.1-8B-Instruct
   WANDB_PROJECT: oumi-eval
   OUMI_RUN_NAME: llama8b.eval
 
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
@@ -23,7 +23,7 @@ envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
   # NOTE: For LoRA, instead update this to point to your LoRA adapter.
   #       The base model will be inferred automatically.
-  MODEL_CHECKPOINT_DIR: meta-llama/Meta-Llama-3.1-8B-Instruct
+  MODEL_CHECKPOINT_DIR: meta-llama/Llama-3.1-8B-Instruct
   WANDB_PROJECT: oumi-eval
 
 # `setup` will always be executed before `run`. It's strongly suggested to set any PBS

--- a/configs/recipes/llama3_1/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/70b_infer.yaml
@@ -10,7 +10,7 @@
 #   - Other inference configs: configs/**/inference/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"
+  model_name: "meta-llama/Llama-3.1-70B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 2048
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/inference/8b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_infer.yaml
@@ -10,7 +10,7 @@
 #   - Other inference configs: configs/**/inference/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 2048
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -6,7 +6,7 @@
 # Sample command to start vLLM server:
 # python -u -m vllm.entrypoints.openai.api_server \
 #   --port 6864 \
-#   --model meta-llama/Meta-Llama-3.1-8B-Instruct  \
+#   --model meta-llama/Llama-3.1-8B-Instruct  \
 #   --trust-remote-code \
 #   --dtype=bfloat16 \
 #   --device=cuda \
@@ -26,7 +26,7 @@
 #   - Other inference configs: configs/**/inference/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 2048
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Sample command to start SGLang server:
 # CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server \
-#     --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
+#     --model-path meta-llama/Llama-3.1-8B-Instruct \
 #     --port 6864 --disable-cuda-graph --mem-fraction-static=0.9
 # For GPU-s with less than 40GB of VRAM, try --mem-fraction-static=0.99
 #
@@ -16,7 +16,7 @@
 #   - Other inference configs: configs/**/inference/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   adapter_model: null  # Update for LoRA-tuned models.
   model_max_length: 2048
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
@@ -38,7 +38,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/pretraining/8b/train.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/train.yaml
@@ -10,7 +10,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B"
+  model_name: "meta-llama/Llama-3.1-8B"
   chat_template: "chat_ml"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -10,7 +10,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"
+  model_name: "meta-llama/Llama-3.1-405B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-405B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"
+  model_name: "meta-llama/Llama-3.1-405B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Download the model from HF.
   # We exclude original/* because it contains two redundant copies of the model weights.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-405B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-405B-Instruct"
+  model_name: "meta-llama/Llama-3.1-405B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
@@ -48,7 +48,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -3,7 +3,7 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_full.yaml
 #
 # Strongly recommend downloading the model first:
-# HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+# HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 #
 # Usage:
 #   oumi train -c configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -18,7 +18,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"
+  model_name: "meta-llama/Llama-3.1-70B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
@@ -37,7 +37,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"
+  model_name: "meta-llama/Llama-3.1-70B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
@@ -41,7 +41,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -13,7 +13,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-70B-Instruct"
+  model_name: "meta-llama/Llama-3.1-70B-Instruct"
   model_max_length: 2048
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
@@ -38,7 +38,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
@@ -17,7 +17,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 32_768
   torch_dtype_str: "bfloat16" # Train in BF16 to save memory
   attn_implementation: "sdpa" # pytorch native flash-attention, helps reduce vram

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
@@ -36,7 +36,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
@@ -38,7 +38,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
@@ -36,7 +36,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -12,7 +12,7 @@
 #   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
 
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -104,7 +104,7 @@ Oumi integrates with HuggingFace (HF) Hub for access to models and datasets. Whi
 Llama models are gated on HF Hub. To gain access, sign the agreement on your desired Llama model's Hub page. It usually takes a few hours to get access to the model after signing the agreement. There is a separate agreement for each version of Llama:
 
 - [Llama 2](https://huggingface.co/meta-llama/Llama-2-70b-hf)
-- [Llama 3](https://huggingface.co/meta-llama/Llama-3-70B-Instruct)
+- [Llama 3](https://huggingface.co/meta-llama/Meta-Llama-3-70B-Instruct)
 - [Llama 3.1](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)
 - [Llama 3.2](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision-Instruct)
 - [Llama 3.3](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -104,7 +104,7 @@ Oumi integrates with HuggingFace (HF) Hub for access to models and datasets. Whi
 Llama models are gated on HF Hub. To gain access, sign the agreement on your desired Llama model's Hub page. It usually takes a few hours to get access to the model after signing the agreement. There is a separate agreement for each version of Llama:
 
 - [Llama 2](https://huggingface.co/meta-llama/Llama-2-70b-hf)
-- [Llama 3](https://huggingface.co/meta-llama/Meta-Llama-3-70B-Instruct)
+- [Llama 3](https://huggingface.co/meta-llama/Llama-3-70B-Instruct)
 - [Llama 3.1](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)
 - [Llama 3.2](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision-Instruct)
 - [Llama 3.3](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)

--- a/docs/user_guides/infer/common_workflows.md
+++ b/docs/user_guides/infer/common_workflows.md
@@ -18,7 +18,7 @@ from oumi.core.types.conversation import Conversation, Message, Role
 # Initialize engine
 engine = VLLMInferenceEngine(
     model_params=ModelParams(
-        model_name="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        model_name="meta-llama/Llama-3.1-8B-Instruct",
         torch_dtype="bfloat16"
     )
 )

--- a/docs/user_guides/infer/configuration.md
+++ b/docs/user_guides/infer/configuration.md
@@ -23,7 +23,7 @@ A typical configuration file has this structure:
 
 ```yaml
 model:  # Model settings
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   trust_remote_code: true
   model_kwargs:
     device_map: "auto"

--- a/docs/user_guides/infer/configuration.md
+++ b/docs/user_guides/infer/configuration.md
@@ -52,7 +52,7 @@ Configure the model architecture and loading using the {py:obj}`~oumi.core.confi
 ```yaml
 model:
   # Required
-  model_name: "meta-llama/Llama-3.3-70B-Instruct"    # Model ID or path (REQUIRED)
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"    # Model ID or path (REQUIRED)
 
   # Model loading
   adapter_model: null                                # Path to adapter model (auto-detected if model_name is adapter)

--- a/docs/user_guides/infer/configuration.md
+++ b/docs/user_guides/infer/configuration.md
@@ -52,32 +52,32 @@ Configure the model architecture and loading using the {py:obj}`~oumi.core.confi
 ```yaml
 model:
   # Required
-  model_name: "meta-llama/Llama-2-7b-hf"    # Model ID or path (REQUIRED)
+  model_name: "meta-llama/Llama-3.3-70B-Instruct"    # Model ID or path (REQUIRED)
 
   # Model loading
-  adapter_model: null                        # Path to adapter model (auto-detected if model_name is adapter)
-  tokenizer_name: null                       # Custom tokenizer name/path (defaults to model_name)
-  tokenizer_pad_token: null                  # Override pad token
-  tokenizer_kwargs: {}                       # Additional tokenizer args
-  model_max_length: null                     # Max sequence length (positive int or null)
-  load_pretrained_weights: true              # Load pretrained weights
-  trust_remote_code: false                   # Allow remote code execution (use with trusted models only)
+  adapter_model: null                                # Path to adapter model (auto-detected if model_name is adapter)
+  tokenizer_name: null                               # Custom tokenizer name/path (defaults to model_name)
+  tokenizer_pad_token: null                          # Override pad token
+  tokenizer_kwargs: {}                               # Additional tokenizer args
+  model_max_length: null                             # Max sequence length (positive int or null)
+  load_pretrained_weights: true                      # Load pretrained weights
+  trust_remote_code: false                           # Allow remote code execution (use with trusted models only)
 
   # Model precision and hardware
-  torch_dtype_str: "float32"                 # Model precision (float32/float16/bfloat16/float64)
-  device_map: "auto"                         # Device placement strategy (auto/null)
-  compile: false                             # JIT compile model
+  torch_dtype_str: "float32"                         # Model precision (float32/float16/bfloat16/float64)
+  device_map: "auto"                                 # Device placement strategy (auto/null)
+  compile: false                                     # JIT compile model
 
   # Attention and optimization
-  attn_implementation: null                  # Attention impl (null/sdpa/flash_attention_2/eager)
-  enable_liger_kernel: false                 # Enable Liger CUDA kernel for potential speedup
+  attn_implementation: null                          # Attention impl (null/sdpa/flash_attention_2/eager)
+  enable_liger_kernel: false                         # Enable Liger CUDA kernel for potential speedup
 
   # Model behavior
-  chat_template: null                        # Chat formatting template
-  freeze_layers: []                          # Layer names to freeze during training
+  chat_template: null                                # Chat formatting template
+  freeze_layers: []                                  # Layer names to freeze during training
 
   # Additional settings
-  model_kwargs: {}                           # Additional model constructor args
+  model_kwargs: {}                                   # Additional model constructor args
 ```
 
 ### Generation Configuration

--- a/docs/user_guides/infer/inference_cli.md
+++ b/docs/user_guides/infer/inference_cli.md
@@ -43,7 +43,7 @@ Example `config.yaml`:
 
 ```yaml
 model:
-  model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"
   model_kwargs:
     device_map: "auto"
     torch_dtype: "float16"

--- a/docs/user_guides/infer/inference_engines.md
+++ b/docs/user_guides/infer/inference_engines.md
@@ -119,7 +119,7 @@ pip install vllm
 ```python
 engine = VLLMInferenceEngine(
     ModelParams(
-        model_name="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        model_name="meta-llama/Llama-3.1-8B-Instruct",
     )
 )
 ```
@@ -221,7 +221,7 @@ model_params = ModelParams(
 
 ```bash
 python -m vllm.entrypoints.openai.api_server \
-    --model meta-llama/Meta-Llama-3.1-8B-Instruct \
+    --model meta-llama/Llama-3.1-8B-Instruct \
     --port 6864
 ```
 
@@ -229,7 +229,7 @@ python -m vllm.entrypoints.openai.api_server \
 
 ```bash
 python -m vllm.entrypoints.openai.api_server \
-    --model meta-llama/Meta-Llama-3.1-70B-Instruct \
+    --model meta-llama/Llama-3.1-70B-Instruct \
     --port 6864 \
     --tensor-parallel-size 4
 
@@ -243,7 +243,7 @@ The client can be configured with different reliability and performance options 
 # Basic client with timeout and retry settings
 engine = RemoteVLLMInferenceEngine(
     model_params=ModelParams(
-        model_name="meta-llama/Meta-Llama-3.1-8B-Instruct"
+        model_name="meta-llama/Llama-3.1-8B-Instruct"
     ),
     remote_params=RemoteParams(
         api_url="http://localhost:6864",
@@ -261,7 +261,7 @@ engine = RemoteVLLMInferenceEngine(
 
 ```bash
 python -m sglang.launch_server \
-    --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
     --port 6864 \
     --disable-cuda-graph \
     --mem-fraction-static=0.99
@@ -276,7 +276,7 @@ The client can be configured with different reliability and performance options 
 ```{testcode}
 engine = SGLangInferenceEngine(
     model_params=ModelParams(
-        model_name="meta-llama/Meta-Llama-3.1-8B-Instruct"
+        model_name="meta-llama/Llama-3.1-8B-Instruct"
     ),
     remote_params=RemoteParams(
         api_url="http://localhost:6864"

--- a/docs/user_guides/infer/inference_engines.md
+++ b/docs/user_guides/infer/inference_engines.md
@@ -229,7 +229,7 @@ python -m vllm.entrypoints.openai.api_server \
 
 ```bash
 python -m vllm.entrypoints.openai.api_server \
-    --model meta-llama/Llama-3.1-70B-Instruct \
+    --model meta-llama/Llama-3.3-70B-Instruct \
     --port 6864 \
     --tensor-parallel-size 4
 

--- a/docs/user_guides/train/configuration.md
+++ b/docs/user_guides/train/configuration.md
@@ -58,7 +58,7 @@ Configure the model architecture and loading using the {py:obj}`~oumi.core.confi
 ```yaml
 model:
   # Required
-  model_name: "meta-llama/Llama-3.3-70B-Instruct"    # Model ID or path (REQUIRED)
+  model_name: "meta-llama/Llama-3.1-8B-Instruct"    # Model ID or path (REQUIRED)
 
   # Model loading
   adapter_model: null                                # Path to adapter model (auto-detected if model_name is adapter)

--- a/docs/user_guides/train/configuration.md
+++ b/docs/user_guides/train/configuration.md
@@ -58,32 +58,32 @@ Configure the model architecture and loading using the {py:obj}`~oumi.core.confi
 ```yaml
 model:
   # Required
-  model_name: "meta-llama/Llama-2-7b-hf"    # Model ID or path (REQUIRED)
+  model_name: "meta-llama/Llama-3.3-70B-Instruct"    # Model ID or path (REQUIRED)
 
   # Model loading
-  adapter_model: null                        # Path to adapter model (auto-detected if model_name is adapter)
-  tokenizer_name: null                       # Custom tokenizer name/path (defaults to model_name)
-  tokenizer_pad_token: null                  # Override pad token
-  tokenizer_kwargs: {}                       # Additional tokenizer args
-  model_max_length: null                     # Max sequence length (positive int or null)
-  load_pretrained_weights: true              # Load pretrained weights
-  trust_remote_code: false                   # Allow remote code execution (use with trusted models only)
+  adapter_model: null                                # Path to adapter model (auto-detected if model_name is adapter)
+  tokenizer_name: null                               # Custom tokenizer name/path (defaults to model_name)
+  tokenizer_pad_token: null                          # Override pad token
+  tokenizer_kwargs: {}                               # Additional tokenizer args
+  model_max_length: null                             # Max sequence length (positive int or null)
+  load_pretrained_weights: true                      # Load pretrained weights
+  trust_remote_code: false                           # Allow remote code execution (use with trusted models only)
 
   # Model precision and hardware
-  torch_dtype_str: "float32"                 # Model precision (float32/float16/bfloat16/float64)
-  device_map: "auto"                         # Device placement strategy (auto/null)
-  compile: false                             # JIT compile model (use TrainingParams.compile for training)
+  torch_dtype_str: "float32"                         # Model precision (float32/float16/bfloat16/float64)
+  device_map: "auto"                                 # Device placement strategy (auto/null)
+  compile: false                                     # JIT compile model (use TrainingParams.compile for training)
 
   # Attention and optimization
-  attn_implementation: null                  # Attention impl (null/sdpa/flash_attention_2/eager)
-  enable_liger_kernel: false                 # Enable Liger CUDA kernel for potential speedup
+  attn_implementation: null                          # Attention impl (null/sdpa/flash_attention_2/eager)
+  enable_liger_kernel: false                         # Enable Liger CUDA kernel for potential speedup
 
   # Model behavior
-  chat_template: null                        # Chat formatting template
-  freeze_layers: []                          # Layer names to freeze during training
+  chat_template: null                                # Chat formatting template
+  freeze_layers: []                                  # Layer names to freeze during training
 
   # Additional settings
-  model_kwargs: {}                           # Additional model constructor args
+  model_kwargs: {}                                   # Additional model constructor args
 ```
 
 ### Data Configuration

--- a/docs/user_guides/train/train.md
+++ b/docs/user_guides/train/train.md
@@ -123,7 +123,7 @@ The simplest workflow is to fine-tune a pre-trained model on a dataset. The foll
 
 ```yaml
 model:
-  model_name: "meta-llama/Meta-Llama-3.2-3B-Instruct"  # Replace with your model
+  model_name: "meta-llama/Llama-3.2-3B-Instruct"  # Replace with your model
   trust_remote_code: true
   dtype: "bfloat16"
 
@@ -148,7 +148,7 @@ Excellent results can be achieved at a fraction of the computational cost by fin
 
 ```yaml
 model:
-  model_name: "meta-llama/Meta-Llama-3.2-3B-Instruct"  # Replace with your model
+  model_name: "meta-llama/Llama-3.2-3B-Instruct"  # Replace with your model
   trust_remote_code: true
   dtype: "bfloat16"
 

--- a/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
+++ b/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
@@ -371,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
+++ b/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
@@ -343,7 +343,7 @@
     "  # Filepath to the GGUF model, which we just downloaded, see `model_path` output above\n",
     "  model_name: \"Meta-Llama-3.1-70B-Instruct-Q4_K_S.gguf\"  \n",
     "  # GGUF files do not have a config. We need to specify the tokenizer name manually.\n",
-    "  tokenizer_name: \"meta-llama/Meta-Llama-3.3-70B-Instruct\"  \n",
+    "  tokenizer_name: \"meta-llama/Llama-3.3-70B-Instruct\"  \n",
     "  model_max_length: 512\n",
     "  torch_dtype_str: \"float16\"  # GGUF models require float16\n",
     "  trust_remote_code: True\n",

--- a/scripts/polaris/jobs/llama_tune.sh
+++ b/scripts/polaris/jobs/llama_tune.sh
@@ -156,11 +156,11 @@ elif [ "$MODEL_SIZE" == "8b" ]; then
     # Copy 8B weights from Eagle to local scratch.
     if [ "$TRAINING_MODE" == "pretrain" ]; then
     copyModelToLocalScratch \
-        "models--meta-llama--Meta-Llama-3.1-8B" \
+        "models--meta-llama--Llama-3.1-8B" \
         "8d10549bcf802355f2d6203a33ed27e81b15b9e5"
     else
     copyModelToLocalScratch \
-        "models--meta-llama--Meta-Llama-3.1-8B-Instruct" \
+        "models--meta-llama--Llama-3.1-8B-Instruct" \
         "0e9e39f249a16976918f6564b8830bc894c89659"
     fi
     if [ "$DISTRIBUTION_MODE" == "ddp" ]; then
@@ -188,7 +188,7 @@ elif [ "$MODEL_SIZE" == "8b" ]; then
 elif [ "$MODEL_SIZE" == "70b" ]; then
     # Copy 70B weights from Eagle to local scratch.
     copyModelToLocalScratch \
-        "models--meta-llama--Meta-Llama-3.1-70B-Instruct" \
+        "models--meta-llama--Llama-3.1-70B-Instruct" \
         "945c8663693130f8be2ee66210e062158b2a9693"
 
     if [ "$TRAINING_MODE" == "pretrain" ]; then
@@ -210,7 +210,7 @@ else # 405B
     # Copy 405B weights from Eagle to local scratch. This reduces the total time
     # needed to load the model from 3 hours to 15 min copy + 10 min loading.
     copyModelToLocalScratch \
-        "models--meta-llama--Meta-Llama-3.1-405B-Instruct" \
+        "models--meta-llama--Llama-3.1-405B-Instruct" \
         "be673f326cab4cd22ccfef76109faf68e41aa5f1"
 
     # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf

--- a/scripts/polaris/notebooks/Oumi - Tuning Llama.ipynb
+++ b/scripts/polaris/notebooks/Oumi - Tuning Llama.ipynb
@@ -33,7 +33,7 @@
     "- You have a valid ALCF account with access to Polaris\n",
     "- You're familiar with our tuning flow\n",
     "- You're familiar with how to launch Oumi workflows on Polaris. [Here's a relevant tutorial](https://github.com/oumi-ai/oumi/blob/main/notebooks/Oumi%20-%20Deploying%20a%20Job.ipynb)\n",
-    "- You've signed [Llama's agreement on HuggingFace](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B)"
+    "- You've signed [Llama's agreement on HuggingFace](https://huggingface.co/meta-llama/Llama-3.1-8B)"
    ]
   },
   {

--- a/tests/unit/utils/test_torch_naming_heuristics.py
+++ b/tests/unit/utils/test_torch_naming_heuristics.py
@@ -84,17 +84,17 @@ MODEL_CONFIGS = [
         AutoModelForCausalLM,
     ),
     (
-        "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        "meta-llama/Llama-3.1-8B-Instruct",
         "LlamaDecoderLayer",
         AutoModelForCausalLM,
     ),
     (
-        "meta-llama/Meta-Llama-3.1-70B-Instruct",
+        "meta-llama/Llama-3.1-70B-Instruct",
         "LlamaDecoderLayer",
         AutoModelForCausalLM,
     ),
-    ("meta-llama/Meta-Llama-3-8B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
-    ("meta-llama/Meta-Llama-3-70B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
+    ("meta-llama/Llama-3-8B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
+    ("meta-llama/Llama-3-70B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
     ("microsoft/Phi-3-mini-4k-instruct", "Phi3DecoderLayer", AutoModelForCausalLM),
     # Only available on nightly build
     # ("Qwen/Qwen2-VL-2B-Instruct", "QwenDecoderLayer", AutoModelForVision2Seq),

--- a/tests/unit/utils/test_torch_naming_heuristics.py
+++ b/tests/unit/utils/test_torch_naming_heuristics.py
@@ -84,6 +84,21 @@ MODEL_CONFIGS = [
         AutoModelForCausalLM,
     ),
     (
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "LlamaDecoderLayer",
+        AutoModelForCausalLM,
+    ),
+    (
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "LlamaDecoderLayer",
+        AutoModelForCausalLM,
+    ),
+    (
+        "meta-llama/Llama-3.2-3B-Instruct",
+        "LlamaDecoderLayer",
+        AutoModelForCausalLM,
+    ),
+    (
         "meta-llama/Llama-3.1-8B-Instruct",
         "LlamaDecoderLayer",
         AutoModelForCausalLM,
@@ -93,8 +108,13 @@ MODEL_CONFIGS = [
         "LlamaDecoderLayer",
         AutoModelForCausalLM,
     ),
-    ("meta-llama/Llama-3-8B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
-    ("meta-llama/Llama-3-70B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
+    (
+        "meta-llama/Llama-3.1-405B-Instruct",
+        "LlamaDecoderLayer",
+        AutoModelForCausalLM,
+    ),
+    ("meta-llama/Meta-Llama-3-8B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
+    ("meta-llama/Meta-Llama-3-70B-Instruct", "LlamaDecoderLayer", AutoModelForCausalLM),
     ("microsoft/Phi-3-mini-4k-instruct", "Phi3DecoderLayer", AutoModelForCausalLM),
     # Only available on nightly build
     # ("Qwen/Qwen2-VL-2B-Instruct", "QwenDecoderLayer", AutoModelForVision2Seq),


### PR DESCRIPTION
# Description

Llama 3.1 8B Instruct used to be named `meta-llama/Meta-Llama-3.1-8B-Instruct`, but it's now been renamed to `meta-llama/Llama-3.1-8B-Instruct`, which is how the models have been named in Llama 3.2 and after. The page for the former now redirects to the latter: https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct.

We make the following renames:
- `meta-llama/Meta-Llama-3.1-8B` -> `meta-llama/Llama-3.1-8B`
- `meta-llama/Meta-Llama-3.1-8B-Instruct` -> `meta-llama/Llama-3.1-8B-Instruct`
- `meta-llama/Meta-Llama-3.1-70B-Instruct` -> `meta-llama/Llama-3.1-70B-Instruct`
- `meta-llama/Meta-Llama-3.1-405B-Instruct` -> `meta-llama/Llama-3.1-405B-Instruct`

I also updated references to Llama 2 or 3 to instead use the latest versions.
Tested one of the configs to verify it still works

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
