### PR TITLE
[Evaluation][Custom] Removing restrictions and better error checking

### DIFF
--- a/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
+++ b/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
@@ -275,7 +275,7 @@
     "\n",
     "\n",
     "@register_evaluation_function(\"my_custom_evaluation\")\n",
-    "def my_custom_evaluation(task_params, config, inference_engine, dataset):\n",
+    "def my_custom_evaluation(inference_engine, dataset):\n",
     "    \"\"\"Custom evaluation function registered as `my_custom_evaluation`.\"\"\"\n",
     "    # Run inference to generate the model responses.\n",
     "    conversations = inference_engine.infer(dataset.conversations())\n",

--- a/src/oumi/core/evaluation/evaluator.py
+++ b/src/oumi/core/evaluation/evaluator.py
@@ -130,7 +130,7 @@ class Evaluator:
 
         # Redirect the evaluation execution to the appropriate evaluation backend.
         if evaluation_backend == EvaluationBackend.LM_HARNESS:
-            lm_harness_task_params = Evaluator._get_backend_task_params(task_params)
+            lm_harness_task_params = self._get_backend_task_params(task_params)
             assert isinstance(lm_harness_task_params, LMHarnessTaskParams)
 
             # Destroy the inference engine, if created by a previous task. LM Harness
@@ -145,7 +145,7 @@ class Evaluator:
                 **kwargs,  # random_seed, numpy_random_seed, torch_random_seed
             )
         elif evaluation_backend == EvaluationBackend.ALPACA_EVAL:
-            alpaca_eval_task_params = Evaluator._get_backend_task_params(task_params)
+            alpaca_eval_task_params = self._get_backend_task_params(task_params)
             assert isinstance(alpaca_eval_task_params, AlpacaEvalTaskParams)
 
             evaluation_result = evaluate_alpaca_eval(
@@ -156,9 +156,9 @@ class Evaluator:
             )
         elif evaluation_backend == EvaluationBackend.CUSTOM:
             evaluation_fn_name = task_params.task_name or ""
-            evaluation_fn = Evaluator._get_custom_evaluation_fn(evaluation_fn_name)
-            custom_kwargs = Evaluator._merge_kwargs(kwargs, task_params.eval_kwargs)
-            Evaluator._validate_custom_kwargs(
+            evaluation_fn = self._get_custom_evaluation_fn(evaluation_fn_name)
+            custom_kwargs = self._merge_kwargs(kwargs, task_params.eval_kwargs)
+            self._validate_custom_kwargs(
                 custom_kwargs=custom_kwargs,
                 evaluation_fn=evaluation_fn,
                 evaluation_fn_name=evaluation_fn_name,
@@ -374,8 +374,8 @@ class Evaluator:
         fn_signature = inspect.signature(evaluation_fn)
         fn_input_params = [param.name for param in fn_signature.parameters.values()]
 
-        provided_keys: set = custom_kwargs.keys() - set(RESERVED_KEYS)
-        expected_keys: set = set(fn_input_params) - set(RESERVED_KEYS)
+        provided_keys: set[str] = custom_kwargs.keys() - set(RESERVED_KEYS)
+        expected_keys: set[str] = set(fn_input_params) - set(RESERVED_KEYS)
 
         if unrecognized_keys := provided_keys - expected_keys:
             raise RuntimeError(

--- a/src/oumi/core/evaluation/evaluator.py
+++ b/src/oumi/core/evaluation/evaluator.py
@@ -36,6 +36,18 @@ from oumi.core.inference import BaseInferenceEngine
 from oumi.core.registry import REGISTRY
 
 _EVALUATION_FN_INFERENCE_ENGINE_INPUT_PARAM_NAME = "inference_engine"
+_EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME = "task_params"
+_EVALUATION_FN_CONFIG_INPUT_PARAM_NAME = "config"
+
+# Reserved keys that a custom evaluation function might define as inputs. The values of
+# these keys, if defined as inputs, will be automatically populated by the Evaluator.
+# The user is NOT allowed to pass these as keyword arguments when calling the
+# `Evaluator.evaluate()` function.
+RESERVED_KEYS = {
+    _EVALUATION_FN_INFERENCE_ENGINE_INPUT_PARAM_NAME,
+    _EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME,
+    _EVALUATION_FN_CONFIG_INPUT_PARAM_NAME,
+}
 
 
 class Evaluator:
@@ -143,15 +155,22 @@ class Evaluator:
                 **kwargs,
             )
         elif evaluation_backend == EvaluationBackend.CUSTOM:
-            evaluation_fn = Evaluator._get_custom_evaluation_fn(task_params.task_name)
-            self._add_inference_engine_if_needed(evaluation_fn, kwargs, config)
+            evaluation_fn_name = task_params.task_name or ""
+            evaluation_fn = Evaluator._get_custom_evaluation_fn(evaluation_fn_name)
             custom_kwargs = Evaluator._merge_kwargs(kwargs, task_params.eval_kwargs)
-
-            evaluation_result = evaluation_fn(
+            Evaluator._validate_custom_kwargs(
+                custom_kwargs=custom_kwargs,
+                evaluation_fn=evaluation_fn,
+                evaluation_fn_name=evaluation_fn_name,
+            )
+            self._add_reserved_keys_into_custom_kwargs(
+                custom_kwargs=custom_kwargs,
+                evaluation_fn=evaluation_fn,
                 task_params=task_params,
                 config=config,
-                **custom_kwargs,
             )
+            evaluation_result = evaluation_fn(**custom_kwargs)
+
             if not isinstance(evaluation_result, EvaluationResult):
                 raise ValueError(
                     f"The custom evaluation function `{task_params.task_name}` must "
@@ -319,6 +338,88 @@ class Evaluator:
                 f"dictionaries are unique: `{kwargs_1.keys()}` and `{kwargs_2.keys()}`"
             )
         return kwargs_1 | kwargs_2
+
+    @staticmethod
+    def _validate_custom_kwargs(
+        custom_kwargs: dict[str, Any],
+        evaluation_fn: Callable,
+        evaluation_fn_name: str,
+    ) -> None:
+        """Validates the keyword arguments of the custom evaluation function."""
+        # Ensure that user-provided keyword arguments, which are passed into method
+        # `Evaluator.evaluate`, do NOT contain any reserved keys.
+        if reserved_keys_used := RESERVED_KEYS & custom_kwargs.keys():
+            raise RuntimeError(
+                "Reserved keys are present when calling `Evaluator.evaluate()`. "
+                "You are not allowed to pass the following keyword arguments into "
+                f"the `{evaluation_fn_name}` function: {sorted(RESERVED_KEYS)}. "
+                "However, you have passed the following reserved keys: "
+                f"{sorted(reserved_keys_used)}. These keys can (optionally) be inputs "
+                f"of your registered evaluation function `{evaluation_fn_name}`. "
+                "If you choose to use them, they will be automatically populated "
+                "by the Evaluator. "
+                f"The `{_EVALUATION_FN_INFERENCE_ENGINE_INPUT_PARAM_NAME}` input "
+                "will provide you with an inference engine that is generated "
+                "according to the `EvaluationConfig.inference_engine` type that "
+                "you have specified in the evaluation config. "
+                f"Then, `{_EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME}`, "
+                f"`{_EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME}` will provide you "
+                "with the task parameters and the evaluation configuration, "
+                "respectively."
+            )
+
+        # Ensure that user-provided keyword arguments, which are passed into method
+        # `Evaluator.evaluate`, match the expected input parameters of the custom
+        # evaluation function `evaluation_fn`.
+        fn_signature = inspect.signature(evaluation_fn)
+        fn_input_params = [param.name for param in fn_signature.parameters.values()]
+
+        provided_keys: set = custom_kwargs.keys() - set(RESERVED_KEYS)
+        expected_keys: set = set(fn_input_params) - set(RESERVED_KEYS)
+
+        if unrecognized_keys := provided_keys - expected_keys:
+            raise RuntimeError(
+                "Unrecognized keyword arguments are present when calling "
+                "`Evaluator.evaluate()`. You have passed the following unrecognized "
+                f"keys: {sorted(unrecognized_keys)}. Please ensure that the provided "
+                "keys match the expected input parameters of the custom evaluation "
+                f"function `{evaluation_fn_name}`. The expected input parameters "
+                f"of the function are: {fn_input_params}."
+            )
+        elif missing_keys := expected_keys - provided_keys:
+            raise RuntimeError(
+                "Missing keyword arguments have been identified when calling "
+                "`Evaluator.evaluate()`. You have not passed the following expected "
+                f"keys: {missing_keys}. Please ensure that the provided keys match "
+                "the expected input parameters of the custom evaluation function "
+                f"`{evaluation_fn_name}`. The expected input parameters of the "
+                f"function are: {fn_input_params}."
+            )
+
+    def _add_reserved_keys_into_custom_kwargs(
+        self,
+        custom_kwargs: dict[str, Any],
+        evaluation_fn: Callable,
+        task_params: EvaluationTaskParams,
+        config: EvaluationConfig,
+    ) -> None:
+        """Adds reserved keys into the keyword arguments, if needed.
+
+        Reserved keys are keys that, if defined in the custom evaluation function
+        (`evaluation_fn`), are automatically populated by the Evaluator. This function
+        is responsible to add them into the keyword arguments.
+        """
+        fn_signature = inspect.signature(evaluation_fn)
+        fn_input_params = [param.name for param in fn_signature.parameters.values()]
+
+        if _EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME in fn_input_params:
+            custom_kwargs[_EVALUATION_FN_TASK_PARAMS_INPUT_PARAM_NAME] = task_params
+        if _EVALUATION_FN_CONFIG_INPUT_PARAM_NAME in fn_input_params:
+            custom_kwargs[_EVALUATION_FN_CONFIG_INPUT_PARAM_NAME] = config
+        if _EVALUATION_FN_INFERENCE_ENGINE_INPUT_PARAM_NAME in fn_input_params:
+            custom_kwargs[_EVALUATION_FN_INFERENCE_ENGINE_INPUT_PARAM_NAME] = (
+                self._get_inference_engine(config)
+            )
 
     def _add_inference_engine_if_needed(
         self,

--- a/src/oumi/core/registry/registry.py
+++ b/src/oumi/core/registry/registry.py
@@ -14,7 +14,6 @@
 
 import functools
 import importlib.util
-import inspect
 import os
 import sys
 from collections import namedtuple
@@ -347,20 +346,6 @@ def register_evaluation_function(registry_name: str) -> Callable:
                 f"Registry `{registry_name}` does not correspond to a callable object. "
                 "It is required that registered evaluation functions of type "
                 f"`{RegistryType.EVALUATION_FUNCTION}` must be callable."
-            )
-
-        signature = inspect.signature(evaluation_fn)
-        if (
-            "task_params" not in signature.parameters
-            or "config" not in signature.parameters
-        ):
-            raise TypeError(
-                f"The evaluation function ({registry_name}) can not be registered "
-                "because it does not have the correct signature. This function "
-                "must have `task_params` (type: `EvaluationTaskParams`) and `config` "
-                "(type: `EvaluationConfig`) as input arguments and return a value "
-                "(type:`EvaluationResult`). However, the signature that was provided "
-                f"is: {inspect.signature(evaluation_fn)}"
             )
 
     def decorator_register(obj):

--- a/tests/unit/core/test_registry.py
+++ b/tests/unit/core/test_registry.py
@@ -534,36 +534,19 @@ def test_register_evaluation_fn_without_annotations_happy_path():
     assert evaluation_result.backend_config == {"config": "dummy_config"}
 
 
-def test_register_evaluation_fn_missing_task_params():
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"^The evaluation function \(incompatible\) can not be registered because "
-            "it does not have the correct signature"
-        ),
-    ):
+def test_register_evaluation_fn_without_inputs_happy_path():
+    @register_evaluation_function("test_evaluation_fn")
+    def oumi_test_evaluation_fn():
+        """Dummy evaluation function for unit testing."""
+        return EvaluationResult(
+            task_name="unknown_task",
+            task_result={"result": "dummy_result"},
+            backend_config={"config": "dummy_config"},
+        )
 
-        @register_evaluation_function("incompatible")
-        def oumi_test_incompatible_evaluation_fn(
-            config: EvaluationConfig,
-        ) -> EvaluationResult:
-            """Evaluation function with incorrect signature for unit testing."""
-            return EvaluationResult()
-
-
-def test_register_evaluation_fn_missing_config():
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"^The evaluation function \(incompatible\) can not be registered because "
-            "it does not have the correct signature"
-        ),
-    ):
-
-        @register_evaluation_function("incompatible")
-        def oumi_test_incompatible_evaluation_fn(
-            task_params: EvaluationTaskParams,
-            optional_param: int,
-        ) -> EvaluationResult:
-            """Evaluation function with incorrect signature for unit testing."""
-            return EvaluationResult()
+    evaluation_fn = REGISTRY.get_evaluation_function("test_evaluation_fn")
+    assert evaluation_fn
+    evaluation_result = evaluation_fn()
+    assert evaluation_result.task_name == "unknown_task"
+    assert evaluation_result.task_result == {"result": "dummy_result"}
+    assert evaluation_result.backend_config == {"config": "dummy_config"}


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
1. Removing restrictions: Making the arguments `task_params` and `config` of the custom evaluation function optional. If users choose to define them, these will be populated but our Evaluator. If they don't need these, we should not make this function unnecessarily more complex by forcing them to define these.
2. Adding error checking for keyword arguments and providing better explanations when custom evals fail. Specifically: 
- Ensuring that user-provided keyword arguments, which are passed into method `Evaluator.evaluate` do NOT contain any reserved keys.
- Ensuring that user-provided keyword arguments match the expected input parameters of the custom evaluation function. If not, display to the user which specific arguments are unrecognized (provided by the user, but not known to the evaluation function) or missing (not provided by the user but required by the evaluation function).
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->
Towards OPE-1097

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
