### PR TITLE
Refactor dataset creation to take `DataParams` as input instead of `TrainingConfig`

### DIFF
--- a/docs/resources/datasets/datasets.md
+++ b/docs/resources/datasets/datasets.md
@@ -32,6 +32,7 @@ The fastest way to get started is using one of our pre-built datasets. These dat
 
 ::::{tab-set}
 :::{tab-item} YAML Config
+
 ```yaml
 data:
   train:
@@ -39,9 +40,11 @@ data:
       - dataset_name: tatsu-lab/alpaca
         split: train
 ```
+
 :::
 
 :::{tab-item} Python API
+
 ```python
 from oumi.builders import build_dataset
 from oumi.core.configs import DatasetSplit
@@ -60,6 +63,7 @@ for batch in dataloader:
     # Your training code here
     pass
 ```
+
 :::
 ::::
 
@@ -69,6 +73,7 @@ For more complex training scenarios, you might want to combine multiple datasets
 
 ::::{tab-set}
 :::{tab-item} YAML Config
+
 ```yaml
 data:
   train:
@@ -80,15 +85,19 @@ data:
     mixture_strategy: first_exhausted  # Strategy for combining multiple datasets
     collator_name: text_with_padding
 ```
+
 :::
 
 :::{tab-item} Python API
-```python
-from oumi.core.configs import DataParams, DatasetParams
-from oumi.builders import build_dataset_mixture
 
+```python
+from oumi.builders import build_dataset_mixture
+from oumi.core.configs import DataParams, DatasetParams, DatasetSplit, DatasetSplitParams
+from oumi.core.tokenizers import BaseTokenizer
+
+tokenizer: BaseTokenizer = ...
 # Build a mixture of datasets
-config = DataParams(
+data_params = DataParams(
     train=DatasetSplitParams(
         datasets=[
             DatasetParams(dataset_name="tatsu-lab/alpaca"),
@@ -99,10 +108,12 @@ config = DataParams(
 )
 
 dataset = build_dataset_mixture(
-    config=config,
-    split=DatasetSplit.TRAIN
+    data_params=data_params,
+    tokenizer=tokenizer,
+    dataset_split=DatasetSplit.TRAIN
 )
 ```
+
 :::
 ::::
 
@@ -138,6 +149,7 @@ data:
 ```
 
 This separation between the dataset class and data source makes it easy to:
+
 - Use the same processing logic with different data sources.
   - For example, the {py:class}`~oumi.datasets.sft.alpaca.AlpacaDataset` class can be used with both the default Alpaca data (`"tatsu-lab/alpaca"`), or one of the cleaned verions (`yahma/alpaca-cleaned`), or any other file that follows the same format.
 - Apply consistent formatting across your own datasets

--- a/docs/resources/datasets/pretraining_datasets.md
+++ b/docs/resources/datasets/pretraining_datasets.md
@@ -46,16 +46,16 @@ To use a specific pre-training dataset in your code, you can leverage the {py:fu
 
 ```python
 from oumi.builders import build_dataset_mixture
-from oumi.core.configs import TrainingConfig, DatasetSplit
+from oumi.core.configs import DataParams, DatasetSplit
 from oumi.core.tokenizers import BaseTokenizer
 
 # Assume you have your config and tokenizer initialized
-config: TrainingConfig = ...
+data_params: DataParams = ...
 tokenizer: BaseTokenizer = ...
 
 # Build the dataset
 dataset = build_dataset_mixture(
-    config=config,
+    data_params=data_params,
     tokenizer=tokenizer,
     dataset_split=DatasetSplit.TRAIN
 )

--- a/scripts/benchmarks/benchmark_dataloader.py
+++ b/scripts/benchmarks/benchmark_dataloader.py
@@ -14,6 +14,7 @@ from torch.utils.data.distributed import DistributedSampler
 from tqdm.auto import tqdm
 
 from oumi.builders import build_dataset_mixture, build_tokenizer
+from oumi.core.configs import DatasetSplit, TrainingConfig
 from oumi.core.distributed import (
     cleanup_distributed,
     init_distributed,
@@ -21,7 +22,6 @@ from oumi.core.distributed import (
     is_local_process_zero,
     is_world_process_zero,
 )
-from oumi.core.types import DatasetSplit, TrainingConfig
 from oumi.datasets.debug import DebugPretrainingDataset
 from oumi.utils.io_utils import save_json
 from oumi.utils.logging import logger, update_logger_level
@@ -70,7 +70,7 @@ def main(args):
 
         tokenizer = build_tokenizer(config.model)
         init_time, dataset = _load_dataset(
-            build_dataset_mixture, config, tokenizer, DatasetSplit.TRAIN
+            build_dataset_mixture, config.data, tokenizer, DatasetSplit.TRAIN
         )
 
         # Anything that's useful for debugging / slicing plots.

--- a/src/oumi/builders/data.py
+++ b/src/oumi/builders/data.py
@@ -24,7 +24,6 @@ from oumi.core.configs import (
     DatasetSplit,
     DatasetSplitParams,
     MixtureStrategy,
-    TrainingConfig,
 )
 from oumi.core.datasets.base_pretraining_dataset import BasePretrainingDataset
 from oumi.core.datasets.pretraining_async_text_dataset import (
@@ -39,24 +38,28 @@ DatasetType = TypeVar("DatasetType", datasets.Dataset, datasets.IterableDataset)
 
 
 def build_dataset_mixture(
-    config: TrainingConfig,
+    data_params: DataParams,
     tokenizer: Optional[BaseTokenizer],
     dataset_split: DatasetSplit,
+    seq_length: Optional[int] = None,
     seed: Optional[int] = None,
 ) -> Union[DatasetType, PretrainingAsyncTextDataset]:
     """Builds a dataset for the specified split.
 
     Args:
-        config: The training config.
+        data_params: The data params.
         tokenizer: The tokenizer object to use for preprocessing.
         dataset_split: The split of the dataset to load.
+        seq_length: The length each example will be packed to. This is only used if
+            packing is requested, and the dataset isn't already packed. If not provided,
+            defaults to 1024.
         seed: If specified, a seed used for random sampling.
         kwargs: Keyword arguments.
 
     Returns:
         dataset: The built dataset for `dataset_split`.
     """
-    dataset_split_params: DatasetSplitParams = config.data.get_split(dataset_split)
+    dataset_split_params: DatasetSplitParams = data_params.get_split(dataset_split)
     if dataset_split_params.use_torchdata:
         from oumi.builders.oumi_data import build_dataset_mixture as build_oumi_dataset
 
@@ -68,7 +71,7 @@ def build_dataset_mixture(
         # We return a torchdata.IterDataPipe instead of a HuggingFace Dataset or
         # IterableDataset. This is a temporary workaround until torchdata is stable
         # and becomes the default processing pipeline.
-        return build_oumi_dataset(config, tokenizer, dataset_split, seed)  # type: ignore
+        return build_oumi_dataset(data_params, tokenizer, dataset_split, seed)  # type: ignore
 
     # Check if the underlying dataset is already packed, or if we need to pack it
     # ourselves.
@@ -100,8 +103,8 @@ def build_dataset_mixture(
     if dataset_split_params.pack and not is_packed:
         # Fetch max sequence length. If not specified, defaults to 1024.
         dataset_kwargs = {}
-        if config.model.model_max_length:
-            dataset_kwargs["seq_length"] = config.model.model_max_length
+        if seq_length is not None:
+            dataset_kwargs["seq_length"] = seq_length
 
         dataset = PretrainingAsyncTextDataset(
             tokenizer,
@@ -125,19 +128,17 @@ def build_dataset_from_params(
     Please refer to `DatasetParams` & `DatasetSplitParams` for a description of
     all the arguments.
     """
-    training_config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                datasets=[dataset_params],
-                stream=stream,
-                pack=pack,
-                use_torchdata=use_torchdata,
-            )
+    data_params = DataParams(
+        train=DatasetSplitParams(
+            datasets=[dataset_params],
+            stream=stream,
+            pack=pack,
+            use_torchdata=use_torchdata,
         )
     )
 
     return build_dataset_mixture(
-        config=training_config,
+        data_params=data_params,
         dataset_split=DatasetSplit.TRAIN,
         tokenizer=tokenizer,
         seed=seed,

--- a/src/oumi/builders/oumi_data.py
+++ b/src/oumi/builders/oumi_data.py
@@ -28,14 +28,14 @@ from oumi.core.configs import (
     DatasetSplit,
     DatasetSplitParams,
     MixtureStrategy,
-    TrainingConfig,
 )
+from oumi.core.configs.params.data_params import DataParams
 from oumi.core.registry import REGISTRY
 from oumi.core.tokenizers import BaseTokenizer
 
 
 def build_dataset_mixture(
-    config: TrainingConfig,
+    data_params: DataParams,
     tokenizer: Optional[BaseTokenizer],
     dataset_split: DatasetSplit,
     seed: Optional[int] = None,
@@ -43,7 +43,7 @@ def build_dataset_mixture(
     """Builds a dataset for the specified split.
 
     Args:
-        config: The training config.
+        data_params: The data params.
         tokenizer: The tokenizer object to use for preprocessing.
         dataset_split: The split of the dataset to load.
         seed: If specified, a seed used for random sampling.
@@ -51,7 +51,7 @@ def build_dataset_mixture(
     Returns:
         dataset: The built dataset for `dataset_split`.
     """
-    dataset_split_params: DatasetSplitParams = config.data.get_split(dataset_split)
+    dataset_split_params: DatasetSplitParams = data_params.get_split(dataset_split)
 
     if len(dataset_split_params.datasets) == 0:
         raise ValueError("No datasets specified in the split.")
@@ -123,8 +123,9 @@ def build_dataset_mixture(
 
     # Apply packing if needed
     # TODO: handle pre-packed datasets, non-iterable datasets
+    # Need to add `seq_length as an argument passed in from build_dataset_mixture
     # if dataset_split_params.pack:
-    #     combined_datapipe = combined_datapipe.batch(config.model.model_max_length)
+    #     combined_datapipe = combined_datapipe.batch(seq_length)
     #     combined_datapipe = combined_datapipe.map(
     #         functools.partial(pack_tokens, tokenizer=tokenizer)
     #     )

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -292,11 +292,21 @@ def train(config: TrainingConfig, **kwargs) -> None:
             )
 
     # Load data & preprocessing
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
 
     eval_dataset = None
     if len(config.data.get_split(DatasetSplit.VALIDATION).datasets) != 0:
-        eval_dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
+        eval_dataset = build_dataset_mixture(
+            config.data,
+            tokenizer,
+            DatasetSplit.VALIDATION,
+            seq_length=config.model.model_max_length,
+        )
 
     # trl's SFTTrainer has its own dataset processing code. We should skip it if
     # the dataset is already processed, i.e. it's tokenized and has an `input_ids`

--- a/tests/integration/datasets/test_sft_vision_datasets_load_datasets.py
+++ b/tests/integration/datasets/test_sft_vision_datasets_load_datasets.py
@@ -184,7 +184,7 @@ def test_build_dataset_mixture(info: LoadDatasetInfo):
     train_config = TrainingConfig(
         model=model_params, data=DataParams(train=train_split)
     )
-    dataset = build_dataset_mixture(train_config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(train_config.data, tokenizer, DatasetSplit.TRAIN)
 
     assert isinstance(dataset, datasets.Dataset)
 

--- a/tests/integration/datasets/test_sft_vision_datasets_load_datasets.py
+++ b/tests/integration/datasets/test_sft_vision_datasets_load_datasets.py
@@ -14,7 +14,6 @@ from oumi.core.configs import (
     DatasetSplit,
     DatasetSplitParams,
     ModelParams,
-    TrainingConfig,
 )
 from oumi.core.datasets import VisionLanguageSftDataset
 from oumi.core.registry import REGISTRY, RegistryType
@@ -181,10 +180,9 @@ def test_build_dataset_mixture(info: LoadDatasetInfo):
             )
         ],
     )
-    train_config = TrainingConfig(
-        model=model_params, data=DataParams(train=train_split)
+    dataset = build_dataset_mixture(
+        DataParams(train=train_split), tokenizer, DatasetSplit.TRAIN
     )
-    dataset = build_dataset_mixture(train_config.data, tokenizer, DatasetSplit.TRAIN)
 
     assert isinstance(dataset, datasets.Dataset)
 

--- a/tests/integration/train/test_custom_models.py
+++ b/tests/integration/train/test_custom_models.py
@@ -72,7 +72,12 @@ def test_train_native_pt_model_from_api():
 
         tokenizer = build_tokenizer(config.model)
 
-        dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+        dataset = build_dataset_mixture(
+            config.data,
+            tokenizer,
+            DatasetSplit.TRAIN,
+            seq_length=config.model.model_max_length,
+        )
 
         model = build_model(model_params=config.model)
 

--- a/tests/unit/builders/test_build_data.py
+++ b/tests/unit/builders/test_build_data.py
@@ -17,7 +17,6 @@ from oumi.core.configs import (
     DatasetParams,
     DatasetSplit,
     DatasetSplitParams,
-    TrainingConfig,
 )
 from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.datasets import BaseIterableDataset, BaseMapDataset
@@ -261,30 +260,28 @@ def test_build_dataset_mixture(
 ):
     """Test building a mixture of datasets with specified proportions."""
     # Create config with dataset mixture
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                datasets=[
-                    DatasetParams(
-                        dataset_name="text_sft_jsonl",
-                        dataset_path=str(sample_conversations_jsonl),
-                        mixture_proportion=0.7,
-                    ),
-                    DatasetParams(
-                        dataset_name="text_sft",
-                        dataset_path=str(sample_conversations_jsonl),
-                        mixture_proportion=0.3,
-                    ),
-                ],
-                mixture_strategy="all_exhausted",
-                seed=42,
-                stream=stream,
-            )
+    data_params = DataParams(
+        train=DatasetSplitParams(
+            datasets=[
+                DatasetParams(
+                    dataset_name="text_sft_jsonl",
+                    dataset_path=str(sample_conversations_jsonl),
+                    mixture_proportion=0.7,
+                ),
+                DatasetParams(
+                    dataset_name="text_sft",
+                    dataset_path=str(sample_conversations_jsonl),
+                    mixture_proportion=0.3,
+                ),
+            ],
+            mixture_strategy="all_exhausted",
+            seed=42,
+            stream=stream,
         )
     )
 
     dataset = build_dataset_mixture(
-        config=config,
+        data_params=data_params,
         tokenizer=gpt2_tokenizer,
         dataset_split=DatasetSplit.TRAIN,
     )

--- a/tests/unit/builders/test_data_mixtures.py
+++ b/tests/unit/builders/test_data_mixtures.py
@@ -103,7 +103,12 @@ def test_data_single_dataset_in_mixture(stream: bool):
         DatasetSplit.TRAIN,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
     assert _get_dataset_size(dataset, stream) == 5
 
 
@@ -160,7 +165,12 @@ def test_data_multiple_datasets(stream: bool):
         DatasetSplit.TEST,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TEST)
+    dataset = dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TEST,
+        seq_length=config.model.model_max_length,
+    )
     assert _get_dataset_size(dataset, stream) == 100 * 2  # Duplicated dataset
 
 
@@ -182,7 +192,12 @@ def test_data_multiple_datasets_local_sample(stream: bool):
         DatasetSplit.VALIDATION,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.VALIDATION,
+        seq_length=config.model.model_max_length,
+    )
     assert _get_dataset_size(dataset, stream) == 5 + 201
 
 
@@ -214,7 +229,12 @@ def test_data_multiple_datasets_shuffle_different_seeds(stream: bool):
         DatasetSplit.VALIDATION,
     )
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.VALIDATION)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.VALIDATION,
+        seq_length=config.model.model_max_length,
+    )
     assert _get_dataset_size(dataset, stream) == 20
     # Read all the data to handle streaming / nonstreaming in a unified manner.
     data = []
@@ -257,7 +277,12 @@ def test_data_multiple_datasets_local_mixed(stream: bool):
     config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "first_exhausted"
     config.data.get_split(DatasetSplit.TRAIN).seed = 1
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
     # The dataset size should be small. We stop merging when the smallest dataset is
     # exhausted.
     assert _get_dataset_size(dataset, stream) == 9
@@ -291,7 +316,12 @@ def test_data_multiple_datasets_local_mixed_all_exhausted(stream: bool):
     config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "all_exhausted"
     config.data.get_split(DatasetSplit.TRAIN).seed = 1
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
     # The dataset size should be larger. We stop merging when all datasets have been
     # exhausted.
     assert _get_dataset_size(dataset, stream) == 124
@@ -351,7 +381,14 @@ def test_data_multiple_datasets_different_mix_seeds(stream: bool):
         config.data.get_split(DatasetSplit.TRAIN).mixture_strategy = "first_exhausted"
         config.data.get_split(DatasetSplit.TRAIN).seed = seed
         tokenizer = build_tokenizer(config.model)
-        datasets.append(build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN))
+        datasets.append(
+            build_dataset_mixture(
+                config.data,
+                tokenizer,
+                DatasetSplit.TRAIN,
+                seq_length=config.model.model_max_length,
+            )
+        )
     dataset_a = datasets[0]
     dataset_b = datasets[1]
     assert _get_dataset_size(dataset_a, stream) != _get_dataset_size(dataset_b, stream)
@@ -386,7 +423,12 @@ def test_data_multiple_datasets_packing(stream: bool):
     config.data.get_split(DatasetSplit.TEST).mixture_strategy = "first_exhausted"
     config.data.get_split(DatasetSplit.TEST).seed = 1
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TEST)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TEST,
+        seq_length=config.model.model_max_length,
+    )
     # The packed dataset should be even smaller.
     assert _get_dataset_size(dataset, stream, pack=True) == 3
 
@@ -409,7 +451,12 @@ def test_packing_without_streaming_with_sft_dataset(stream: bool):
     )
 
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
 
     # Verify it returns a PretrainingAsyncTextDataset
     assert isinstance(dataset, PretrainingAsyncTextDataset)
@@ -448,7 +495,12 @@ def test_packing_without_streaming_with_pretraining_dataset(stream: bool):
     )
 
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
 
     # Verify it returns a IterableDataset
     assert isinstance(dataset, IterableDataset)
@@ -493,7 +545,12 @@ def test_mixed_dataset_packing(stream: bool):
     )
 
     tokenizer = build_tokenizer(config.model)
-    dataset = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    dataset = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+        seq_length=config.model.model_max_length,
+    )
 
     # Verify type and basic functionality
     assert isinstance(dataset, PretrainingAsyncTextDataset)

--- a/tests/unit/builders/test_oumi_data.py
+++ b/tests/unit/builders/test_oumi_data.py
@@ -212,7 +212,11 @@ def test_load_dataset_huggingface(tokenizer, monkeypatch):
 
 def test_build_dataset_mixture_single(tokenizer):
     config = create_training_config([create_dataset_params("small_map_dataset")])
-    result = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    result = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+    )
     assert isinstance(result, IterDataPipe)
     assert len(list(result)) == 11
 
@@ -227,7 +231,11 @@ def test_build_dataset_mixture_multiple(tokenizer):
         ]
     )
     assert config.data.train.mixture_strategy == MixtureStrategy.FIRST_EXHAUSTED
-    result = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    result = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+    )
     assert isinstance(result, IterDataPipe)
     # It's 18 (9*2), not 20 (11+9) because of FIRST_EXHAUSTED strategy
     assert len(list(result)) == 18
@@ -238,7 +246,11 @@ def test_build_dataset_mixture_sampling(tokenizer):
     dataset_params.sample_count = 5
     dataset_params.shuffle_buffer_size = 10
     config = create_training_config([dataset_params])
-    result = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN)
+    result = build_dataset_mixture(
+        config.data,
+        tokenizer,
+        DatasetSplit.TRAIN,
+    )
     assert isinstance(result, IterDataPipe)
     assert len(list(result)) == 5
 
@@ -252,7 +264,7 @@ def test_build_dataset_mixture(tokenizer):
     )
     config.data.train.datasets[0].mixture_proportion = 0.7
     config.data.train.datasets[1].mixture_proportion = 0.3
-    result = build_dataset_mixture(config, tokenizer, DatasetSplit.TRAIN, seed=42)
+    result = build_dataset_mixture(config.data, tokenizer, DatasetSplit.TRAIN, seed=42)
     assert isinstance(result, IterDataPipe)
     samples = list(result)
     assert len(samples) == 20


### PR DESCRIPTION
# Description

Currently, datasets are created with `build_dataset_mixture()`, which takes a `TrainingConfig` as input. This is because our datasets code is currently only integrated with training. However, it'd be useful to allow datasets to be passed via config for  inference and evaluation as well. For the latter, this is useful to support custom evaluation.

This is a fairly simple refactor, as aside from the `DataParams` within `TrainingConfig`, the only other field we use is `model.model_max_length` (which is only used for packing). This PR also fixes a related example in docs that was broken, and simplifies affected tests.

## Related issues

Towards OPE-1152

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
