### PR TITLE
Lazy load skypilot

### DIFF
--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 def _get_sky_cloud_from_job(job: JobConfig) -> "sky.clouds.Cloud":
     """Returns the sky.Cloud object from the JobConfig."""
+    # Delay sky import: https://github.com/oumi-ai/oumi/issues/1605
     import sky
 
     if job.resources.cloud == SkyClient.SupportedClouds.GCP.value:
@@ -45,6 +46,7 @@ def _get_sky_cloud_from_job(job: JobConfig) -> "sky.clouds.Cloud":
 
 def _get_sky_storage_mounts_from_job(job: JobConfig) -> dict[str, "sky.data.Storage"]:
     """Returns the sky.StorageMount objects from the JobConfig."""
+    # Delay sky import: https://github.com/oumi-ai/oumi/issues/1605
     import sky.data
 
     sky_mounts = {}
@@ -132,6 +134,7 @@ class SkyClient:
 
     def __init__(self):
         """Initializes a new instance of the SkyClient class."""
+        # Delay sky import: https://github.com/oumi-ai/oumi/issues/1605
         import sky
 
         self._sky_lib = sky

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -175,8 +175,7 @@ class SkyClient:
                     "No idle_minutes_to_autostop provided. "
                     f"Defaulting to {idle_minutes_to_autostop} minutes."
                 )
-        except Exception as e:
-            logger.warning(e)
+        except Exception:
             logger.info(
                 f"{sky_cloud._REPR} does not support stopping clusters. "
                 "Will not set autostop."

--- a/src/oumi/launcher/clusters/sky_cluster.py
+++ b/src/oumi/launcher/clusters/sky_cluster.py
@@ -14,8 +14,6 @@
 
 from typing import Any, Optional
 
-import sky.exceptions
-
 from oumi.core.configs import JobConfig
 from oumi.core.launcher import BaseCluster, JobStatus
 from oumi.launcher.clients.sky_client import SkyClient
@@ -26,6 +24,10 @@ class SkyCluster(BaseCluster):
 
     def __init__(self, name: str, client: SkyClient) -> None:
         """Initializes a new instance of the SkyCluster class."""
+        # Delay sky import: https://github.com/oumi-ai/oumi/issues/1605
+        import sky.exceptions
+
+        self._sky_exceptions = sky.exceptions
         self._name = name
         self._client = client
 
@@ -78,7 +80,7 @@ class SkyCluster(BaseCluster):
                 self._convert_sky_job_to_status(job)
                 for job in self._client.queue(self.name())
             ]
-        except sky.exceptions.ClusterNotUpError:
+        except self._sky_exceptions.ClusterNotUpError:
             return []
 
     def cancel_job(self, job_id: str) -> JobStatus:

--- a/tests/unit/launcher/clouds/test_sky_cloud.py
+++ b/tests/unit/launcher/clouds/test_sky_cloud.py
@@ -16,7 +16,11 @@ from oumi.launcher.clusters.sky_cluster import SkyCluster
 #
 @pytest.fixture
 def mock_sky_client():
-    yield Mock(spec=SkyClient)
+    with patch("oumi.launcher.clouds.sky_cloud.SkyClient") as client:
+        client.SupportedClouds = SkyClient.SupportedClouds
+        client_instance = Mock(spec=SkyClient)
+        client.return_value = client_instance
+        yield client_instance
 
 
 @pytest.fixture
@@ -122,7 +126,7 @@ def test_sky_cloud_up_cluster(mock_sky_client, mock_sky_cluster):
         },
     ]
     mock_sky_client.launch.return_value = expected_job_status
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     job_status = cloud.up_cluster(_get_default_job("gcp"), "new_cluster_name")
     mock_sky_client.launch.assert_called_once_with(
         _get_default_job("gcp"), "new_cluster_name"
@@ -183,7 +187,7 @@ def test_sky_cloud_up_cluster_kwargs(mock_sky_client, mock_sky_cluster):
         },
     ]
     mock_sky_client.launch.return_value = expected_job_status
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     job_status = cloud.up_cluster(
         _get_default_job("gcp"), "new_cluster_name", custom_kwarg=1
     )
@@ -246,14 +250,14 @@ def test_sky_cloud_up_cluster_no_name(mock_sky_client, mock_sky_cluster):
         },
     ]
     mock_sky_client.launch.return_value = expected_job_status
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     job_status = cloud.up_cluster(_get_default_job("gcp"), None)
     mock_sky_client.launch.assert_called_once_with(_get_default_job("gcp"), None)
     assert job_status == expected_job_status
 
 
 def test_sky_cloud_list_clusters_gcp(mock_sky_client):
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -301,7 +305,7 @@ def test_sky_cloud_list_clusters_gcp(mock_sky_client):
 
 
 def test_sky_cloud_list_clusters_runpod(mock_sky_client):
-    cloud = SkyCloud("runpod", mock_sky_client)
+    cloud = SkyCloud("runpod")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -339,7 +343,7 @@ def test_sky_cloud_list_clusters_runpod(mock_sky_client):
 
 
 def test_sky_cloud_list_clusters_lambda(mock_sky_client):
-    cloud = SkyCloud("lambda", mock_sky_client)
+    cloud = SkyCloud("lambda")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -377,7 +381,7 @@ def test_sky_cloud_list_clusters_lambda(mock_sky_client):
 
 
 def test_sky_cloud_list_clusters_lambda_no_cluster(mock_sky_client):
-    cloud = SkyCloud("lambda", mock_sky_client)
+    cloud = SkyCloud("lambda")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -406,7 +410,7 @@ def test_sky_cloud_list_clusters_lambda_no_cluster(mock_sky_client):
 
 
 def test_sky_cloud_list_clusters_lambda_multiple_cluster(mock_sky_client):
-    cloud = SkyCloud("lambda", mock_sky_client)
+    cloud = SkyCloud("lambda")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -458,7 +462,7 @@ def test_sky_cloud_list_clusters_lambda_multiple_cluster(mock_sky_client):
 
 
 def test_sky_cloud_list_clusters_invalid_cloud(mock_sky_client):
-    cloud = SkyCloud("fake_cloud", mock_sky_client)
+    cloud = SkyCloud("fake_cloud")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -506,7 +510,7 @@ def test_sky_cloud_list_clusters_invalid_cloud(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_gcp_success(mock_sky_client):
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -545,7 +549,7 @@ def test_sky_cloud_get_cluster_gcp_success(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_runpod_success(mock_sky_client):
-    cloud = SkyCloud("runpod", mock_sky_client)
+    cloud = SkyCloud("runpod")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -584,7 +588,7 @@ def test_sky_cloud_get_cluster_runpod_success(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_lambda_success(mock_sky_client):
-    cloud = SkyCloud("lambda", mock_sky_client)
+    cloud = SkyCloud("lambda")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -623,7 +627,7 @@ def test_sky_cloud_get_cluster_lambda_success(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_aws_success(mock_sky_client):
-    cloud = SkyCloud("aws", mock_sky_client)
+    cloud = SkyCloud("aws")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -662,7 +666,7 @@ def test_sky_cloud_get_cluster_aws_success(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_azure_success(mock_sky_client):
-    cloud = SkyCloud("azure", mock_sky_client)
+    cloud = SkyCloud("azure")
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
     mock_gcp_handler.launched_resources = Mock()
@@ -701,7 +705,7 @@ def test_sky_cloud_get_cluster_azure_success(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_failure_wrong_cloud(mock_sky_client):
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
 
     mock_runpod_cluster = Mock(spec=sky.clouds.RunPod)
     mock_runpod_handler = Mock()
@@ -731,7 +735,7 @@ def test_sky_cloud_get_cluster_failure_wrong_cloud(mock_sky_client):
 
 
 def test_sky_cloud_get_cluster_failure_empty(mock_sky_client):
-    cloud = SkyCloud("gcp", mock_sky_client)
+    cloud = SkyCloud("gcp")
     mock_sky_client.status.return_value = []
     cluster = cloud.get_cluster("gcp_cluster")
     mock_sky_client.status.assert_called_once()

--- a/tests/unit/launcher/test_launcher.py
+++ b/tests/unit/launcher/test_launcher.py
@@ -1185,4 +1185,6 @@ def test_launcher_no_sky_dependency():
     process = Process(target=_verify_no_extra_import, args=["sky"])
     process.start()
     process.join()
-    assert process.exitcode == 0, "Sky was imported in the CLI. This is a regression."
+    assert process.exitcode == 0, (
+        "Sky was imported in as part of the launcher module. " "This is a regression."
+    )

--- a/tests/unit/launcher/test_launcher.py
+++ b/tests/unit/launcher/test_launcher.py
@@ -1185,6 +1185,6 @@ def test_launcher_no_sky_dependency():
     process = Process(target=_verify_no_extra_import, args=["sky"])
     process.start()
     process.join()
-    assert process.exitcode == 0, (
-        "Sky was imported as part of the launcher module. " "This is a regression."
-    )
+    assert (
+        process.exitcode == 0
+    ), "Sky was imported as part of the launcher module. This is a regression."

--- a/tests/unit/launcher/test_launcher.py
+++ b/tests/unit/launcher/test_launcher.py
@@ -1,3 +1,4 @@
+from multiprocessing import Process, set_start_method
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1165,3 +1166,23 @@ def test_launcher_export_methods(mock_registry):
     assert LAUNCHER.stop == stop
     assert LAUNCHER.get_cloud == get_cloud
     assert LAUNCHER.which_clouds == which_clouds
+
+
+def _verify_no_extra_import(extra_module: str):
+    """Verifies that extra modules are not imported."""
+    import sys
+
+    import oumi.launcher  # noqa
+
+    assert extra_module not in sys.modules, f"{extra_module} was imported."
+
+
+def test_launcher_no_sky_dependency():
+    # Ensure that sky is lazy loaded so it doesn't cause DB contention in multinode
+    # jobs: https://github.com/oumi-ai/oumi/issues/1605
+
+    set_start_method("spawn", force=True)
+    process = Process(target=_verify_no_extra_import, args=["sky"])
+    process.start()
+    process.join()
+    assert process.exitcode == 0, "Sky was imported in the CLI. This is a regression."

--- a/tests/unit/launcher/test_launcher.py
+++ b/tests/unit/launcher/test_launcher.py
@@ -1186,5 +1186,5 @@ def test_launcher_no_sky_dependency():
     process.start()
     process.join()
     assert process.exitcode == 0, (
-        "Sky was imported in as part of the launcher module. " "This is a regression."
+        "Sky was imported as part of the launcher module. " "This is a regression."
     )


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
This change updates all skypilot entry points to lazy load the `sky` library. This prevents DB locking that can occur when using skypilot in a multithreaded environment.

I also added a test to ensure that `sky` is not loaded when importing the `oumi.launcher` module.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes #1605

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
