### PR TITLE
[tiny] Add warning that Oumi doesn't support Intel Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,12 @@ help:
 	@echo "  doctest           - Run doctests on documentation files"
 	@echo "  doctest-file      - Run doctests on a specific documentation file"
 
+# If we detect the system is an Intel Mac, print an error message and exit.
 setup:
+	@if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+		echo "Cannot install oumi on Intel Macs because Pytorch has deprecated support for them!"; \
+		exit 1; \
+	fi
 	@if command -v conda >/dev/null 2>&1; then \
 		if conda env list | grep -q "^$(CONDA_ENV) "; then \
 			echo "Conda environment '$(CONDA_ENV)' already exists. Updating dependencies..."; \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ help:
 # If we detect the system is an Intel Mac, print an error message and exit.
 setup:
 	@if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
-		echo "Cannot install oumi on Intel Macs because Pytorch has deprecated support for them!"; \
+		echo "Cannot install oumi on Intel Macs because PyTorch has deprecated support for them!"; \
 		exit 1; \
 	fi
 	@if command -v conda >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -46,38 +46,39 @@ help:
 
 # If we detect the system is an Intel Mac, print an error message and exit.
 setup:
-	@if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
-		echo "Cannot install oumi on Intel Macs because PyTorch dropped support for them!"; \
-		exit 1; \
-	fi
-	@if command -v conda >/dev/null 2>&1; then \
-		if conda env list | grep -q "^$(CONDA_ENV) "; then \
-			echo "Conda environment '$(CONDA_ENV)' already exists. Updating dependencies..."; \
-			$(CONDA_RUN) pip install -U uv; \
-			$(CONDA_RUN) uv pip install -U -e ".[dev]"; \
-		else \
-			echo "Creating new conda environment '$(CONDA_ENV)'..."; \
-			conda create -n $(CONDA_ENV) python=3.11 -y; \
-			$(CONDA_RUN) pip install uv; \
-			$(CONDA_RUN) uv pip install -e ".[dev]"; \
-			$(CONDA_RUN) pre-commit install; \
-			$(CONDA_RUN) python -m ipykernel install --user --name $(CONDA_ENV); \
+	@bash -c '\
+		if [ "$$(uname -s)" = "Darwin" ] && [ "$$(uname -m)" = "x64_64" ]; then \
+			echo "Cannot install Oumi on Intel Macs because PyTorch dropped support for that platform!"; \
+			exit 1; \
 		fi; \
-	else \
-		echo "Error: Conda is not installed or not in PATH."; \
-		echo "Please run 'make install-miniconda' to install Miniconda, then run 'make setup' again."; \
-		exit 1; \
-	fi
-	@echo "Installation complete. Testing if oumi package can be imported..."
-	@if $(CONDA_RUN) python -c "import oumi" >/dev/null 2>&1; then \
-		echo "oumi package imported successfully!"; \
-		echo "To start using your new environment, run: \"conda activate $(CONDA_ENV)\"."; \
-		echo "Happy fine-tuning!"; \
-	else \
-		echo "Error: Failed to import oumi package. Please check your installation."; \
-		echo "Please open an issue at https://github.com/oumi-ai/oumi/issues if the problem persists."; \
-		exit 1; \
-	fi
+		if command -v conda >/dev/null 2>&1; then \
+			if conda env list | grep -q "^$(CONDA_ENV) "; then \
+				echo "Conda environment $(CONDA_ENV) already exists. Updating dependencies..."; \
+				$(CONDA_RUN) pip install -U uv; \
+				$(CONDA_RUN) uv pip install -U -e ".[dev]"; \
+			else \
+				echo "Creating new conda environment $(CONDA_ENV)..."; \
+				conda create -n $(CONDA_ENV) python=3.11 -y; \
+				$(CONDA_RUN) pip install uv; \
+				$(CONDA_RUN) uv pip install -e ".[dev]"; \
+				$(CONDA_RUN) pre-commit install; \
+				$(CONDA_RUN) python -m ipykernel install --user --name $(CONDA_ENV); \
+			fi; \
+		else \
+			echo "Error: Conda is not installed or not in PATH."; \
+			echo "Please run `make install-miniconda` to install Miniconda, then run `make setup` again."; \
+			exit 1; \
+		fi; \
+		echo "Installation complete. Testing if oumi package can be imported..."; \
+		if $(CONDA_RUN) python -c "import oumi" >/dev/null 2>&1; then \
+			echo "oumi package imported successfully!"; \
+			echo "To start using your new environment, run: \"conda activate $(CONDA_ENV)\"."; \
+			echo "Happy fine-tuning!"; \
+		else \
+			echo "Error: Failed to import oumi package. Please check your installation."; \
+			echo "Please open an issue at https://github.com/oumi-ai/oumi/issues if the problem persists."; \
+			exit 1; \
+		fi'
 
 install-miniconda:
 	@bash -c '\

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ help:
 # If we detect the system is an Intel Mac, print an error message and exit.
 setup:
 	@if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
-		echo "Cannot install oumi on Intel Macs because PyTorch has deprecated support for them!"; \
+		echo "Cannot install oumi on Intel Macs because PyTorch dropped support for them!"; \
 		exit 1; \
 	fi
 	@if command -v conda >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ pip install oumi[gpu]  # For GPU training
 pip install git+https://github.com/oumi-ai/oumi.git
 ```
 
+❗NOTE: Since PyTorch dropped support for Intel Macs, you cannot install Oumi there. Consider running Oumi on free Colab GPU instances, using our notebooks above!
+
 For more advanced installation options, see the [installation guide](https://oumi.ai/docs/en/latest/get_started/installation.html).
 
 

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -4,6 +4,8 @@ This guide will help you install Oumi and its dependencies.
 
 ## Requirements
 
+❗NOTE: Since PyTorch dropped support for Intel Macs, you cannot install Oumi there. Consider running Oumi on free Colab GPU instances, using our {doc}`notebook tutorials </get_started/tutorials>`!
+
 Before installing Oumi, ensure you have the following:
 
 - Python 3.9 or later


### PR DESCRIPTION
# Description

PyTorch dropped support for Intel Macs around a year ago, and since we use the latest Pytorch version, Oumi can't be installed on that platform.

Tested that the Makefile error works.

## Related issues

Fixes #1416

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
