### PR TITLE
Update e2e tests to run on lambda

### DIFF
--- a/tests/e2e/test_train_e2e.py
+++ b/tests/e2e/test_train_e2e.py
@@ -427,7 +427,7 @@ def test_train_text_1gpu_24gb(
     _test_train_impl(test_config=test_config, tmp_path=tmp_path, use_distributed=False)
 
 
-@requires_gpus(count=4, min_gb=40.0)
+@requires_gpus(count=4, min_gb=39.0)
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -475,7 +475,7 @@ def test_train_multimodal_4gpu_40gb(test_config: TrainTestConfig, tmp_path: Path
     )
 
 
-@requires_gpus(count=1, min_gb=40.0)
+@requires_gpus(count=1, min_gb=39.0)
 @pytest.mark.parametrize(
     "test_config",
     [

--- a/tests/e2e/test_train_e2e.py
+++ b/tests/e2e/test_train_e2e.py
@@ -427,18 +427,19 @@ def test_train_text_1gpu_24gb(
     _test_train_impl(test_config=test_config, tmp_path=tmp_path, use_distributed=False)
 
 
-@requires_gpus(count=1, min_gb=24.0)
+@requires_gpus(count=4, min_gb=40.0)
 @pytest.mark.parametrize(
     "test_config",
     [
         TrainTestConfig(
-            test_name="train_mm_qwen2_vl_2b_trl_sft",
+            test_name="train_mm_qwen2_vl_2b_trl_sft_fft",
             config_path=(
                 get_configs_dir()
                 / "recipes"
                 / "vision"
                 / "qwen2_vl_2b"
                 / "sft"
+                / "full"
                 / "train.yaml"
             ),
             trainer_type=TrainerType.TRL_SFT,
@@ -446,13 +447,14 @@ def test_train_text_1gpu_24gb(
             save_steps=5,
         ),
         TrainTestConfig(
-            test_name="train_mm_qwen2_vl_2b_oumi",
+            test_name="train_mm_qwen2_vl_2b_oumi_fft",
             config_path=(
                 get_configs_dir()
                 / "recipes"
                 / "vision"
                 / "qwen2_vl_2b"
                 / "sft"
+                / "full"
                 / "train.yaml"
             ),
             trainer_type=TrainerType.OUMI,
@@ -464,8 +466,40 @@ def test_train_text_1gpu_24gb(
     ids=get_train_test_id_fn,
 )
 @pytest.mark.e2e
+@pytest.mark.multi_gpu
+def test_train_multimodal_4gpu_40gb(test_config: TrainTestConfig, tmp_path: Path):
+    _test_train_impl(
+        test_config=test_config,
+        tmp_path=tmp_path,
+        use_distributed=True,
+    )
+
+
+@requires_gpus(count=1, min_gb=40.0)
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        TrainTestConfig(
+            test_name="train_mm_qwen2_vl_2b_trl_sft_lora",
+            config_path=(
+                get_configs_dir()
+                / "recipes"
+                / "vision"
+                / "qwen2_vl_2b"
+                / "sft"
+                / "lora"
+                / "train.yaml"
+            ),
+            trainer_type=TrainerType.TRL_SFT,
+            max_steps=5,
+            save_steps=5,
+        ),
+    ],
+    ids=get_train_test_id_fn,
+)
+@pytest.mark.e2e
 @pytest.mark.single_gpu
-def test_train_multimodal_1gpu_24gb(test_config: TrainTestConfig, tmp_path: Path):
+def test_train_multimodal_lora_1gpu_40gb(test_config: TrainTestConfig, tmp_path: Path):
     _test_train_impl(
         test_config=test_config,
         tmp_path=tmp_path,

--- a/tests/scripts/lambda_e2e_tests_job.yaml
+++ b/tests/scripts/lambda_e2e_tests_job.yaml
@@ -2,11 +2,11 @@
 # https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 
 # Sample command:
-# oumi launch up --config tests/scripts/gcp_e2e_tests_job.yaml --cluster oumi-e2e-tests-cluster
+# oumi launch up --config tests/scripts/lambda_e2e_tests_job.yaml --cluster oumi-e2e-tests-cluster
 name: oumi-e2e-tests
 
 resources:
-  cloud: gcp
+  cloud: lambda
   accelerators: "A100:4" # "A100:1", "A100-80GB:1", "A100-80GB:4"
   use_spot: false
   disk_size: 1000 # Disk size in GBs

--- a/tests/scripts/launch_tests.sh
+++ b/tests/scripts/launch_tests.sh
@@ -8,7 +8,9 @@ echo "Using test config: ${E2E_TEST_CONFIG}"
 export E2E_CLUSTER_PREFIX="oumi-${USER}-e2e-tests"
 export E2E_USE_SPOT_VM=0 # Whether to use Spot VMs.
 
-declare -a accelerators_arr=("A100:1" "A100:4" "A100-80GB:4")
+# An alternative to H100 is A100-80GB, if they are available.
+# However, A100-80GB:4 isn't available in Lambda.
+declare -a accelerators_arr=("A100:1" "A100:4" "H100:4")
 
 # Reset the variable to make sure that CLI `--resources.use_spot` arg is not ignored.
 OUMI_USE_SPOT_VM=""

--- a/tests/scripts/launch_tests.sh
+++ b/tests/scripts/launch_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-E2E_TEST_CONFIG="${SCRIPT_DIR}/gcp_e2e_tests_job.yaml"
+E2E_TEST_CONFIG="${SCRIPT_DIR}/lambda_e2e_tests_job.yaml"
 echo "Using test config: ${E2E_TEST_CONFIG}"
 
 export E2E_CLUSTER_PREFIX="oumi-${USER}-e2e-tests"

--- a/tests/scripts/launch_tests.sh
+++ b/tests/scripts/launch_tests.sh
@@ -7,6 +7,7 @@ echo "Using test config: ${E2E_TEST_CONFIG}"
 
 export E2E_CLUSTER_PREFIX="oumi-${USER}-e2e-tests"
 export E2E_USE_SPOT_VM=0 # Whether to use Spot VMs.
+export E2E_CLUSTER="" # Cloud provider to use (e.g., "lambda", "aws", etc.)
 
 # An alternative to H100 is A100-80GB, if they are available.
 # However, A100-80GB:4 isn't available in Lambda.
@@ -27,10 +28,20 @@ do
       CLUSTER_SUFFIX="${CLUSTER_SUFFIX}-spot"
    fi
    CLUSTER_NAME="${E2E_CLUSTER_PREFIX}-${CLUSTER_SUFFIX}"
+
+   CLOUD_ARG=""
+   if [ -n "$E2E_CLUSTER" ]; then
+      CLOUD_ARG="--resources.cloud=${E2E_CLUSTER}"
+   else
+      CLOUD_ARG="--resources.cloud=lambda"
+   fi
+
+   set -x
    oumi launch up \
       --config "${E2E_TEST_CONFIG}" \
       --resources.accelerators="${CURR_GPU_NAME}" \
       "${USE_SPOT_ARG}" \
+      "${CLOUD_ARG}" \
       --cluster "${CLUSTER_NAME}" \
       --detach
 done


### PR DESCRIPTION
# Description

- Swapped e2e tests to run on Lambda
- Swapped A100-80GB:4 with H100:4 since the former isn't available in Lambda
- Fixed a broken qwen e2e test, since the config `configs/recipes/vision/qwen2_vl_2b/sft/train.yaml` was moved to `configs/recipes/vision/qwen2_vl_2b/sft/full/train.yaml`.
    - I updated the test to run multi-GPU since that's how the config is running it; wasn't sure if there's a specific reason it was set to be a 24GB 1 GPU test before.
- Added a test for the parallel `configs/recipes/vision/qwen2_vl_2b/sft/lora/train.yaml` config.

I've tested that "A100:1" and "H100:4"GPU tests work. I've been unable to schedule "A100:4" tests work since there hasn't been enough capacity on Lambda, but the tests are covered by the H100:4 tests.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
