### PR TITLE
[tiny] Remove `use_liger` argument

### DIFF
--- a/src/oumi/core/configs/training_config.py
+++ b/src/oumi/core/configs/training_config.py
@@ -136,6 +136,7 @@ class TrainingConfig(BaseConfig):
             if trainer_type in (
                 TrainerType.TRL_SFT,
                 TrainerType.TRL_DPO,
+                TrainerType.TRL_GRPO,
                 TrainerType.HF,
             ):
                 self.training.trainer_kwargs["use_liger_kernel"] = True

--- a/src/oumi/core/configs/training_config.py
+++ b/src/oumi/core/configs/training_config.py
@@ -132,13 +132,12 @@ class TrainingConfig(BaseConfig):
 
         # Set Liger kernel flags if using a HF trainer, and if so, don't do Liger
         # patch ourselves.
-        # TODO(OPE-1117): Clean up this logic after upgrading to trl 0.16.
         if self.model.enable_liger_kernel:
-            if trainer_type == TrainerType.TRL_SFT:
-                self.training.trainer_kwargs["use_liger"] = True
-                self.training.trainer_kwargs["use_liger_kernel"] = True
-                self.model.enable_liger_kernel = False
-            elif trainer_type in (TrainerType.TRL_DPO, TrainerType.HF):
+            if trainer_type in (
+                TrainerType.TRL_SFT,
+                TrainerType.TRL_DPO,
+                TrainerType.HF,
+            ):
                 self.training.trainer_kwargs["use_liger_kernel"] = True
                 self.model.enable_liger_kernel = False
             elif trainer_type == TrainerType.OUMI:

--- a/src/oumi/core/trainers/oumi_trainer.py
+++ b/src/oumi/core/trainers/oumi_trainer.py
@@ -30,7 +30,6 @@ import torch.distributed.checkpoint as dcp
 import torch.utils.tensorboard as tensorboard
 
 import mlflow  # isort: skip
-import transformers
 
 import wandb  # isort: skip
 from torch.distributed.checkpoint.state_dict import (
@@ -161,11 +160,11 @@ class Trainer(BaseTrainer):
         # Prepare model for training
         # ----------------------------------
         if args.enable_gradient_checkpointing:
-            if not isinstance(model, transformers.PreTrainedModel):
+            if not hasattr(model, "gradient_checkpointing_enable"):
                 raise ValueError(
-                    "Gradient checkpointing is only supported for transformers models."
+                    "Gradient checkpointing is only supported for Hugging Face models."
                 )
-            model.gradient_checkpointing_enable(args.gradient_checkpointing_kwargs)
+            model.gradient_checkpointing_enable(args.gradient_checkpointing_kwargs)  # type: ignore
         model = cast(torch.nn.Module, model)
         model.to(self.device)
         if is_distributed():

--- a/tests/e2e/test_train_e2e.py
+++ b/tests/e2e/test_train_e2e.py
@@ -446,6 +446,20 @@ def test_train_text_1gpu_24gb(
             save_steps=5,
             is_lora=True,
         ),
+        TrainTestConfig(
+            test_name="train_text_llama3_1_8b_trl_sft_full",
+            config_path=(
+                get_configs_dir()
+                / "recipes"
+                / "llama3_1"
+                / "sft"
+                / "8b_full"
+                / "train.yaml"
+            ),
+            trainer_type=TrainerType.TRL_SFT,
+            max_steps=5,
+            save_steps=5,
+        ),
     ],
     ids=get_train_test_id_fn,
 )


### PR DESCRIPTION
# Description

This parameter for SFTConfig is now deprecated. This PR also adds a new test case to integration test cases so that a Liger kernel model is covered.

## Related issues

Fixes OPE-1117

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
