### PR TITLE
Add `oumi[quantization]` optional dependency

### DIFF
--- a/configs/examples/quantization/README.md
+++ b/configs/examples/quantization/README.md
@@ -4,6 +4,8 @@
 
 This directory contains example configurations for model quantization using Oumi's AWQ and BitsAndBytes quantization methods.
 
+> **NOTE**: Quantization requires a GPU to run.
+
 ## Configuration Files
 
 - **`awq_quantization_config.yaml`** - AWQ 4-bit quantization with calibration
@@ -15,7 +17,7 @@ This directory contains example configurations for model quantization using Oumi
 # Simplest command-line usage
 oumi quantize --method awq_q4_0 --model "TinyLlama/TinyLlama-1.1B-Chat-v1.0" --output quantized_model
 
-# Using configuration file (requires GPU)
+# Using configuration file
 oumi quantize --config configs/examples/quantization/awq_quantization_config.yaml
 ```
 
@@ -40,10 +42,12 @@ oumi quantize --config configs/examples/quantization/awq_quantization_config.yam
 ## Requirements
 
 ```bash
-# For AWQ quantization
+pip install oumi[quantization]
+
+# Alternatively, for AWQ quantization only
 pip install autoawq
 
-# For BitsAndBytes quantization
+# Alternatively, for BitsAndBytes quantization only
 pip install bitsandbytes
 ```
 

--- a/docs/user_guides/quantization.md
+++ b/docs/user_guides/quantization.md
@@ -4,6 +4,8 @@
 
 This guide covers the `oumi quantize` command for reducing model size while maintaining performance.
 
+> **NOTE**: Quantization requires a GPU to run.
+
 ## Quick Start
 
 ```bash
@@ -93,10 +95,12 @@ Currently supported output formats:
 ## Installation
 
 ```bash
-# For AWQ quantization
+pip install oumi[quantization]
+
+# Alternatively, for AWQ quantization only
 pip install autoawq
 
-# For BitsAndBytes quantization
+# Alternatively, for BitsAndBytes quantization only
 pip install bitsandbytes
 ```
 

--- a/notebooks/Oumi - Quantization Tutorial.ipynb
+++ b/notebooks/Oumi - Quantization Tutorial.ipynb
@@ -34,8 +34,7 @@
     "First, let's install Oumi with GPU support and the required quantization libraries:\n",
     "\n",
     "```bash\n",
-    "pip install oumi[gpu]\n",
-    "pip install autoawq\n",
+    "pip install oumi[gpu,quantization]\n",
     "pip install triton==3.0.0  # Required for AWQ inference compatibility\n",
     "```"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ evaluation = [
     "sentencepiece>=0.1.98",
 ]
 
+quantization = ["autoawq>=0.2.0,<0.3", "bitsandbytes>=0.45.0,<0.46"]
+
 bitnet = ["onebitllms>=0.0.3"]
 
 cambrian = [

--- a/src/oumi/quantize/awq_quantizer.py
+++ b/src/oumi/quantize/awq_quantizer.py
@@ -60,7 +60,7 @@ class AwqQuantization(BaseQuantization):
         if self._awq is None:
             raise RuntimeError(
                 "AWQ quantization requires autoawq library.\n"
-                "Install with: `pip install autoawq`\n"
+                "Install with: `pip install oumi[quantization]`\n"
             )
 
         if not torch.cuda.is_available():


### PR DESCRIPTION
# Description

Add optional dependency group to Oumi package for quantization libraries.

## Related issues

Towards OPE-1425

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
