### PR TITLE
[verl] Support resuming from checkpoint

### DIFF
--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -33,7 +33,7 @@ envs:
 
 setup: |
   set -e
-  pip install uv && uv pip install -e '.[gpu]'
+  pip install uv && uv pip install oumi[gpu]
   # 2.8.0.post2 has installation issues.
   pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
 

--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -33,8 +33,9 @@ envs:
 
 setup: |
   set -e
-  pip install uv && uv pip install oumi[gpu]
-  pip install -U flash-attn --no-build-isolation
+  pip install uv && uv pip install -e '.[gpu]'
+  # 2.8.0.post2 has installation issues.
+  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -28,7 +28,7 @@ data:
 training:
   trainer_type: "VERL_GRPO"
   num_train_epochs: 1
-  save_steps: -1
+  save_steps: 1
   eval_strategy: "steps"
   eval_steps: 50
 
@@ -74,5 +74,6 @@ training:
       n_gpus_per_node: 2
       nnodes: 1
 
+  resume_from_checkpoint: "output/grpo_verl_countdown/verl_output/global_step_1"
   output_dir: "output/grpo_verl_countdown"
   enable_wandb: True

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -28,7 +28,7 @@ data:
 training:
   trainer_type: "VERL_GRPO"
   num_train_epochs: 1
-  save_steps: 1
+  save_steps: -1
   eval_strategy: "steps"
   eval_steps: 50
 
@@ -74,6 +74,5 @@ training:
       n_gpus_per_node: 2
       nnodes: 1
 
-  resume_from_checkpoint: "output/grpo_verl_countdown/verl_output/global_step_1"
   output_dir: "output/grpo_verl_countdown"
   enable_wandb: True

--- a/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
+++ b/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
@@ -41,7 +41,7 @@ setup: |
   # In the meantime, we need to use this specific commit to support vLLM 0.8.3:
   # https://github.com/volcengine/verl/pull/912
   pip install git+https://github.com/volcengine/verl.git@1ee730163f6326e9679644db62eb32c8d1947c7f
-  pip install -U flash-attn --no-build-isolation
+  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/docs/user_guides/train/training_methods.md
+++ b/docs/user_guides/train/training_methods.md
@@ -395,6 +395,8 @@ verl is an RL training framework created by Alibaba. Many Oumi config fields, wh
 | training.max_steps                              | trainer.total_training_steps                          |
 | training.eval_steps/training.eval_strategy      | trainer.test_freq                                     |
 | training.save_steps/training.save_epoch         | trainer.save_freq                                     |
+| training.resume_from_checkpoint                 | trainer.resume_mode/trainer.resume_from_path          |
+| training.try_resume_from_last_checkpoint        | trainer.resume_mode                                   |
 | training.logging_strategy/training.enable_wandb | trainer.logger                                        |
 | training.run_name                               | trainer.experiment_name                               |
 | training.output_dir                             | trainer.default_local_dir                             |

--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -777,10 +777,6 @@ class TrainingParams(BaseParams):
             save_strategy=save_strategy,
             logging_first_step=self.logging_first_step,
             torch_empty_cache_steps=self.empty_device_cache_steps,
-            # Note that this isn't used by the HF Trainer. To specify the checkpoint
-            # to resume from, we specify the resume_from_checkpoint arg of the `train`
-            # function.
-            resume_from_checkpoint=self.resume_from_checkpoint,
             eval_strategy=self.eval_strategy,
             eval_steps=self.eval_steps,
             dataloader_num_workers=dataloader_num_workers,

--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -777,6 +777,9 @@ class TrainingParams(BaseParams):
             save_strategy=save_strategy,
             logging_first_step=self.logging_first_step,
             torch_empty_cache_steps=self.empty_device_cache_steps,
+            # Note that this isn't used by the HF Trainer. To specify the checkpoint
+            # to resume from, we specify the resume_from_checkpoint arg of the `train`
+            # function.
             resume_from_checkpoint=self.resume_from_checkpoint,
             eval_strategy=self.eval_strategy,
             eval_steps=self.eval_steps,

--- a/src/oumi/core/trainers/base_trainer.py
+++ b/src/oumi/core/trainers/base_trainer.py
@@ -20,7 +20,7 @@ from oumi.core.configs import TrainingConfig
 
 class BaseTrainer(ABC):
     @abstractmethod
-    def train(self, resume_from_checkpoint: Optional[str]) -> None:
+    def train(self, resume_from_checkpoint: Optional[str] = None) -> None:
         """Trains a model."""
 
     @abstractmethod

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -359,6 +359,11 @@ class VerlGrpoTrainer(BaseTrainer):
         config.trainer.project_name = os.environ.get("WANDB_PROJECT", "oumi_verl")
         config.trainer.experiment_name = training_params.run_name
         config.trainer.default_local_dir = str(self._temp_output_dir or "")
+        if training_params.resume_from_checkpoint:
+            config.resume_mode = "resume_path"
+            config.resume_from_path = training_params.resume_from_checkpoint
+        elif training_params.try_resume_from_last_checkpoint:
+            config.resume_mode = "auto"
 
         # 3. Apply user overrides
         overrides_config = OmegaConf.create(training_params.verl_config_overrides)
@@ -434,15 +439,8 @@ class VerlGrpoTrainer(BaseTrainer):
             val_reward_fn=val_reward_fn,
         )
 
-    def train(self, resume_from_checkpoint: Optional[str] = None) -> None:
-        """Trains the model using verl's RayPPOTrainer.
-
-        Args:
-            resume_from_checkpoint: Optional path to a checkpoint to resume from.
-        """
-        if resume_from_checkpoint:
-            raise NotImplementedError("Resuming from checkpoint is not implemented.")
-
+    def train(self) -> None:
+        """Trains the model using verl's RayPPOTrainer."""
         logger.info("Initializing verl trainer workers...")
         self._verl_trainer.init_workers()
         logger.info("Starting verl training...")

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -354,10 +354,10 @@ class VerlGrpoTrainer(BaseTrainer):
         # Specific checkpoint to resume from takes precedence over starting
         # from last checkpoint.
         if training_params.resume_from_checkpoint:
-            config.resume_mode = "resume_path"
-            config.resume_from_path = training_params.resume_from_checkpoint
+            config.trainer.resume_mode = "resume_path"
+            config.trainer.resume_from_path = training_params.resume_from_checkpoint
         elif training_params.try_resume_from_last_checkpoint:
-            config.resume_mode = "auto"
+            config.trainer.resume_mode = "auto"
 
         config.trainer.logger = []
         if training_params.logging_strategy != "no":

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -351,6 +351,14 @@ class VerlGrpoTrainer(BaseTrainer):
         if not training_params.save_epoch:
             config.trainer.save_freq = training_params.save_steps
 
+        # Specific checkpoint to resume from takes precedence over starting
+        # from last checkpoint.
+        if training_params.resume_from_checkpoint:
+            config.resume_mode = "resume_path"
+            config.resume_from_path = training_params.resume_from_checkpoint
+        elif training_params.try_resume_from_last_checkpoint:
+            config.resume_mode = "auto"
+
         config.trainer.logger = []
         if training_params.logging_strategy != "no":
             config.trainer.logger.append("console")
@@ -359,11 +367,6 @@ class VerlGrpoTrainer(BaseTrainer):
         config.trainer.project_name = os.environ.get("WANDB_PROJECT", "oumi_verl")
         config.trainer.experiment_name = training_params.run_name
         config.trainer.default_local_dir = str(self._temp_output_dir or "")
-        if training_params.resume_from_checkpoint:
-            config.resume_mode = "resume_path"
-            config.resume_from_path = training_params.resume_from_checkpoint
-        elif training_params.try_resume_from_last_checkpoint:
-            config.resume_mode = "auto"
 
         # 3. Apply user overrides
         overrides_config = OmegaConf.create(training_params.verl_config_overrides)


### PR DESCRIPTION
# Description

- For verl trainer, don't run our logic to find latest checkpoint. Verl will handle this.
- Remove resume_from_checkpoint fn for train() function of verl trainer. We instead set it in the class initialization.

## Related issues

Towards OPE-1260

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
