### PR TITLE
Add adaptive semaphore to enable future adaptive throughput scenarios

### DIFF
--- a/src/oumi/inference/adaptive_semaphore.py
+++ b/src/oumi/inference/adaptive_semaphore.py
@@ -15,8 +15,10 @@
 import asyncio
 from collections import deque
 
+from oumi.core.async_utils import safe_asyncio_run
 
-class AdaptiveSemaphore:
+
+class AdaptiveSemaphore(asyncio.Semaphore):
     """A semaphore that can dynamically adjust capacity while preserving waiters."""
 
     def __init__(self, initial_capacity: int):
@@ -25,71 +27,106 @@ class AdaptiveSemaphore:
         Args:
             initial_capacity: The initial capacity of the semaphore.
         """
-        self._capacity = initial_capacity
-        self._current_count = initial_capacity
+        if initial_capacity <= 0:
+            raise ValueError("Initial capacity must be greater than 0.")
+
+        self._max_capacity = initial_capacity
+        self._current_capacity = initial_capacity
         self._waiters: deque = deque()
-        self._condition = asyncio.Condition()
+        self._lock = asyncio.Lock()
 
-    async def acquire(self):
+    async def __aenter__(self):
+        """Enter the context manager."""
+        await self.acquire()
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        """Exit the context manager."""
+        self.release()
+
+    def __repr__(self):
+        """Return a string representation of the semaphore."""
+        return (
+            f"AdaptiveSemaphore(capacity={self._max_capacity}, "
+            f"current_count={self._current_capacity})"
+        )
+
+    def locked(self):
+        """Return True if the semaphore is locked."""
+        return self._current_capacity <= 0
+
+    async def acquire(self) -> bool:
         """Acquire a permit."""
-        waiter = None
-        async with self._condition:
-            if self._current_count <= 0:
-                waiter = asyncio.get_event_loop().create_future()
-                self._waiters.append(waiter)
+        waiter_future = None
+        async with self._lock:
+            if self.locked():
+                waiter_future = asyncio.get_event_loop().create_future()
+                self._waiters.append(waiter_future)
             else:
-                self._current_count -= 1
+                self._current_capacity -= 1
 
-        if waiter is None:
-            return
+        if waiter_future is None:
+            return True
 
         try:
-            await waiter
+            await waiter_future
         except asyncio.CancelledError:
             # Remove cancelled waiter
-            async with self._condition:
-                try:
-                    self._waiters.remove(waiter)
-                except ValueError:
-                    pass
-                raise
+            await self._remove_waiter_from_queue(waiter_future)
+            raise
+        finally:
+            await self._remove_waiter_from_queue(waiter_future)
 
-    def release(self):
+        return True
+
+    async def _remove_waiter_from_queue(self, waiter: asyncio.Future):
+        """Remove a waiter from the queue."""
+        async with self._lock:
+            try:
+                self._waiters.remove(waiter)
+            except ValueError:
+                pass
+
+    async def _release_async(self):
         """Release a permit."""
-
-        async def _release():
-            async with self._condition:
-                self._current_count += 1
+        async with self._lock:
+            self._current_capacity += 1
+            self._current_capacity = min(self._current_capacity, self._max_capacity)
 
             # Wake up the next waiter if any
-            while self._waiters and self._current_count > 0:
+            while self._waiters and self._current_capacity > 0:
                 waiter = self._waiters.popleft()
                 if not waiter.cancelled():
-                    self._current_count -= 1
+                    self._current_capacity -= 1
                     waiter.set_result(None)
                     break
 
-        # Schedule the release to run in the event loop
-        asyncio.create_task(_release())
+    def release(self):
+        """Release a permit."""
+        safe_asyncio_run(self._release_async())
 
     async def adjust_capacity(self, new_capacity: int):
         """Adjust the semaphore capacity, handling waiters appropriately."""
-        async with self._condition:
-            capacity_change = new_capacity - self._capacity
-            self._capacity = new_capacity
-            self._current_count += capacity_change
+        if new_capacity <= 0:
+            raise ValueError("New capacity must be greater than 0.")
+
+        async with self._lock:
+            capacity_change = new_capacity - self._max_capacity
+            self._max_capacity = new_capacity
+            self._current_capacity += capacity_change
+            self._current_capacity = max(self._current_capacity, 0)
 
             # If we increased capacity, wake up waiters
             if capacity_change > 0:
                 woken = 0
                 while (
                     self._waiters
-                    and self._current_count > 0
+                    and self._current_capacity > 0
                     and woken < capacity_change
                 ):
                     waiter = self._waiters.popleft()
                     if not waiter.cancelled():
-                        self._current_count -= 1
+                        self._current_capacity -= 1
                         waiter.set_result(None)
                         woken += 1
 

--- a/src/oumi/inference/adaptive_semaphore.py
+++ b/src/oumi/inference/adaptive_semaphore.py
@@ -90,7 +90,7 @@ class AdaptiveSemaphore:
     async def _release_async(self):
         """Release a permit."""
         async with self._lock:
-            self._current_capacity = min(self._current_capacity+1, self._max_capacity)
+            self._current_capacity = min(self._current_capacity + 1, self._max_capacity)
 
             # Wake up the next waiter if any
             while self._waiters and self._current_capacity > 0:

--- a/src/oumi/inference/adaptive_semaphore.py
+++ b/src/oumi/inference/adaptive_semaphore.py
@@ -90,8 +90,7 @@ class AdaptiveSemaphore:
     async def _release_async(self):
         """Release a permit."""
         async with self._lock:
-            self._current_capacity += 1
-            self._current_capacity = min(self._current_capacity, self._max_capacity)
+            self._current_capacity = min(self._current_capacity+1, self._max_capacity)
 
             # Wake up the next waiter if any
             while self._waiters and self._current_capacity > 0:

--- a/src/oumi/inference/adaptive_semaphore.py
+++ b/src/oumi/inference/adaptive_semaphore.py
@@ -18,7 +18,7 @@ from collections import deque
 from oumi.core.async_utils import safe_asyncio_run
 
 
-class AdaptiveSemaphore(asyncio.Semaphore):
+class AdaptiveSemaphore:
     """A semaphore that can dynamically adjust capacity while preserving waiters."""
 
     def __init__(self, initial_capacity: int):

--- a/src/oumi/inference/adaptive_semaphore.py
+++ b/src/oumi/inference/adaptive_semaphore.py
@@ -1,0 +1,97 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from collections import deque
+
+
+class AdaptiveSemaphore:
+    """A semaphore that can dynamically adjust capacity while preserving waiters."""
+
+    def __init__(self, initial_capacity: int):
+        """Initialize the adaptive semaphore.
+
+        Args:
+            initial_capacity: The initial capacity of the semaphore.
+        """
+        self._capacity = initial_capacity
+        self._current_count = initial_capacity
+        self._waiters: deque = deque()
+        self._condition = asyncio.Condition()
+
+    async def acquire(self):
+        """Acquire a permit."""
+        waiter = None
+        async with self._condition:
+            if self._current_count <= 0:
+                waiter = asyncio.get_event_loop().create_future()
+                self._waiters.append(waiter)
+            else:
+                self._current_count -= 1
+
+        if waiter is None:
+            return
+
+        try:
+            await waiter
+        except asyncio.CancelledError:
+            # Remove cancelled waiter
+            async with self._condition:
+                try:
+                    self._waiters.remove(waiter)
+                except ValueError:
+                    pass
+                raise
+
+    def release(self):
+        """Release a permit."""
+
+        async def _release():
+            async with self._condition:
+                self._current_count += 1
+
+            # Wake up the next waiter if any
+            while self._waiters and self._current_count > 0:
+                waiter = self._waiters.popleft()
+                if not waiter.cancelled():
+                    self._current_count -= 1
+                    waiter.set_result(None)
+                    break
+
+        # Schedule the release to run in the event loop
+        asyncio.create_task(_release())
+
+    async def adjust_capacity(self, new_capacity: int):
+        """Adjust the semaphore capacity, handling waiters appropriately."""
+        async with self._condition:
+            capacity_change = new_capacity - self._capacity
+            self._capacity = new_capacity
+            self._current_count += capacity_change
+
+            # If we increased capacity, wake up waiters
+            if capacity_change > 0:
+                woken = 0
+                while (
+                    self._waiters
+                    and self._current_count > 0
+                    and woken < capacity_change
+                ):
+                    waiter = self._waiters.popleft()
+                    if not waiter.cancelled():
+                        self._current_count -= 1
+                        waiter.set_result(None)
+                        woken += 1
+
+            # If we decreased capacity below current usage, we don't forcibly
+            # revoke permits, but future acquires will be limited by the new capacity

--- a/tests/unit/inference/test_adaptive_semaphore.py
+++ b/tests/unit/inference/test_adaptive_semaphore.py
@@ -1,0 +1,361 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from oumi.inference.adaptive_semaphore import AdaptiveSemaphore
+
+
+class TestAdaptiveSemaphore:
+    """Test suite for AdaptiveSemaphore class."""
+
+    @pytest.mark.asyncio
+    async def test_initialization(self):
+        """Test semaphore initialization with different capacities."""
+        # Test basic initialization
+        semaphore = AdaptiveSemaphore(5)
+        assert semaphore._capacity == 5
+        assert semaphore._current_count == 5
+        assert len(semaphore._waiters) == 0
+
+        # Test with capacity of 1
+        semaphore = AdaptiveSemaphore(1)
+        assert semaphore._capacity == 1
+        assert semaphore._current_count == 1
+
+    @pytest.mark.asyncio
+    async def test_basic_acquire_release(self):
+        """Test basic acquire and release functionality."""
+        semaphore = AdaptiveSemaphore(2)
+
+        # First acquire should succeed immediately
+        await semaphore.acquire()
+        assert semaphore._current_count == 1
+
+        # Second acquire should succeed immediately
+        await semaphore.acquire()
+        assert semaphore._current_count == 0
+
+        # Release one permit
+        semaphore.release()
+        # Wait for async release to complete
+        await asyncio.sleep(0.01)
+        assert semaphore._current_count == 1
+
+        # Release another permit
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        assert semaphore._current_count == 2
+
+    @pytest.mark.asyncio
+    async def test_acquire_blocking_when_capacity_reached(self):
+        """Test that acquire blocks when capacity is reached."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # First acquire should succeed immediately
+        await semaphore.acquire()
+        assert semaphore._current_count == 0
+
+        # Second acquire should block
+        acquire_task = asyncio.create_task(semaphore.acquire())
+        await asyncio.sleep(0.01)  # Give task a chance to run
+        assert not acquire_task.done()
+        assert len(semaphore._waiters) == 1
+
+        # Release should unblock the waiting acquire
+        semaphore.release()
+        await asyncio.sleep(0.01)  # Give release task a chance to complete
+        await acquire_task  # This should complete now
+        assert semaphore._current_count == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_waiters(self):
+        """Test handling of multiple waiting tasks."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # Acquire the only permit
+        await semaphore.acquire()
+        assert semaphore._current_count == 0
+
+        # Create multiple waiting tasks
+        task1 = asyncio.create_task(semaphore.acquire())
+        task2 = asyncio.create_task(semaphore.acquire())
+        task3 = asyncio.create_task(semaphore.acquire())
+
+        await asyncio.sleep(0.01)  # Let tasks start waiting
+        assert len(semaphore._waiters) == 3
+        assert not task1.done()
+        assert not task2.done()
+        assert not task3.done()
+
+        # Release should wake up first waiter
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await task1  # Should complete
+        assert not task2.done()
+        assert not task3.done()
+        assert len(semaphore._waiters) == 2
+
+        # Release again should wake up second waiter
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await task2  # Should complete
+        assert not task3.done()
+        assert len(semaphore._waiters) == 1
+
+        # Release again should wake up third waiter
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await task3  # Should complete
+        assert len(semaphore._waiters) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiters_handling(self):
+        """Test that cancelled waiters are properly removed."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # Acquire the only permit
+        await semaphore.acquire()
+
+        # Create waiting tasks
+        task1 = asyncio.create_task(semaphore.acquire())
+        task2 = asyncio.create_task(semaphore.acquire())
+
+        await asyncio.sleep(0.01)
+        assert len(semaphore._waiters) == 2
+
+        # Cancel first task
+        task1.cancel()
+        try:
+            await task1
+        except asyncio.CancelledError:
+            pass
+
+        # Release should wake up the non-cancelled waiter
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await task2  # Should complete
+        assert len(semaphore._waiters) == 0
+
+    @pytest.mark.asyncio
+    async def test_adjust_capacity_increase(self):
+        """Test increasing semaphore capacity."""
+        semaphore = AdaptiveSemaphore(2)
+
+        # Acquire both permits
+        await semaphore.acquire()
+        await semaphore.acquire()
+        assert semaphore._current_count == 0
+
+        # Create waiting tasks
+        task1 = asyncio.create_task(semaphore.acquire())
+        task2 = asyncio.create_task(semaphore.acquire())
+
+        await asyncio.sleep(0.01)
+        assert len(semaphore._waiters) == 2
+
+        # Increase capacity should wake up waiters
+        await semaphore.adjust_capacity(4)
+        assert semaphore._capacity == 4
+        await asyncio.sleep(0.01)
+
+        await task1  # Should complete
+        await task2  # Should complete
+        assert len(semaphore._waiters) == 0
+        assert semaphore._current_count == 0  # 4 capacity - 4 acquired
+
+    @pytest.mark.asyncio
+    async def test_adjust_capacity_decrease(self):
+        """Test decreasing semaphore capacity."""
+        semaphore = AdaptiveSemaphore(5)
+
+        # Acquire 2 permits
+        await semaphore.acquire()
+        await semaphore.acquire()
+        assert semaphore._current_count == 3
+
+        # Decrease capacity
+        await semaphore.adjust_capacity(3)
+        assert semaphore._capacity == 3
+        assert semaphore._current_count == 1  # 3 - 2 acquired
+
+        # Should be able to acquire one more
+        await semaphore.acquire()
+        assert semaphore._current_count == 0
+
+        # Next acquire should block
+        task = asyncio.create_task(semaphore.acquire())
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        assert len(semaphore._waiters) == 1
+
+        # Clean up
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await task
+
+    @pytest.mark.asyncio
+    async def test_adjust_capacity_with_existing_waiters(self):
+        """Test capacity adjustment when there are existing waiters."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # Acquire the permit
+        await semaphore.acquire()
+
+        # Create multiple waiters
+        tasks = [asyncio.create_task(semaphore.acquire()) for _ in range(3)]
+        await asyncio.sleep(0.01)
+        assert len(semaphore._waiters) == 3
+
+        # Increase capacity to 3 should wake up 2 waiters
+        await semaphore.adjust_capacity(3)
+        await asyncio.sleep(0.01)
+
+        # First two tasks should complete, third should still wait
+        await tasks[0]
+        await tasks[1]
+        assert not tasks[2].done()
+        assert len(semaphore._waiters) == 1
+
+        # Release one more to complete the last task
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        await tasks[2]
+
+    @pytest.mark.asyncio
+    async def test_adjust_capacity_decrease_below_current_usage(self):
+        """Test decreasing capacity below current usage doesn't revoke permits."""
+        semaphore = AdaptiveSemaphore(5)
+
+        # Acquire 4 permits
+        for _ in range(4):
+            await semaphore.acquire()
+        assert semaphore._current_count == 1
+
+        # Decrease capacity below current usage
+        await semaphore.adjust_capacity(2)
+        assert semaphore._capacity == 2
+        # Current count becomes negative (2 - 4 = -2)
+        assert semaphore._current_count == -2
+
+        # No new acquires should succeed until enough permits are released
+        task = asyncio.create_task(semaphore.acquire())
+        await asyncio.sleep(0.01)
+        assert not task.done()
+
+        # Release 3 permits to get back to positive count
+        for _ in range(3):
+            semaphore.release()
+        await asyncio.sleep(0.01)
+
+        # Now the waiting task should complete
+        await task
+
+    @pytest.mark.asyncio
+    async def test_concurrent_operations(self):
+        """Test concurrent acquire/release/adjust operations."""
+        semaphore = AdaptiveSemaphore(3)
+
+        async def worker(worker_id: int, results: list):
+            try:
+                await semaphore.acquire()
+                await asyncio.sleep(0.01)  # Simulate work
+                results.append(f"worker_{worker_id}_done")
+                semaphore.release()
+            except Exception as e:
+                results.append(f"worker_{worker_id}_error_{e}")
+
+        # Start multiple workers
+        results = []
+        tasks = [asyncio.create_task(worker(i, results)) for i in range(5)]
+
+        # Adjust capacity while workers are running
+        await asyncio.sleep(0.005)
+        await semaphore.adjust_capacity(2)
+        await asyncio.sleep(0.005)
+        await semaphore.adjust_capacity(4)
+
+        # Wait for all workers to complete
+        await asyncio.gather(*tasks)
+
+        # All workers should complete successfully
+        assert len(results) == 5
+        assert all("_done" in result for result in results)
+
+    @pytest.mark.asyncio
+    async def test_zero_capacity(self):
+        """Test semaphore behavior with zero capacity."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # Reduce to zero capacity
+        await semaphore.adjust_capacity(0)
+        assert semaphore._capacity == 0
+        assert semaphore._current_count == 0
+
+        # New acquires should block
+        task = asyncio.create_task(semaphore.acquire())
+        await asyncio.sleep(0.01)
+        assert not task.done()
+
+        # Increase capacity should allow acquire
+        await semaphore.adjust_capacity(1)
+        await asyncio.sleep(0.01)
+        await task  # Should complete now
+
+    @pytest.mark.asyncio
+    async def test_edge_case_empty_waiters_on_release(self):
+        """Test release when there are no waiters."""
+        semaphore = AdaptiveSemaphore(2)
+
+        # Acquire one permit
+        await semaphore.acquire()
+        assert semaphore._current_count == 1
+
+        # Release without any waiters
+        semaphore.release()
+        await asyncio.sleep(0.01)
+        assert semaphore._current_count == 2
+        assert len(semaphore._waiters) == 0
+
+    @pytest.mark.asyncio
+    async def test_waiter_cancellation_during_release(self):
+        """Test handling of waiter cancellation during release."""
+        semaphore = AdaptiveSemaphore(1)
+
+        # Acquire the permit
+        await semaphore.acquire()
+
+        # Create waiters
+        task1 = asyncio.create_task(semaphore.acquire())
+        task2 = asyncio.create_task(semaphore.acquire())
+
+        await asyncio.sleep(0.01)
+        assert len(semaphore._waiters) == 2
+
+        # Cancel first waiter
+        task1.cancel()
+
+        # Release should skip cancelled waiter and wake up second one
+        semaphore.release()
+        await asyncio.sleep(0.01)
+
+        try:
+            await task1
+        except asyncio.CancelledError:
+            pass
+
+        await task2  # Should complete
+        assert len(semaphore._waiters) == 0


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Bounded Semaphores are a lock mechanism allowing a finite amount of "permits" to allow so many "waiters" to access a given resource.

Traditionally, bounded semaphores are a fixed size - once initialized, they keep that capacity.

This PR introduced an Adaptive Semaphore - one which can change its size allocation. For size decreases, nothing special really happens - the existing permits stay valid, but no new permits are granted.

For size increases, the semaphore will immediately grant <delta> waiters access to the resource.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards OPE-1307

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
