### PR TITLE
Add verl GRPO Countdown configs

### DIFF
--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -1,0 +1,47 @@
+# VERL GRPO job config for Countdown.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#   - Log into HF: `huggingface-cli login`
+#
+# Usage:
+#   oumi launch up -c configs/examples/grpo_verl_countdown/gcp_job.yaml --cluster grpo-verl-countdown
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: grpo-verl-countdown
+
+resources:
+  cloud: gcp
+  accelerators: "A100-80GB:2"
+  use_spot: false
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: verl-countdown.grpo
+
+setup: |
+  set -e
+  pip install uv && uv pip install oumi[gpu]
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi train \
+      -c configs/examples/grpo_verl_countdown/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -34,6 +34,7 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install oumi[gpu]
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -1,0 +1,76 @@
+# VERL GRPO training config for Countdown.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c configs/examples/grpo_verl_countdown/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+model:
+  model_name: "d1shs0ap/cognitive-behaviors-Llama-3.2-3B"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "d1shs0ap/countdown"
+        split: "train"
+  validation:
+    datasets:
+      - dataset_name: "d1shs0ap/countdown"
+        split: "test"
+
+training:
+  trainer_type: "VERL_GRPO"
+  num_train_epochs: 1
+  save_steps: -1
+  eval_steps: 50
+
+  learning_rate: 1.0e-6
+  enable_gradient_checkpointing: True
+
+  reward_functions: ["countdown"]
+
+  grpo:
+    max_completion_length: 1024
+    use_vllm: True
+    temperature: 1.0
+    vllm_gpu_memory_utilization: 0.4
+
+  verl_config_overrides:
+    data:
+      train_batch_size: 64
+      val_batch_size: 640
+      max_prompt_length: 256
+    actor_rollout_ref:
+      model:
+        use_remove_padding: True
+        ppo_mini_batch_size: 16
+        ppo_micro_batch_size: 4
+        use_kl_loss: True
+        kl_loss_coef: 0.001
+        kl_loss_type: "low_var_kl"
+      rollout:
+        log_prob_micro_batch_size: 4
+        tensor_model_parallel_size: 2
+        n: 16
+      ref:
+        log_prob_micro_batch_size: 2
+        fsdp_config:
+          param_offload: True
+    algorithm:
+      kl_ctrl:
+        kl_coef: 0.001
+    trainer:
+      critic_warmup: 0
+      val_before_train: False
+      n_gpus_per_node: 2
+      nnodes: 1
+
+  output_dir: "output/grpo_verl_countdown"
+  enable_wandb: True

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -50,11 +50,12 @@ training:
     actor_rollout_ref:
       model:
         use_remove_padding: True
-        ppo_mini_batch_size: 16
-        ppo_micro_batch_size: 4
+      actor:
         use_kl_loss: True
         kl_loss_coef: 0.001
         kl_loss_type: "low_var_kl"
+        ppo_mini_batch_size: 16
+        ppo_micro_batch_size: 4
       rollout:
         log_prob_micro_batch_size: 4
         tensor_model_parallel_size: 2

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -29,6 +29,7 @@ training:
   trainer_type: "VERL_GRPO"
   num_train_epochs: 1
   save_steps: -1
+  eval_strategy: "steps"
   eval_steps: 50
 
   learning_rate: 1.0e-6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ gpu = [
     "liger-kernel>=0.5.0,<0.6",
     "nvidia-ml-py>=12.560.30,<12.561",
     "bitsandbytes>=0.45.0,<0.46",      # Used for QLora, and PagedAdam implementation
+    # When updating verl version, make sure to also update the default config:
+    # src/oumi/core/trainers/verl_trainer_config.yaml.
     "verl>=0.3.0,<0.4",                # Used for the VERL_GRPO trainer.
     "vllm>=0.7.3,<0.8.0",              # For VLLMInferenceEngine
 ]

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -146,11 +146,16 @@ class VerlGrpoTrainer(BaseTrainer):
             grpo_params.vllm_gpu_memory_utilization
         )
 
-        if not training_params.save_epoch:
-            config.trainer.save_freq = training_params.save_steps
+        # Normally, training steps is determined by the number of epochs.
+        # If max_steps is set, it will override this.
+        config.trainer.total_epochs = training_params.num_train_epochs
+        if training_params.max_steps != -1:
+            config.trainer.total_training_steps = training_params.max_steps
+
         if training_params.eval_strategy == "steps":
             config.trainer.test_freq = training_params.eval_steps
-        config.trainer.total_epochs = training_params.num_train_epochs
+        if not training_params.save_epoch:
+            config.trainer.save_freq = training_params.save_steps
 
         if training_params.enable_wandb:
             config.trainer.logger = ["wandb"]

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -17,7 +17,6 @@
 import copy
 import os
 from pathlib import Path
-from pprint import pformat
 from typing import Callable, Optional, Union, cast
 
 from datasets import Dataset
@@ -186,7 +185,7 @@ class VerlGrpoTrainer(BaseTrainer):
                 "Please install it with 'pip install `oumi[gpu]`'."
             )
         self._verl_config = self._create_config()
-        logger.info(f"verl config: {pformat(self._verl_config)}")
+        logger.info(f"verl config: {self._verl_config}")
 
         tokenizer = self._processing_class
 

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -1,6 +1,6 @@
-# Default Verl PPO trainer config.
-# Copied from https://github.com/volcengine/verl/blob/25b0f2262ffb668b0a183fd21433adeca76b46f5/verl/trainer/config/ppo_trainer.yaml
-# For documentation, see https://verl.readthedocs.io/en/latest/examples/config.html
+# Default Verl PPO trainer config (from verl version v0.3.0.post1).
+# Copied from https://github.com/volcengine/verl/blob/v0.3.0.post1/verl/trainer/config/ppo_trainer.yaml
+# For documentation, see https://verl.readthedocs.io/en/v0.3.x/examples/config.html
 #
 # Changes:
 # - Changed trainer.project_name to "oumi_verl"
@@ -11,7 +11,6 @@ data:
   train_files: ~/data/rlhf/gsm8k/train.parquet
   val_files: ~/data/rlhf/gsm8k/test.parquet
   prompt_key: prompt
-  reward_fn_key: data_source
   max_prompt_length: 512
   max_response_length: 512
   train_batch_size: 1024
@@ -19,14 +18,9 @@ data:
   return_raw_input_ids: False  # This should be set to true when the tokenizer between policy and rm differs
   return_raw_chat: False
   shuffle: True
-  filter_overlong_prompts: False # for large-scale dataset, filtering overlong prompts could be timeconsuming. You cat set the filter_overlong_prompts_workers to use multiprocessing to speed up.
-  filter_overlong_prompts_workers: 1
+  filter_overlong_prompts: False # for large-scale dataset, filtering overlong prompts could be timeconsuming. You should disable this and set `truncation='left'
   truncation: error
   image_key: images
-  video_key: videos
-  custom_cls:
-      path: null
-      name: null
 
 actor_rollout_ref:
   hybrid_engine: True
@@ -36,7 +30,6 @@ actor_rollout_ref:
     override_config: { }
     enable_gradient_checkpointing: True
     use_remove_padding: False
-    use_liger: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256
@@ -45,13 +38,8 @@ actor_rollout_ref:
     use_dynamic_bsz: False
     ppo_max_token_len_per_gpu: 16384 # n * ${data.max_prompt_length} + ${data.max_response_length}
     grad_clip: 1.0
-    # pg_losses2 = -advantages * torch.clamp(ratio, 1 - cliprange_low, 1 + cliprange_high)
-    clip_ratio: 0.2 # default value if clip_ratio_low and clip_ratio_high are not specified
-    clip_ratio_low: 0.2
-    clip_ratio_high: 0.2
-    clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
-    loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
-    entropy_coeff: 0
+    clip_ratio: 0.2
+    entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO
     use_torch_compile: True # False to disable torch compile
     kl_loss_coef: 0.001 # for grpo
@@ -60,7 +48,7 @@ actor_rollout_ref:
     shuffle: False
     ulysses_sequence_parallel_size: 1 # sp size
     checkpoint:
-      contents: ['model', 'optimizer', 'extra']  # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
+      contents: ['model', 'hf_model', 'optimizer', 'extra']  # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
     optim:
       lr: 1e-6
       lr_warmup_steps: -1 # Prioritized. Negative values mean delegating to lr_warmup_steps_ratio.
@@ -68,7 +56,6 @@ actor_rollout_ref:
       min_lr_ratio: null   # only useful for warmup with cosine
       warmup_style: constant  # select from constant/cosine
       total_training_steps: -1  # must be override by program
-      weight_decay: 0.01
     fsdp_config:
       wrap_policy:
         # transformer_layer_cls_to_wrap: None
@@ -77,7 +64,6 @@ actor_rollout_ref:
       optimizer_offload: False
       fsdp_size: -1
   ref:
-    strategy: fsdp
     fsdp_config:
       param_offload: False
       wrap_policy:
@@ -117,8 +103,6 @@ actor_rollout_ref:
     do_sample: True
     # number of responses (i.e. num sample times)
     n: 1 # > 1 for grpo
-    engine_kwargs: # inference engine parameters
-      swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout
@@ -128,7 +112,6 @@ actor_rollout_ref:
       do_sample: False # default eager for validation
 
 critic:
-  rollout_n: ${actor_rollout_ref.rollout.n}
   strategy: fsdp
   optim:
     lr: 1e-5
@@ -136,7 +119,6 @@ critic:
     min_lr_ratio: null   # only useful for warmup with cosine
     warmup_style: constant  # select from constant/cosine
     total_training_steps: -1  # must be override by program
-    weight_decay: 0.01
   model:
     path: ~/models/deepseek-llm-7b-chat
     tokenizer_path: ${actor_rollout_ref.model.path}
@@ -165,7 +147,7 @@ critic:
   grad_clip: 1.0
   cliprange_value: 0.5
   checkpoint:
-    contents: ['model', 'optimizer', 'extra']  # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
+    contents: ['model', 'hf_model', 'optimizer', 'extra']  # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
 
 reward_model:
   enable: False
@@ -196,13 +178,10 @@ algorithm:
   gamma: 1.0
   lam: 1.0
   adv_estimator: gae
-  use_kl_in_reward: False
   kl_penalty: kl  # how to estimate kl divergence
   kl_ctrl:
     type: fixed
     kl_coef: 0.001
-    horizon: 10000
-    target_kl: 0.1
 
 trainer:
   balance_batch: True
@@ -211,14 +190,13 @@ trainer:
   project_name: oumi_verl
   experiment_name: null
   logger: [ 'console', 'wandb' ]
-  log_val_generations: 0
+  val_generations_to_log_to_wandb: 0
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1
   # auto: find the last ckpt to resume. If can't find, start from scratch
   resume_mode: auto # or disable or resume_path if resume_from_path is set
   resume_from_path: null
-  val_before_train: True
   test_freq: -1
   critic_warmup: 0
   default_hdfs_dir: null
@@ -226,5 +204,3 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
-  # The timeout for ray worker group to wait for the register center to be ready
-  ray_wait_register_center_timeout: 300


### PR DESCRIPTION
# Description

- Add job and train configs for Countdown task using verl GRPO. The majority of the params are passed in via the `verl_config_overrides` field.
- Changed version of default verl config to the one from version 0.3.0post1, as opposed to the latest one.
- Always add a reference policy, since KL loss is always enabled for GRPO.

## Related issues

Towards OPE-1192

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
