### PR TITLE
Update link to Oumi banner image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![# Oumi: Open Universal Machine Intelligence](docs/_static/logo/header_logo.png)
+![Oumi Logo](https://github.com/oumi-ai/oumi/raw/main/docs/_static/logo/header_logo.png)
 
 [![Documentation](https://img.shields.io/badge/Documentation-oumi-blue.svg)](https://oumi.ai/docs/en/latest/index.html)
 [![Blog](https://img.shields.io/badge/Blog-oumi-blue.svg)](https://oumi.ai/blog)


### PR DESCRIPTION
# Description

<img width="399" alt="Screenshot 2025-06-10 at 2 47 18 PM" src="https://github.com/user-attachments/assets/64b63803-688c-4c0f-bfa3-7566f4df789a" />

Our banner currently doesn't display on PyPI. I changed the link to an absolute URL, which I've seen other repos use.

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
