### PR TITLE
Fix local models to not break the registry.

### DIFF
--- a/src/oumi/core/registry/registry.py
+++ b/src/oumi/core/registry/registry.py
@@ -67,15 +67,11 @@ def _load_user_requirements(requirements_file: str):
                 continue
             import_count += 1
             import_path = Path(line)
-            logger.debug(f"Loading user-defined registry module: {import_path}")
-            mod_name = f"oumi_registry_user_defined_module_{idx}"
-            spec = importlib.util.spec_from_file_location(mod_name, import_path)
-            if not spec or not spec.loader:
-                raise ImportError(f"Failed to load user-defined module: {line}")
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[mod_name] = module
+            logger.info(f"Loading user-defined registry module: {import_path}")
+            mod_name = import_path.stem
+            sys.path.append(str(import_path.parent))
             try:
-                spec.loader.exec_module(module)
+                importlib.import_module(mod_name)
             except Exception as e:
                 logger.error(
                     "Failed to load a user-defined module in "


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Previously we were loading external deps using an arbitrary module name. This had the benefit of preventing of preventing module conflicts, but the downside of python not being able to recognize when a module was already imported.

For custom models, this led to a scenario where a module would be imported twice, causing python to try to register the model 2x with Oumi. This is currently a fatal error, and crashes out.

The new change temporarily appends the directory of the python module to the user's sys path (this is reset when the python session ends). This means local references to the module will now resolve properly. The main downside here is that users must be careful that their *.py files don't conflict with any other packages they need (like `pathlib`, `time`, etc).
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes #1475

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
