### PR TITLE
Make the tulu3 unit tests hermetic.

### DIFF
--- a/tests/unit/datasets/test_tulu3_sft_mixture.py
+++ b/tests/unit/datasets/test_tulu3_sft_mixture.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from oumi.core.types.conversation import Conversation, Role
@@ -29,20 +31,22 @@ def invalid_role_tulu_entry():
 
 
 def test_tulu3_mixture_dataset(sample_tulu_entry):
-    dataset = Tulu3MixtureDataset()
-    conversation = dataset.transform_conversation(sample_tulu_entry)
-    assert isinstance(conversation, Conversation)
-    assert len(conversation.messages) == 3
-    assert conversation.messages[0].role == Role.SYSTEM
-    assert conversation.messages[1].role == Role.USER
-    assert conversation.messages[2].role == Role.ASSISTANT
-    for converted, original in zip(
-        conversation.messages, sample_tulu_entry["messages"]
-    ):
-        assert converted.content == original["content"]
+    with mock.patch.object(Tulu3MixtureDataset, "__init__", return_value=None) as _:
+        dataset = Tulu3MixtureDataset()
+        conversation = dataset.transform_conversation(sample_tulu_entry)
+        assert isinstance(conversation, Conversation)
+        assert len(conversation.messages) == 3
+        assert conversation.messages[0].role == Role.SYSTEM
+        assert conversation.messages[1].role == Role.USER
+        assert conversation.messages[2].role == Role.ASSISTANT
+        for converted, original in zip(
+            conversation.messages, sample_tulu_entry["messages"]
+        ):
+            assert converted.content == original["content"]
 
 
 def test_tulu3_mixture_dataset_throws_valueerror_on_bad_role(invalid_role_tulu_entry):
-    dataset = Tulu3MixtureDataset()
-    with pytest.raises(ValueError):
-        dataset.transform_conversation(invalid_role_tulu_entry)
+    with mock.patch.object(Tulu3MixtureDataset, "__init__", return_value=None) as _:
+        dataset = Tulu3MixtureDataset()
+        with pytest.raises(ValueError):
+            dataset.transform_conversation(invalid_role_tulu_entry)


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
I noticed that occasional unit test runs were timing out. The root cause is that the tulu3 dataset loads real data in its initializer. However, the test only tests instance methods that are stateless.

I've mocked out the `__init__` method to make these tests hermetic.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

N/A

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
