### PR TITLE
[tiny] Remove vllm install commands

### DIFF
--- a/configs/examples/berry_bench/evaluation/gcp_job.yaml
+++ b/configs/examples/berry_bench/evaluation/gcp_job.yaml
@@ -38,7 +38,6 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install oumi[gpu]
-  pip install "vllm>=0.7.3,<0.8.0"
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/letter_counting/evaluation/gcp_job.yaml
+++ b/configs/examples/letter_counting/evaluation/gcp_job.yaml
@@ -38,7 +38,6 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install oumi[gpu]
-  pip install "vllm>=0.7.3,<0.8.0"
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/projects/halloumi/halloumi_inference_notebook.ipynb
+++ b/configs/projects/halloumi/halloumi_inference_notebook.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Install Oumi, so that you can use our inference engines. You can find more detailed instructions about Oumi installation [here](https://oumi.ai/docs/en/latest/get_started/installation.html).\n"
+    "Install Oumi, so that you can use our inference engines. You can find more detailed instructions about Oumi installation [here](https://oumi.ai/docs/en/latest/get_started/installation.html). If you're running this notebook on a CUDA-compatible GPU and want to use vLLM for inference, make sure to install the optional Oumi `[gpu]` dependencies.\n"
    ]
   },
   {
@@ -51,23 +51,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install oumi"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you're running this notebook on a CUDA-compatible GPU and want to use vLLM for inference, make sure to install it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install \"vllm>=0.7.3,<0.8.0\""
+    "%pip install oumi\n",
+    "# %pip install oumi[gpu]"
    ]
   },
   {

--- a/configs/recipes/llama4/inference/scout_instruct_vllm_infer.yaml
+++ b/configs/recipes/llama4/inference/scout_instruct_vllm_infer.yaml
@@ -1,7 +1,7 @@
-# Inference config for Llama 4 Scout-17B-16E Instruct with a NATIVE engine.
+# vLLM Inference config for Llama 4 Scout-17B-16E Instruct.
 #
 # Requirements:
-#   - Run `pip install vllm`
+#   - Run `pip install oumi[gpu]`
 #   - Log into HF: `huggingface-cli login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #

--- a/notebooks/Oumi - Train a Letter Counting Model using GRPO.ipynb
+++ b/notebooks/Oumi - Train a Letter Counting Model using GRPO.ipynb
@@ -64,8 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install git+https://github.com/oumi-ai/oumi.git\n",
-    "%pip install \"vllm>=0.7.3,<0.8.0\""
+    "%pip install oumi[gpu]"
    ]
   },
   {


### PR DESCRIPTION
# Description

With oumi 0.1.12 published on PyPI today, vllm is now included in the [gpu] optional dependencies. Tested on GCP.

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
