### PR TITLE
docs: add troubleshooting note for Conda Terms of Service error in de…

### DIFF
--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -51,17 +51,17 @@ make setup
 > **Note:**
 > If you see an error like
 > `CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels...`
-> 
-> This means you must manually accept the Terms of Service for the Anaconda package channels.  
+>
+> This means you must manually accept the Terms of Service for the Anaconda package channels.
 > To resolve, run the following commands in your terminal for each required channel:
 >
 > ```shell
 > conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
 > conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
 > ```
-> 
+>
 > After accepting, re-run the `make setup` command.
-> 
+>
 
 If you'd like to only run the pre-commits before a push, instead of every commit, you can run:
 

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -48,6 +48,21 @@ This command creates a new Conda env, installs relevant packages, and installs p
 make setup
 ```
 
+> **Note:**
+> If you see an error like
+> `CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels...`
+> 
+> This means you must manually accept the Terms of Service for the Anaconda package channels.  
+> To resolve, run the following commands in your terminal for each required channel:
+>
+> ```shell
+> conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+> conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+> ```
+> 
+> After accepting, re-run the `make setup` command.
+> 
+
 If you'd like to only run the pre-commits before a push, instead of every commit, you can run:
 
 ```shell


### PR DESCRIPTION
# Description
This commit adds a troubleshooting note to the development setup documentation to help users resolve the "CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels..." error.
This issue can block new users from creating or activating the necessary Conda environment for Oumi development.

The note provides copy-pasteable commands for accepting the Terms of Service or removing problematic channels, addressing possible installation blockers that may not be familiar to all contributors. This should help speed up onboarding and reduce confusion during the initial installation process.

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [X] This PR only changes documentation. (You can ignore the following checks in that case)
- [X] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
