### PR TITLE
[0] Add attribute formatter for samples

### DIFF
--- a/src/oumi/core/synthesis/attribute_formatter.py
+++ b/src/oumi/core/synthesis/attribute_formatter.py
@@ -1,0 +1,135 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oumi.core.configs.params.synthesis_params import GeneralSynthesisParams
+from oumi.utils.placeholders import resolve_placeholders
+
+
+class _AttributeValueInfo:
+    """Information about a value of a permutable attribute.
+
+    Used to format the string for a sample.
+    """
+
+    def __init__(self, value_name: str, value_description: str):
+        """Initialize the attribute value info."""
+        self._value_name = value_name
+        self.description = value_description
+
+    def __str__(self) -> str:
+        return self._value_name
+
+
+class _AttributeInfo:
+    """Information about a permutable attribute.
+
+    Used to format the string for a sample.
+    """
+
+    def __init__(
+        self,
+        attribute_id: str,
+        attribute_name: str,
+        attribute_description: str,
+        value_name: str,
+        value_description: str,
+    ):
+        """Initialize the attribute value info."""
+        self.attribute_id = attribute_id
+        self._attribute_name = attribute_name
+        self.description = attribute_description
+        self.value = _AttributeValueInfo(value_name, value_description)
+
+    def __str__(self) -> str:
+        return self._attribute_name
+
+
+class AttributeFormatter:
+    """Formats a sample using a format string.
+
+    Integrates information from permutable attributes to support
+    formatting of placeholders in the format string (i.e. {attribute_id.value}).
+    """
+
+    def __init__(self, params: GeneralSynthesisParams):
+        """Initialize the formatter."""
+        self._params = params
+        self._permutable_attribute_map = (
+            {perm_attr.id: perm_attr for perm_attr in params.permutable_attributes}
+            if params.permutable_attributes
+            else {}
+        )
+        self._permutable_attribute_info = {}
+
+        # Pre-compute the attribute info for each possible value
+        for attribute_id, attribute in self._permutable_attribute_map.items():
+            for value in attribute.possible_values:
+                key = (attribute_id, value.id)
+                self._permutable_attribute_info[key] = _AttributeInfo(
+                    attribute_id=attribute_id,
+                    attribute_name=attribute.attribute,
+                    attribute_description=attribute.description,
+                    value_name=value.value,
+                    value_description=value.description,
+                )
+
+    def format(
+        self,
+        sample: dict[str, str],
+        format_string: str,
+        missing_values_allowed: bool = False,
+    ) -> str:
+        """Format a sample using a format string.
+
+        Args:
+            sample: The sample to format.
+            format_string: The format string to use.
+            missing_values_allowed: If True, missing values are allowed in the sample.
+
+        Returns:
+            The formatted string.
+        """
+        attr_values = {}
+        for attribute_id, attribute_value in sample.items():
+            if self._is_permutable_attribute(attribute_id):
+                value_id = attribute_value
+                attr_values[attribute_id] = self._get_permutable_attribute_value_info(
+                    attribute_id, value_id
+                )
+            else:
+                attr_values[attribute_id] = attribute_value
+
+        formatted_string = resolve_placeholders(
+            format_string,
+            attr_values,
+            missing_values_allowed=missing_values_allowed,
+        )
+        return formatted_string
+
+    def _is_permutable_attribute(self, attribute_id: str) -> bool:
+        """Check if the attribute is a permutable attribute."""
+        return attribute_id in self._permutable_attribute_map
+
+    def _get_permutable_attribute_value_info(
+        self, attribute_id: str, attribute_value_id: str
+    ) -> _AttributeInfo:
+        """Get the string representation information for a permutable attribute."""
+        key = (attribute_id, attribute_value_id)
+        if key in self._permutable_attribute_info:
+            return self._permutable_attribute_info[key]
+
+        raise ValueError(
+            f"Attribute value {attribute_value_id} not found for "
+            f"attribute {attribute_id}"
+        )

--- a/tests/unit/core/synthesis/test_attribute_formatter.py
+++ b/tests/unit/core/synthesis/test_attribute_formatter.py
@@ -1,0 +1,280 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from oumi.core.configs.params.synthesis_params import (
+    GeneralSynthesisParams,
+    PermutableAttribute,
+    PermutableAttributeValue,
+)
+from oumi.core.synthesis.attribute_formatter import AttributeFormatter
+
+
+def test_format_with_permutable_attributes():
+    """Test formatting with permutable attributes."""
+    # Setup permutable attributes
+    tone_values = [
+        PermutableAttributeValue(
+            id="formal",
+            value="Formal",
+            description="A formal tone of voice",
+        ),
+        PermutableAttributeValue(
+            id="casual",
+            value="Casual",
+            description="A casual tone of voice",
+        ),
+    ]
+
+    style_values = [
+        PermutableAttributeValue(
+            id="concise",
+            value="Concise",
+            description="Brief and to the point",
+        ),
+        PermutableAttributeValue(
+            id="detailed",
+            value="Detailed",
+            description="Comprehensive and thorough",
+        ),
+    ]
+
+    permutable_attrs = [
+        PermutableAttribute(
+            id="tone",
+            attribute="Tone",
+            description="The tone of voice to use",
+            possible_values=tone_values,
+        ),
+        PermutableAttribute(
+            id="style",
+            attribute="Style",
+            description="The writing style to use",
+            possible_values=style_values,
+        ),
+    ]
+
+    params = GeneralSynthesisParams(permutable_attributes=permutable_attrs)
+    formatter = AttributeFormatter(params)
+
+    # Test formatting
+    sample = {"tone": "formal", "style": "concise"}
+    format_string = "Use {tone.value} tone and {style.value} style"
+
+    result = formatter.format(sample, format_string)
+    expected = "Use Formal tone and Concise style"
+
+    assert result == expected
+
+
+def test_format_with_mixed_attributes():
+    """Test formatting with both permutable and non-permutable attributes."""
+    tone_values = [
+        PermutableAttributeValue(
+            id="friendly",
+            value="Friendly",
+            description="A friendly tone",
+        ),
+    ]
+
+    permutable_attrs = [
+        PermutableAttribute(
+            id="tone",
+            attribute="Tone",
+            description="The tone to use",
+            possible_values=tone_values,
+        ),
+    ]
+
+    params = GeneralSynthesisParams(permutable_attributes=permutable_attrs)
+    formatter = AttributeFormatter(params)
+
+    sample = {"tone": "friendly", "name": "Alice"}
+    format_string = "Use {tone.value} tone when talking to {name}"
+
+    result = formatter.format(sample, format_string)
+    expected = "Use Friendly tone when talking to Alice"
+
+    assert result == expected
+
+
+def test_format_with_missing_values():
+    """Test formatting with missing values allowed and not allowed."""
+    params = GeneralSynthesisParams()
+    formatter = AttributeFormatter(params)
+
+    sample = {"name": "John"}
+    format_string = "Hello {name}, your age is {age}"
+
+    result = formatter.format(sample, format_string, missing_values_allowed=True)
+    expected = "Hello John, your age is {age}"
+
+    assert result == expected
+
+    with pytest.raises(ValueError, match="Missing value for placeholder: age"):
+        formatter.format(sample, format_string, missing_values_allowed=False)
+
+
+def test_format_with_invalid_permutable_attribute_value():
+    """Test formatting with invalid permutable attribute value."""
+    tone_values = [
+        PermutableAttributeValue(
+            id="formal",
+            value="Formal",
+            description="A formal tone",
+        ),
+    ]
+
+    permutable_attrs = [
+        PermutableAttribute(
+            id="tone",
+            attribute="Tone",
+            description="The tone to use",
+            possible_values=tone_values,
+        ),
+    ]
+
+    params = GeneralSynthesisParams(permutable_attributes=permutable_attrs)
+    formatter = AttributeFormatter(params)
+
+    sample = {"tone": "invalid_value"}
+    format_string = "Use {tone.value} tone"
+
+    with pytest.raises(
+        ValueError, match="Attribute value invalid_value not found for attribute tone"
+    ):
+        formatter.format(sample, format_string)
+
+
+def test_format_with_empty_sample():
+    """Test formatting with empty sample."""
+    params = GeneralSynthesisParams()
+    formatter = AttributeFormatter(params)
+
+    sample = {}
+    format_string = "This is a static string"
+
+    result = formatter.format(sample, format_string)
+    expected = "This is a static string"
+
+    assert result == expected
+
+
+def test_format_with_empty_format_string():
+    """Test formatting with empty format string."""
+    params = GeneralSynthesisParams()
+    formatter = AttributeFormatter(params)
+
+    sample = {"name": "John"}
+    format_string = ""
+
+    result = formatter.format(sample, format_string)
+    expected = ""
+
+    assert result == expected
+
+
+def test_format_with_multiple_same_placeholder():
+    """Test formatting with the same placeholder used multiple times."""
+    tone_values = [
+        PermutableAttributeValue(
+            id="excited",
+            value="Excited",
+            description="An excited tone",
+        ),
+    ]
+
+    permutable_attrs = [
+        PermutableAttribute(
+            id="tone",
+            attribute="Tone",
+            description="The tone to use",
+            possible_values=tone_values,
+        ),
+    ]
+
+    params = GeneralSynthesisParams(permutable_attributes=permutable_attrs)
+    formatter = AttributeFormatter(params)
+
+    sample = {"tone": "excited"}
+    format_string = "Use {tone.value} tone! Yes, {tone.value} tone!"
+
+    result = formatter.format(sample, format_string)
+    expected = "Use Excited tone! Yes, Excited tone!"
+
+    assert result == expected
+
+
+def test_format_with_attribute_name_vs_value():
+    """Test the difference between {attribute} and {attribute.value}."""
+    tone_values = [
+        PermutableAttributeValue(
+            id="polite",
+            value="Polite",
+            description="A polite tone",
+        ),
+    ]
+
+    permutable_attrs = [
+        PermutableAttribute(
+            id="tone",
+            attribute="Tone",
+            description="The tone to use",
+            possible_values=tone_values,
+        ),
+    ]
+
+    params = GeneralSynthesisParams(permutable_attributes=permutable_attrs)
+    formatter = AttributeFormatter(params)
+
+    sample = {"tone": "polite"}
+
+    # Test attribute name
+    format_string = "The {tone} should be polite"
+    result = formatter.format(sample, format_string)
+    expected = "The Tone should be polite"
+    assert result == expected
+
+    # Test attribute value
+    format_string = "The tone should be {tone.value}"
+    result = formatter.format(sample, format_string)
+    expected = "The tone should be Polite"
+    assert result == expected
+
+    # Test attribute description
+    format_string = "The tone should be {tone.description}"
+    result = formatter.format(sample, format_string)
+    expected = "The tone should be The tone to use"
+    assert result == expected
+
+    # Test value description
+    format_string = "The tone should be {tone.value.description}"
+    result = formatter.format(sample, format_string)
+    expected = "The tone should be A polite tone"
+    assert result == expected
+
+
+def test_format_with_none_permutable_attributes():
+    """Test formatting when permutable_attributes is None."""
+    params = GeneralSynthesisParams(permutable_attributes=None)
+    formatter = AttributeFormatter(params)
+
+    sample = {"name": "Bob"}
+    format_string = "Hello {name}"
+
+    result = formatter.format(sample, format_string)
+    expected = "Hello Bob"
+
+    assert result == expected


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
The AttributeFormatter allows us to apply more advanced formatting logic using attribute values from samples in a dataset (think columns).

For the below examples, `attribute_id` is basically `column_name` in a CSV-style dataset.

Samples are formatted with varying logic:
{attribute_id} for the value of a given column
{attribute_id} for the name of a permutable attribute column
{attribute_id.description} for the description of a permutable attribute column
{attribute_id.value} for the specific value of a permutable attribute for that sample
{attribute_id.value.description} for the description of that value

To properly format strings of this type with samples, we need to construct the necessary information into objects (_AttributeInfo and _AttributeValueInfo), which will allow `resolve_placeholders` to do the rest of the work for us.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards OPE-1355

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
