### PR TITLE
Add verl Countdown Slurm config

### DIFF
--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -1,4 +1,4 @@
-# VERL GRPO job config for Countdown.
+# verl GRPO job config for Countdown.
 #
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup

--- a/configs/examples/grpo_verl_countdown/slurm_job.yaml
+++ b/configs/examples/grpo_verl_countdown/slurm_job.yaml
@@ -1,10 +1,10 @@
-# verl Slurm GRPO job config for GSM8K.
+# verl Slurm GRPO job config for Countdown.
 #
 # Requirements:
 #   - Set OUMI_SLURM_CONNECTIONS to your Slurm user@host
 #
 # Usage:
-#   oumi launch up -c configs/examples/grpo_verl_gsm8k/slurm_job.yaml --cluster $OUMI_SLURM_CONNECTIONS --user <slurm_user>
+#   oumi launch up -c configs/examples/grpo_verl_countdown/slurm_job.yaml --cluster $OUMI_SLURM_CONNECTIONS --user <slurm_user>
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
@@ -12,8 +12,8 @@
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
 #   - Other job configs: configs/**/*job.yaml
 
-name: grpo-verl-gsm8k
-num_nodes: 2
+name: grpo-verl-countdown
+num_nodes: 1
 
 resources:
   cloud: slurm
@@ -26,8 +26,8 @@ envs:
 
 setup: |
   #SBATCH --ntasks-per-node=1
-  #SBATCH --cpus-per-task=8
-  #SBATCH --gpus-per-task=4
+  #SBATCH --cpus-per-task=4
+  #SBATCH --gpus-per-task=2
   #SBATCH --mem-per-gpu=32G
   #SBATCH --time=02:00:00
   # Num nodes is set by num_nodes field above.
@@ -45,6 +45,6 @@ run: |
   ray job submit --address="http://127.0.0.1:8265" \
   -- \
   oumi train \
-  -c configs/examples/grpo_verl_gsm8k/train.yaml \
+  -c configs/examples/grpo_verl_countdown/train.yaml \
   --training.verl_config_overrides.trainer.n_gpus_per_node=$SLURM_GPUS_ON_NODE \
   --training.verl_config_overrides.trainer.nnodes=$SLURM_JOB_NUM_NODES

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -1,4 +1,4 @@
-# VERL GRPO training config for Countdown.
+# verl GRPO training config for Countdown.
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -58,11 +58,11 @@ training:
         ppo_mini_batch_size: 16
         ppo_micro_batch_size: 4
       rollout:
-        log_prob_micro_batch_size: 4
+        log_prob_micro_batch_size_per_gpu: 2
         tensor_model_parallel_size: 2
         n: 16
       ref:
-        log_prob_micro_batch_size: 2
+        log_prob_micro_batch_size_per_gpu: 1
         fsdp_config:
           param_offload: True
     algorithm:

--- a/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
+++ b/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
@@ -1,4 +1,4 @@
-# VERL GRPO VLM training config on Geometry3K dataset.
+# verl GRPO VLM training config on Geometry3K dataset.
 #
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup

--- a/configs/examples/grpo_verl_geometry3k/train.yaml
+++ b/configs/examples/grpo_verl_geometry3k/train.yaml
@@ -1,4 +1,4 @@
-# VERL GRPO VLM training config on Geometry3K dataset.
+# verl GRPO VLM training config on Geometry3K dataset.
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`

--- a/configs/recipes/vision/molmo/grpo/train.yaml
+++ b/configs/recipes/vision/molmo/grpo/train.yaml
@@ -1,4 +1,4 @@
-# VERL GRPO VLM training config on Geometry3K dataset.
+# verl GRPO VLM training config on Geometry3K dataset.
 #
 # EXPERIMENTAL: This config is not yet fully tested.
 #


### PR DESCRIPTION
# Description

- Add Slurm Countdown for config that mirrors the GCP config
- Swap from deprecated `log_prob_micro_batch_size` param to `log_prob_micro_batch_size_per_gpu`. With the former, there's a bug where if `log_prob_micro_batch_size` is less than the number of GPUs, training will hang until it OOMs.

## Related issues

Fixes OPE-1371

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
