### PR TITLE
[tiny] Remove references to missing job configs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,14 @@ You can run jobs remotely on cloud platforms (AWS, Azure, GCP, Lambda, etc.) usi
 # GCP
 oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
 
-# Modify the job config to run on another cluster like AWS
+# AWS
 oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --resources.cloud aws
+
+# Azure
+oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --resources.cloud azure
+
+# Lambda
+oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --resources.cloud lambda
 ```
 
 **Note:** Oumi is in <ins>beta</ins> and under active development. The core features are stable, but some advanced features might change as the platform improves.

--- a/README.md
+++ b/README.md
@@ -93,14 +93,8 @@ You can run jobs remotely on cloud platforms (AWS, Azure, GCP, Lambda, etc.) usi
 # GCP
 oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml
 
-# AWS
-oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_aws_job.yaml
-
-# Azure
-oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_azure_job.yaml
-
-# Lambda
-oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_lambda_job.yaml
+# Modify the job config to run on another cluster like AWS
+oumi launch up -c configs/recipes/smollm/sft/135m/quickstart_gcp_job.yaml --resources.cloud aws
 ```
 
 **Note:** Oumi is in <ins>beta</ins> and under active development. The core features are stable, but some advanced features might change as the platform improves.


### PR DESCRIPTION
# Description

We don't have quickstart job configs for the other cloud providers. Instead of adding them, I opted to override the cloud value instead:
- The configs would have high overlap
- This demonstrates how simple it is to switch clouds from the CLI
- Takes up less real estate on the README page

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
