### PR TITLE
[tiny] Remove deprecated `use_async_dataset` from configs

### DIFF
--- a/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
@@ -36,7 +36,6 @@ data:
     stream: True
     pack: True
     target_col: "text"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT" # or OUMI

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
@@ -36,7 +36,6 @@ data:
     stream: True
     pack: True
     target_col: "text"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -19,7 +19,6 @@ data:
         seed: 42
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
   validation:
     datasets:
@@ -27,7 +26,6 @@ data:
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
 
 training:

--- a/configs/projects/coalm/70b_train.yaml
+++ b/configs/projects/coalm/70b_train.yaml
@@ -19,7 +19,6 @@ data:
         seed: 42
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
   validation:
     datasets:
@@ -27,7 +26,6 @@ data:
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
 
 training:

--- a/configs/projects/coalm/8b_train.yaml
+++ b/configs/projects/coalm/8b_train.yaml
@@ -19,7 +19,6 @@ data:
         seed: 42
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
   validation:
     datasets:
@@ -27,7 +26,6 @@ data:
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
-    use_async_dataset: True
     seed: 42
 
 training:

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
@@ -26,7 +26,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
@@ -25,7 +25,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
@@ -25,7 +25,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
@@ -27,7 +27,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/pretraining/8b/train.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/train.yaml
@@ -39,7 +39,6 @@ data:
     stream: True
     pack: True
     target_col: "text"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -35,7 +35,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -30,7 +30,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/longctx_train.yaml
@@ -50,6 +50,5 @@ data:
         dataset_kwargs:
           seq_length: 32_768
     target_col: "text"
-    use_async_dataset: True
     stream: True
     pack: True

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -31,7 +31,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/1b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/1b_full/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -30,7 +30,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -29,7 +29,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -30,7 +30,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama4/sft/scout_base_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_base_full/train.yaml
@@ -25,7 +25,6 @@ data:
   train:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
@@ -25,7 +25,6 @@ data:
   train:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
@@ -25,7 +25,6 @@ data:
   train:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
@@ -25,7 +25,6 @@ data:
   train:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/phi4/sft/reasoning_plus/full_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/full_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/qwen3/sft/32b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/qwq/sft/full_train.yaml
+++ b/configs/recipes/qwq/sft/full_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/qwq/sft/lora_train.yaml
+++ b/configs/recipes/qwq/sft/lora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/recipes/qwq/sft/qlora_train.yaml
+++ b/configs/recipes/qwq/sft/qlora_train.yaml
@@ -24,7 +24,6 @@ data:
     datasets:
       - dataset_name: "yahma/alpaca-cleaned" # 51,760 examples
     target_col: "prompt"
-    use_async_dataset: True
 
 training:
   trainer_type: "TRL_SFT"


### PR DESCRIPTION
# Description

This is a deprecated unused parameter, and this PR deletes all usages of it. A future PR will delete the parameter altogether for a future Oumi version release.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
