### PR TITLE
Fix printing errors in oumi env for non-string values.

### DIFF
--- a/src/oumi/cli/env.py
+++ b/src/oumi/cli/env.py
@@ -140,11 +140,11 @@ def env():
         cuda_table = Table(show_header=False, show_lines=False)
         cuda_table.add_row("CUDA available", str(torch.cuda.is_available()))
         if torch.cuda.is_available():
-            cuda_table.add_row("CUDA version", torch.version.cuda)
+            cuda_table.add_row("CUDA version", str(torch.version.cuda))
             cuda_table.add_row(
                 "cuDNN version", format_cudnn_version(torch.backends.cudnn.version())
             )
-            cuda_table.add_row("Number of GPUs", torch.cuda.device_count())
+            cuda_table.add_row("Number of GPUs", str(torch.cuda.device_count()))
             cuda_table.add_row("GPU type", torch.cuda.get_device_name())
             total_memory_gb = float(torch.cuda.mem_get_info()[1]) / float(
                 1024 * 1024 * 1024


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
`device_count()` has no type annotation and can return a number, which typer cannot parse. This CL casts erroneous values to strings before printing.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

N/A

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
