### PR TITLE
[tiny]Update trl to 0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     # Llama Vision attention is broken as late as 4.48.2 if gradient checkpointing is
     # enabled. See OPE-875 and https://github.com/huggingface/transformers/issues/36040.
     "transformers>=4.48.0,<4.49",
-    "trl>=0.13.0,<0.14",
+    "trl>=0.15.0,<0.16",
     "typer",                      # Used by CLI
     "typing_extensions",          # Backports of typing updates to python 3.9
     "wandb>=0.19.3,<0.20",        # Logging to Weights and Biases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     # Llama Vision attention is broken as late as 4.48.2 if gradient checkpointing is
     # enabled. See OPE-875 and https://github.com/huggingface/transformers/issues/36040.
     "transformers>=4.48.0,<4.49",
-    "trl>=0.15.0,<0.16",
+    "trl>=0.14.0,<0.15",
     "typer",                      # Used by CLI
     "typing_extensions",          # Backports of typing updates to python 3.9
     "wandb>=0.19.3,<0.20",        # Logging to Weights and Biases.


### PR DESCRIPTION
# Description

This is needed for the GRPO trainer., which was added in 0.14.0. We'd ideally like to upgrade to the latest, 0.15.1, which seems to have a decent number of updates to GRPOTrainer. However, 0.15.0 changes the SFTTrainer to only accept HF datasets or a ConstantLengthDataset. Our custom PyTorch datasets thus no longer work, and additional time is needed to do a migration to fix this.

Release history:
- 0.13.0: 12/16/24
- 0.14.0: 1/29/25
- 0.15.0: 2/13/25
- 0.15.1: 2/18/25

TRL release notes: https://github.com/huggingface/trl/releases. At a glance, there doesn't seem to be any other breaking changes for this version update.

Tested by running `configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml` and `configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml` as a sanity check.

## Related issues

Towards #1351

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
