### PR TITLE
Fix a bug where overriding remote_params fails via the CLI (oumi infer)

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -366,6 +366,17 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         headers[_AUTHORIZATION_KEY] = f"Bearer {self._get_api_key(remote_params)}"
         return headers
 
+    def _set_required_fields_for_inference(self, remote_params: RemoteParams):
+        """Set required fields for inference."""
+        if not remote_params.api_url:
+            remote_params.api_url = self._remote_params.api_url or self.base_url
+        if not remote_params.api_key_env_varname:
+            remote_params.api_key_env_varname = (
+                self._remote_params.api_key_env_varname or self.api_key_env_varname
+            )
+        if not remote_params.api_key:
+            remote_params.api_key = self._remote_params.api_key
+
     async def _query_api(
         self,
         conversation: Conversation,
@@ -393,10 +404,7 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             generation_params = inference_config.generation or self._generation_params
             output_path = inference_config.output_path
 
-        if not remote_params.api_url:
-            remote_params.api_url = self._remote_params.api_url or self.base_url
-
-        # Validate API URL one final time.
+        self._set_required_fields_for_inference(remote_params)
         if not remote_params.api_url:
             raise ValueError("API URL is required for remote inference.")
         async with semaphore:

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -365,7 +365,8 @@ def test_infer_online_falls_back_to_default_url():
 
 def test_infer_online_falls_back_to_default_api_key():
     def callback(url, **kwargs):
-        assert "Bearer xyz"
+        # Verify our headers
+        assert kwargs["headers"]["Authorization"] == "Bearer 1234"
 
     with aioresponses() as m:
         m.post(
@@ -381,6 +382,7 @@ def test_infer_online_falls_back_to_default_api_key():
                     }
                 ]
             ),
+            callback=callback,
         )
 
         engine = RemoteInferenceEngine(
@@ -435,7 +437,85 @@ def test_infer_online_falls_back_to_default_api_key():
             inference_config,
         )
         assert expected_result == result
-        m.assert_called_once_with("foo")
+
+
+def test_infer_online_falls_back_to_default_api_key_env_varname(monkeypatch):
+    def callback(url, **kwargs):
+        # Verify our headers
+        assert kwargs["headers"]["Authorization"] == "Bearer 4321"
+
+    monkeypatch.setenv("NEW_API_KEY_VAR", "4321")
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=200,
+            payload=dict(
+                choices=[
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "The first time I saw",
+                        }
+                    }
+                ]
+            ),
+            callback=callback,
+        )
+
+        engine = RemoteInferenceEngine(
+            model_params=_get_default_model_params(),
+            remote_params=RemoteParams(
+                api_url=_TARGET_SERVER, api_key_env_varname="NEW_API_KEY_VAR"
+            ),
+        )
+        conversation = Conversation(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        ContentItem(
+                            content="Hello world!",
+                            type=Type.TEXT,
+                        ),
+                        ContentItem(
+                            content="/tmp/hello/again.png",
+                            binary=b"a binary image",
+                            type=Type.IMAGE_PATH,
+                        ),
+                        ContentItem(
+                            content="a url for our image",
+                            type=Type.IMAGE_URL,
+                        ),
+                        ContentItem(
+                            binary=b"a binary image",
+                            type=Type.IMAGE_BINARY,
+                        ),
+                    ],
+                ),
+            ],
+            metadata={"foo": "bar"},
+            conversation_id="123",
+        )
+        expected_result = [
+            Conversation(
+                messages=[
+                    *conversation.messages,
+                    Message(
+                        content="The first time I saw",
+                        role=Role.ASSISTANT,
+                    ),
+                ],
+                metadata={"foo": "bar"},
+                conversation_id="123",
+            )
+        ]
+        inference_config = _get_default_inference_config()
+        inference_config.remote_params = None
+        result = engine.infer_online(
+            [conversation],
+            inference_config,
+        )
+        assert expected_result == result
 
 
 def test_infer_no_remote_params_api_url():

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -363,6 +363,81 @@ def test_infer_online_falls_back_to_default_url():
         assert expected_result == result
 
 
+def test_infer_online_falls_back_to_default_api_key():
+    def callback(url, **kwargs):
+        assert "Bearer xyz"
+
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=200,
+            payload=dict(
+                choices=[
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "The first time I saw",
+                        }
+                    }
+                ]
+            ),
+        )
+
+        engine = RemoteInferenceEngine(
+            model_params=_get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, api_key="1234"),
+        )
+        conversation = Conversation(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        ContentItem(
+                            content="Hello world!",
+                            type=Type.TEXT,
+                        ),
+                        ContentItem(
+                            content="/tmp/hello/again.png",
+                            binary=b"a binary image",
+                            type=Type.IMAGE_PATH,
+                        ),
+                        ContentItem(
+                            content="a url for our image",
+                            type=Type.IMAGE_URL,
+                        ),
+                        ContentItem(
+                            binary=b"a binary image",
+                            type=Type.IMAGE_BINARY,
+                        ),
+                    ],
+                ),
+            ],
+            metadata={"foo": "bar"},
+            conversation_id="123",
+        )
+        expected_result = [
+            Conversation(
+                messages=[
+                    *conversation.messages,
+                    Message(
+                        content="The first time I saw",
+                        role=Role.ASSISTANT,
+                    ),
+                ],
+                metadata={"foo": "bar"},
+                conversation_id="123",
+            )
+        ]
+        inference_config = _get_default_inference_config()
+        inference_config.remote_params = None
+        result = engine.infer_online(
+            [conversation],
+            inference_config,
+        )
+        assert expected_result == result
+        m.assert_called_once_with("foo")
+
+
 def test_infer_no_remote_params_api_url():
     with pytest.raises(ValueError, match="API URL is required for remote inference."):
         engine = RemoteInferenceEngine(


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

During inference, `oumi infer` would fail if the user specified any remote_params via the CLI for wrapper engines (engines that inherit from the RemoteInferenceEngine). This is because the merged config specified at inference time had `None` values for required API fields.

Updated the infer method to gracefully fallback to previous values if `None` values are detected at runtime.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

N/A

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
