### PR TITLE
[verl] Populate verl config from Oumi config

### DIFF
--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -613,11 +613,32 @@ class TrainingParams(BaseParams):
     """
 
     trainer_kwargs: dict[str, Any] = field(default_factory=dict)
-    """Additional keyword arguments to pass to the Trainer.
+    """Additional keyword arguments to pass to the HF/TRL Trainer.
 
     This allows for customization of the Trainer beyond the standard parameters
     defined in this class. Any key-value pairs added here will be passed directly
-    to the Trainer's constructor.
+    to the Trainer's constructor. Note that this field is only used for
+    HuggingFace and TRL trainers (TRL_SFT, TRL_DPO, TRL_GRPO, HF).
+    """
+
+    verl_config_overrides: dict[str, Any] = field(default_factory=dict)
+    """Values to override in the verl config.
+
+    This field is only used for the `VERL_GRPO` trainer.
+    To see supported params in verl, see:
+    https://verl.readthedocs.io/en/latest/examples/config.html
+
+    The verl config is a nested dict, so the kwargs should be structured accordingly.
+    For example, to set `actor_rollout_ref.actor.use_kl_loss` to `True`, you can use:
+    `{"actor_rollout_ref": {"actor": {"use_kl_loss": True}}}`.
+
+    The priority of setting verl config params, from highest to lowest, is:
+    1. Values specified by this field.
+    2. Values automatically set by Oumi in
+        `src/oumi/core/trainers/verl_grpo_trainer.py:_create_config()` for verl params
+        which have corresponding Oumi params. For example,
+        Oumi's `training.output_dir` -> verl's `trainer.default_local_dir`
+    3. Default verl config values in `src/oumi/core/trainers/verl_trainer_config.yaml`.
     """
 
     profiler: ProfilerParams = field(default_factory=ProfilerParams)

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -15,6 +15,7 @@
 """Volcano Engine Reinforcement Learning (verl) GRPO Trainer."""
 
 import copy
+import os
 from pathlib import Path
 from typing import Callable, Optional, Union, cast
 
@@ -41,7 +42,7 @@ except ModuleNotFoundError:
     ray = None
 
 
-from oumi.core.configs import TrainingConfig, TrainingParams
+from oumi.core.configs import TrainingConfig
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.trainers.base_trainer import BaseTrainer
 from oumi.utils.logging import logger
@@ -60,7 +61,7 @@ class VerlGrpoTrainer(BaseTrainer):
     def __init__(
         self,
         processing_class: Optional[BaseTokenizer],
-        args: TrainingParams,
+        config: TrainingConfig,
         reward_funcs: list[Callable],
         train_dataset: Dataset,
         eval_dataset: Dataset,
@@ -71,7 +72,7 @@ class VerlGrpoTrainer(BaseTrainer):
 
         Args:
             processing_class: The tokenizer for the model.
-            args: Training parameters.
+            config: Training config.
             reward_funcs: List of reward functions to use.
             train_dataset: Training dataset.
             eval_dataset: Validation dataset. This is required by verl.
@@ -87,7 +88,7 @@ class VerlGrpoTrainer(BaseTrainer):
             "VerlGrpoTrainer is experimental, and the interface is subject to change."
         )
         self._processing_class = processing_class
-        self._params = copy.deepcopy(args)
+        self._oumi_config = copy.deepcopy(config)
         # TODO: OPE-1192 - Support multiple reward functions.
         if len(reward_funcs) > 1:
             raise ValueError("We only support up to one reward function.")
@@ -123,6 +124,45 @@ class VerlGrpoTrainer(BaseTrainer):
         config.algorithm.adv_estimator = "grpo"
         config.data.train_files = self._train_filepath
         config.data.val_files = self._val_filepath
+
+        grpo_params = self._oumi_config.training.grpo
+        model_params = self._oumi_config.model
+        training_params = self._oumi_config.training
+
+        config.data.max_response_length = grpo_params.max_completion_length
+        config.actor_rollout_ref.model.path = model_params.model_name
+        config.actor_rollout_ref.actor.optim.lr = training_params.learning_rate
+        config.actor_rollout_ref.model.enable_gradient_checkpointing = (
+            training_params.enable_gradient_checkpointing
+        )
+        if grpo_params.use_vllm:
+            config.actor_rollout_ref.rollout.name = "vllm"
+        else:
+            config.actor_rollout_ref.rollout.name = "hf"
+        config.actor_rollout_ref.rollout.temperature = grpo_params.temperature
+        config.actor_rollout_ref.rollout.gpu_memory_utilization = (
+            grpo_params.vllm_gpu_memory_utilization
+        )
+
+        if not training_params.save_epoch:
+            config.trainer.save_freq = training_params.save_steps
+        if training_params.eval_strategy == "steps":
+            config.trainer.test_freq = training_params.eval_steps
+        config.trainer.total_epochs = training_params.num_train_epochs
+
+        if training_params.enable_wandb:
+            config.trainer.logger = ["wandb"]
+        config.trainer.project_name = os.environ.get("WANDB_PROJECT", "oumi_verl")
+        config.trainer.experiment_name = training_params.run_name
+        config.trainer.default_local_dir = training_params.output_dir
+
+        # Could be auto-set
+        config.trainer.n_gpus_per_node = 2
+        config.trainer.nnodes = 1
+
+        # Apply user overrides
+        overrides_config = OmegaConf.create(training_params.verl_config_overrides)
+        config = cast(DictConfig, OmegaConf.merge(config, overrides_config))
 
         if config.actor_rollout_ref.actor.strategy == "fsdp":
             assert config.actor_rollout_ref.actor.strategy == config.critic.strategy

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -162,7 +162,7 @@ class VerlGrpoTrainer(BaseTrainer):
         overrides_config = OmegaConf.create(training_params.verl_config_overrides)
         config = cast(DictConfig, OmegaConf.merge(config, overrides_config))
 
-        # 4. Validate config.s
+        # 4. Validate config.
         if (
             config.actor_rollout_ref.actor.strategy == "fsdp"
             and config.actor_rollout_ref.actor.strategy != config.critic.strategy

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -208,7 +208,7 @@ trainer:
   balance_batch: True
   total_epochs: 30
   total_training_steps: null
-  project_name: oum_verl
+  project_name: oumi_verl
   experiment_name: null
   logger: [ 'console', 'wandb' ]
   log_val_generations: 0

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -1,6 +1,10 @@
 # Default Verl PPO trainer config.
 # Copied from https://github.com/volcengine/verl/blob/25b0f2262ffb668b0a183fd21433adeca76b46f5/verl/trainer/config/ppo_trainer.yaml
 # For documentation, see https://verl.readthedocs.io/en/latest/examples/config.html
+#
+# Changes:
+# - Changed trainer.project_name to "oumi_verl"
+# - Changed trainer.experiment_name to null
 
 data:
   tokenizer: null
@@ -204,8 +208,8 @@ trainer:
   balance_batch: True
   total_epochs: 30
   total_training_steps: null
-  project_name: verl_examples
-  experiment_name: gsm8k
+  project_name: oum_verl
+  experiment_name: null
   logger: [ 'console', 'wandb' ]
   log_val_generations: 0
   nnodes: 1

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -355,7 +355,7 @@ def train(
         partial_trainer = functools.partial(
             create_trainer_fn,
             processing_class=tokenizer,
-            args=config.training,
+            config=config,
             train_dataset=dataset,
             eval_dataset=eval_dataset,
             **training_kwargs,

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -17,7 +17,7 @@ def test_init_without_verl():
         with pytest.raises(RuntimeError, match="verl is not installed"):
             VerlGrpoTrainer(
                 processing_class=MagicMock(),
-                args=MagicMock(),
+                config=MagicMock(),
                 reward_funcs=[MagicMock()],
                 train_dataset=MagicMock(),
                 eval_dataset=MagicMock(),
@@ -29,7 +29,7 @@ def test_init_with_multiple_reward_funcs():
     with pytest.raises(ValueError, match="We only support up to one reward function"):
         VerlGrpoTrainer(
             processing_class=MagicMock(),
-            args=MagicMock(),
+            config=MagicMock(),
             reward_funcs=[MagicMock(), MagicMock()],
             train_dataset=MagicMock(),
             eval_dataset=MagicMock(),


### PR DESCRIPTION
# Description

- Add a `verl_config_overrides` field in TrainingParams to allow setting any verl config value. This is similar to what `trainer_kwargs` does for HF/TRL trainers, and gives users flexibility to pass in fields we don't have in Oumi configs.
- Replace `TrainingParams` with `TrainingConfig` in verl trainer initialization since values in the latter are needed for verl.
- Populate verl config from some Oumi config fields and user-provided overrides.

Future work
- Add more Oumi -> verl config field converters. This PR only adds a few, but adding more is time-consuming. There are 200 verl config values, and I need to read into the verl codebase for many as similarly-named params in Oumi/trl/verl are not the same. For example, `max_prompt_length` in Oumi/trl will truncate prompts longer than that value, but in verl, it will result in an error for longer prompts.
- Add new fields in Oumi configs for verl param values we believe are important enough to get their own Oumi param field, as opposed to having be passed through `verl_config_overrides`.
- Add countdown training/gcp job configs.

## Related issues

Towards OPE-1172

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
