### PR TITLE
Update transformers version to 4.48

### DIFF
--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
@@ -39,6 +39,8 @@ envs:
   OUMI_RUN_NAME: llama32v.11b.sft
   ACCELERATE_LOG_LEVEL: info
   TOKENIZERS_PARALLELISM: false
+  # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
+  PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 
 setup: |
   set -e

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
@@ -49,9 +49,9 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
-  enable_gradient_checkpointing: True
-  per_device_train_batch_size: 8
-  gradient_accumulation_steps: 1
+  enable_gradient_checkpointing: False
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 4
   max_steps: 20
 
   gradient_checkpointing_kwargs:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
@@ -49,6 +49,8 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
+  # TODO: OPE-875 - Re-enable. Currently broken at `transformers==4.48.2`.
+  # GitHub issue: https://github.com/huggingface/transformers/issues/36040.
   enable_gradient_checkpointing: False
   per_device_train_batch_size: 2
   gradient_accumulation_steps: 4

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
@@ -39,6 +39,8 @@ envs:
   OUMI_RUN_NAME: llama32v.11b.sft.lora
   ACCELERATE_LOG_LEVEL: info
   TOKENIZERS_PARALLELISM: false
+  # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
+  PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 
 setup: |
   set -e

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -36,10 +36,10 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
-  enable_gradient_checkpointing: True
+  enable_gradient_checkpointing: False
   use_peft: True
-  per_device_train_batch_size: 16
-  gradient_accumulation_steps: 1
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 8
   max_steps: 10 # Train for a few steps only (demonstration purposes)
 
   gradient_checkpointing_kwargs:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -36,6 +36,8 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
+  # TODO: OPE-875 - Re-enable. Currently broken at `transformers==4.48.2`.
+  # GitHub issue: https://github.com/huggingface/transformers/issues/36040.
   enable_gradient_checkpointing: False
   use_peft: True
   per_device_train_batch_size: 2

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
@@ -39,6 +39,8 @@ envs:
   OUMI_RUN_NAME: llama32v.90b.sft
   ACCELERATE_LOG_LEVEL: info
   TOKENIZERS_PARALLELISM: false
+  # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
+  PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 
 setup: |
   set -e

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -36,8 +36,8 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
-  enable_gradient_checkpointing: True
-  per_device_train_batch_size: 1
+  enable_gradient_checkpointing: False
+  per_device_train_batch_size: 2
   max_steps: 5 # Train for a few steps only (demonstration purposes)
 
   gradient_checkpointing_kwargs:

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -36,6 +36,8 @@ data:
 training:
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
+  # TODO: OPE-875 - Re-enable. Currently broken at `transformers==4.48.2`.
+  # GitHub issue: https://github.com/huggingface/transformers/issues/36040.
   enable_gradient_checkpointing: False
   per_device_train_batch_size: 2
   max_steps: 5 # Train for a few steps only (demonstration purposes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ dependencies = [
     "tqdm",
     # NOTE: Liger kernel will soon deprecate support for versions < 4.46.1.
     # https://github.com/linkedin/Liger-Kernel/blob/5c5a7b4f67772f2196efd69d0821b28c0e4ac45e/src/liger_kernel/transformers/monkey_patch.py#L40
-    "transformers>=4.45.2,<4.46",
-    "trl>=0.11.4,<0.12",
+    "transformers>=4.48.0,<4.49",
+    "trl>=0.13.0,<0.14",
     "typer",                      # Used by CLI
     "typing_extensions",          # Backports of typing updates to python 3.9
     "wandb>=0.19.3,<0.20",        # Logging to Weights and Biases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,8 @@ dependencies = [
     "torchdata>=0.9.0,<0.10.0",  # Used by data pipes loader
     "torchvision>=0.20.0,<0.21", # Used by some VLM-s (multimodal)
     "tqdm",
-    # NOTE: Liger kernel will soon deprecate support for versions < 4.46.1.
-    # https://github.com/linkedin/Liger-Kernel/blob/5c5a7b4f67772f2196efd69d0821b28c0e4ac45e/src/liger_kernel/transformers/monkey_patch.py#L40
-    "transformers>=4.48.0,<4.49",
+    # Llama vision attention is broken in 4.48.0.
+    "transformers>=4.48.2,<4.49",
     "trl>=0.13.0,<0.14",
     "typer",                      # Used by CLI
     "typing_extensions",          # Backports of typing updates to python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,9 @@ dependencies = [
     "torchdata>=0.9.0,<0.10.0",  # Used by data pipes loader
     "torchvision>=0.20.0,<0.21", # Used by some VLM-s (multimodal)
     "tqdm",
-    # Llama vision attention is broken in 4.48.0.
-    "transformers>=4.48.2,<4.49",
+    # Llama vision attention is broken as late as 4.48.2 if gradient checkpointing is
+    # enabled. See OPE-875 and https://github.com/huggingface/transformers/issues/36040.
+    "transformers>=4.48.0,<4.49",
     "trl>=0.13.0,<0.14",
     "typer",                      # Used by CLI
     "typing_extensions",          # Backports of typing updates to python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "torchdata>=0.9.0,<0.10.0",  # Used by data pipes loader
     "torchvision>=0.20.0,<0.21", # Used by some VLM-s (multimodal)
     "tqdm",
-    # Llama vision attention is broken as late as 4.48.2 if gradient checkpointing is
+    # Llama Vision attention is broken as late as 4.48.2 if gradient checkpointing is
     # enabled. See OPE-875 and https://github.com/huggingface/transformers/issues/36040.
     "transformers>=4.48.0,<4.49",
     "trl>=0.13.0,<0.14",

--- a/scripts/benchmarks/minimal_fsdp_training.py
+++ b/scripts/benchmarks/minimal_fsdp_training.py
@@ -74,7 +74,7 @@ def test_fsdp_trainer():
     # Initialize trainer
     trainer = Trainer(
         model=model,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         args=training_params,
         train_dataset=dataset,
         fsdp_params=fsdp_params,
@@ -92,7 +92,7 @@ def test_fsdp_trainer():
     new_model = MLPEncoder(input_dim=1024, hidden_dim=128, output_dim=1024)
     new_trainer = Trainer(
         model=new_model,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         args=training_params,
         train_dataset=dataset,
         fsdp_params=fsdp_params,

--- a/scripts/benchmarks/minimal_multimodal_training.py
+++ b/scripts/benchmarks/minimal_multimodal_training.py
@@ -249,7 +249,7 @@ def test_multimodal_trainer(
 
     trainer = Trainer(
         model=model,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         args=training_params,
         train_dataset=dataset,
         fsdp_params=fsdp_params,

--- a/src/oumi/core/trainers/oumi_trainer.py
+++ b/src/oumi/core/trainers/oumi_trainer.py
@@ -77,7 +77,7 @@ class Trainer(BaseTrainer):
     def __init__(
         self,
         model: torch.nn.Module,
-        tokenizer: Optional[BaseTokenizer],
+        processing_class: Optional[BaseTokenizer],
         args: TrainingParams,
         train_dataset: Dataset,
         processor: Optional[BaseProcessor] = None,
@@ -96,7 +96,7 @@ class Trainer(BaseTrainer):
         self.start_time = time.perf_counter()
         self.collator_fn = data_collator
 
-        self.tokenizer = tokenizer
+        self.processing_class = processing_class
         self._processor = processor
         self.params = copy.deepcopy(args)
         self.train_dataset = train_dataset
@@ -317,10 +317,10 @@ class Trainer(BaseTrainer):
 
                 # Count tokens on CPU.
                 with self._telemetry_block("computing tokens"):
-                    if self.tokenizer is not None and "input_ids" in batch:
+                    if self.processing_class is not None and "input_ids" in batch:
                         num_tokens = (
                             batch["input_ids"]
-                            .ne(self.tokenizer.pad_token_id)
+                            .ne(self.processing_class.pad_token_id)
                             .sum()
                             .item()
                         )

--- a/src/oumi/models/layers/ring_attention.py
+++ b/src/oumi/models/layers/ring_attention.py
@@ -118,9 +118,11 @@ def new_decoder_forward(
     **kwargs,
 ) -> tuple[torch.FloatTensor, Optional[tuple[torch.FloatTensor, torch.FloatTensor]]]:
     """New decoder forward."""
+    # Was originally LlamaFlashAttention2, but this was deleted in transformers 4.48.0.
     assert isinstance(
         self.self_attn,
         transformers_models.llama.modeling_llama.LlamaAttention,
+        # Ditto but with MistralFlashAttention2.
     ) or isinstance(
         self.self_attn,
         transformers_models.mistral.modeling_mistral.MistralAttention,

--- a/src/oumi/models/layers/ring_attention.py
+++ b/src/oumi/models/layers/ring_attention.py
@@ -120,10 +120,10 @@ def new_decoder_forward(
     """New decoder forward."""
     assert isinstance(
         self.self_attn,
-        transformers_models.llama.modeling_llama.LlamaFlashAttention2,
+        transformers_models.llama.modeling_llama.LlamaAttention,
     ) or isinstance(
         self.self_attn,
-        transformers_models.mistral.modeling_mistral.MistralFlashAttention2,
+        transformers_models.mistral.modeling_mistral.MistralAttention,
     ), (
         "Please toggle on the Flash Attention 2 implementation "
         "when using zigzag ring attention monkey patch."

--- a/tests/integration/models/test_integration_cnn_classifier.py
+++ b/tests/integration/models/test_integration_cnn_classifier.py
@@ -302,7 +302,7 @@ def test_basic_training_and_prediction():
 
         trainer = Trainer(
             model=model,
-            tokenizer=None,  # No tokenizer! The custom model is non-textual
+            processing_class=None,  # No tokenizer! The custom model is non-textual
             args=training_params,
             train_dataset=test_data.train_dataset,
             dataloader_num_workers=2,

--- a/tests/integration/train/test_custom_models.py
+++ b/tests/integration/train/test_custom_models.py
@@ -80,7 +80,7 @@ def test_train_native_pt_model_from_api():
 
         trainer = Trainer(
             model=model,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             args=training_args,
             train_dataset=dataset,
         )

--- a/tests/unit/core/trainers/test_oumi_trainer.py
+++ b/tests/unit/core/trainers/test_oumi_trainer.py
@@ -106,7 +106,7 @@ def mock_params():
 def trainer(model, mock_tokenizer, mock_params, mock_dataset):
     return Trainer(
         model=model,
-        tokenizer=mock_tokenizer,
+        processing_class=mock_tokenizer,
         processor=None,
         args=mock_params,
         train_dataset=mock_dataset,
@@ -121,7 +121,7 @@ def test_trainer_initialization(
     trainer, model, mock_tokenizer, mock_params, mock_dataset
 ):
     assert trainer.model == model
-    assert trainer.tokenizer == mock_tokenizer
+    assert trainer.processing_class == mock_tokenizer
     assert trainer.params == mock_params
     assert trainer.train_dataset == mock_dataset
     assert trainer.eval_dataset == mock_dataset
@@ -311,7 +311,7 @@ def test_cuda_initialization(model, mock_tokenizer, mock_params, mock_dataset):
     assert next(model.parameters()).is_cpu
     trainer = Trainer(
         model=model,
-        tokenizer=mock_tokenizer,
+        processing_class=mock_tokenizer,
         processor=None,
         args=mock_params,
         train_dataset=mock_dataset,
@@ -326,7 +326,7 @@ def test_mps_initialization(model, mock_tokenizer, mock_params, mock_dataset):
     assert next(model.parameters()).is_cpu, "Model should initially be on CPU"
     trainer = Trainer(
         model=model,
-        tokenizer=mock_tokenizer,
+        processing_class=mock_tokenizer,
         processor=None,
         args=mock_params,
         train_dataset=mock_dataset,


### PR DESCRIPTION
# Description

Llama vision attention is still broken. Nikolai determined it occurs when gradient checkpointing is enabled, and filed an issue here: https://github.com/huggingface/transformers/issues/36040.

Since this can be worked around, and only affects one family of models, we still want to upgrade the version. 4.45 is 4 months old, and we need newer transformers versions to support new vision models.

We attempted this previously, and reverted it in #1111 due to the same issue.

Main code changes required are:
- Rename `tokenizer` to `processing_class`
- Update some attention class names due to HF Transformers' attention refactor https://github.com/huggingface/transformers/pull/35235

## Related issues

Fixes OPE-738, OPE-875
Towards OPE-1018

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
