### PR TITLE
[Feature] Save evaluation config as YAML in output_dir #1546

### DIFF
--- a/src/oumi/core/evaluation/utils/save_utils.py
+++ b/src/oumi/core/evaluation/utils/save_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
+import copy, yaml, enum
 from pathlib import Path
 from typing import Any, Optional
 
@@ -30,6 +30,7 @@ OUTPUT_FILENAME_MODEL_PARAMS = "model_params.json"
 OUTPUT_FILENAME_GENERATION_PARAMS = "generation_params.json"
 OUTPUT_FILENAME_INFERENCE_PARAMS = "inference_params.json"
 OUTPUT_FILENAME_PACKAGE_VERSIONS = "package_versions.json"
+OUTPUT_FILENAME_EVALUATION_CONFIG_YAML = "evaluation_config.yaml"
 
 
 def _save_to_file(output_path: Path, data: Any) -> None:
@@ -75,6 +76,28 @@ def _find_non_existing_output_dir_from_base_dir(base_dir: Path) -> Path:
 
     return new_dir
 
+
+def _convert_to_serializable(obj):
+    """Recursively convert object to dict if possible and handle Enums properly."""
+    if isinstance(obj, dict):
+        return {k: _convert_to_serializable(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_convert_to_serializable(v) for v in obj]
+    elif isinstance(obj, enum.Enum):
+        return obj.value  # convert Enum values
+    elif hasattr(obj, "to_dict"):
+        return _convert_to_serializable(obj.to_dict())
+    elif hasattr(obj, "__dict__"):
+        return _convert_to_serializable(vars(obj))
+    elif isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    else:
+        # fallback to string representation if nothing else works
+        return str(obj)
+    
+def save_yaml_file(path: Path, data: Any) -> None:
+    with open(path, "w") as yaml_out:
+        yaml.safe_dump(data, yaml_out, default_flow_style=False, sort_keys=False)
 
 def save_evaluation_output(
     backend_name: str,
@@ -134,6 +157,12 @@ def save_evaluation_output(
 
     # Save all relevant Oumi configurations.
     if config:
+        try:
+            config_dict = _convert_to_serializable(config)
+            save_yaml_file(output_dir / OUTPUT_FILENAME_EVALUATION_CONFIG_YAML, config_dict)
+        except Exception as e:
+            logger.error(f"Failed to save EvaluationConfig as YAML: {e}")
+            
         if config.model:
             _save_to_file(output_dir / OUTPUT_FILENAME_MODEL_PARAMS, config.model)
         if config.generation:


### PR DESCRIPTION
# Description

This PR adds functionality to serialize and save the `EvaluationConfig` used during `oumi evaluate` into the output directory as a YAML file (`evaluation_config.yaml`). This ensures configuration details are stored with evaluation outputs, improving reproducibility and experiment transparency.

**Key changes:**

- Added `_convert_to_serializable` utility to handle serialization of complex types (Enums, nested custom classes), addressing limitations in default YAML serialization.
- Integrated config saving into `save_evaluation_output` pipeline.
- Verified output directory contains complete `evaluation_config.yaml`.

## Related Issues

Fixes #1546 ([https://github.com/oumi-ai/oumi/issues/1546](https://github.com/oumi-ai/oumi/issues/1546))

## Testing

- [x] Manually verified `oumi evaluate` generates correct `evaluation_config.yaml`.

## Before submitting

- [x] This PR does not only change documentation.
- [x] I have read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md).
- [x] I have linked the related issue in the section above.
- [x] Tested locally that `oumi evaluate` generates the correct `evaluation_config.yaml`.
- [ ] Tests added or updated where needed

## Reviewers

- wizeng23: [William Zeng](https://github.com/wizeng23)
