### PR TITLE
Unpin `flash-attn` version

### DIFF
--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -34,8 +34,7 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install oumi[gpu]
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
+++ b/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
@@ -41,8 +41,7 @@ setup: |
   # In the meantime, we need to use this specific commit to support vLLM 0.8.3:
   # https://github.com/volcengine/verl/pull/912
   pip install git+https://github.com/volcengine/verl.git@1ee730163f6326e9679644db62eb32c8d1947c7f
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi3/sft/full/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/full/oumi_gcp_job.yaml
@@ -45,8 +45,7 @@ setup: |
   # downloading the model during training.
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
 
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi3/sft/full/trl_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/full/trl_gcp_job.yaml
@@ -45,8 +45,7 @@ setup: |
   # downloading the model during training.
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
 
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi3/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/lora/gcp_job.yaml
@@ -45,8 +45,7 @@ setup: |
   # downloading the model during training.
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
 
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi4/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/phi4/sft/full/gcp_job.yaml
@@ -42,9 +42,7 @@ setup: |
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-multimodal-instruct
 
   # The model requires flash_attention_2! Install it here.
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
-
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi4/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/phi4/sft/lora/gcp_job.yaml
@@ -42,9 +42,7 @@ setup: |
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-multimodal-instruct
 
   # The model requires flash_attention_2! Install it here.
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
-
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/full/gcp_job.yaml
@@ -44,8 +44,7 @@ setup: |
   # Also, if you want to try it with a more efficient attention implementation,
   # you can install the `flash_attention_2` package and set `attn_implementation:
   # "flash_attention_2"` in the model config.
-  #  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  #  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/gcp_job.yaml
@@ -44,8 +44,7 @@ setup: |
   # Also, if you want to try it with a more efficient attention implementation,
   # you can install the `flash_attention_2` package and set `attn_implementation:
   # "flash_attention_2"` in the model config.
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  # pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  # pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -38,8 +38,7 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install oumi[gpu] hf_transfer
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.

--- a/configs/recipes/vision/smolvlm/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/full/gcp_job.yaml
@@ -41,8 +41,7 @@ setup: |
   # downloading the model during training.
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
 
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/smolvlm/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/lora/gcp_job.yaml
@@ -41,8 +41,7 @@ setup: |
   # downloading the model during training.
   HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
 
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -e  # Exit if any command failed.

--- a/tests/scripts/e2e_tests_job.yaml
+++ b/tests/scripts/e2e_tests_job.yaml
@@ -32,8 +32,7 @@ envs:
 setup: |
   set -e
   pip install uv && uv pip install -U ".[ci_gpu]" hf_transfer
-  # TODO: OPE-1336 - Remove version pin when error with later versions is fixed.
-  pip install -U "flash-attn==2.7.4.post1" --no-build-isolation
+  pip install -U flash-attn --no-build-isolation
 
 run: |
   set -xe  # Exit if any command failed.


### PR DESCRIPTION
# Description

Since we upgraded the PyTorch version, the pinned flash-attn version 2.7.4.post1 doesn't have a prebuilt wheel and has to be built from source. Tested that the error we previously encountered about an unknown symbol doesn't show up after unpinning.

Tested with e2e tests.

## Related issues

Towards OPE-1336

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
