### PR TITLE
feat (env): include mlflow in displayed dependencies

### DIFF
--- a/src/oumi/cli/env.py
+++ b/src/oumi/cli/env.py
@@ -104,6 +104,7 @@ def env():
             "typer",
             "vllm",
             "wandb",
+            "mlflow",
         ]
     )
     package_versions = {


### PR DESCRIPTION
# Description

This PR adds `mlflow` to the list of core packages shown when running the `oumi env` command. This change allows users to see the installed version of `mlflow` as part of the environment report, which is helpful for debugging.

## Related issues

#1600 

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

@oumi-ai/oumi-staff
