### PR TITLE
Feat: add falcon-e integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
         types: [python]
         pass_filenames: false
         args: [--warnings]
+        exclude: tests/
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ Explore the growing collection of ready-to-use configurations for state-of-the-a
 | Llama 3.3 70B | [FFT](/configs/recipes/llama3_3/sft/70b_full/train.yaml) • [LoRA](/configs/recipes/llama3_3/sft/70b_lora/train.yaml) • [QLoRA](/configs/recipes/llama3_3/sft/70b_qlora/train.yaml) • [Inference (vLLM)](/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml) • [Inference](/configs/recipes/llama3_3/inference/70b_infer.yaml) • [Evaluation](/configs/recipes/llama3_3/evaluation/70b_eval.yaml) |
 | Llama 3.2 Vision 11B | [SFT](/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml) • [Inference (vLLM)](/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml) • [Inference (SGLang)](/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml) • [Evaluation](/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml) |
 
+### 🦅 Falcon family
+
+| Model | Example Configurations |
+|-------|------------------------|
+| [Falcon-H1](https://huggingface.co/collections/tiiuae/falcon-h1-6819f2795bc406da60fab8df) | [FFT](/configs/recipes/falcon_h1/sft/) • [Inference](/configs/recipes/falcon_h1/inference/) • [Evaluation](/configs/recipes/falcon_h1/evaluation/) |
+| [Falcon-E (BitNet)](https://huggingface.co/collections/tiiuae/falcon-edge-series-6804fd13344d6d8a8fa71130) | [FFT](/configs/recipes/falcon_e/sft/) • [Evaluation](/configs/recipes/falcon_e/evaluation/) |
+
 ### 🎨 Vision Models
 
 | Model | Example Configurations |

--- a/configs/recipes/falcon_e/evaluation/falcon_e_1b/eval.yaml
+++ b/configs/recipes/falcon_e/evaluation/falcon_e_1b/eval.yaml
@@ -1,0 +1,13 @@
+model:
+  model_name: "output/falcon_e_1b.fft/checkpoint-800-quantized"
+  torch_dtype_str: "bfloat16"
+
+inference_engine: NATIVE
+
+tasks:
+  - evaluation_backend: lm_harness
+    task_name: mmlu_college_computer_science
+
+output_dir: "output/falcon_e_1b.fft/evaluation"
+generation:
+  batch_size: null # This will let LM HARNESS find the maximum possible batch size.

--- a/configs/recipes/falcon_e/evaluation/falcon_e_1b_instruct/eval.yaml
+++ b/configs/recipes/falcon_e/evaluation/falcon_e_1b_instruct/eval.yaml
@@ -1,0 +1,13 @@
+model:
+  model_name: "output/falcon_e_1b_instruct.fft/checkpoint-800-quantized"
+  torch_dtype_str: "bfloat16"
+
+inference_engine: NATIVE
+
+tasks:
+  - evaluation_backend: lm_harness
+    task_name: mmlu_college_computer_science
+
+output_dir: "output/falcon_e_1b_instruct.fft/evaluation"
+generation:
+  batch_size: null # This will let LM HARNESS find the maximum possible batch size.

--- a/configs/recipes/falcon_e/evaluation/falcon_e_3b/eval.yaml
+++ b/configs/recipes/falcon_e/evaluation/falcon_e_3b/eval.yaml
@@ -1,0 +1,13 @@
+model:
+  model_name: "output/falcon_e_3b.fft/checkpoint-800-quantized"
+  torch_dtype_str: "bfloat16"
+
+inference_engine: NATIVE
+
+tasks:
+  - evaluation_backend: lm_harness
+    task_name: mmlu_college_computer_science
+
+output_dir: "output/falcon_e_3b.fft/evaluation"
+generation:
+  batch_size: null # This will let LM HARNESS find the maximum possible batch size.

--- a/configs/recipes/falcon_e/evaluation/falcon_e_3b_instruct/eval.yaml
+++ b/configs/recipes/falcon_e/evaluation/falcon_e_3b_instruct/eval.yaml
@@ -1,0 +1,13 @@
+model:
+  model_name: "output/falcon_e_3b_instruct.fft/checkpoint-800-quantized"
+  torch_dtype_str: "bfloat16"
+
+inference_engine: NATIVE
+
+tasks:
+  - evaluation_backend: lm_harness
+    task_name: mmlu_college_computer_science
+
+output_dir: "output/falcon_e_3b_instruct.fft/evaluation"
+generation:
+  batch_size: null # This will let LM HARNESS find the maximum possible batch size.

--- a/configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
@@ -1,0 +1,53 @@
+# FFT config for tiiuae/Falcon-E-1B-Base.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c oumi://configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+
+model:
+  model_name: "tiiuae/Falcon-E-1B-Base"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  enable_liger_kernel: False
+  tokenizer_kwargs:
+    pad_token: "<|pad|>"
+  model_kwargs:
+    revision: "prequantized"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+
+training:
+  trainer_type: "TRL_SFT" # Could also be TRL_DPO.
+  save_steps: 800
+
+  enable_gradient_checkpointing: False # Not needed for small models.
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 32.0e-06
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/falcon_e_1b.fft"
+  include_performance_metrics: True
+  enable_wandb: True

--- a/configs/recipes/falcon_e/sft/falcon_e_1b_instruct/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_1b_instruct/full_train.yaml
@@ -1,0 +1,53 @@
+# FFT config for tiiuae/Falcon-E-1B-Base.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c oumi://configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+
+model:
+  model_name: "tiiuae/Falcon-E-1B-Instruct"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  enable_liger_kernel: False
+  tokenizer_kwargs:
+    pad_token: "<|pad|>"
+  model_kwargs:
+    revision: "prequantized"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+
+training:
+  trainer_type: "TRL_SFT" # Could also be TRL_DPO.
+  save_steps: 800
+
+  enable_gradient_checkpointing: False # Not needed for small models.
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 32.0e-06
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/falcon_e_1b.fft"
+  include_performance_metrics: True
+  enable_wandb: True

--- a/configs/recipes/falcon_e/sft/falcon_e_3b/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_3b/full_train.yaml
@@ -1,0 +1,53 @@
+# FFT config for tiiuae/Falcon-E-1B-Base.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c oumi://configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+
+model:
+  model_name: "tiiuae/Falcon-E-3B-Base"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  enable_liger_kernel: False
+  tokenizer_kwargs:
+    pad_token: "<|pad|>"
+  model_kwargs:
+    revision: "prequantized"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+
+training:
+  trainer_type: "TRL_SFT" # Could also be TRL_DPO.
+  save_steps: 800
+
+  enable_gradient_checkpointing: False # Not needed for small models.
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 32.0e-06
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/falcon_e_1b.fft"
+  include_performance_metrics: True
+  enable_wandb: True

--- a/configs/recipes/falcon_e/sft/falcon_e_3b_instruct/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_3b_instruct/full_train.yaml
@@ -1,0 +1,53 @@
+# FFT config for tiiuae/Falcon-E-1B-Base.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c oumi://configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/pretraining/, configs/**/sft/, configs/**/dpo/
+
+
+model:
+  model_name: "tiiuae/Falcon-E-3B-Instruct"
+  model_max_length: 2048
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  enable_liger_kernel: False
+  tokenizer_kwargs:
+    pad_token: "<|pad|>"
+  model_kwargs:
+    revision: "prequantized"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"
+
+training:
+  trainer_type: "TRL_SFT" # Could also be TRL_DPO.
+  save_steps: 800
+
+  enable_gradient_checkpointing: False # Not needed for small models.
+  gradient_checkpointing_kwargs:
+    use_reentrant: False
+  ddp_find_unused_parameters: False
+  optimizer: "adamw_torch_fused"
+  learning_rate: 32.0e-06
+  compile: False
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 32
+
+  logging_steps: 100
+  log_model_summary: False
+  empty_device_cache_steps: 50
+  output_dir: "output/falcon_e_1b.fft"
+  include_performance_metrics: True
+  enable_wandb: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,10 @@ evaluation = [
     "sentencepiece>=0.1.98",
 ]
 
+bitnet = [
+    "onebitllms>=0.0.3"
+]
+
 cambrian = [
     "timm==0.9.16",
     "open_clip_torch",

--- a/src/oumi/builders/callbacks.py
+++ b/src/oumi/builders/callbacks.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import torch
 
 from oumi.core.callbacks.base_trainer_callback import BaseTrainerCallback
+from oumi.core.callbacks.bitnet_callback import BitNetCallback
 from oumi.core.callbacks.hf_mfu_callback import HfMfuTrainerCallback
 from oumi.core.callbacks.mfu_callback import MfuTrainerCallback
 from oumi.core.callbacks.nan_inf_detection_callback import NanInfDetectionCallback
@@ -136,5 +137,14 @@ def build_training_callbacks(
             track_gpu_temperature=config.training.telemetry.track_gpu_temperature,
         )
     )
+
+    # Add the BitNet saving callbacks if relevant
+    if config.model.model_name in (
+        "tiiuae/Falcon-E-1B-Base",
+        "tiiuae/Falcon-E-1B-Instruct",
+        "tiiuae/Falcon-E-3B-Base",
+        "tiiuae/Falcon-E-3B-Instruct",
+    ):
+        result.append(BitNetCallback())
 
     return result

--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -42,6 +42,13 @@ try:
 except ImportError:
     liger_kernel = None
 
+# Import `onebitllms` utils methods
+try:
+    import onebitllms
+    from onebitllms import replace_linear_with_bitnet_linear
+except ImportError:
+    onebitllms = None
+
 
 def build_model(
     model_params: ModelParams,
@@ -84,6 +91,19 @@ def build_model(
 
     if model_params.enable_liger_kernel:
         _patch_model_for_liger_kernel(model)
+
+    if model_params.model_name in (
+        "tiiuae/Falcon-E-1B-Base",
+        "tiiuae/Falcon-E-1B-Instruct",
+        "tiiuae/Falcon-E-3B-Base",
+        "tiiuae/Falcon-E-3B-Instruct",
+    ):
+        if onebitllms is None:
+            raise ValueError(
+                """Please install `onebitllms` in order to fine-tune
+                `Falcon-E` models - `pip install onebitllms`"""
+            )
+        model = replace_linear_with_bitnet_linear(model)
 
     if len(model_params.freeze_layers) > 0:
         num_frozen = freeze_model_layers(model, model_params.freeze_layers)
@@ -209,8 +229,13 @@ def build_huggingface_model(
         f"Building model using device_map: {device_map} ({device_rank_info})..."
     )
 
+    # Get the model revision through `model_kwargs`
+    revision = model_params.model_kwargs.get("revision", None)
+
     hf_config = find_model_hf_config(
-        model_params.model_name, trust_remote_code=model_params.trust_remote_code
+        model_params.model_name,
+        trust_remote_code=model_params.trust_remote_code,
+        revision=revision,
     )
 
     # (Experimental) Detects dropout probabilities in config and sets them to 0.0.
@@ -237,6 +262,7 @@ def build_huggingface_model(
             pretrained_model_name_or_path=model_params.model_name,
             quantization_config=quantization_config,
             attn_implementation=model_params.attn_implementation,
+            revision=revision,
             **kwargs,
         )
     else:

--- a/src/oumi/core/callbacks/__init__.py
+++ b/src/oumi/core/callbacks/__init__.py
@@ -21,6 +21,7 @@ early stopping, etc.
 """
 
 from oumi.core.callbacks.base_trainer_callback import BaseTrainerCallback
+from oumi.core.callbacks.bitnet_callback import BitNetCallback
 from oumi.core.callbacks.hf_mfu_callback import HfMfuTrainerCallback
 from oumi.core.callbacks.mfu_callback import MfuTrainerCallback
 from oumi.core.callbacks.nan_inf_detection_callback import NanInfDetectionCallback
@@ -29,6 +30,7 @@ from oumi.core.callbacks.telemetry_callback import TelemetryCallback
 
 __all__ = [
     "BaseTrainerCallback",
+    "BitNetCallback",
     "HfMfuTrainerCallback",
     "MfuTrainerCallback",
     "NanInfDetectionCallback",

--- a/src/oumi/core/callbacks/bitnet_callback.py
+++ b/src/oumi/core/callbacks/bitnet_callback.py
@@ -1,0 +1,68 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simple Bitnet model saving callback."""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import transformers
+from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
+
+from oumi.core.callbacks.base_trainer_callback import BaseTrainerCallback
+from oumi.core.configs import TrainingParams
+
+# Import `onebitllms` utils methods
+try:
+    import onebitllms
+    from onebitllms import quantize_to_1bit
+except ImportError:
+    onebitllms = None
+
+
+class BitNetCallback(BaseTrainerCallback):
+    """BitNet model saving callback.
+
+    Simple callback that saves the model into BitNet quantized
+    format during training.
+    """
+
+    def on_save(
+        self,
+        args: Union[transformers.TrainingArguments, TrainingParams],
+        state: Optional[transformers.TrainerState] = None,
+        control: Optional[transformers.TrainerControl] = None,
+        **kwargs,
+    ):
+        """Saving callback.
+
+        Gets triggered at each saving step to quantize trained models
+        in 1bit precision.
+        """
+        if onebitllms is None:
+            raise ValueError(
+                """You need `onebitllms` to be installed in order to save
+                correctly BitNet models - `pip install onebitllms`"""
+            )
+
+        output_dir = Path(args.output_dir)  # type: ignore
+        quantized_subdir = Path(
+            f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}-quantized"  # type: ignore
+        )
+        output_subdir = Path(f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}")  # type: ignore
+
+        checkpoint_folder = output_dir / output_subdir
+        quantized_checkpoint_folder = output_dir / quantized_subdir
+
+        quantize_to_1bit(str(checkpoint_folder), str(quantized_checkpoint_folder))

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -33,12 +33,15 @@ from oumi.utils.logging import logger
 
 
 @functools.cache
-def find_model_hf_config(model_name: str, *, trust_remote_code: bool):
+def find_model_hf_config(
+    model_name: str, *, trust_remote_code: bool, revision: Optional[str] = None
+):
     """Finds HF model config by model name."""
     hf_config, unused_kwargs = transformers.AutoConfig.from_pretrained(
         model_name,
         trust_remote_code=trust_remote_code,
         return_unused_kwargs=True,
+        revision=revision,
     )
     if unused_kwargs:
         logger.warning(


### PR DESCRIPTION
# Description

This PR adds the fine-tuning support for [Falcon-E (Falcon-Edge)](https://huggingface.co/collections/tiiuae/falcon-edge-series-6804fd13344d6d8a8fa71130) models. Falcon-E series are a set of fine-tunable bitnet models. To correctly perform fine-tuning, one has to use `onebitllms`, a lightweight toolkit library to patch the models linear layers with `BitNetLinear`, as well as exposing a saving callback to correctly save the model in BitNet format after fine-tuning. 

Tested FFT and evaluation on a small 1B model: https://huggingface.co/tiiuae/Falcon-E-1B-Base

@wizeng23 @oelachqar 