### PR TITLE
Add multi-node verl SLURM job

### DIFF
--- a/configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml
+++ b/configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml
@@ -20,10 +20,6 @@ resources:
 
 working_dir: .
 
-file_mounts:
-  ~/.netrc: ~/.netrc # WandB credentials
-  ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
-
 envs:
   RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING: 1
   RAY_BACKEND_LOG_LEVEL: debug

--- a/configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml
+++ b/configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml
@@ -1,0 +1,68 @@
+# VERL GRPO job config for GSM8K.
+#
+# Requirements:
+#   - Run step 1 of verl quickstart: https://verl.readthedocs.io/en/latest/start/quickstart.html
+#
+# Usage:
+#   oumi launch up -c configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml --cluster $OUMI_SLURM_CONNECTIONS --user wizeng
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: grpo-verl-gsm8k
+num_nodes: 2
+
+resources:
+  cloud: slurm
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc # WandB credentials
+  ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
+
+envs:
+  RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING: 1
+  RAY_BACKEND_LOG_LEVEL: debug
+
+setup: |
+  #SBATCH --ntasks-per-node=1
+  #SBATCH --cpus-per-task=32
+  #SBATCH --gpus-per-task=2
+  #SBATCH --mem-per-gpu=128G
+  #SBATCH --time=05:00:00
+  # Num nodes is set by num_nodes field above.
+
+  # Initialize Ray cluster on SLURM nodes.
+  source ./configs/examples/misc/slurm_ray_init.sh
+
+run: |
+  set -e  # Exit if any command failed.
+
+  set -x
+  ray job submit --address="http://127.0.0.1:8265" \
+  --runtime-env="src/oumi/core/trainers/verl_ray_runtime_env.yaml" \
+  -- \
+  python3 -m verl.trainer.main_ppo \
+  data.train_files=$HOME/data/gsm8k/train.parquet \
+  data.val_files=$HOME/data/gsm8k/test.parquet \
+  data.train_batch_size=256 \
+  data.max_prompt_length=512 \
+  data.max_response_length=256 \
+  actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
+  actor_rollout_ref.actor.optim.lr=1e-6 \
+  actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+  actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+  actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
+  critic.model.path=Qwen/Qwen2.5-0.5B-Instruct \
+  critic.ppo_micro_batch_size_per_gpu=4 \
+  trainer.logger=['console'] \
+  trainer.default_hdfs_dir=null \
+  trainer.n_gpus_per_node=$SLURM_GPUS_ON_NODE \
+  trainer.nnodes=$SLURM_JOB_NUM_NODES 

--- a/configs/examples/misc/slurm_ray_init.sh
+++ b/configs/examples/misc/slurm_ray_init.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Env vars required by this script (should be set by SLURM):
+# SLURM_JOB_NODELIST: list of nodes in the job.
+# SLURM_CPUS_PER_TASK: number of CPUs per node.
+# SLURM_GPUS_ON_NODE: number of GPUs per node.
+
+set -e
+source ~/miniconda3/etc/profile.d/conda.sh # Required for conda.
+conda activate oumi
+pip install uv && uv pip install 'oumi[gpu]'
+
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+scontrol show hostnames "$SLURM_JOB_NODELIST" > nodes.txt
+nodes_array=($nodes)
+echo "nodes_array: $nodes_array" > nodesarray.txt
+head_node=${nodes_array[0]}
+head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
+
+# if we detect a space character in the head node IP, we'll
+# convert it to an ipv4 address. This step is optional.
+if [[ "$head_node_ip" == *" "* ]]; then
+IFS=' ' read -ra ADDR <<<"$head_node_ip"
+if [[ ${#ADDR[0]} -gt 16 ]]; then
+head_node_ip=${ADDR[1]}
+else
+head_node_ip=${ADDR[0]}
+fi
+echo "IPV6 address detected. We split the IPV4 address as $head_node_ip"
+fi
+
+port=6379
+ip_head=$head_node_ip:$port
+export ip_head
+
+echo "Info----------"
+echo "SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST"
+echo "CPUs per node: $SLURM_CPUS_PER_TASK"
+echo "GPUs per node: $SLURM_GPUS_ON_NODE"
+echo "IP Head: $ip_head"
+
+echo "Starting HEAD at $head_node"
+srun --nodes=1 --ntasks=1 -w "$head_node" \
+    ray start --head --node-ip-address="$head_node_ip" --port=$port \
+    --num-cpus "$SLURM_CPUS_PER_TASK" --num-gpus "$SLURM_GPUS_ON_NODE" \
+    --block &
+
+# number of nodes other than the head node
+worker_num=$((SLURM_JOB_NUM_NODES - 1))
+
+for ((i = 1; i <= worker_num; i++)); do
+    node_i=${nodes_array[$i]}
+    echo "Starting WORKER $i at $node_i"
+    srun --nodes=1 --ntasks=1 -w "$node_i" \
+        ray start --address "$ip_head" \
+        --num-cpus "$SLURM_CPUS_PER_TASK" --num-gpus "$SLURM_GPUS_ON_NODE" \
+        --block &
+    sleep 5
+done
+
+# Print cluster status to confirm setup.
+ray status

--- a/configs/examples/misc/slurm_ray_init.sh
+++ b/configs/examples/misc/slurm_ray_init.sh
@@ -32,7 +32,6 @@ port=6379
 ip_head=$head_node_ip:$port
 export ip_head
 
-echo "Info----------"
 echo "SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST"
 echo "CPUs per node: $SLURM_CPUS_PER_TASK"
 echo "GPUs per node: $SLURM_GPUS_ON_NODE"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_frontier_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_frontier_job.yaml
@@ -2,9 +2,8 @@
 #
 # Requirements:
 #   - Set up your OLCF account (only available to Oumi core team)
-#   - Set `user` to your OLCF username
+#   - Set $OLCF_USER to your OLCF username
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
-#   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:
 #   oumi launch up -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_frontier_job.yaml --cluster batch.$OLCF_USER --user $OLCF_USER --log-level DEBUG

--- a/configs/recipes/smollm/sft/135m/gcp_job.yaml
+++ b/configs/recipes/smollm/sft/135m/gcp_job.yaml
@@ -31,7 +31,9 @@ run: |
   source ./configs/examples/misc/sky_init.sh
 
   set -x
-  oumi train -c configs/recipes/smollm/sft/135m/train.yaml \
-    --training.enable_wandb false
+  oumi train \
+      -c configs/recipes/smollm/sft/135m/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}" \
+      --training.enable_wandb=False
 
   echo "Training complete!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ gpu = [
     "bitsandbytes>=0.45.0,<0.46",      # Used for QLora, and PagedAdam implementation
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.
-    "verl>=0.4.0,<0.5", # Used for the VERL_GRPO trainer.
+    "verl==0.4.0", # Used for the VERL_GRPO trainer.
     "vllm>=0.8.3,<0.9", # For VLLMInferenceEngine, and vLLM-powered GRPO training.
 ]
 

--- a/src/oumi/cli/launch.py
+++ b/src/oumi/cli/launch.py
@@ -239,9 +239,11 @@ def _poll_job(
             f"status [yellow]{final_status.status}[/yellow]"
         )
         cli_utils.CONSOLE.print(
-            f"Job metadata: [yellow]{final_status.metadata}[/yellow]"
+            "Job metadata:"
         )
-
+        cli_utils.CONSOLE.print(
+            f"[yellow]{final_status.metadata}[/yellow]"
+        )
 
 # ----------------------------
 # Launch CLI subcommands

--- a/src/oumi/core/trainers/verl_ray_runtime_env.yaml
+++ b/src/oumi/core/trainers/verl_ray_runtime_env.yaml
@@ -1,0 +1,5 @@
+working_dir: ./
+excludes: ["/.git/"]
+conda: "oumi"
+env_vars:
+  TORCH_NCCL_AVOID_RECORD_STREAMS: "1"


### PR DESCRIPTION
# Description

- Add Ray runtime env config `src/oumi/core/trainers/verl_ray_runtime_env.yaml`, referencing https://github.com/volcengine/verl/blob/main/verl/trainer/runtime_env.yaml, with the addition of activating the oumi conda env
- Add `configs/examples/misc/slurm_ray_init.sh`, which sets up a Ray cluster on Slurm nodes. Reference: https://docs.ray.io/en/latest/cluster/vms/user-guides/community/slurm.html.
- Add example config `configs/examples/misc/grpo_verl_gsm8k_slurm_job.yaml` for running verl on Slurm, using an Oumi job config
- Pin verl version to 0.4.0. We can't use 0.4.1 yet since it added new config fields we don't have yet.
- Misc fixes

## Related issues

Towards OPE-1338

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
