### PR TITLE
Update transformers to 4.51.0

### DIFF
--- a/configs/recipes/vision/qwen2_5_vl_3b/README.md
+++ b/configs/recipes/vision/qwen2_5_vl_3b/README.md
@@ -2,23 +2,3 @@
 
 Configs for the **`Qwen2.5-VL`** 3B model.
 🔗 **Reference:** [Qwen2.5-VL-3B-Instruct on Hugging Face](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct)
-
----
-
-❗ **Important Note**
-As of **February 2025**, `Qwen2.5-VL` is integrated into the **latest** `transformers` _dev_ version.
-
-⚠️ **Earlier versions may cause a runtime error:**
-KeyError: ‘qwen2_5_vl’
-
-Oumi has successfully tested this integration with:
-- **SFT training**
-- **Native inference** using **`transformers 4.49.0.dev0`**
-
-To update `transformers` to this version, run:
-
-```sh
-pip install git+https://github.com/huggingface/transformers.git
-```
-
-⚠️ Caution: This upgrade may break other Oumi utilities. Proceed carefully.

--- a/configs/recipes/vision/qwen2_5_vl_3b/inference/infer.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/inference/infer.yaml
@@ -1,13 +1,8 @@
 # Qwen 2.5 VL 3B inference config.
 #
-# Requirements:
-#   !Important! this model requires the latest (dev) version of transformers.
-#   Please read more at qwen2_5_vl_3b/README.md
-#
 # Usage:
 #   oumi infer -i -c configs/recipes/vision/qwen2_5_vl_3b/inference/infer.yaml \
 #     --image "tests/testdata/images/the_great_wave_off_kanagawa.jpg"
-#
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html

--- a/configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml
@@ -3,9 +3,6 @@
 # Requirements:
 #   - Run `pip install oumi[gpu]`
 #
-#   !Important! this model also requires the latest (dev) version of transformers.
-#   Please read more at qwen2_5_vl_3b/README.md
-#
 # Usage:
 #   oumi infer -i -c configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml \
 #     --image "tests/testdata/images/the_great_wave_off_kanagawa.jpg"

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/full/train.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/full/train.yaml
@@ -4,9 +4,6 @@
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #   - (optional) If you want to use flash attention, run `pip install -U flash-attn --no-build-isolation`
 #
-# !Important! this model requires the latest (dev) version of transformers.
-# Please read more at qwen2_5_vl_3b/README.md
-#
 # Usage:
 #   oumi train -c configs/recipes/vision/qwen2_5_vl_3b/sft/full/train.yaml
 #

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml
@@ -4,9 +4,6 @@
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #   - (optional) If you want to use flash attention, run `pip install -U flash-attn --no-build-isolation`
 #
-# !Important! this model requires the latest (dev) version of transformers.
-# Please read more at qwen2_5_vl_3b/README.md
-#
 # Usage:
 #   oumi train -c configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "tqdm",
     # Llama Vision attention is broken as late as 4.48.2 if gradient checkpointing is
     # enabled. See OPE-875 and https://github.com/huggingface/transformers/issues/36040.
-    "transformers>=4.49.0,<4.50",
+    "transformers>=4.51.0,<4.52",
     # >=0.14.0 is needed for GRPOTrainer.
     "trl>=0.15.0,<0.16",
     "typer",               # Used by CLI

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -298,6 +298,7 @@ def test_eval_multimodal_1gpu_24gb(test_config: EvalTestConfig, tmp_path: Path):
                 / "eval.yaml"
             ),
             num_samples=20,
+            use_simple_oumi_evaluate_command=True,
         ),
         EvalTestConfig(
             test_name="eval_text_deepseek_r1_distill_llama70b_multi_gpu",

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -134,7 +134,7 @@ def test_build_chat_template_removes_indentation_and_newlines():
         ("llava-hf/llava-1.5-7b-hf", False, True),
         ("Salesforce/blip2-opt-2.7b", False, True),
         ("microsoft/Phi-3-vision-128k-instruct", True, True),
-        # ("HuggingFaceTB/SmolVLM-Instruct", False, True), # requires transformers>=4.46
+        ("HuggingFaceTB/SmolVLM-Instruct", False, True),
     ],
 )
 def test_is_image_text_llm(


### PR DESCRIPTION
# Description

This is needed for the new Llama 4 models.

After this is pushed to PyPi, we can remove the transformers import line in Llama 4 configs.

Additional changes:
- Remove stale comments in `configs/recipes/vision/qwen2_5_vl_3b` about transformer version
- Fix eval E2E test (make the Llama 8B model a simple evaluate)
- Update `test_models.py` now that our transformers version is updated

Tested by running `tests/scripts/launch_tests.sh`. I didn't observe any errors mentioned by #/1577.

## Related issues

Fixes #1619 

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
