### PR TITLE
Create `pad_to_max_dim_and_stack()` function in torch_utils

### DIFF
--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -490,7 +490,7 @@ def _get_dims_min_max_size(tensors_list: list[torch.Tensor]) -> list[_DimMinMaxS
     ]
 
 
-def _pad_to_max_dim_and_stack(
+def _pad_to_max_dim_and_stack_impl(
     tensors_list: list[torch.Tensor],
     *,
     padding_value: float = 0,
@@ -579,7 +579,7 @@ def pad_to_max_dim_and_stack(
     input_tensors = convert_to_list_of_tensors(tensors_list)
 
     try:
-        return _pad_to_max_dim_and_stack(
+        return _pad_to_max_dim_and_stack_impl(
             input_tensors,
             padding_value=padding_value,
             pad_on_left_side=pad_on_left_side,

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -354,9 +354,16 @@ def convert_to_list_of_tensors(values: list[T]) -> list[torch.Tensor]:
 def _pad_sequences_impl(
     sequences: list[torch.Tensor], *, padding_value: float = 0
 ) -> torch.Tensor:
-    return torch.nn.utils.rnn.pad_sequence(
-        sequences, batch_first=True, padding_value=padding_value
-    )
+    try:
+        return torch.nn.utils.rnn.pad_sequence(
+            sequences, batch_first=True, padding_value=padding_value
+        )
+    except RuntimeError:
+        logger.error(
+            "Failed to collate sequences with the shapes: "
+            + ", ".join([f"{t.shape}" for t in sequences])
+        )
+        raise
 
 
 def pad_sequences_right_side(
@@ -438,6 +445,146 @@ def pad_sequences(
 
     raise ValueError(
         f"Unsupported padding side: '{padding_side}'. Valid values: 'right', 'left'."
+    )
+
+
+class _DimMinMaxSizes(NamedTuple):
+    dim_index: int
+
+    min_size: int
+    max_size: int
+
+    @property
+    def has_variable_sizes(self) -> bool:
+        return self.min_size != self.max_size
+
+
+def _get_dims_min_max_size(tensors_list: list[torch.Tensor]) -> list[_DimMinMaxSizes]:
+    num_tensors = len(tensors_list)
+    if num_tensors <= 0:
+        return []
+
+    first_shape = tensors_list[0].shape
+
+    min_dim_sizes = list(first_shape)
+    max_dim_sizes = list(first_shape)
+    num_dims = len(min_dim_sizes)
+
+    for tensor_idx in range(num_tensors - 1):
+        curr_shape = tensors_list[tensor_idx + 1].shape
+        if num_dims != len(curr_shape):
+            raise ValueError(
+                "Tensors have different number of dimensions: "
+                f"{num_dims} vs {len(curr_shape)}! "
+                f"Shapes: {first_shape}, {curr_shape}"
+            )
+        for idx in range(num_dims):
+            min_dim_sizes[idx] = min(min_dim_sizes[idx], curr_shape[idx])
+            max_dim_sizes[idx] = max(max_dim_sizes[idx], curr_shape[idx])
+
+    return [
+        _DimMinMaxSizes(
+            dim_index=idx, min_size=min_dim_sizes[idx], max_size=max_dim_sizes[idx]
+        )
+        for idx in range(num_dims)
+    ]
+
+
+def _stack_and_pad_to_max_dim(
+    tensors_list: list[torch.Tensor],
+    *,
+    padding_value: float = 0,
+    pad_on_left_side: bool = False,
+) -> torch.Tensor:
+    num_tensors = len(tensors_list)
+    if num_tensors == 0:
+        raise ValueError("Empty list of tensors is not allowed.")
+    dim_sizes: list[_DimMinMaxSizes] = _get_dims_min_max_size(tensors_list)
+    all_same_size = all((not item.has_variable_sizes) for item in dim_sizes)
+    if all_same_size:
+        # No need to pad anything, just `stack()`.
+        return torch.stack(tensors_list)
+
+    max_dim_sizes = [item.max_size for item in dim_sizes]
+    result_shape = torch.Size([num_tensors] + max_dim_sizes)
+
+    result = torch.full(
+        result_shape,
+        padding_value,
+        dtype=tensors_list[0].dtype,
+        device=tensors_list[0].device,
+    )
+
+    max_dim_sizes = torch.Size(max_dim_sizes)
+    for i, input_tensor in enumerate(tensors_list):
+        target = result.select(0, i)
+        if max_dim_sizes == input_tensor.shape:
+            target[...] = input_tensor
+            continue
+
+        target_view = target[...]
+
+        if pad_on_left_side:
+            for dim_idx, curr_size in enumerate(input_tensor.shape):
+                max_size = max_dim_sizes[dim_idx]
+                if curr_size < max_size:
+                    target_view = target_view.narrow(
+                        dim_idx, start=(max_size - curr_size), length=curr_size
+                    )
+        else:
+            for dim_idx, curr_size in enumerate(input_tensor.shape):
+                max_size = max_dim_sizes[dim_idx]
+                if curr_size < max_size:
+                    target_view = target_view.narrow(dim_idx, start=0, length=curr_size)
+
+        assert target_view.shape == input_tensor.shape
+        target_view[...] = input_tensor
+
+    return result
+
+
+def stack_and_pad_to_max_dim(
+    tensors_list: list[T],
+    *,
+    padding_value: float = 0,
+    padding_side: Optional[str] = None,
+) -> torch.Tensor:
+    """Stacks variable-length tensors to a single tensor with dimension expansion.
+
+    Some examples:
+    1) Two tensors with shapes [24,8], [32,8] are combined to [2,32,8].
+    2) Two tensors with shapes [24,1,8], [32,4,8] are combined to [2,32,4,8].
+    3) Three tensors with shapes [7,3,5],[8,2,6],[9,1,7] are combined to [3,9,3,7].
+
+    For 1D input tensors, the function is equivalent to `pad_sequences()`.
+
+    If all tensors have the same shape and no padding is required, then the function
+    is equivalent to `torch.stack()`.
+
+    Args:
+        tensors_list: list of tensors with potentially .
+        padding_value: value for padded elements. Default: 0.
+        padding_side: side to apply padding to. Valid values:  'right', 'left'.
+
+    Returns:
+        A tensor with shape (B, L, ...), where B is a batch size (`len(sequences)`),
+        L is the longest length (`max(len(sequences[i]))`)
+    """
+    pad_on_left_side: bool = False
+    if not padding_side or padding_side == "right":
+        pad_on_left_side = False
+    elif padding_side == "left":
+        pad_on_left_side = True
+    else:
+        raise ValueError(
+            f"Unsupported padding side: '{padding_side}'. "
+            "Valid values: 'right', 'left'."
+        )
+
+    input_tensors = convert_to_list_of_tensors(tensors_list)
+
+    return _stack_and_pad_to_max_dim(
+        input_tensors, padding_value=padding_value, pad_on_left_side=pad_on_left_side
     )
 
 

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -490,7 +490,7 @@ def _get_dims_min_max_size(tensors_list: list[torch.Tensor]) -> list[_DimMinMaxS
     ]
 
 
-def _stack_and_pad_to_max_dim(
+def _pad_to_max_dim_and_stack(
     tensors_list: list[torch.Tensor],
     *,
     padding_value: float = 0,
@@ -543,7 +543,7 @@ def _stack_and_pad_to_max_dim(
     return result
 
 
-def stack_and_pad_to_max_dim(
+def pad_to_max_dim_and_stack(
     tensors_list: list[T],
     *,
     padding_value: float = 0,
@@ -583,7 +583,7 @@ def stack_and_pad_to_max_dim(
 
     input_tensors = convert_to_list_of_tensors(tensors_list)
 
-    return _stack_and_pad_to_max_dim(
+    return _pad_to_max_dim_and_stack(
         input_tensors, padding_value=padding_value, pad_on_left_side=pad_on_left_side
     )
 

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -524,18 +524,13 @@ def _pad_to_max_dim_and_stack(
 
         target_view = target[...]
 
-        if pad_on_left_side:
-            for dim_idx, curr_size in enumerate(input_tensor.shape):
-                max_size = max_dim_sizes[dim_idx]
-                if curr_size < max_size:
-                    target_view = target_view.narrow(
-                        dim_idx, start=(max_size - curr_size), length=curr_size
-                    )
-        else:
-            for dim_idx, curr_size in enumerate(input_tensor.shape):
-                max_size = max_dim_sizes[dim_idx]
-                if curr_size < max_size:
-                    target_view = target_view.narrow(dim_idx, start=0, length=curr_size)
+        for dim_idx, curr_size in enumerate(input_tensor.shape):
+            max_size = max_dim_sizes[dim_idx]
+            if curr_size < max_size:
+                start_idx = (max_size - curr_size) if pad_on_left_side else 0
+                target_view = target_view.narrow(
+                    dim_idx, start=start_idx, length=curr_size
+                )
 
         assert target_view.shape == input_tensor.shape
         target_view[...] = input_tensor

--- a/src/oumi/utils/torch_utils.py
+++ b/src/oumi/utils/torch_utils.py
@@ -360,7 +360,7 @@ def _pad_sequences_impl(
         )
     except RuntimeError:
         logger.error(
-            "Failed to collate sequences with the shapes: "
+            "Failed to pad and stack sequences with the shapes: "
             + ", ".join([f"{t.shape}" for t in sequences])
         )
         raise
@@ -583,9 +583,18 @@ def pad_to_max_dim_and_stack(
 
     input_tensors = convert_to_list_of_tensors(tensors_list)
 
-    return _pad_to_max_dim_and_stack(
-        input_tensors, padding_value=padding_value, pad_on_left_side=pad_on_left_side
-    )
+    try:
+        return _pad_to_max_dim_and_stack(
+            input_tensors,
+            padding_value=padding_value,
+            pad_on_left_side=pad_on_left_side,
+        )
+    except RuntimeError:
+        logger.error(
+            "Failed to pad and stack tensors with the shapes: "
+            + ", ".join([f"{t.shape}" for t in input_tensors])
+        )
+        raise
 
 
 def create_ones_like(

--- a/tests/unit/utils/test_torch_utils.py
+++ b/tests/unit/utils/test_torch_utils.py
@@ -15,7 +15,7 @@ from oumi.utils.torch_utils import (
     pad_sequences,
     pad_sequences_left_side,
     pad_sequences_right_side,
-    stack_and_pad_to_max_dim,
+    pad_to_max_dim_and_stack,
 )
 
 
@@ -122,13 +122,13 @@ def test_pad_sequences_right_side(padding_value: int):
     # Verify `stack_and_pad_to_max_dim()` returns exact same result for 1D sequences.
     assert np.all(
         result.numpy()
-        == stack_and_pad_to_max_dim(
+        == pad_to_max_dim_and_stack(
             test_sequences, padding_side="right", padding_value=padding_value
         ).numpy()
     )
     assert np.all(
         result.numpy()
-        == stack_and_pad_to_max_dim(test_sequences, padding_value=padding_value).numpy()
+        == pad_to_max_dim_and_stack(test_sequences, padding_value=padding_value).numpy()
     )
 
 
@@ -158,7 +158,7 @@ def test_pad_sequences_left_side(padding_value: int):
     # Verify `stack_and_pad_to_max_dim()` returns exact same result for 1D sequences.
     assert np.all(
         result.numpy()
-        == stack_and_pad_to_max_dim(
+        == pad_to_max_dim_and_stack(
             test_sequences, padding_side="left", padding_value=padding_value
         ).numpy()
     )
@@ -167,7 +167,7 @@ def test_pad_sequences_left_side(padding_value: int):
 def test_stack_and_pad_to_max_dim_invalid_side():
     test_sequences = [[1, 2, 3, 4], [5], [6, 7]]
     with pytest.raises(ValueError, match="Unsupported padding side: 'top'"):
-        stack_and_pad_to_max_dim(test_sequences, padding_side="top", padding_value=1)
+        pad_to_max_dim_and_stack(test_sequences, padding_side="top", padding_value=1)
 
 
 def test_stack_and_pad_to_max_dim_incompatible_dimensionality():
@@ -179,7 +179,7 @@ def test_stack_and_pad_to_max_dim_incompatible_dimensionality():
             "Shapes: torch.Size([4]), torch.Size([2, 2])"
         ),
     ):
-        stack_and_pad_to_max_dim(test_sequences, padding_value=1)
+        pad_to_max_dim_and_stack(test_sequences, padding_value=1)
 
 
 @pytest.mark.parametrize(
@@ -188,7 +188,7 @@ def test_stack_and_pad_to_max_dim_incompatible_dimensionality():
 )
 def test_stack_and_pad_to_max_dim_right_side(padding_value):
     test_sequences = [torch.ones([5, 1, 2]), torch.full([3, 2, 1], 2)]
-    result = stack_and_pad_to_max_dim(test_sequences, padding_value=padding_value)
+    result = pad_to_max_dim_and_stack(test_sequences, padding_value=padding_value)
     assert result.shape == (2, 5, 2, 2)
 
     expected = torch.full((2, 5, 2, 2), padding_value)
@@ -209,7 +209,7 @@ def test_stack_and_pad_to_max_dim_left_side(padding_value):
         torch.full([3, 2, 1, 1], 2),
         torch.full([1, 1, 1, 1], -3),
     ]
-    result = stack_and_pad_to_max_dim(
+    result = pad_to_max_dim_and_stack(
         test_sequences, padding_side="left", padding_value=padding_value
     )
     assert result.shape == (3, 5, 2, 2, 1)

--- a/tests/unit/utils/test_torch_utils.py
+++ b/tests/unit/utils/test_torch_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 import torch
@@ -13,6 +15,7 @@ from oumi.utils.torch_utils import (
     pad_sequences,
     pad_sequences_left_side,
     pad_sequences_right_side,
+    stack_and_pad_to_max_dim,
 )
 
 
@@ -87,6 +90,12 @@ def test_convert_to_list_of_tensors_from_tensors():
     assert np.all(result[2].numpy() == np.asarray([6, 7]))
 
 
+def test_pad_sequences_invalid_side():
+    test_sequences = [[1, 2, 3, 4], [5], [6, 7]]
+    with pytest.raises(ValueError, match="Unsupported padding side: 'bottom'"):
+        pad_sequences(test_sequences, padding_side="bottom", padding_value=1)
+
+
 @pytest.mark.parametrize(
     "padding_value",
     [0, -100, 7],
@@ -108,6 +117,18 @@ def test_pad_sequences_right_side(padding_value: int):
         == pad_sequences(
             test_sequences, padding_side="right", padding_value=padding_value
         ).numpy()
+    )
+
+    # Verify `stack_and_pad_to_max_dim()` returns exact same result for 1D sequences.
+    assert np.all(
+        result.numpy()
+        == stack_and_pad_to_max_dim(
+            test_sequences, padding_side="right", padding_value=padding_value
+        ).numpy()
+    )
+    assert np.all(
+        result.numpy()
+        == stack_and_pad_to_max_dim(test_sequences, padding_value=padding_value).numpy()
     )
 
 
@@ -133,6 +154,73 @@ def test_pad_sequences_left_side(padding_value: int):
             test_sequences, padding_side="left", padding_value=padding_value
         ).numpy()
     )
+
+    # Verify `stack_and_pad_to_max_dim()` returns exact same result for 1D sequences.
+    assert np.all(
+        result.numpy()
+        == stack_and_pad_to_max_dim(
+            test_sequences, padding_side="left", padding_value=padding_value
+        ).numpy()
+    )
+
+
+def test_stack_and_pad_to_max_dim_invalid_side():
+    test_sequences = [[1, 2, 3, 4], [5], [6, 7]]
+    with pytest.raises(ValueError, match="Unsupported padding side: 'top'"):
+        stack_and_pad_to_max_dim(test_sequences, padding_side="top", padding_value=1)
+
+
+def test_stack_and_pad_to_max_dim_incompatible_dimensionality():
+    test_sequences = [[1, 2, 3, 4], [5], [[6, 7], [8, 9]]]
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Tensors have different number of dimensions: 1 vs 2! "
+            "Shapes: torch.Size([4]), torch.Size([2, 2])"
+        ),
+    ):
+        stack_and_pad_to_max_dim(test_sequences, padding_value=1)
+
+
+@pytest.mark.parametrize(
+    "padding_value",
+    [0, -100, 7],
+)
+def test_stack_and_pad_to_max_dim_right_side(padding_value):
+    test_sequences = [torch.ones([5, 1, 2]), torch.full([3, 2, 1], 2)]
+    result = stack_and_pad_to_max_dim(test_sequences, padding_value=padding_value)
+    assert result.shape == (2, 5, 2, 2)
+
+    expected = torch.full((2, 5, 2, 2), padding_value)
+    expected[0, :, :1, :] = 1
+    expected[1, :3, :, :1] = 2
+    assert np.all(
+        result.numpy() == expected.numpy()
+    ), f"result: {result} expected: {expected}"
+
+
+@pytest.mark.parametrize(
+    "padding_value",
+    [0, -100, 7],
+)
+def test_stack_and_pad_to_max_dim_left_side(padding_value):
+    test_sequences = [
+        torch.ones([5, 1, 2, 1]),
+        torch.full([3, 2, 1, 1], 2),
+        torch.full([1, 1, 1, 1], -3),
+    ]
+    result = stack_and_pad_to_max_dim(
+        test_sequences, padding_side="left", padding_value=padding_value
+    )
+    assert result.shape == (3, 5, 2, 2, 1)
+
+    expected = torch.full((3, 5, 2, 2, 1), padding_value)
+    expected[0, :, -1:, :, :] = 1
+    expected[1, -3:, :, -1:, :] = 2
+    expected[2, -1:, -1:, -1:, :] = -3
+    assert np.all(
+        result.numpy() == expected.numpy()
+    ), f"result: {result} expected: {expected}"
 
 
 def test_create_ones_from_empty():


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

-- The function pads input tensors to maximum size in each dimension, then stacks them
-- This is similar to `pad_sequences()` except it can pad to more than one dimension, which is needed e.g., for `cross_attention_mask` which has two variable dimensions: `seq_len`, `num_images` for multi-image multimodal examples
-- The integration of this new function into data pipeline is coming in a separate PR.
-- Minor error logging improvements in padding utils

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards OPE-355

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [X] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [X] Did you link the issue(s) related to this PR in the section above?
- [X] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
