### PR TITLE
Add additional_model_kwargs and additional_trainer_kwargs to train function

### DIFF
--- a/src/oumi/__init__.py
+++ b/src/oumi/__init__.py
@@ -240,11 +240,19 @@ def judge_dataset(config: JudgeConfig, dataset: BaseSftDataset) -> list[dict[str
     return oumi.judge.judge_dataset(config, dataset)
 
 
-def train(config: TrainingConfig, **kwargs) -> None:
+def train(
+    config: TrainingConfig,
+    additional_model_kwargs: dict[str, Any] | None = None,
+    additional_trainer_kwargs: dict[str, Any] | None = None,
+) -> None:
     """Trains a model using the provided configuration."""
     import oumi.train
 
-    return oumi.train.train(config, *kwargs)
+    return oumi.train.train(
+        config,
+        additional_model_kwargs=additional_model_kwargs,
+        additional_trainer_kwargs=additional_trainer_kwargs,
+    )
 
 
 __all__ = [

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -189,6 +189,7 @@ def _create_optional_training_kwargs(
     metrics_function: Optional[Callable],
     reward_functions: list[Callable],
     collator: Optional[Callable],
+    additional_trainer_kwargs: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {"processing_class": tokenizer}
     if trainer_type == TrainerType.OUMI:
@@ -204,10 +205,15 @@ def _create_optional_training_kwargs(
         if collator:
             raise ValueError(f"collator isn't supported for {trainer_type}")
         kwargs["reward_funcs"] = reward_functions
+    kwargs.update(additional_trainer_kwargs or {})
     return kwargs
 
 
-def train(config: TrainingConfig, **kwargs) -> None:
+def train(
+    config: TrainingConfig,
+    additional_model_kwargs: Optional[dict[str, Any]] = None,
+    additional_trainer_kwargs: Optional[dict[str, Any]] = None,
+) -> None:
     """Trains a model using the provided configuration."""
     _START_TIME = time.time()
 
@@ -275,7 +281,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
     model = build_model(
         model_params=config.model,
         peft_params=config.peft if use_peft else None,
-        *kwargs,
+        **(additional_model_kwargs or {}),
     )
 
     if use_peft:
@@ -354,6 +360,7 @@ def train(config: TrainingConfig, **kwargs) -> None:
         metrics_function,
         reward_functions,
         collator,
+        additional_trainer_kwargs=additional_trainer_kwargs,
     )
 
     # Reclaim memory before training starts.


### PR DESCRIPTION
<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
This pull request includes several changes to the `train` function and related methods in the `oumi` module to support additional model and trainer keyword arguments. The motivation was to allow passing non-serializable keyword arguments into the trainer class (and the model class). The most important changes are as follows:

### Enhancements to `train` function:

* Modified the `train` function in `src/oumi/__init__.py` to accept `additional_model_kwargs` and `additional_trainer_kwargs` parameters and pass them to the `oumi.train.train` function.

### Enhancements to `train` function in `src/oumi/train.py`:

* Updated the `_create_optional_training_kwargs` function to accept an `additional_trainer_kwargs` parameter and include it in the returned dictionary. [[1]](diffhunk://#diff-883bb6b1dff705e291235aa01c36f1b4d1a80d1907c27b30bcf299f7c63972d2R192) [[2]](diffhunk://#diff-883bb6b1dff705e291235aa01c36f1b4d1a80d1907c27b30bcf299f7c63972d2R208-R216)
* Modified the `train` function to accept `additional_model_kwargs` and `additional_trainer_kwargs` parameters and use them when building the model and creating optional training kwargs. [[1]](diffhunk://#diff-883bb6b1dff705e291235aa01c36f1b4d1a80d1907c27b30bcf299f7c63972d2L278-R284) [[2]](diffhunk://#diff-883bb6b1dff705e291235aa01c36f1b4d1a80d1907c27b30bcf299f7c63972d2R363)

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes #1623 by allowing user to pass a `preprocess_logits_for_metrics` function to `additional_trainer_kwargs` in the `train` function.

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
