### PR TITLE
Remove uneeded env vars from job configs

### DIFF
--- a/configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/gcp_job.yaml
@@ -26,7 +26,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: fineweb.pt.fsdp
-  ACCELERATE_LOG_LEVEL: info
 
 setup: |
   set -e

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -33,6 +33,7 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3.8b.aya.fft
+  TOKENIZERS_PARALLELISM: true
 
 setup: |
   set -e

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -33,7 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3.8b.aya.fft
-  TOKENIZERS_PARALLELISM: true
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
@@ -29,9 +29,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3.1_8B_hsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
@@ -33,9 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama405b.lora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
@@ -32,9 +32,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama405b.qlora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
   # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
   PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 

--- a/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
@@ -39,9 +39,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.fft.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
@@ -28,9 +28,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.lora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
@@ -32,9 +32,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.qlora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
@@ -29,9 +29,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama8b.fft
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama8b.lora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
@@ -29,9 +29,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama8b.lora
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama8b.qlora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
@@ -28,9 +28,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.fft.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
@@ -28,9 +28,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.fft
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.lora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.lora
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.qlora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
@@ -27,9 +27,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama3b.qlora
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
@@ -41,9 +41,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.fft.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
@@ -32,9 +32,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.lora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
@@ -32,9 +32,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama70b.qlora.fsdp
-  ACCELERATE_LOG_LEVEL: info
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/smollm/sft/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/gcp_job.yaml
@@ -21,8 +21,6 @@ working_dir: .
 
 envs:
   OUMI_RUN_NAME: smollm135m.train
-  # https://github.com/huggingface/tokenizers/issues/899#issuecomment-1027739758
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
@@ -37,8 +37,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama32v.11b.sft
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
   # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
   PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
@@ -37,8 +37,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama32v.11b.sft.lora
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
   # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
   PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
@@ -37,8 +37,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llama32v.90b.sft
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
   # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
   PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 

--- a/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
@@ -33,8 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llava.7b.fft.oumi
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
@@ -33,8 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: llava.7b.fft.trl
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/oumi_gcp_job.yaml
@@ -37,8 +37,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: phi3.fft.oumi
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/vision/phi3/sft/trl_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/trl_gcp_job.yaml
@@ -37,8 +37,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: phi3.fft.trl
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/gcp_job.yaml
@@ -33,8 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: qwen2-vl.fft.oumi
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
   # https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
   PYTORCH_CUDA_ALLOC_CONF: "garbage_collection_threshold:0.8,max_split_size_mb:128"
 

--- a/configs/recipes/vision/smolvlm/sft/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/gcp_job.yaml
@@ -33,8 +33,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: smolvlm.fft.oumi
-  ACCELERATE_LOG_LEVEL: info
-  TOKENIZERS_PARALLELISM: false
 
 setup: |
   set -e

--- a/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
+++ b/src/experimental/configs/recipes/phi3/dpo/fsdp_gcp_job.yaml
@@ -25,7 +25,6 @@ file_mounts:
 envs:
   WANDB_PROJECT: oumi-train
   OUMI_RUN_NAME: phi3.dpo.nvidia.24g.fsdp
-  ACCELERATE_LOG_LEVEL: info
 
 setup: |
   set -e


### PR DESCRIPTION
# Description

ACCELERATE_LOG_LEVEL and TOKENIZERS_PARALLELISM are set in https://github.com/oumi-ai/oumi/blob/06a6ad4296ecbb329b815285d6c152835f46c7f5/src/oumi/cli/cli_utils.py#L97. We can remove them from our configs to reduce fluff.

## Related issues

Towards OPE-1022

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
