### PR TITLE
Additional HF trainer parameters for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 
 # Mac
 .DS_Store
+
+# VS Code Workspace
+oumi.code-workspace

--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -267,8 +267,9 @@ class TrainingParams(BaseParams):
     https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
     for more details. If using distributed training,
     this will override ddp_find_unused_parameters to False and will
-    also use ddp_broadcast_buffers. Note that this will not guarantee
-    reproducibility, but will help to reduce the variance between runs.
+    also use ddp_broadcast_buffers, and disable gradient checkpointing.
+    Note that this will not guarantee full reproducibility,
+    but will help to reduce the variance between runs.
     """
 
     full_determinism: bool = False
@@ -624,6 +625,9 @@ class TrainingParams(BaseParams):
         dispatch_batches = self.dataloader_main_process_only
 
         if self.use_deterministic:
+            self.enable_gradient_checkpointing = (
+                False  # Fails ddp_broadcast_buffers=True
+            )
             dispatch_batches = False  # Prevents dynamic batch redistribution
             self.ddp_find_unused_parameters = False  # Helps with determinism in DDP
             ddp_broadcast_buffers = True  # Ensures consistent buffer states

--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -254,8 +254,8 @@ class TrainingParams(BaseParams):
 
     data_seed: int = 42
     """Random data_seed used for initialization.
-    The seed to use for the underlying generator when using 
-    use_seedable_sampler. If None, the generator will use 
+    The seed to use for the underlying generator when using
+    use_seedable_sampler. If None, the generator will use
     the current default seed from torch.
     Used only by the HuggingFace trainers.
     """
@@ -267,7 +267,7 @@ class TrainingParams(BaseParams):
     https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
     for more details. If using a HF compatible trainer,
     this will also set full_determinism to True. If using distributed training,
-    this will override ddp_find_unused_parameters to False and will 
+    this will override ddp_find_unused_parameters to False and will
     also use ddp_broadcast_buffers. Note that this will not guarantee
     reproducibility, but will help to reduce the variance between runs.
     """
@@ -509,9 +509,9 @@ class TrainingParams(BaseParams):
 
     dataloader_persistent_workers: bool = False
     """Whether to use persistent workers for data loading (HF Trainers only).
-    If True, the data loader will not shut down the worker processes after 
-    a dataset has been consumed once. This allows to maintain the workers 
-    Dataset instances alive. Can potentially speed up training, but will 
+    If True, the data loader will not shut down the worker processes after
+    a dataset has been consumed once. This allows to maintain the workers
+    Dataset instances alive. Can potentially speed up training, but will
     increase RAM usage. Will default to False.
     """
 
@@ -620,8 +620,8 @@ class TrainingParams(BaseParams):
         if self.use_deterministic:
             full_determinism = True
             dispatch_batches = False  # Prevents dynamic batch redistribution
-            self.ddp_find_unused_parameters = False # Helps with determinism in DDP
-            ddp_broadcast_buffers = True      # Ensures consistent buffer states
+            self.ddp_find_unused_parameters = False  # Helps with determinism in DDP
+            ddp_broadcast_buffers = True  # Ensures consistent buffer states
         else:
             full_determinism = False
             ddp_broadcast_buffers = None


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

Passed in several new parameters to HF Trainer. Added new behavior to use_deterministic to make it more deterministic in distributed training environments. Resolves OPE-891.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
