### PR TITLE
Upgrade omegaconf to 2.4.0dev3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dependencies = [
     "jsonlines",
     "lm_eval[wandb]>=0.4.5,<0.5.0",
     "numpy>=1.26.4,<2.0",
-    "omegaconf>=2.3.0,<2.4",
+    # The latest stable version, 2.3.0, is two years old and is causing dependency
+    # conflicts. We'll use the dev version until a new stable version is released.
+    # See https://github.com/oumi-ai/oumi/issues/1377
+    "omegaconf==2.4.0dev3",
     "packaging",
     "pandas>=2.0.3,<3",
     "peft>=0.14.0,<0.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # The latest stable version, 2.3.0, is two years old and is causing dependency
     # conflicts. We'll use the dev version until a new stable version is released.
     # See https://github.com/oumi-ai/oumi/issues/1377
-    "omegaconf==2.4.0dev3",
+    "omegaconf>=2.4.0dev3,<2.5",
     "packaging",
     "pandas>=2.0.3,<3",
     "peft>=0.14.0,<0.15",


### PR DESCRIPTION
# Description

The last stable version of omegaconf is two years old and is causing dependency issues with azure. It's in maintenance mode, and there's no certainty on when the next stable version will release, so we'll upgrade to the dev version for now (which is a year old).

Tested that `pip install '.[azure]'` works in a fresh conda env, and that a simple training job works.

## Related issues

Fixes #1377

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
