### PR TITLE
Update verl GRPO countdown configs

### DIFF
--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -18,7 +18,7 @@ name: grpo-verl-countdown
 
 resources:
   cloud: gcp
-  accelerators: "A100-80GB:2"
+  accelerators: "H100:8"
   use_spot: false
 
 working_dir: .

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -18,19 +18,19 @@ model:
 data:
   train:
     datasets:
-      - dataset_name: "d1shs0ap/countdown"
+      - dataset_name: "d1shs0ap/countdown-final"
         split: "train"
   validation:
     datasets:
-      - dataset_name: "d1shs0ap/countdown"
+      - dataset_name: "d1shs0ap/countdown-final"
         split: "test"
 
 training:
   trainer_type: "VERL_GRPO"
-  num_train_epochs: 1
-  save_steps: -1
+  num_train_epochs: 5
+  save_steps: 150
   eval_strategy: "steps"
-  eval_steps: 50
+  eval_steps: 12
 
   learning_rate: 1.0e-6
   enable_gradient_checkpointing: True
@@ -40,38 +40,44 @@ training:
   grpo:
     max_completion_length: 1024
     use_vllm: True
-    temperature: 1.0
-    vllm_gpu_memory_utilization: 0.4
+    temperature: 0.6
+    vllm_gpu_memory_utilization: 0.7
 
   verl_config_overrides:
     data:
-      train_batch_size: 64
-      val_batch_size: 640
+      train_files: "/home/cmu/countdown-curriculum/data/countdown/train-3-3.parquet"
+      val_files: "/home/cmu/countdown-curriculum/data/countdown/test-3-10.parquet"
+      train_batch_size: 128
+      val_batch_size: 256
       max_prompt_length: 256
+      max_extrapolation_length: 2048
+      shuffle: False
     actor_rollout_ref:
       model:
         use_remove_padding: True
       actor:
+        ppo_mini_batch_size: 32
+        use_dynamic_bsz: True
+        gradients: "normal"
         use_kl_loss: True
         kl_loss_coef: 0.001
         kl_loss_type: "low_var_kl"
-        ppo_mini_batch_size: 16
-        ppo_micro_batch_size: 4
+        entropy_coeff: 0
       rollout:
-        log_prob_micro_batch_size: 4
         tensor_model_parallel_size: 2
-        n: 16
+        n: 8
+        enforce_eager: False
+        free_cache_engine: False
+        val_kwargs:
+          temperature: 0.6
+          n: 8
+          do_sample: True
+        max_num_batched_tokens: 16384
       ref:
-        log_prob_micro_batch_size: 2
         fsdp_config:
           param_offload: True
-    algorithm:
-      kl_ctrl:
-        kl_coef: 0.001
     trainer:
-      critic_warmup: 0
-      val_before_train: False
-      n_gpus_per_node: 2
+      n_gpus_per_node: 8
       nnodes: 1
 
   output_dir: "output/grpo_verl_countdown"

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -5,6 +5,7 @@
 # Changes:
 # - Changed trainer.project_name to "oumi_verl"
 # - Changed trainer.experiment_name to null
+# - Changed trainer.logger to []
 
 data:
   tokenizer: null
@@ -189,7 +190,7 @@ trainer:
   total_training_steps: null
   project_name: oumi_verl
   experiment_name: null
-  logger: [ 'console', 'wandb' ]
+  logger: []
   val_generations_to_log_to_wandb: 0
   nnodes: 1
   n_gpus_per_node: 8


### PR DESCRIPTION
# Description

Update configs to match the first experiment in https://github.com/matthewyryang/countdown-curriculum/blob/main/scripts/grpo/3_6_curriculum/run_difficulty.sh.

Also updated verl trainer to resolve variable interpolations in config.

Tested on GCP, and verified that our resulting config is equivalent to the one in the original experiment, aside from differences due to differing verl versions (we use v0.3.0.post1, the original uses a later commit from April 8).

The following is the delta between the configs. "verl" means the original experiment, and "Oumi" means the verl config generated by the Oumi config in this PR.

```
# Only in original experiment config
actor_rollout_ref.actor.clip_ratio_c: 3.0
actor_rollout_ref.actor.clip_ratio_high: 0.2
actor_rollout_ref.actor.clip_ratio_low: 0.2
actor_rollout_ref.actor.loss_agg_mode: token-mean
actor_rollout_ref.actor.optim.weight_decay: 0.01
actor_rollout_ref.rollout.extrapolation_length: 2048
algorithm.use_kl_in_reward: False
algorithm.kl_ctrl.horizon: 10000
algorithm.kl_ctrl.target_kl: 0.1
critic.rollout_n: 8
data.filter_overlong_prompts_workers: 1
data.reward_fn_only in verl dict, value: data_source
trainer.log_val_generations: 0
trainer.val_before_train: True
critic.optim.weight_decay: 0.01

# Only in Oumi config
trainer.val_generations_to_log_to_wandb: 0

# Keys with differing values.
# In verl:
actor_rollout_ref.actor.checkpoint.contents: ['model', 'optimizer', 'extra']
critic.checkpoint.contents: ['model', 'optimizer', 'extra']
custom_reward_function.path: /home/gcpuser/countdown-curriculum/verl/utils/reward_score/countdown.py
trainer.default_local_dir: /home/gcpuser/countdown-curriculum/checkpoints/difficulty
trainer.experiment_name: difficulty
trainer.project_name: Countdown-curriculum

# In Oumi:
actor_rollout_ref.actor.checkpoint.contents: ['model', 'hf_model', 'optimizer', 'extra']
critic.checkpoint.contents: ['model', 'hf_model', 'optimizer', 'extra']
custom_reward_function.path: None
trainer.default_local_dir: output/grpo_verl_countdown
trainer.experiment_name: verl-countdown.grpo.sky-2025-05-12-21-53-36-580286_countdown_3
trainer.project_name: oumi-train
```

## Related issues

Towards OPE-1192

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?