### PR TITLE
Fix Oumi launcher to be able to run on RunPod and Lambda

### DIFF
--- a/docs/user_guides/launch/launch.md
+++ b/docs/user_guides/launch/launch.md
@@ -537,7 +537,7 @@ To stop the cluster when you are done to avoid extra charges, run:
 oumi launch stop --cluster my-cluster
 ```
 
-In addition, the Oumi launcher automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running.
+In addition, the Oumi launcher automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running. Note that this isn't done for clouds that don't support stopping jobs, like RunPod and Lambda.
 
 Stopped clusters preserve their disk, and are quicker to initialize than turning up a brand new cluster. Stopped clusters can be automatically restarted by specifying them in an `oumi launch up` command.
 
@@ -558,7 +558,7 @@ import oumi.launcher as launcher
 launcher.stop(cloud_name="gcp", cluster_name="my-cluster")
 ```
 
-In addition, Oumi automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running.
+In addition, Oumi automatically sets [`idle_minutes_to_autostop`](https://docs.skypilot.co/en/latest/reference/api.html#sky.launch) to 60, i.e. clusters will stop automatically after 60 minutes of no jobs running. Note that this isn't done for clouds that don't support stopping jobs, like RunPod and Lambda.
 
 Stopped clusters preserve their disk, and are quicker to initialize than turning up a brand new cluster. Stopped clusters can be automatically restarted by specifying them in a `launcher.up(...)` command.
 

--- a/src/oumi/core/configs/job_config.py
+++ b/src/oumi/core/configs/job_config.py
@@ -100,11 +100,12 @@ class JobResources:
     Ignored by Polaris.
     """
 
-    disk_tier: Optional[str] = "medium"
+    disk_tier: Optional[str] = None
     """Disk tier to use for OS (optional).
 
-    For sky-based clouds this Could be one of 'low', 'medium', 'high' or 'best'
-    (default: 'medium').
+    For sky-based clouds this Could be one of 'low', 'medium', 'high', 'ultra', or
+    'best' (default: None). As of Feb '25, only AWS, Azure, GCP, and OCI support
+    disk tiers.
     """
 
 

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -23,7 +23,7 @@ def _get_default_job(cloud: str) -> JobConfig:
         cloud=cloud,
         region="us-central1",
         zone=None,
-        accelerators="A100-80",
+        accelerators="A100-80GB",
         cpus="4",
         memory="64",
         instance_type=None,
@@ -124,6 +124,35 @@ def test_sky_client_launch(
             cluster_name=None,
             detach_run=True,
             idle_minutes_to_autostop=60,
+        )
+
+
+def test_sky_client_launch_no_stop(
+    mock_sky_data_storage,
+):
+    with patch("sky.launch") as mock_launch:
+        job = _get_default_job("runpod")
+        job.resources.region = "ca"
+        job.resources.disk_tier = "best"
+        mock_resource_handle = Mock()
+        mock_resource_handle.cluster_name = "mycluster"
+        mock_launch.return_value = (1, mock_resource_handle)
+        client = SkyClient()
+        job_status = client.launch(job)
+        expected_job_status = JobStatus(
+            name="",
+            id="1",
+            cluster="mycluster",
+            status="",
+            metadata="",
+            done=False,
+        )
+        assert job_status == expected_job_status
+        mock_launch.assert_called_once_with(
+            ANY,
+            cluster_name=None,
+            detach_run=True,
+            idle_minutes_to_autostop=None,
         )
 
 


### PR DESCRIPTION
# Description

Two bug fixes were made to enable running on RunPod and Lambda:

1. Change the default value of `disk_tier` from "medium" to None. This is because only AWS, Azure, GCP, and OCI support low/medium/high disk tiers, and the rest only support "best'.
    - This should still default to medium in SkyPilot, for clouds that support it I assume: https://github.com/skypilot-org/skypilot/blob/8ee8230c5519d42d0ac8fb9203f01a8950377f92/sky/resources.py#L140.
    - IMO we can also set the default value to "best", as disk cost is likely minimal compared to GPU cost, and using higher tiers makes disk I/O less likely to bottleneck.
2. Only set autostop if the cloud supports it. RunPod and Lambda both don't support it. Referencing this code: https://github.com/skypilot-org/skypilot/blob/aa3c387f04fbdd4468751b7d66fcb381bd3449dc/sky/clouds/cloud.py#L592

Tested that launching on RunPod works with these fixes.

## Related issues

Fixes #1458 
Fixes #1459 
Fixes #1461 

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?