### PR TITLE
Delete evaluation_platform

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -492,7 +492,7 @@ def run_demo():
         },
         "tasks": [
             {
-                "evaluation_platform": "lm_harness",
+                "evaluation_backend": "lm_harness",
                 "task_name": benchmarks[i]["value"],
                 "num_samples": 10,
             }

--- a/src/oumi/core/configs/params/evaluation_params.py
+++ b/src/oumi/core/configs/params/evaluation_params.py
@@ -17,7 +17,6 @@ from enum import Enum
 from typing import Any, Optional
 
 from oumi.core.configs.params.base_params import BaseParams
-from oumi.utils.logging import logger
 
 
 class EvaluationBackend(Enum):

--- a/src/oumi/core/configs/params/evaluation_params.py
+++ b/src/oumi/core/configs/params/evaluation_params.py
@@ -117,9 +117,6 @@ class EvaluationTaskParams(BaseParams):
     covered by other fields in TaskParams classes.
     """
 
-    evaluation_platform: Optional[str] = ""
-    """DEPRECATED; Please use `evaluation_backend` instead."""
-
     def get_evaluation_backend(self) -> EvaluationBackend:
         """Returns the evaluation backend as an Enum."""
         if not self.evaluation_backend:
@@ -148,25 +145,6 @@ class EvaluationTaskParams(BaseParams):
         """Verifies params."""
         if self.num_samples is not None and self.num_samples <= 0:
             raise ValueError("`num_samples` must be None or a positive integer.")
-
-        # Handle deprecated evaluation_platform parameter.
-        if not self.evaluation_platform and not self.evaluation_backend:
-            raise ValueError("`evaluation_backend` must be set!")
-        if (
-            self.evaluation_platform
-            and self.evaluation_backend
-            and self.evaluation_platform != self.evaluation_backend
-        ):
-            raise ValueError(
-                "Conflicting values for `evaluation_platform` and `evaluation_backend`!"
-            )
-        if self.evaluation_platform:
-            logger.warning(
-                "The input parameter `evaluation_platform` is deprecated and will be "
-                "removed at v0.2.0. Please use `evaluation_backend` instead."
-            )
-            self.evaluation_backend = self.evaluation_platform
-            self.evaluation_platform = ""
 
 
 @dataclass

--- a/tests/unit/core/evaluation/test_save_utils.py
+++ b/tests/unit/core/evaluation/test_save_utils.py
@@ -84,8 +84,6 @@ def test_save_evaluation_output_happy_path():
         task_params_path = os.path.join(output_path, OUTPUT_FILENAME_TASK_PARAMS)
         with open(task_params_path, encoding="utf-8") as file_ptr:
             task_params_dict = json.load(file_ptr)
-        if "evaluation_platform" in task_params_dict:
-            task_params_dict.pop("evaluation_platform")  # deprecated field.
         assert task_params_dict == {
             "evaluation_backend": "lm_harness",
             "task_name": "mmlu",


### PR DESCRIPTION
# Description

We added the deprecation warning for this param 4 months ago. With Oumi 0.2 now released, we can delete it.

## Related issues

Fixes OPE-1097

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
