### PR TITLE
Add support for document ingestion during data synthesis

### DIFF
--- a/src/oumi/core/synthesis/planner.py
+++ b/src/oumi/core/synthesis/planner.py
@@ -18,11 +18,13 @@ from typing import Optional
 from oumi.core.configs.params.synthesis_params import (
     AttributeCombination,
     DatasetSource,
+    DocumentSource,
     ExampleSource,
     GeneralSynthesisParams,
     PermutableAttribute,
 )
 from oumi.core.synthesis.dataset_ingestion import DatasetReader
+from oumi.core.synthesis.document_ingestion import DocumentReader, DocumentSegmenter
 
 
 class DatasetPlanner:
@@ -37,10 +39,14 @@ class DatasetPlanner:
         representing a sample of the dataset with a particular attribute value for
         each attribute.
 
+        - Example sources are used to populate the dataset plan with a set of examples
+          for specific attributes, with each example being used round-robin.
+        - Document sources are used to populate the dataset plan with documents and/or
+          document segments, each sample of a document source being used round-robin.
         - Dataset sources are used to populate the dataset plan with values for the
           attributes, with each sample of a dataset source being used round-robin.
         - Permutable attributes have their values sampled from a distribution.
-        - Combination sampling overrides the distribution for particular attribute value
+        - Combination sampling overrides the distribution for particular attribute-value
           combinations.
 
         The final list of dictionaries will be used to create a dataset.
@@ -62,6 +68,10 @@ class DatasetPlanner:
 
         dataset_sample_sets = self._ingest_dataset_sources(synthesis_params.input_data)
 
+        document_sample_sets = self._ingest_document_sources(
+            synthesis_params.input_documents
+        )
+
         permutable_attribute_samples = self._plan_permutable_attributes(
             synthesis_params.permutable_attributes,
             synthesis_params.combination_sampling,
@@ -73,6 +83,7 @@ class DatasetPlanner:
             permutable_attribute_samples,
             example_sample_sets,
             dataset_sample_sets,
+            document_sample_sets,
         )
 
     def _create_dataset_plan(
@@ -81,6 +92,7 @@ class DatasetPlanner:
         permutable_attribute_samples: list[dict],
         example_sample_sets: list[list[dict]],
         dataset_sample_sets: list[list[dict]],
+        document_sample_sets: list[list[dict]],
     ) -> list[dict]:
         """Create the final dataset plan."""
         samples = []
@@ -93,6 +105,10 @@ class DatasetPlanner:
             for dataset in dataset_sample_sets:
                 index = i % len(dataset)
                 sample.update(dataset[index])
+
+            for document_set in document_sample_sets:
+                index = i % len(document_set)
+                sample.update(document_set[index])
 
             samples.append(sample)
 
@@ -111,7 +127,7 @@ class DatasetPlanner:
         self,
         example_sources: Optional[list[ExampleSource]],
     ) -> list[list[dict]]:
-        """Ingest the example sources."""
+        """Read examples from the example sources."""
         if example_sources is None or len(example_sources) == 0:
             return []
 
@@ -122,12 +138,43 @@ class DatasetPlanner:
         self,
         dataset_sources: Optional[list[DatasetSource]],
     ) -> list[list[dict]]:
-        """Ingest the dataset sources."""
+        """Read in datasets from the dataset sources."""
         if dataset_sources is None or len(dataset_sources) == 0:
             return []
 
         data_reader = DatasetReader()
         return [data_reader.read(dataset_source) for dataset_source in dataset_sources]
+
+    def _ingest_document_sources(
+        self,
+        document_sources: Optional[list[DocumentSource]],
+    ) -> list[list[dict]]:
+        """Read documents from the document sources and segment them if necessary."""
+        if document_sources is None or len(document_sources) == 0:
+            return []
+
+        document_reader = DocumentReader()
+        per_source_records = []
+        for document_source in document_sources:
+            records = []
+            path = document_source.path
+            documents = document_reader.read(path)
+            if document_source.segmentation_params is None:
+                for document in documents:
+                    records.append({document_source.id: document})
+            else:
+                segmenter = DocumentSegmenter(document_source.segmentation_params)
+                for document in documents:
+                    segments = segmenter.segment(document)
+                    for segment in segments:
+                        record = {document_source.segmentation_params.id: segment}
+                        if document_source.segmentation_params.keep_original_text:
+                            record[document_source.id] = document
+                        records.append(record)
+
+            per_source_records.append(records)
+
+        return per_source_records
 
     def _plan_permutable_attributes(
         self,

--- a/src/oumi/core/synthesis/planner.py
+++ b/src/oumi/core/synthesis/planner.py
@@ -150,7 +150,7 @@ class DatasetPlanner:
         document_sources: Optional[list[DocumentSource]],
     ) -> list[list[dict]]:
         """Read documents from the document sources and segment them if necessary."""
-        if document_sources is None or len(document_sources) == 0:
+        if not document_sources:
             return []
 
         document_reader = DocumentReader()

--- a/tests/unit/core/synthesis/test_planner.py
+++ b/tests/unit/core/synthesis/test_planner.py
@@ -20,10 +20,13 @@ import pytest
 from oumi.core.configs.params.synthesis_params import (
     AttributeCombination,
     DatasetSource,
+    DocumentSegmentationParams,
+    DocumentSource,
     ExampleSource,
     GeneralSynthesisParams,
     PermutableAttribute,
     PermutableAttributeValue,
+    SegmentationStrategy,
 )
 from oumi.core.synthesis.planner import DatasetPlanner
 
@@ -131,6 +134,70 @@ def mock_example_sources():
                 {"example_attr1": "example_value2", "example_attr2": "example_valueB"},
             ]
         )
+    ]
+
+
+@pytest.fixture
+def mock_document_sources():
+    """Mock document sources for testing."""
+    return [
+        DocumentSource(path="test_document1.pdf", id="doc1"),
+        DocumentSource(path="test_document2.txt", id="doc2"),
+    ]
+
+
+@pytest.fixture
+def mock_document_sources_with_segmentation():
+    """Mock document sources with segmentation for testing."""
+    return [
+        DocumentSource(
+            path="test_document1.pdf",
+            id="doc1",
+            segmentation_params=DocumentSegmentationParams(
+                id="doc1_segment",
+                segmentation_strategy=SegmentationStrategy.TOKENS,
+                segment_length=512,
+                segment_overlap=50,
+                keep_original_text=False,
+            ),
+        ),
+        DocumentSource(
+            path="test_document2.txt",
+            id="doc2",
+            segmentation_params=DocumentSegmentationParams(
+                id="doc2_segment",
+                segmentation_strategy=SegmentationStrategy.TOKENS,
+                segment_length=1024,
+                segment_overlap=100,
+                keep_original_text=True,
+            ),
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_document_data():
+    """Mock document data that would be returned by DocumentReader."""
+    return [
+        "This is the content of document 1. It contains multiple sentences and "
+        "paragraphs.",
+        "This is the content of document 2. It has different text content from "
+        "document 1.",
+        "This is the content of document 3. It provides additional context for "
+        "testing.",
+    ]
+
+
+@pytest.fixture
+def mock_document_segments():
+    """Mock document segments that would be returned by DocumentSegmenter."""
+    return [
+        ["This is segment 1 of document 1.", "This is segment 2 of document 1."],
+        [
+            "This is segment 1 of document 2.",
+            "This is segment 2 of document 2.",
+            "This is segment 3 of document 2.",
+        ],
     ]
 
 
@@ -483,3 +550,382 @@ def test_plan_with_dataset_sources_only(
 
         # Should have only dataset attributes
         assert len(sample) == 2
+
+
+# Document handling tests
+def test_plan_with_no_document_sources(planner, mock_permutable_attributes):
+    """Dataset plan should still be created if no document sources are provided."""
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=None,
+    )
+    result = planner.plan(params, sample_count=5)
+
+    assert len(result) == 5
+    # Should only contain permutable attributes
+    for sample in result:
+        assert "attr1" in sample
+        assert "attr2" in sample
+        assert len(sample) == 2
+
+
+def test_plan_with_empty_document_sources(planner, mock_permutable_attributes):
+    """Dataset plan should still be created if document sources are empty."""
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=None,  # Use None instead of [] to avoid validation error
+    )
+    result = planner.plan(params, sample_count=5)
+
+    assert len(result) == 5
+    # Should only contain permutable attributes
+    for sample in result:
+        assert "attr1" in sample
+        assert "attr2" in sample
+        assert len(sample) == 2
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+def test_plan_with_single_document_source_no_segmentation(
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_sources,
+    mock_document_data,
+):
+    """Test plan with single document source without segmentation."""
+    mock_reader = Mock()
+    mock_reader.read.return_value = mock_document_data[:1]  # Only first document
+    mock_reader_class.return_value = mock_reader
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=[mock_document_sources[0]],
+    )
+    result = planner.plan(params, sample_count=3)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    mock_reader.read.assert_called_once_with(mock_document_sources[0].path)
+
+    assert len(result) == 3
+    # Each sample should have both document attributes and permutable attributes
+    for i, sample in enumerate(result):
+        # Check document attributes (round-robin) - only one document, so always index 0
+        expected_doc_content = mock_document_data[0]
+        assert sample["doc1"] == expected_doc_content
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 3 attributes (1 from document + 2 permutable)
+        assert len(sample) == 3
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+def test_plan_with_multiple_document_sources_no_segmentation(
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_sources,
+    mock_document_data,
+):
+    """Test plan with multiple document sources without segmentation."""
+    mock_reader = Mock()
+    mock_reader.read.side_effect = [
+        [mock_document_data[0]],  # Document 1
+        [mock_document_data[1]],  # Document 2
+    ]
+    mock_reader_class.return_value = mock_reader
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=mock_document_sources,
+    )
+    result = planner.plan(params, sample_count=4)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    assert mock_reader.read.call_count == 2
+
+    assert len(result) == 4
+    # Each sample should have attributes from both documents and permutable attributes
+    for i, sample in enumerate(result):
+        # Check first document attributes (round-robin) - only one document per source
+        expected_doc1_content = mock_document_data[0]
+        assert sample["doc1"] == expected_doc1_content
+
+        # Check second document attributes (round-robin) - only one document per source
+        expected_doc2_content = mock_document_data[1]
+        assert sample["doc2"] == expected_doc2_content
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 4 attributes (2 from documents + 2 permutable)
+        assert len(sample) == 4
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+@patch("oumi.core.synthesis.planner.DocumentSegmenter")
+def test_plan_with_document_source_with_segmentation(
+    mock_segmenter_class,
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_sources_with_segmentation,
+    mock_document_data,
+    mock_document_segments,
+):
+    """Test plan with document source that has segmentation."""
+    mock_reader = Mock()
+    mock_reader.read.return_value = [mock_document_data[0]]
+    mock_reader_class.return_value = mock_reader
+
+    mock_segmenter = Mock()
+    mock_segmenter.segment.return_value = mock_document_segments[0]
+    mock_segmenter_class.return_value = mock_segmenter
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=[mock_document_sources_with_segmentation[0]],
+    )
+    result = planner.plan(params, sample_count=4)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    mock_reader.read.assert_called_once_with(
+        mock_document_sources_with_segmentation[0].path
+    )
+
+    # Verify DocumentSegmenter was called correctly
+    mock_segmenter_class.assert_called_once_with(
+        mock_document_sources_with_segmentation[0].segmentation_params
+    )
+    mock_segmenter.segment.assert_called_once_with(mock_document_data[0])
+
+    assert len(result) == 4
+    # Each sample should have both document segment attributes and permutable attributes
+    for i, sample in enumerate(result):
+        # Check document segment attributes (round-robin)
+        segment_index = i % len(mock_document_segments[0])
+        expected_segment = mock_document_segments[0][segment_index]
+        assert sample["doc1_segment"] == expected_segment
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 3 attributes (1 from document segments + 2 permutable)
+        assert len(sample) == 3
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+@patch("oumi.core.synthesis.planner.DocumentSegmenter")
+def test_plan_with_document_source_with_segmentation_keep_original(
+    mock_segmenter_class,
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_sources_with_segmentation,
+    mock_document_data,
+    mock_document_segments,
+):
+    """Test plan with document source that has segmentation and keeps original text."""
+    mock_reader = Mock()
+    mock_reader.read.return_value = [mock_document_data[0]]
+    mock_reader_class.return_value = mock_reader
+
+    mock_segmenter = Mock()
+    mock_segmenter.segment.return_value = mock_document_segments[0]
+    mock_segmenter_class.return_value = mock_segmenter
+
+    # Use the second document source which has keep_original_text=True
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=[mock_document_sources_with_segmentation[1]],
+    )
+    result = planner.plan(params, sample_count=4)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    mock_reader.read.assert_called_once_with(
+        mock_document_sources_with_segmentation[1].path
+    )
+
+    # Verify DocumentSegmenter was called correctly
+    mock_segmenter_class.assert_called_once_with(
+        mock_document_sources_with_segmentation[1].segmentation_params
+    )
+    mock_segmenter.segment.assert_called_once_with(mock_document_data[0])
+
+    assert len(result) == 4
+    # Each sample should have both document segment attributes, original document, and
+    # permutable attributes
+    for i, sample in enumerate(result):
+        # Check document segment attributes (round-robin)
+        segment_index = i % len(mock_document_segments[0])
+        expected_segment = mock_document_segments[0][segment_index]
+        assert sample["doc2_segment"] == expected_segment
+
+        # Check original document is preserved
+        assert sample["doc2"] == mock_document_data[0]
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 4 attributes
+        # (1 from document segments + 1 original document + 2 permutable)
+        assert len(sample) == 4
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+@patch("oumi.core.synthesis.planner.DocumentSegmenter")
+def test_plan_with_mixed_document_sources(
+    mock_segmenter_class,
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_data,
+    mock_document_segments,
+):
+    """Test plan with mix of segmented and non-segmented document sources."""
+    mock_reader = Mock()
+    mock_reader.read.side_effect = [
+        [mock_document_data[0]],  # Document 1 (non-segmented)
+        [mock_document_data[1]],  # Document 2 (segmented)
+    ]
+    mock_reader_class.return_value = mock_reader
+
+    mock_segmenter = Mock()
+    mock_segmenter.segment.return_value = mock_document_segments[1]
+    mock_segmenter_class.return_value = mock_segmenter
+
+    # Create mixed document sources
+    mixed_sources = [
+        DocumentSource(path="doc1.pdf", id="doc1"),  # No segmentation
+        DocumentSource(
+            path="doc2.txt",
+            id="doc2",
+            segmentation_params=DocumentSegmentationParams(
+                id="doc2_segment",
+                segment_length=512,
+                keep_original_text=False,
+            ),
+        ),  # With segmentation
+    ]
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=mixed_sources,
+    )
+    result = planner.plan(params, sample_count=6)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    assert mock_reader.read.call_count == 2
+
+    # Verify DocumentSegmenter was called correctly (only for the segmented document)
+    mock_segmenter_class.assert_called_once_with(mixed_sources[1].segmentation_params)
+    mock_segmenter.segment.assert_called_once_with(mock_document_data[1])
+
+    assert len(result) == 6
+    # Each sample should have attributes from both documents and permutable attributes
+    for i, sample in enumerate(result):
+        # Check first document attributes (non-segmented)
+        assert sample["doc1"] == mock_document_data[0]
+
+        # Check second document segment attributes (segmented, round-robin)
+        segment_index = i % len(mock_document_segments[1])
+        expected_segment = mock_document_segments[1][segment_index]
+        assert sample["doc2_segment"] == expected_segment
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 4 attributes
+        # (1 from non-segmented document + 1 from segmented document + 2 permutable)
+        assert len(sample) == 4
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+def test_plan_with_document_sources_only(
+    mock_reader_class, planner, mock_document_sources, mock_document_data
+):
+    """Test plan with only document sources and no permutable attributes."""
+    mock_reader = Mock()
+    mock_reader.read.side_effect = [
+        [mock_document_data[0]],  # Document 1
+        [mock_document_data[1]],  # Document 2
+    ]
+    mock_reader_class.return_value = mock_reader
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=None,
+        input_documents=mock_document_sources,
+    )
+    result = planner.plan(params, sample_count=3)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    assert mock_reader.read.call_count == 2
+
+    assert len(result) == 3
+    # Each sample should only have document attributes
+    for i, sample in enumerate(result):
+        # Check document attributes
+        assert sample["doc1"] == mock_document_data[0]
+        assert sample["doc2"] == mock_document_data[1]
+
+        # Should have only document attributes
+        assert len(sample) == 2
+
+
+@patch("oumi.core.synthesis.planner.DocumentReader")
+def test_plan_with_combined_sources_including_documents(
+    mock_reader_class,
+    planner,
+    mock_permutable_attributes,
+    mock_document_sources,
+    mock_document_data,
+    mock_example_sources,
+):
+    """Test plan with combination of documents, examples, and permutable attributes."""
+    mock_reader = Mock()
+    mock_reader.read.return_value = [mock_document_data[0]]
+    mock_reader_class.return_value = mock_reader
+
+    params = GeneralSynthesisParams(
+        permutable_attributes=mock_permutable_attributes,
+        input_documents=[mock_document_sources[0]],
+        input_examples=mock_example_sources,
+    )
+    result = planner.plan(params, sample_count=4)
+
+    # Verify DocumentReader was called correctly
+    mock_reader_class.assert_called_once()
+    mock_reader.read.assert_called_once_with(mock_document_sources[0].path)
+
+    assert len(result) == 4
+    # Each sample should have attributes from all sources
+    for i, sample in enumerate(result):
+        # Check document attributes
+        assert sample["doc1"] == mock_document_data[0]
+
+        # Check example attributes (round-robin)
+        example_index = i % 2
+        expected_example_attr1 = ["example_value1", "example_value2"][example_index]
+        expected_example_attr2 = ["example_valueA", "example_valueB"][example_index]
+        assert sample["example_attr1"] == expected_example_attr1
+        assert sample["example_attr2"] == expected_example_attr2
+
+        # Check permutable attributes are present
+        assert "attr1" in sample
+        assert "attr2" in sample
+
+        # Should have 5 attributes (1 from document + 2 from examples + 2 permutable)
+        assert len(sample) == 5


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Integrates document ingestion into the dataset planning process, allowing users to specify attributes in their dataset plan which will be filled with documents and/or document segments, which can then be usable during generation.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes OPE-1297

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
