### PR TITLE
Support for custom `processor args`: misc improvements

### DIFF
--- a/configs/recipes/vision/phi4/sft/lora/train.yaml
+++ b/configs/recipes/vision/phi4/sft/lora/train.yaml
@@ -24,9 +24,6 @@ model:
   torch_dtype_str: "bfloat16"
   model_max_length: 4096
   trust_remote_code: True
-  processor_kwargs:
-    min_pixels: 1000
-    max_pixels": 111140000
   attn_implementation: "flash_attention_2" # The model requires Flash Attention.
 
 

--- a/configs/recipes/vision/phi4/sft/lora/train.yaml
+++ b/configs/recipes/vision/phi4/sft/lora/train.yaml
@@ -24,6 +24,9 @@ model:
   torch_dtype_str: "bfloat16"
   model_max_length: 4096
   trust_remote_code: True
+  processor_kwargs:
+    min_pixels: 1000
+    max_pixels": 111140000
   attn_implementation: "flash_attention_2" # The model requires Flash Attention.
 
 

--- a/scripts/benchmarks/minimal_multimodal_training.py
+++ b/scripts/benchmarks/minimal_multimodal_training.py
@@ -307,6 +307,7 @@ def test_multimodal_trainer(
     collator_kwargs = {}
     if collator_name == "vision_language_sft":
         collator_kwargs["processor_name"] = model_name.value
+        collator_kwargs["processor_kwargs"] = model_params.processor_kwargs
         collator_kwargs["trust_remote_code"] = model_params.trust_remote_code
 
     # Initialize trainer with custom collator

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -111,9 +111,11 @@ def build_data_collator(
         processor_name = kwargs.pop("processor_name", None)
         if not processor_name:
             raise ValueError(f"Empty processor_name for '{collator_name}'")
+        processor_kwargs = kwargs.pop("processor_kwargs", None)
         return VisionLanguageSftCollator(
             tokenizer=tokenizer,
             processor_name=processor_name,
+            processor_kwargs=processor_kwargs,
             max_length=max_length,
             truncation=enable_truncation,
             label_ignore_index=label_ignore_index,

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -175,6 +175,7 @@ def build_collator_from_config(
         if not processor_name:
             raise ValueError(f"Processor name must be provided for '{collator_name}'!")
         collator_kwargs["processor_name"] = processor_name
+        collator_kwargs["processor_kwargs"] = config.model.processor_kwargs
 
         collator_kwargs["trust_remote_code"] = collator_kwargs.get(
             "trust_remote_code", config.model.trust_remote_code

--- a/src/oumi/core/collators/vision_language_sft_collator.py
+++ b/src/oumi/core/collators/vision_language_sft_collator.py
@@ -28,6 +28,7 @@ class VisionLanguageSftCollator:
         tokenizer: BaseTokenizer,
         processor_name: str,
         *,
+        processor_kwargs: Optional[dict[str, Any]] = None,
         max_length: Optional[int] = None,
         truncation: bool = False,
         truncation_side: str = "right",
@@ -40,6 +41,9 @@ class VisionLanguageSftCollator:
         Args:
             tokenizer: The tokenizer used for encoding the data.
             processor_name: The name of the processor to use for feature generation.
+            processor_kwargs: A dictionary of processor-specific parameters.
+                These parameters are passed to the processor constructor.
+                They can override model-specific parameters.
             max_length: Padding length.
             truncation: Whether to truncate long inputs to `max_length`.
                 If False, the long inputs are preserved as is even if they exceed
@@ -60,6 +64,7 @@ class VisionLanguageSftCollator:
             VisionLanguageConversationFeatureGenerator(
                 tokenizer=tokenizer,
                 processor_name=processor_name,
+                processor_kwargs=processor_kwargs,
                 trust_remote_code=trust_remote_code,
                 return_tensors="pt",
                 truncation=truncation,

--- a/src/oumi/core/configs/training_config.py
+++ b/src/oumi/core/configs/training_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Final
 
@@ -151,7 +152,11 @@ class TrainingConfig(BaseConfig):
         # one column: 'conversation_json' (JSON-encoded `Conversation`)!
         collator_name: Final[str] = self.data.train.collator_name or ""
         if collator_name == "vision_language_sft":
-            for dataset_params in self.data.train.datasets:
+            for dataset_params in itertools.chain(
+                self.data.train.datasets,
+                self.data.validation.datasets,
+                self.data.test.datasets,
+            ):
                 if not dataset_params.dataset_kwargs.get("return_conversations", True):
                     raise ValueError(
                         "`return_conversations` must be True "
@@ -179,7 +184,11 @@ class TrainingConfig(BaseConfig):
             model_processor_name: Final[str] = (
                 self.model.tokenizer_name or self.model.model_name
             )
-            for dataset_params in self.data.train.datasets:
+            for dataset_params in itertools.chain(
+                self.data.train.datasets,
+                self.data.validation.datasets,
+                self.data.test.datasets,
+            ):
                 if (
                     "processor_name" not in dataset_params.dataset_kwargs
                     or "processor_kwargs" in dataset_params.dataset_kwargs

--- a/src/oumi/core/configs/training_config.py
+++ b/src/oumi/core/configs/training_config.py
@@ -174,3 +174,23 @@ class TrainingConfig(BaseConfig):
                 dataset_kwargs = self.training.trainer_kwargs.get("dataset_kwargs", {})
                 dataset_kwargs["skip_prepare_dataset"] = True
                 self.training.trainer_kwargs["dataset_kwargs"] = dataset_kwargs
+
+        if len(self.model.processor_kwargs) > 0:
+            model_processor_name: Final[str] = (
+                self.model.tokenizer_name or self.model.model_name
+            )
+            for dataset_params in self.data.train.datasets:
+                if (
+                    "processor_name" not in dataset_params.dataset_kwargs
+                    or "processor_kwargs" in dataset_params.dataset_kwargs
+                ):
+                    continue
+                dataset_processor_name: str = dataset_params.dataset_kwargs[
+                    "processor_name"
+                ]
+                if dataset_processor_name == model_processor_name:
+                    # Copy processor kwargs from the model if processor names match
+                    # and the dataset doesn't override them.
+                    dataset_params.dataset_kwargs["processor_kwargs"] = {
+                        **self.model.processor_kwargs
+                    }

--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 from typing_extensions import override
 
@@ -68,6 +68,7 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
         tokenizer: Optional[BaseTokenizer] = None,
         processor: Optional[BaseProcessor] = None,
         processor_name: Optional[str] = None,
+        processor_kwargs: Optional[dict[str, Any]] = None,
         limit: Optional[int] = None,
         trust_remote_code: bool = False,
         max_images: Optional[int] = None,
@@ -85,6 +86,9 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
             tokenizer: A tokenizer for encoding text data.
             processor: An optional processor object for generating features.
             processor_name: The name of the processor to use for feature generation.
+            processor_kwargs: A dictionary of processor-specific parameters.
+                These parameters are passed to the processor constructor.
+                They can override model-specific parameters.
             limit: An optional limit on the number of examples to load.
             trust_remote_code: Whether to trust remote code execution for the processor.
             return_conversations: Whether to return raw `Conversation` objects.
@@ -105,6 +109,7 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
                 tokenizer=tokenizer,
                 processor=processor,
                 processor_name=processor_name,
+                processor_kwargs=processor_kwargs,
                 trust_remote_code=trust_remote_code,
                 return_tensors=self._return_tensors,
             )

--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -25,7 +25,6 @@ from oumi.core.types.conversation import (
     Conversation,
 )
 from oumi.utils.conversation_utils import remove_excessive_images_from_conversation
-from oumi.utils.logging import logger
 
 
 class VisionLanguageSftDataset(BaseSftDataset, ABC):
@@ -102,8 +101,6 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
         super().__init__(tokenizer=tokenizer, **kwargs)
 
         self._max_images = max_images
-
-        logger.info(f"processor_kwargs: {processor_kwargs}")
 
         self._feature_generator = (
             None

--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -25,6 +25,7 @@ from oumi.core.types.conversation import (
     Conversation,
 )
 from oumi.utils.conversation_utils import remove_excessive_images_from_conversation
+from oumi.utils.logging import logger
 
 
 class VisionLanguageSftDataset(BaseSftDataset, ABC):
@@ -101,6 +102,8 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
         super().__init__(tokenizer=tokenizer, **kwargs)
 
         self._max_images = max_images
+
+        logger.info(f"processor_kwargs: {processor_kwargs}")
 
         self._feature_generator = (
             None

--- a/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
+++ b/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 import numpy as np
 import torch
@@ -68,6 +68,7 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
         tokenizer: Optional[BaseTokenizer] = None,
         processor: Optional[BaseProcessor] = None,
         processor_name: Optional[str] = None,
+        processor_kwargs: Optional[dict[str, Any]] = None,
         trust_remote_code: bool = False,
         return_tensors: Optional[str] = None,
         max_length: Optional[int] = None,
@@ -108,10 +109,18 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
                     "Both processor and processor_name are provided. "
                     f"Ignoring processor_name: {processor_name}"
                 )
+            if processor_kwargs is not None and len(processor_kwargs) > 0:
+                logger.warning(
+                    "Both processor and processor_kwargs are provided. "
+                    f"Ignoring processor_name: {processor_name}"
+                )
         elif processor_name:
             # TODO OPE-1185 Add plumbing for processor_kwargs
             processor = build_processor(
-                processor_name, tokenizer, trust_remote_code=trust_remote_code
+                processor_name,
+                tokenizer,
+                trust_remote_code=trust_remote_code,
+                processor_kwargs=processor_kwargs,
             )
         else:
             raise ValueError(

--- a/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
+++ b/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
@@ -112,7 +112,7 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
             if processor_kwargs is not None and len(processor_kwargs) > 0:
                 logger.warning(
                     "Both processor and processor_kwargs are provided. "
-                    f"Ignoring processor_name: {processor_name}"
+                    f"Ignoring processor_kwargs: {processor_kwargs}"
                 )
         elif processor_name:
             # TODO OPE-1185 Add plumbing for processor_kwargs

--- a/tests/unit/core/configs/test_training_config.py
+++ b/tests/unit/core/configs/test_training_config.py
@@ -1,0 +1,128 @@
+from oumi.core.configs import (
+    DataParams,
+    DatasetParams,
+    DatasetSplitParams,
+    ModelParams,
+    TrainingConfig,
+)
+
+
+def test_training_config_processor_kwargs():
+    """Test that json, regex, and choice parameters are mutually exclusive."""
+    config = TrainingConfig(
+        model=ModelParams(
+            model_name="llava-hf/llava-1.5-7b-hf",
+            processor_kwargs={"num_patches": 16},
+        ),
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="llava_collator",
+                datasets=[
+                    DatasetParams(
+                        dataset_name="merve/vqav2-small",
+                        split="train",
+                        dataset_kwargs={"processor_name": "llava-hf/llava-1.5-7b-hf"},
+                    ),
+                    DatasetParams(
+                        dataset_name="HuggingFaceH4/llava-instruct-mix-vsft",
+                        split="train",
+                        dataset_kwargs={
+                            "processor_name": "llava-hf/llava-1.5-7b-hf",
+                            "processor_kwargs": {"num_patches": 32, "foo": "bar"},
+                        },
+                    ),
+                    DatasetParams(
+                        dataset_name="coco_captions",
+                        split="train",
+                        dataset_kwargs={
+                            "processor_name": "microsoft/Phi-3-vision-128k-instruct"
+                        },
+                    ),
+                    DatasetParams(
+                        dataset_name="coco_captions",
+                        split="test",
+                        dataset_kwargs={
+                            "processor_name": "llava-hf/llava-1.5-7b-hf",
+                            "processor_kwargs": {},
+                        },
+                    ),
+                ],
+            ),
+            validation=DatasetSplitParams(
+                collator_name="llava_collator",
+                datasets=[
+                    DatasetParams(
+                        dataset_name="merve/vqav2-small",
+                        split="validation",
+                        dataset_kwargs={"processor_name": "llava-hf/llava-1.5-7b-hf"},
+                    )
+                ],
+            ),
+            test=DatasetSplitParams(
+                collator_name="llava_collator",
+                datasets=[
+                    DatasetParams(
+                        dataset_name="HuggingFaceH4/llava-instruct-mix-vsft",
+                        split="test",
+                        dataset_kwargs={"processor_name": "llava-hf/llava-1.5-7b-hf"},
+                    )
+                ],
+            ),
+        ),
+    )
+    assert len(config.data.train.datasets) == 4
+    assert config.data.train.datasets[0] == DatasetParams(
+        dataset_name="merve/vqav2-small",
+        split="train",
+        dataset_kwargs={
+            "processor_name": "llava-hf/llava-1.5-7b-hf",
+            "processor_kwargs": {
+                "num_patches": 16,
+            },
+        },
+    )
+    assert config.data.train.datasets[1] == DatasetParams(
+        dataset_name="HuggingFaceH4/llava-instruct-mix-vsft",
+        split="train",
+        dataset_kwargs={
+            "processor_name": "llava-hf/llava-1.5-7b-hf",
+            "processor_kwargs": {"num_patches": 32, "foo": "bar"},
+        },
+    )
+    assert config.data.train.datasets[2] == DatasetParams(
+        dataset_name="coco_captions",
+        split="train",
+        dataset_kwargs={"processor_name": "microsoft/Phi-3-vision-128k-instruct"},
+    )
+    assert config.data.train.datasets[3] == DatasetParams(
+        dataset_name="coco_captions",
+        split="test",
+        dataset_kwargs={
+            "processor_name": "llava-hf/llava-1.5-7b-hf",
+            "processor_kwargs": {},
+        },
+    )
+
+    assert len(config.data.validation.datasets) == 1
+    assert config.data.validation.datasets[0] == DatasetParams(
+        dataset_name="merve/vqav2-small",
+        split="validation",
+        dataset_kwargs={
+            "processor_name": "llava-hf/llava-1.5-7b-hf",
+            "processor_kwargs": {
+                "num_patches": 16,
+            },
+        },
+    )
+
+    assert len(config.data.test.datasets) == 1
+    assert config.data.test.datasets[0] == DatasetParams(
+        dataset_name="HuggingFaceH4/llava-instruct-mix-vsft",
+        split="test",
+        dataset_kwargs={
+            "processor_name": "llava-hf/llava-1.5-7b-hf",
+            "processor_kwargs": {
+                "num_patches": 16,
+            },
+        },
+    )


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

-- Plumbing to populate `processor_kwargs` in VL SFT collator and in VL SFT dataset
-- Copy `model.processor_kwargs` to `dataset_kwargs` if the same processor name is used in both, and if `processor_kwargs`   isn't already configured there.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards OPE-1185

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
