### PR TITLE
Add tokenized example debugging during training

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -33,12 +33,21 @@ from oumi.utils.logging import logger
 _VERY_LARGE_INTEGER = int(1e30)
 
 
+def log_tokenized_example(raw_example, formatted_example, tokenized_example, model_input):
+    """Logs raw, formatted, tokenized examples, and model input for debugging."""
+    logger.debug("Raw Example: %s", raw_example)
+    logger.debug("Formatted Example: %s", formatted_example)
+    logger.debug("Tokenized Example: %s", tokenized_example)
+    logger.debug("Model Input: %s", model_input)
+
+
 def build_data_collator(
     collator_name: str,
     tokenizer: BaseTokenizer,
     *,
     max_length: Optional[int],
     label_ignore_index: Optional[int] = constants.LABEL_IGNORE_INDEX,
+    debug: bool = False,
     **kwargs,
 ) -> Callable:
     """Builds a data collator based on the given collator name.
@@ -57,6 +66,7 @@ def build_data_collator(
             PyTorch convention is to use -100 as the `ignore_index` label. Refer to
             the `ignore_index` parameter of `torch.nn.CrossEntropyLoss()`
             for more details.
+        debug: Whether to enable logging of tokenized examples for debugging.
         **kwargs: Additional keyword arguments to pass to the collator constructor.
 
     Returns:
@@ -92,6 +102,7 @@ def build_data_collator(
             max_length=max_length,
             label_ignore_index=label_ignore_index,
             truncation=enable_truncation,
+            debug=debug,
             **kwargs,
         )
     elif collator_name == "vision_language_with_padding":
@@ -100,6 +111,7 @@ def build_data_collator(
             max_length=max_length,
             label_ignore_index=label_ignore_index,
             truncation=enable_truncation,
+            debug=debug,
             **kwargs,
         )
     elif collator_name == "text_completions_only_with_padding":
@@ -107,6 +119,7 @@ def build_data_collator(
             tokenizer=tokenizer,
             instruction_prefix="<|start_header_id|>user<|end_header_id|>\n\n",
             response_prefix="<|start_header_id|>assistant<|end_header_id|>\n\n",
+            debug=debug,
         )
 
     raise ValueError(f"Unknown data collator name: '{collator_name}'")
@@ -150,5 +163,6 @@ def build_collator_from_config(
         tokenizer=tokenizer,
         max_length=config.model.model_max_length,
         label_ignore_index=label_ignore_index,
+        debug=config.training.debug_tokenized_example,
         **collator_kwargs,
     )

--- a/src/oumi/cli/train.py
+++ b/src/oumi/cli/train.py
@@ -29,6 +29,13 @@ def train(
         ),
     ],
     level: cli_utils.LOG_LEVEL_TYPE = None,
+    debug_tokenized_example: Annotated[
+        bool,
+        typer.Option(
+            default=False,
+            help="Enable logging of tokenized examples during training for debugging.",
+        ),
+    ] = False,
 ):
     """Train a model.
 
@@ -36,6 +43,7 @@ def train(
         ctx: The Typer context object.
         config: Path to the configuration file for training.
         level: The logging level for the specified command.
+        debug_tokenized_example: Enable logging of tokenized examples during training.
     """
     extra_args = cli_utils.parse_extra_cli_args(ctx)
 
@@ -61,6 +69,8 @@ def train(
         config, extra_args, logger=logger
     )
     parsed_config.finalize_and_validate()
+
+    parsed_config.training.debug_tokenized_example = debug_tokenized_example
 
     limit_per_process_memory()
     device_cleanup()

--- a/src/oumi/core/collators/logging_utils.py
+++ b/src/oumi/core/collators/logging_utils.py
@@ -1,0 +1,55 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any
+from oumi.utils.logging import logger
+
+def log_tokenized_example(raw_example: Any, formatted_example: str, tokenized_example: list[tuple[int, str]], model_input: dict[str, Any]):
+    """Logs raw, formatted, tokenized examples, and model input for debugging."""
+    logger.debug("Raw Example: %s", raw_example)
+    logger.debug("Formatted Example: %s", formatted_example)
+    logger.debug("Tokenized Example: %s", tokenized_example)
+    logger.debug("Model Input: %s", model_input)
+
+    # Write the debug information into a nicely-formatted HTML file
+    html_content = f"""
+    <html>
+    <head>
+        <title>Debug Information</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; }}
+            pre {{ background-color: #f4f4f4; padding: 10px; border: 1px solid #ddd; }}
+        </style>
+    </head>
+    <body>
+        <h1>Debug Information</h1>
+        <h2>Raw Example</h2>
+        <pre>{raw_example}</pre>
+        <h2>Formatted Example</h2>
+        <pre>{formatted_example}</pre>
+        <h2>Tokenized Example</h2>
+        <pre>{tokenized_example}</pre>
+        <h2>Model Input</h2>
+        <pre>{model_input}</pre>
+    </body>
+    </html>
+    """
+
+    output_dir = "debug_logs"
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, "debug_info.html")
+    with open(output_file, "w") as f:
+        f.write(html_content)
+    logger.info("Debug information written to %s", output_file)

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -17,13 +17,14 @@ from typing import Any
 import trl
 
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
+from oumi.builders.collators import log_tokenized_example
 
 _INPUT_IDS_KEY = "input_ids"
 
 
 class TextCompletionsCollatorWithPadding:
     def __init__(
-        self, tokenizer: BaseTokenizer, instruction_prefix: str, response_prefix: str
+        self, tokenizer: BaseTokenizer, instruction_prefix: str, response_prefix: str, debug: bool = False
     ):
         """Custom collator for text LLM training.
 
@@ -31,6 +32,7 @@ class TextCompletionsCollatorWithPadding:
         tokenizer: The tokenizer used for encoding the data.
         instruction_prefix: The prefix marking the beginning of the user instruction.
         response_prefix: The prefix marking the beginning of the assistant response.
+        debug: Whether to enable logging of tokenized examples for debugging.
         """
         self._default_collator = trl.DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
@@ -40,6 +42,9 @@ class TextCompletionsCollatorWithPadding:
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:
             raise RuntimeError("Tokenizer doesn't define `pad_token_id`.")
+
+        self._debug = debug
+        self._tokenizer = tokenizer
 
     def _collate(self, inputs: list[Any]) -> dict[str, Any]:
         result = self._default_collator(inputs)
@@ -63,5 +68,14 @@ class TextCompletionsCollatorWithPadding:
 
         # Collate batch prompts.
         collated_text_inputs = self._collate(batch)
+
+        if self._debug:
+            raw_example = batch[0]
+            formatted_example = self._tokenizer.apply_chat_template(raw_example, tokenize=False)
+            tokenized_example = self._tokenizer.apply_chat_template(raw_example)
+            decoded_tokens = [self._tokenizer.decode(t) for t in tokenized_example]
+            tokenized_example = list(zip(tokenized_example, decoded_tokens))
+            model_input = collated_text_inputs
+            log_tokenized_example(raw_example, formatted_example, tokenized_example, model_input)
 
         return collated_text_inputs


### PR DESCRIPTION
Related to #1369

Add functionality to log tokenized examples for debugging during training.

* Add `log_tokenized_example` function in `src/oumi/builders/collators.py` to log raw, formatted, tokenized examples, and model input.
* Modify `build_data_collator` in `src/oumi/builders/collators.py` to accept a `debug` parameter and pass it to the collators.
* Update `build_collator_from_config` in `src/oumi/builders/collators.py` to pass the `debug` parameter from the config to `build_data_collator`.
* Add a new command-line option `--debug-tokenized-example` in `src/oumi/cli/train.py` to enable logging of tokenized examples during training.
* Pass the `debug` flag to the training configuration in `src/oumi/cli/train.py`.
* Modify `TextCollatorWithPadding` in `src/oumi/core/collators/text_collator_with_padding.py` to accept a `debug` parameter and call `log_tokenized_example` in the `__call__` method if `debug` is set to `True`.
* Modify `TextCompletionsCollatorWithPadding` in `src/oumi/core/collators/text_completions_collator_with_padding.py` to accept a `debug` parameter and call `log_tokenized_example` in the `__call__` method if `debug` is set to `True`.

