### PR TITLE
Update mlflow dependency to >=3.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "hdrhistogram>=0.10.3,<0.11",
     "jsonlines",
     "lm_eval[wandb]>=0.4.5,<0.4.9",
-    "mlflow>=2.21.2,<2.22.0",       # Logging to MLflow
+    "mlflow>=3.1.4",                # Logging to MLflow
     "numpy>=1.26.4,<2.0",
     # The latest stable version, 2.3.0, is two years old and is causing dependency
     # conflicts. We'll use the dev version until a new stable version is released.


### PR DESCRIPTION
## Summary
- Updates the mlflow dependency in pyproject.toml from `>=2.21.2,<2.22.0` to `>=3.1.4`
- This is a minor dependency update to allow for newer versions of mlflow

## Test plan
- [ ] Run `pip install -e .` to ensure dependencies install correctly
- [ ] Run existing tests to ensure compatibility
- [ ] Verify mlflow logging functionality still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)