### PR TITLE
Add Qwen3 32B configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ Explore the growing collection of ready-to-use configurations for state-of-the-a
 
 **Note:** These configurations are not an exhaustive list of what's supported, simply examples to get you started. You can find a more exhaustive list of supported [models](https://oumi.ai/docs/en/latest/resources/models/supported_models.html), and datasets ([supervised fine-tuning](https://oumi.ai/docs/en/latest/resources/datasets/sft_datasets.html), [pre-training](https://oumi.ai/docs/en/latest/resources/datasets/pretraining_datasets.html), [preference tuning](https://oumi.ai/docs/en/latest/resources/datasets/preference_datasets.html), and [vision-language finetuning](https://oumi.ai/docs/en/latest/resources/datasets/vl_sft_datasets.html)) in the oumi documentation.
 
+### Qwen Family
+
+| Model | Example Configurations |
+|-------|------------------------|
+| Qwen3 32B | [LoRA](/configs/recipes/qwen3/sft/32b_lora/train.yaml) • [Inference](/configs/recipes/qwen3/inference/32b_infer.yaml) • [Evaluation](/configs/recipes/qwen3/evaluation/32b_eval.yaml) |
+| QwQ 32B | [FFT](/configs/recipes/qwq/sft/full_train.yaml) • [LoRA](/configs/recipes/qwq/sft/lora_train.yaml) • [QLoRA](/configs/recipes/qwq/sft/qlora_train.yaml) • [Inference](/configs/recipes/qwq/inference/infer.yaml) • [Evaluation](/configs/recipes/qwq/evaluation/eval.yaml) |
+| Qwen2.5-VL 3B | [SFT](/configs/recipes/vision/qwen2_5_vl_3b/sft/full/train.yaml) • [LoRA](/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml)• [Inference (vLLM)](configs/recipes/vision/qwen2_5_vl_3b/inference/vllm_infer.yaml) • [Inference](configs/recipes/vision/qwen2_5_vl_3b/inference/infer.yaml) |
+| Qwen2-VL 2B | [SFT](/configs/recipes/vision/qwen2_vl_2b/sft/full/train.yaml) • [LoRA](/configs/recipes/vision/qwen2_vl_2b/sft/lora/train.yaml) • [Inference (vLLM)](configs/recipes/vision/qwen2_vl_2b/inference/vllm_infer.yaml) • [Inference (SGLang)](configs/recipes/vision/qwen2_vl_2b/inference/sglang_infer.yaml) • [Inference](configs/recipes/vision/qwen2_vl_2b/inference/infer.yaml) • [Evaluation](configs/recipes/vision/qwen2_vl_2b/evaluation/eval.yaml) |
+
 ### 🐋 DeepSeek R1 Family
 
 | Model | Example Configurations |

--- a/configs/recipes/qwen3/README.md
+++ b/configs/recipes/qwen3/README.md
@@ -1,0 +1,75 @@
+# Qwen 3
+
+## Summary
+
+Configs for Alibaba's Qwen 3 model family. See the [blog post](https://qwenlm.github.io/blog/qwen3/) for more information. Models in this family include:
+
+- Mixture of Experts
+  - [Qwen/Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B)
+  - [Qwen/Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B)
+- Dense
+  - [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B)
+  - [Qwen/Qwen3-14B](https://huggingface.co/Qwen/Qwen3-14B)
+  - [Qwen/Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B)
+  - [Qwen/Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B)
+  - [Qwen/Qwen3-1.7B](https://huggingface.co/Qwen/Qwen3-1.7B)
+  - [Qwen/Qwen3-0.6B](https://huggingface.co/Qwen/Qwen3-0.6B)
+
+## Quickstart
+
+1. Follow our [quickstart](https://oumi.ai/docs/en/latest/get_started/quickstart.html) for installation.
+2. (Optional) if you wish to kick off jobs on a remote cluster, follow our [job launcher setup guide](https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup).
+3. Run your desired oumi command (examples below)!
+   - Note that installing the Oumi repository is **not required** to run the commands, as we will fetch the config remotely from GitHub thanks to the `oumi://` prefix.
+4. (Optional) If you with to do deeper experimentation, follow our [instructions](https://oumi.ai/docs/en/latest/development/dev_setup.html) to clone the Oumi repository locally.
+   - Make sure to delete the `oumi://` prefix when running Oumi commands, to disable fetching the latest configs from GitHub!
+
+## Example Commands
+
+### Training
+
+To launch Qwen3 32B LoRA training locally:
+
+```shell
+oumi train -c oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml
+```
+
+To launch Qwen3 32B LoRA training on a remote GCP 4x A100 cluster:
+
+```shell
+oumi launch up -c oumi://configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml --cluster qwen3-32b-lora
+```
+
+### Evaluation
+
+To evaluate Qwen3 32B locally:
+
+```shell
+oumi evaluate -c oumi://configs/recipes/qwen3/evaluation/32b_eval.yaml
+```
+
+To instead use the vLLM engine for inference during evaluation:
+
+```shell
+oumi evaluate -c oumi://configs/recipes/qwen3/evaluation/32b_eval.yaml --inference_engine VLLM
+```
+
+To evaluate Qwen3 32B on a remote GCP 4x A100 cluster:
+
+```shell
+oumi launch up -c oumi://configs/recipes/qwen3/evaluation/32b_gcp_job.yaml --cluster qwen3-32b-eval
+```
+
+### Inference
+
+To run interactive inference on Qwen3 32B locally:
+
+```shell
+oumi infer -i -c oumi://configs/recipes/qwen3/inference/32b_infer.yaml
+```
+
+To instead use the vLLM engine for inference:
+
+```shell
+oumi infer -i -c oumi://configs/recipes/qwen3/inference/32b_infer.yaml --engine VLLM
+```

--- a/configs/recipes/qwen3/README.md
+++ b/configs/recipes/qwen3/README.md
@@ -1,8 +1,8 @@
-# Qwen 3
+# Qwen3
 
 ## Summary
 
-Configs for Alibaba's Qwen 3 model family. See the [blog post](https://qwenlm.github.io/blog/qwen3/) for more information. Models in this family include:
+Configs for Alibaba's Qwen3 model family. See the [blog post](https://qwenlm.github.io/blog/qwen3/) for more information. Models in this family include:
 
 - Mixture of Experts
   - [Qwen/Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B)
@@ -20,7 +20,7 @@ Configs for Alibaba's Qwen 3 model family. See the [blog post](https://qwenlm.gi
 1. Follow our [quickstart](https://oumi.ai/docs/en/latest/get_started/quickstart.html) for installation.
 2. (Optional) if you wish to kick off jobs on a remote cluster, follow our [job launcher setup guide](https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup).
 3. Run your desired oumi command (examples below)!
-   - Note that installing the Oumi repository is **not required** to run the commands, as we will fetch the config remotely from GitHub thanks to the `oumi://` prefix.
+   - Note that installing the Oumi repository is **not required** to run the commands. We fetch the latest Oumi config remotely from GitHub thanks to the `oumi://` prefix.
 4. (Optional) If you with to do deeper experimentation, follow our [instructions](https://oumi.ai/docs/en/latest/development/dev_setup.html) to clone the Oumi repository locally.
    - Make sure to delete the `oumi://` prefix when running Oumi commands, to disable fetching the latest configs from GitHub!
 

--- a/configs/recipes/qwen3/evaluation/32b_eval.yaml
+++ b/configs/recipes/qwen3/evaluation/32b_eval.yaml
@@ -15,7 +15,7 @@
 
 model:
   model_name: "Qwen/Qwen3-32B"
-  model_max_length: 131072
+  model_max_length: 32768
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"
   trust_remote_code: True

--- a/configs/recipes/qwen3/evaluation/32b_eval.yaml
+++ b/configs/recipes/qwen3/evaluation/32b_eval.yaml
@@ -33,6 +33,6 @@ tasks:
 
 enable_wandb: True
 
-inference_engine: NATIVE # Can also use VLLM for faster inference on GPUs.
+inference_engine: NATIVE # Can also use `VLLM` for faster inference on GPUs.
 
 output_dir: "output/qwen3_32b/evaluation"

--- a/configs/recipes/qwen3/evaluation/32b_eval.yaml
+++ b/configs/recipes/qwen3/evaluation/32b_eval.yaml
@@ -1,0 +1,38 @@
+# Eval config for Qwen3 32B.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#   - (Optional) Run `pip install oumi[gpu]` if using the VLLM inference engine.
+#
+# Usage:
+#   oumi evaluate -c oumi://configs/recipes/qwen3/evaluation/32b_eval.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
+
+model:
+  model_name: "Qwen/Qwen3-32B"
+  model_max_length: 131072
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  shard_for_eval: True
+
+generation:
+  batch_size: 4
+
+tasks:
+  # For all available tasks, see https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+  - evaluation_backend: lm_harness
+    task_name: mmlu_college_computer_science
+    eval_kwargs:
+      num_fewshot: 5
+
+enable_wandb: True
+
+inference_engine: NATIVE # Can also use VLLM for faster inference on GPUs.
+
+output_dir: "output/qwen3_32b/evaluation"

--- a/configs/recipes/qwen3/evaluation/32b_gcp_job.yaml
+++ b/configs/recipes/qwen3/evaluation/32b_gcp_job.yaml
@@ -1,0 +1,61 @@
+# Job config to eval Qwen3 32B.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c oumi://configs/recipes/qwen3/evaluation/32b_gcp_job.yaml --cluster qwen3-32b-eval
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: qwen3-32b-eval
+
+resources:
+  cloud: gcp
+  accelerators: "A100:4"
+  use_spot: false
+  disk_size: 400 # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  # NOTE: For SFT, update this to point to your model checkpoint.
+  # NOTE: For LoRA, instead update this to point to your LoRA adapter.
+  #       The base model will be inferred automatically.
+  MODEL_CHECKPOINT_DIR: Qwen/Qwen3-32B
+  WANDB_PROJECT: oumi-eval
+  OUMI_RUN_NAME: qwen3-32b.eval
+
+setup: |
+  set -e
+  pip install uv && uv pip install oumi[gpu] hf_transfer
+  # Install model from HF Hub. This tool increases download speed compared to
+  # downloading the model during eval.
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-32B
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  if test ${OUMI_NUM_NODES} -ne 1; then
+    echo "LM Harness supports max 1 node. Actual: ${OUMI_NUM_NODES} nodes."
+    exit 1
+  fi
+
+  echo "Starting evaluation for ${MODEL_CHECKPOINT_DIR} ..."
+  set -x
+
+  oumi evaluate \
+    -c oumi://configs/recipes/qwen3/evaluation/32b_eval.yaml \
+    --run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}" \
+    --model.model_name "${MODEL_CHECKPOINT_DIR}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/qwen3/inference/32b_infer.yaml
+++ b/configs/recipes/qwen3/inference/32b_infer.yaml
@@ -14,12 +14,20 @@
 
 model:
   model_name: "Qwen/Qwen3-32B"
-  model_max_length: 2048
+  model_max_length: 32768
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"
   trust_remote_code: True
 
 generation:
-  max_new_tokens: 2048
+  max_new_tokens: 32768
+  # Set based on recommended Qwen3 best practices for thinking model:
+  # https://huggingface.co/Qwen/Qwen3-235B-A22B#best-practices.
+  temperature: 0.6
+  top_p: 0.95
+  min_p: 0.0
+  use_sampling: True
+  # If repetitions are still present, consider increasing this value (up to 2.0).
+  presence_penalty: 0.0
 
 engine: NATIVE # Can also use `VLLM` for faster inference on GPUs.

--- a/configs/recipes/qwen3/inference/32b_infer.yaml
+++ b/configs/recipes/qwen3/inference/32b_infer.yaml
@@ -22,4 +22,4 @@ model:
 generation:
   max_new_tokens: 2048
 
-engine: NATIVE # Can also use VLLM for faster inference on GPUs.
+engine: NATIVE # Can also use `VLLM` for faster inference on GPUs.

--- a/configs/recipes/qwen3/inference/32b_infer.yaml
+++ b/configs/recipes/qwen3/inference/32b_infer.yaml
@@ -1,0 +1,25 @@
+# Inference config for Qwen3 32B.
+#
+# Requirements:
+#   - (Optional) Run `pip install oumi[gpu]` if using the VLLM inference engine.
+#
+# Usage:
+#   oumi infer -i -c oumi://configs/recipes/qwen3/inference/32b_infer.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "Qwen/Qwen3-32B"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+
+generation:
+  max_new_tokens: 2048
+
+engine: NATIVE # Can also use VLLM for faster inference on GPUs.

--- a/configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml
@@ -1,0 +1,50 @@
+# Job config to LoRA tune Qwen3 32B.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c oumi://configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml --cluster qwen3-32b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: qwen3-32b-lora
+
+resources:
+  cloud: gcp
+  accelerators: "A100:4"
+  use_spot: false
+  disk_size: 400 # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: qwen3-32b.lora
+
+setup: |
+  set -e
+  pip install uv && uv pip install oumi[gpu] hf_transfer
+  # Install model from HF Hub. This tool increases download speed compared to
+  # downloading the model during training.
+  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-32B
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi distributed torchrun \
+      -m oumi train \
+      -c oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/qwen3/sft/32b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/train.yaml
@@ -1,0 +1,72 @@
+# LoRA config for Qwen3 32B.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+model:
+  model_name: "Qwen/Qwen3-32B"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
+    target_col: "prompt"
+    use_async_dataset: True
+
+training:
+  trainer_type: "TRL_SFT"
+  use_peft: True
+  save_steps: 200
+  num_train_epochs: 1
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 8
+  max_grad_norm: null
+
+  enable_gradient_checkpointing: True
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 3.0e-04
+  lr_scheduler_type: "cosine"
+  warmup_steps: 100
+  weight_decay: 0.01
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  empty_device_cache_steps: 50
+  output_dir: "output/qwen3_32b/lora"
+  include_performance_metrics: True
+  enable_wandb: True
+
+peft:
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.0
+  lora_target_modules:
+    - "q_proj"
+    - "k_proj"
+    - "v_proj"
+
+fsdp:
+  enable_fsdp: True
+  forward_prefetch: True
+  sharding_strategy: "FULL_SHARD"
+  auto_wrap_policy: "TRANSFORMER_BASED_WRAP"
+  transformer_layer_cls: "Qwen3DecoderLayer"

--- a/configs/recipes/qwen3/sft/32b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/train.yaml
@@ -4,7 +4,7 @@
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:
-#   oumi train -c oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml
+#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
@@ -14,7 +14,7 @@
 
 model:
   model_name: "Qwen/Qwen3-32B"
-  model_max_length: 2048
+  model_max_length: 32768
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"
   trust_remote_code: True

--- a/src/oumi/cli/alias.py
+++ b/src/oumi/cli/alias.py
@@ -27,9 +27,10 @@ class AliasType(str, Enum):
 
 
 _ALIASES: dict[str, dict[AliasType, str]] = {
+    # Llama 4 family.
     "llama4-scout": {
         AliasType.TRAIN: "oumi://configs/recipes/llama4/sft/scout_base_full/train.yaml",
-        AliasType.JOB: "oumi://configs/recipes/llama4/sft/scout_base_full/train.yaml",
+        AliasType.JOB: "oumi://configs/recipes/llama4/sft/scout_base_full/gcp_job.yaml",
     },
     "llama4-scout-instruct-lora": {
         AliasType.TRAIN: "oumi://configs/recipes/llama4/sft/scout_instruct_lora/train.yaml",
@@ -45,6 +46,15 @@ _ALIASES: dict[str, dict[AliasType, str]] = {
     },
     "llama4-maverick": {
         AliasType.INFER: "oumi://configs/recipes/llama4/inference/maverick_instruct_together_infer.yaml",
+    },
+    # Qwen3 family.
+    "qwen3-32b": {
+        AliasType.INFER: "oumi://configs/recipes/qwen3/inference/32b_infer.yaml",
+        AliasType.EVAL: "oumi://configs/recipes/qwen3/evaluation/32b_eval.yaml",
+    },
+    "qwen3-32b-lora": {
+        AliasType.TRAIN: "oumi://configs/recipes/qwen3/sft/32b_lora/train.yaml",
+        AliasType.JOB: "oumi://configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml",
     },
     # Hosted models.
     "claude-3-5-sonnet": {

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -313,7 +313,7 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
                 **batch, generation_config=generation_config, tokenizer=self._tokenizer
             )
 
-            # For each batch, remove the prepended prompts from all model reponses.
+            # For each batch, remove the prepended prompts from all model responses.
             if generation_params.exclude_prompt_from_response:
                 new_batch_data = []
                 for response_index, response in enumerate(output_batch.data):


### PR DESCRIPTION
# Description

Add configs for Qwen3 32B model for LoRA, eval, and inference, derived from QwQ configs. Also updated the README and aliases.

Note that the model does thinking by default, and a future PR will extend support for non-thinking models. More configs will be added in future PRs as well.

Tested that all these configs work.

## Related issues

Towards OPE-1209

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
