### PR TITLE
Added doc for new QLoRA param

### DIFF
--- a/docs/user_guides/train/configuration.md
+++ b/docs/user_guides/train/configuration.md
@@ -276,6 +276,7 @@ peft:
   use_bnb_nested_quant: false        # Use nested quantization
   bnb_4bit_quant_storage: "uint8"    # Storage type for params
   bnb_4bit_compute_dtype: "float32"  # Compute type for params
+  llm_int8_skip_modules: "none"      # A list of modules that we do not want to convert in 8-bit.
 ```
 
 ### FSDP Configuration


### PR DESCRIPTION
# Description
To get Falcon-H1 model running with the `state-spaces/mamba` and `Dao-AILab/causal-conv1d` libraries, I had to add an additional `bitsandbytes` option to avoid quantizing one of the parameter matrices. This adds documentation for that.

- [X] This PR only changes documentation.