### PR TITLE
Add Kubernetes support for quick deployment

### DIFF
--- a/docs/user_guides/launch/deploy.md
+++ b/docs/user_guides/launch/deploy.md
@@ -13,7 +13,6 @@ Try using our sample helloworld job for this tutorial:
 ```{literalinclude} ../../../configs/examples/misc/hello_world_gcp_job.yaml
 :language: yaml
 ```
-````
 `````
 
 Let's get started with launching a job! Don't worry about the nitty-gritty&mdash;we'll
@@ -199,3 +198,85 @@ job_config.setup = "pip install oumi"
 ```
 :::
 ::::
+
+## Deploying on Kubernetes
+
+You can also deploy your job on a Kubernetes cluster using Helm or Timoni. Follow the instructions below to get started.
+
+### Using Helm
+
+1. Install Helm if you haven't already. Follow the instructions [here](https://helm.sh/docs/intro/install/).
+
+2. Create a `values.yaml` file with the following content:
+
+```yaml
+replicaCount: 1
+
+image:
+  repository: oumi/launcher
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+```
+
+3. Deploy the Helm chart:
+
+```shell
+helm install oumi kubernetes/helm -f values.yaml
+```
+
+### Using Timoni
+
+1. Install Timoni if you haven't already. Follow the instructions [here](https://timoni.sh/docs/installation/).
+
+2. Create a `values.yaml` file with the following content:
+
+```yaml
+replicaCount: 1
+
+image:
+  repository: oumi/launcher
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+```
+
+3. Deploy the Timoni module:
+
+```shell
+timoni apply -f kubernetes/timoni/module.yaml -f values.yaml
+```

--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: oumi
+description: A Helm chart for deploying Oumi on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/kubernetes/helm/templates/deployment.yaml
+++ b/kubernetes/helm/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oumi.fullname" . }}
+  labels:
+    {{- include "oumi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oumi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oumi.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/kubernetes/helm/templates/service.yaml
+++ b/kubernetes/helm/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oumi.fullname" . }}
+  labels:
+    {{- include "oumi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+  selector:
+    {{- include "oumi.selectorLabels" . | nindent 4 }}

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -1,0 +1,24 @@
+replicaCount: 1
+
+image:
+  repository: oumi/launcher
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/kubernetes/timoni/module.yaml
+++ b/kubernetes/timoni/module.yaml
@@ -1,0 +1,80 @@
+apiVersion: timoni.sh/v1alpha1
+kind: Module
+metadata:
+  name: oumi
+  version: 0.1.0
+  description: A Timoni module for deploying Oumi on Kubernetes
+  maintainers:
+    - name: Oumi Team
+      email: support@oumi.ai
+spec:
+  values:
+    - name: replicaCount
+      type: int
+      default: 1
+      description: Number of replicas for the deployment
+    - name: image
+      type: object
+      properties:
+        repository:
+          type: string
+          default: oumi/launcher
+          description: Docker image repository
+        tag:
+          type: string
+          default: latest
+          description: Docker image tag
+        pullPolicy:
+          type: string
+          default: IfNotPresent
+          description: Image pull policy
+    - name: service
+      type: object
+      properties:
+        type:
+          type: string
+          default: ClusterIP
+          description: Service type
+        port:
+          type: int
+          default: 80
+          description: Service port
+    - name: resources
+      type: object
+      properties:
+        limits:
+          type: object
+          properties:
+            cpu:
+              type: string
+              default: 100m
+              description: CPU limit
+            memory:
+              type: string
+              default: 128Mi
+              description: Memory limit
+        requests:
+          type: object
+          properties:
+            cpu:
+              type: string
+              default: 100m
+              description: CPU request
+            memory:
+              type: string
+              default: 128Mi
+              description: Memory request
+    - name: nodeSelector
+      type: object
+      default: {}
+      description: Node selector for pod scheduling
+    - name: tolerations
+      type: array
+      items:
+        type: object
+      default: []
+      description: Tolerations for pod scheduling
+    - name: affinity
+      type: object
+      default: {}
+      description: Affinity rules for pod scheduling

--- a/kubernetes/timoni/templates/deployment.yaml
+++ b/kubernetes/timoni/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oumi
+  labels:
+    app: oumi
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: oumi
+  template:
+    metadata:
+      labels:
+        app: oumi
+    spec:
+      containers:
+        - name: oumi
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              cpu: "{{ .Values.resources.limits.cpu }}"
+              memory: "{{ .Values.resources.limits.memory }}"
+            requests:
+              cpu: "{{ .Values.resources.requests.cpu }}"
+              memory: "{{ .Values.resources.requests.memory }}"
+      nodeSelector: {{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations: {{ toYaml .Values.tolerations | indent 8 }}
+      affinity: {{ toYaml .Values.affinity | indent 8 }}

--- a/kubernetes/timoni/templates/service.yaml
+++ b/kubernetes/timoni/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oumi
+  labels:
+    app: oumi
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+  selector:
+    app: oumi

--- a/kubernetes/timoni/values.yaml
+++ b/kubernetes/timoni/values.yaml
@@ -1,0 +1,24 @@
+replicaCount: 1
+
+image:
+  repository: oumi/launcher
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -37,6 +37,8 @@ def _get_sky_cloud_from_job(job: JobConfig) -> sky.clouds.Cloud:
         return sky.clouds.AWS()
     elif job.resources.cloud == SkyClient.SupportedClouds.AZURE.value:
         return sky.clouds.Azure()
+    elif job.resources.cloud == SkyClient.SupportedClouds.KUBERNETES.value:
+        return sky.clouds.Kubernetes()
     raise ValueError(f"Unsupported cloud: {job.resources.cloud}")
 
 
@@ -121,6 +123,7 @@ class SkyClient:
         GCP = "gcp"
         RUNPOD = "runpod"
         LAMBDA = "lambda"
+        KUBERNETES = "kubernetes"
 
     def launch(
         self, job: JobConfig, cluster_name: Optional[str] = None, **kwargs

--- a/tests/integration/kubernetes_deployment_test.py
+++ b/tests/integration/kubernetes_deployment_test.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import time
+import unittest
+
+class TestKubernetesDeployment(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.helm_chart_path = "../../kubernetes/helm"
+        cls.timoni_module_path = "../../kubernetes/timoni"
+        cls.values_file = "../../kubernetes/helm/values.yaml"
+
+    def test_helm_deployment(self):
+        # Install Helm chart
+        subprocess.run(["helm", "install", "oumi", self.helm_chart_path, "-f", self.values_file], check=True)
+        time.sleep(10)  # Wait for the deployment to stabilize
+
+        # Check if the deployment is running
+        result = subprocess.run(["kubectl", "get", "deployments"], capture_output=True, text=True)
+        self.assertIn("oumi", result.stdout)
+
+        # Uninstall Helm chart
+        subprocess.run(["helm", "uninstall", "oumi"], check=True)
+
+    def test_timoni_deployment(self):
+        # Apply Timoni module
+        subprocess.run(["timoni", "apply", "-f", os.path.join(self.timoni_module_path, "module.yaml"), "-f", self.values_file], check=True)
+        time.sleep(10)  # Wait for the deployment to stabilize
+
+        # Check if the deployment is running
+        result = subprocess.run(["kubectl", "get", "deployments"], capture_output=True, text=True)
+        self.assertIn("oumi", result.stdout)
+
+        # Delete Timoni module
+        subprocess.run(["timoni", "delete", "-f", os.path.join(self.timoni_module_path, "module.yaml")], check=True)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Related to #1337

Add Kubernetes support for quick deployment using Helm and Timoni.

* **Helm Chart**: Add `kubernetes/helm/Chart.yaml`, `kubernetes/helm/values.yaml`, `kubernetes/helm/templates/deployment.yaml`, and `kubernetes/helm/templates/service.yaml` for Helm-based Kubernetes deployment.
* **Timoni Module**: Add `kubernetes/timoni/module.yaml`, `kubernetes/timoni/values.yaml`, `kubernetes/timoni/templates/deployment.yaml`, and `kubernetes/timoni/templates/service.yaml` for Timoni-based Kubernetes deployment.
* **Documentation**: Update `docs/user_guides/launch/deploy.md` to include instructions for deploying on Kubernetes using Helm and Timoni.
* **SkyPilot Integration**: Modify `src/oumi/launcher/clients/sky_client.py` to integrate SkyPilot's Kubernetes support.
* **Tests**: Add `tests/integration/kubernetes_deployment_test.py` to test Kubernetes deployment configurations.

