### PR TITLE
Switch eval yaml configs to use evaluation_platform

### DIFF
--- a/configs/projects/aya/evaluation/eval.yaml
+++ b/configs/projects/aya/evaluation/eval.yaml
@@ -22,59 +22,59 @@ model:
   attn_implementation: "sdpa"
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_ar
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_zh
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_en
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_fr
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_de
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_hi
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_id
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_it
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_pt
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_ro
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_ru
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_es
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_uk
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: m_mmlu_vi
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/eval.yaml
@@ -25,7 +25,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/eval.yaml
@@ -25,7 +25,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_1_5b/eval.yaml
@@ -25,7 +25,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/eval.yaml
@@ -25,7 +25,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/gpt2/evaluation/async_eval.yaml
+++ b/configs/recipes/gpt2/evaluation/async_eval.yaml
@@ -27,7 +27,7 @@ evaluation:
 
   tasks:
     # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-    - evaluation_backend: lm_harness
+    - evaluation_platform: lm_harness
       task_name: mmlu_college_computer_science
       eval_kwargs:
         num_fewshot: 5

--- a/configs/recipes/llama3_1/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_eval.yaml
@@ -28,7 +28,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/llama3_1/evaluation/8b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_eval.yaml
@@ -27,7 +27,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/llama3_2/evaluation/1b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/1b_eval.yaml
@@ -27,7 +27,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/llama3_2/evaluation/3b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/3b_eval.yaml
@@ -27,7 +27,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/llama3_3/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_eval.yaml
@@ -28,7 +28,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/phi3/evaluation/eval.yaml
+++ b/configs/recipes/phi3/evaluation/eval.yaml
@@ -19,27 +19,27 @@ model:
 
 # HuggingFace Leaderboard V1
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: arc_challenge
     eval_kwargs:
       num_fewshot: 25
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: winogrande
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: hellaswag
     eval_kwargs:
       num_fewshot: 10
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: truthfulqa_mc2
     eval_kwargs:
       num_fewshot: 0
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: gsm8k
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/qwq/evaluation/eval.yaml
+++ b/configs/recipes/qwq/evaluation/eval.yaml
@@ -25,7 +25,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/smollm/evaluation/135m/eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/eval.yaml
@@ -22,7 +22,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_eval.yaml
@@ -33,27 +33,27 @@ generation:
 ########################################################################################
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: arc_challenge
     eval_kwargs:
       num_fewshot: 25
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: winogrande
     eval_kwargs:
       num_fewshot: 5
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: hellaswag
     eval_kwargs:
       num_fewshot: 10
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: truthfulqa_mc2
     eval_kwargs:
       num_fewshot: 0
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: gsm8k
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_eval.yaml
@@ -37,18 +37,18 @@ generation:
 ########################################################################################
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: leaderboard_bbh
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: leaderboard_gpqa
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: leaderboard_mmlu_pro
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: leaderboard_musr
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: leaderboard_ifeval
   # # Temporarily disabled due to packaging conflicts
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: leaderboard_math_hard
 
 # NOTE: If you are running this in a remote machine, which is not accessible after the

--- a/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_alpaca_v2_eval.yaml
@@ -25,7 +25,7 @@ generation:
   batch_size: 4
 
 tasks:
-  - evaluation_backend: alpaca_eval
+  - evaluation_platform: alpaca_eval
     num_samples: 3  # Limit the number of eval samples.
     eval_kwargs:
       version: 2.0

--- a/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
+++ b/configs/recipes/smollm/evaluation/135m/quickstart_eval.yaml
@@ -22,7 +22,7 @@ generation:
 
 tasks:
   # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu_college_computer_science
     eval_kwargs:
       num_fewshot: 5

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
@@ -25,71 +25,71 @@ generation:
   batch_size: 1
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: "mmmu_val"
     # num_samples: 100  # Limit the number of eval samples.
     eval_kwargs:
       num_fewshot: 5
   # To enable individual sub-tasks, uncomment the entries of interest below:
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_accounting"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_agriculture"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_architecture_and_engineering"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_art"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_art_theory"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_basic_medical_science"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_biology"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_chemistry"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_clinical_medicine"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_computer_science"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_design"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_diagnostics_and_laboratory_medicine"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_economics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_electronics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_energy_and_power"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_finance"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_geography"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_history"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_literature"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_manage"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_marketing"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_materials"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_math"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_mechanical_engineering"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_music"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_pharmacy"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_physics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_psychology"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_public_health"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_sociology"
 
 enable_wandb: True

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml
@@ -25,72 +25,72 @@ generation:
   batch_size: 2
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmmu_val
     # num_samples: 100  # Limit the number of eval samples.
     eval_kwargs:
       num_fewshot: 5
 
   # To enable individual sub-tasks, uncomment the entries of interest below:
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_accounting"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_agriculture" # This task requires more GPU memory!
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_architecture_and_engineering"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_art"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_art_theory"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_basic_medical_science"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_biology"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_chemistry"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_clinical_medicine"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_computer_science"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_design"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_diagnostics_and_laboratory_medicine"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_economics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_electronics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_energy_and_power"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_finance"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_geography"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_history"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_literature"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_manage"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_marketing"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_materials"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_math"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_mechanical_engineering"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_music"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_pharmacy"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_physics"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_psychology"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_public_health"
-  # - evaluation_backend: lm_harness
+  # - evaluation_platform: lm_harness
   #   task_name: "mmmu_val_sociology"
 
 enable_wandb: True

--- a/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
+++ b/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
@@ -25,7 +25,7 @@ model:
   attn_implementation: "sdpa"
 
 tasks:
-  - evaluation_backend: lm_harness
+  - evaluation_platform: lm_harness
     task_name: mmlu
     eval_kwargs:
       num_fewshot: 5

--- a/src/oumi/core/configs/params/evaluation_params.py
+++ b/src/oumi/core/configs/params/evaluation_params.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
 
-from omegaconf import MISSING
-
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.utils.logging import logger
 
@@ -78,7 +76,7 @@ class EvaluationTaskParams(BaseParams):
             )
     """
 
-    evaluation_backend: str = MISSING
+    evaluation_backend: str = ""
     """The evaluation backend to use for the current task."""
 
     task_name: Optional[str] = None
@@ -150,12 +148,25 @@ class EvaluationTaskParams(BaseParams):
         """Verifies params."""
         if self.num_samples is not None and self.num_samples <= 0:
             raise ValueError("`num_samples` must be None or a positive integer.")
+
+        # Handle deprecated evaluation_platform parameter.
+        if not self.evaluation_platform and not self.evaluation_backend:
+            raise ValueError("`evaluation_backend` must be set!")
+        if (
+            self.evaluation_platform
+            and self.evaluation_backend
+            and self.evaluation_platform != self.evaluation_backend
+        ):
+            raise ValueError(
+                "Conflicting values for `evaluation_platform` and `evaluation_backend`!"
+            )
         if self.evaluation_platform:
             logger.warning(
                 "The input parameter `evaluation_platform` is deprecated. Please use "
                 "`evaluation_backend` instead."
             )
             self.evaluation_backend = self.evaluation_platform
+            self.evaluation_platform = ""
 
 
 @dataclass

--- a/tests/unit/core/evaluation/test_save_utils.py
+++ b/tests/unit/core/evaluation/test_save_utils.py
@@ -138,7 +138,7 @@ def test_save_evaluation_output_empty_results():
         # Run the function to be tested.
         save_evaluation_output(
             backend_name="mock_backend_name",
-            task_params=EvaluationTaskParams(),
+            task_params=EvaluationTaskParams(evaluation_backend="lm_harness"),
             evaluation_result=EvaluationResult(),
             base_output_dir=my_base_output_dir,
             config=EvaluationConfig(),
@@ -172,7 +172,7 @@ def test_save_evaluation_output_missing_backend():
     ):
         save_evaluation_output(
             backend_name="",
-            task_params=EvaluationTaskParams(),
+            task_params=EvaluationTaskParams(evaluation_backend="lm_harness"),
             evaluation_result=EvaluationResult(),
             base_output_dir="",
             config=EvaluationConfig(),

--- a/tests/unit/core/evaluation/test_save_utils.py
+++ b/tests/unit/core/evaluation/test_save_utils.py
@@ -210,7 +210,7 @@ def test_save_evaluation_output_with_preexisting_path(
         # Run the save function to create a new dictionary.
         save_evaluation_output(
             backend_name=backend_dir,
-            task_params=EvaluationTaskParams(),
+            task_params=EvaluationTaskParams(evaluation_backend="lm_harness"),
             evaluation_result=EvaluationResult(),
             base_output_dir=output_temp_dir,
             config=EvaluationConfig(),


### PR DESCRIPTION
# Description

`evaluation_platform` was renamed to `evaluation_backend` throughout our codebase in #1484. This causes an error in all our eval configs at main, which use the YAML config from HEAD but the Oumi package from PyPi (which hasn't picked up this rename).

This PR:
- Renames `evaluation_backend` back to `evaluation_platform` to fix the breakage
- Updates `EvaluationTaskParams` so that `evaluation_backend` is not a required field. This will cause a breakage on main, as our configs don't provide this value anymore. Also updates post_init logic in this class to expect one of the two fields to be populated, not none or both.
- Fixes a test

After the next PyPI push, we can revert this change.

Tested that there's no errors both when using the PyPI package and using source.

## Related issues

Towards OPE-1097

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
