### PR TITLE
Migrate to `logger.warning` usage

### DIFF
--- a/src/oumi/core/tokenizers/utils.py
+++ b/src/oumi/core/tokenizers/utils.py
@@ -103,7 +103,7 @@ def tokenize_for_completions_only_training_with_prefix(
             human_token_ids_idxs.append(human_idx)
 
     if len(human_token_ids_idxs) == 0:
-        logger.warn(
+        logger.warning(
             f"Could not find instruction key `{instruction_template}` in the "
             f"following instance: {tokenizer.decode(batch['input_ids'])} "
             f"This instance will be ignored in loss calculation. "


### PR DESCRIPTION
# Description

This small PR resolves the `logger.warn()` deprecation warnings:
```python
/home/runner/work/oumi/oumi/src/oumi/core/tokenizers/utils.py:106: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Related issues


## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

