### PR TITLE
Add `vllm` to `gpu` optional dependencies

### DIFF
--- a/configs/examples/bulk_inference/gcp_job.yaml
+++ b/configs/examples/bulk_inference/gcp_job.yaml
@@ -46,7 +46,7 @@ envs:
 
 setup: |
   set -e
-  pip install uv && uv pip install oumi[gpu] vllm>=0.7.3
+  pip install uv && uv pip install oumi[gpu]
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/grpo_tldr/gcp_job.yaml
+++ b/configs/examples/grpo_tldr/gcp_job.yaml
@@ -31,7 +31,7 @@ envs:
 
 setup: |
   set -e
-  pip install uv && uv pip install oumi[gpu] "vllm>=0.7.3,<0.8.0"
+  pip install uv && uv pip install oumi[gpu]
   pip install -U flash-attn --no-build-isolation
 
 run: |

--- a/configs/examples/letter_counting/evaluation/eval.yaml
+++ b/configs/examples/letter_counting/evaluation/eval.yaml
@@ -1,7 +1,7 @@
 # Config to eval an LLM's ability to count letters in words.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #
 # Usage:

--- a/configs/examples/letter_counting/evaluation/gcp_job.yaml
+++ b/configs/examples/letter_counting/evaluation/gcp_job.yaml
@@ -36,7 +36,7 @@ envs:
 
 setup: |
   set -e
-  pip install uv && uv pip install oumi[gpu,evaluation] "vllm>=0.7.3,<0.8.0"
+  pip install uv && uv pip install oumi[gpu,evaluation]
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/letter_counting/grpo/gcp_job.yaml
+++ b/configs/examples/letter_counting/grpo/gcp_job.yaml
@@ -34,7 +34,7 @@ envs:
 setup: |
   set -e
   # vLLM needed for vLLM-powered generation during GRPO training.
-  pip install uv && uv pip install oumi[gpu] "vllm>=0.7.3,<0.8.0"
+  pip install uv && uv pip install oumi[gpu]
   pip install -U flash-attn --no-build-isolation
 
 run: |

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 8B Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #

--- a/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 1B Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #

--- a/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3B Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #

--- a/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3.3 70B Instruct with VLLM.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
@@ -1,7 +1,7 @@
 # Remote vLLM inference config for Llama 3.2 11B Vision Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
@@ -1,7 +1,7 @@
 # vLLM inference config for Llama 3.2 11B Vision Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #

--- a/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/llava_7b/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Llava 7B vLLM inference config.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #
 # Usage:
 #   oumi infer -i -c configs/recipes/vision/llava_7b/inference/vllm_infer.yaml \

--- a/configs/recipes/vision/phi3/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/phi3/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Phi3 vision vLLM inference config.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #
 # Usage:
 #   oumi infer -i -c configs/recipes/vision/phi3/inference/vllm_infer.yaml \

--- a/configs/recipes/vision/phi4/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/phi4/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Phi-4-multimodal-instruct 5.6B vLLM inference config.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Run `pip install -U flash-attn --no-build-isolation`
 #
 # Usage:

--- a/configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # Qwen 2.5 VL 3B vLLM inference config.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #
 #   !Important! this model also requires the latest (dev) version of transformers.
 #   Please read more at qwen2_5_vl_3b/README.md

--- a/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml
@@ -1,7 +1,7 @@
 # vLLM inference config for Qwen2 VL 2B Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #
 # Usage:
 #   oumi infer -i -c configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml \

--- a/docs/user_guides/infer/inference_engines.md
+++ b/docs/user_guides/infer/inference_engines.md
@@ -112,6 +112,9 @@ First, make sure to install the vLLM package:
 
 ```bash
 pip install vllm
+# Alternatively, install all Oumi GPU dependencies, which takes care of installing a
+# vLLM version compatible with your current Oumi version.
+pip install oumi[gpu]
 ```
 
 **Basic Usage**

--- a/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
+++ b/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
+++ b/notebooks/Oumi - Build your own Custom Evaluation (Hallucination Classifier).ipynb
@@ -43,16 +43,16 @@
     "\n",
     "### Oumi Installation\n",
     "\n",
-    "First, let's install Oumi and vLLM. You can find more detailed instructions about Oumi installation [here](https://oumi.ai/docs/en/latest/get_started/installation.html)."
+    "First, let's install Oumi. You can find more detailed instructions about Oumi installation [here](https://oumi.ai/docs/en/latest/get_started/installation.html)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi vllm"
+    "%pip install oumi"
    ]
   },
   {

--- a/notebooks/Oumi - Distill a Large Model.ipynb
+++ b/notebooks/Oumi - Distill a Large Model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi[gpu] vllm"
+    "%pip install oumi[gpu]"
    ]
   },
   {

--- a/notebooks/Oumi - Finetuning Tutorial.ipynb
+++ b/notebooks/Oumi - Finetuning Tutorial.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi[gpu] vllm"
+    "%pip install oumi[gpu]"
    ]
   },
   {

--- a/notebooks/Oumi - MiniMath-R1-1.5B.ipynb
+++ b/notebooks/Oumi - MiniMath-R1-1.5B.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi[gpu] vllm"
+    "%pip install oumi[gpu]"
    ]
   },
   {

--- a/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
+++ b/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi[gpu] vllm"
+    "%pip install oumi[gpu]"
    ]
   },
   {

--- a/notebooks/Oumi - Vision Language Models.ipynb
+++ b/notebooks/Oumi - Vision Language Models.ipynb
@@ -431,9 +431,7 @@
     "engine: NATIVE \n",
     "# Let's use the `native` engine (i.e., the underlying machine's default)\n",
     "# for inference.  \n",
-    "# You can also consider VLLM, if are working with GPU for much faster inference. \n",
-    "# To install an Oumi tested/compatible version, use:\n",
-    "# pip install \"vllm>=0.7.3,<0.8.0\""
+    "# You can also consider VLLM, if are working with GPU for much faster inference. "
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,12 @@ docs = [
     "sphinxcontrib-typer",     # Allows us to include typer CLI in the docs
 ]
 
-# Dependencies that require a GPU to install
+# Useful dependencies when running on GPU
 gpu = [
     "liger-kernel>=0.5.0,<0.6",
     "nvidia-ml-py>=12.560.30,<12.561",
     "bitsandbytes>=0.45.0,<0.46",      # Used for QLora, and PagedAdam implementation
+    "vllm>=0.7.3,<0.8.0", # For VLLMInferenceEngine
 ]
 
 # Targets for supported cloud providers
@@ -163,7 +164,6 @@ ci_cpu = [
 # gpu actions runner, so we skip it for now
 ci_gpu = [
     "oumi[dev,docs,gcp,gpu]",
-    "vllm>=0.7.3,<0.8.0",
     "alpaca-eval>=0.6.6,<0.7",
 ]
 

--- a/src/oumi/launcher/clusters/polaris_cluster.py
+++ b/src/oumi/launcher/clusters/polaris_cluster.py
@@ -257,7 +257,7 @@ class PolarisCluster(BaseCluster):
             "if ! command -v uv >/dev/null 2>&1; then",
             "pip install -U uv",
             "fi",
-            "pip install -e '.[gpu]' vllm",  # TODO Re-enable uv OPE-670
+            "pip install -e '.[gpu]'",  # TODO Re-enable uv OPE-670
         ]
         self._client.run_commands(install_cmds)
         # Copy all file mounts.

--- a/tests/unit/launcher/clusters/test_polaris_cluster.py
+++ b/tests/unit/launcher/clusters/test_polaris_cluster.py
@@ -367,7 +367,7 @@ def test_polaris_cluster_run_job(mock_datetime, mock_polaris_client):
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(
@@ -469,7 +469,7 @@ def test_polaris_cluster_run_job_with_conda_setup(mock_datetime, mock_polaris_cl
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(
@@ -570,7 +570,7 @@ def test_polaris_cluster_run_job_no_name(mock_datetime, mock_polaris_client):
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(
@@ -659,7 +659,7 @@ def test_polaris_cluster_run_job_no_mounts(mock_datetime, mock_polaris_client):
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(
@@ -750,7 +750,7 @@ def test_polaris_cluster_run_job_no_pbs(mock_datetime, mock_polaris_client):
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(
@@ -833,7 +833,7 @@ def test_polaris_cluster_run_job_no_setup(mock_datetime, mock_polaris_client):
                     "if ! command -v uv >/dev/null 2>&1; then",
                     "pip install -U uv",
                     "fi",
-                    "pip install -e '.[gpu]' vllm",
+                    "pip install -e '.[gpu]'",
                 ]
             ),
             call(


### PR DESCRIPTION
# Description

Currently, running `pip install oumi vlm` errors, because the latest version of vllm uses a later version of pytorch than what oumi uses. Even if we fix this problem now, it's not sustainable to keep changing our vllm version requirements throughout our codebase instead of in one central place. Since we basically only install vllm whenever we're installing `oumi[gpu]`, i'm moving it back into this target. It seems I initially moved it out because vllm doesn't *require* a gpu to run: https://github.com/oumi-ai/oumi/pull/894/files. However, if you own a GPU, there's a good chance you may want to install vllm, so I think it still makes sense to include it there. I haven't seen a need to install vllm on a non-GPU machine yet.

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
