### PR TITLE
[tiny] Pin exact omegaconf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ dependencies = [
     # The latest stable version, 2.3.0, is two years old and is causing dependency
     # conflicts. We'll use the dev version until a new stable version is released.
     # See https://github.com/oumi-ai/oumi/issues/1377
-    # We pin the exact dev version so that the --pre flag isn't needed for pip install.
-    "omegaconf==2.4.0dev3",
+    # We pin the exact dev version so that the --pre flag isn't needed for uv pip install.
+    "omegaconf==2.4.0.dev3",
     "packaging",
     "pandas>=2.0.3,<3",
     "peft>=0.15.0,<0.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     # The latest stable version, 2.3.0, is two years old and is causing dependency
     # conflicts. We'll use the dev version until a new stable version is released.
     # See https://github.com/oumi-ai/oumi/issues/1377
-    "omegaconf>=2.4.0dev3,<2.5",
+    # We pin the exact dev version so that the --pre flag isn't needed for pip install.
+    "omegaconf==2.4.0dev3",
     "packaging",
     "pandas>=2.0.3,<3",
     "peft>=0.15.0,<0.16",


### PR DESCRIPTION
# Description

See attached Linear issue for details. tl;dr installing oumi with uv often won't work because it is stricter than pip and won't download prerelease packages (i.e. omegaconf) with our current version specifications. Pinning an exact omegaconf version should fix this.

## Related issues

Fixes OPE-1476

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
