### PR TITLE
Add lora `target_parameters` field and upgrade `peft` library

### DIFF
--- a/configs/recipes/qwq/sft/lora_train.yaml
+++ b/configs/recipes/qwq/sft/lora_train.yaml
@@ -29,9 +29,10 @@ training:
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200
+  max_steps: 10
   num_train_epochs: 1
   per_device_train_batch_size: 2
-  gradient_accumulation_steps: 8
+  gradient_accumulation_steps: 4
   max_grad_norm: null
 
   enable_gradient_checkpointing: True

--- a/configs/recipes/qwq/sft/lora_train.yaml
+++ b/configs/recipes/qwq/sft/lora_train.yaml
@@ -29,10 +29,9 @@ training:
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200
-  max_steps: 10
   num_train_epochs: 1
   per_device_train_batch_size: 2
-  gradient_accumulation_steps: 4
+  gradient_accumulation_steps: 8
   max_grad_norm: null
 
   enable_gradient_checkpointing: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "omegaconf==2.4.0.dev3",
     "packaging",
     "pandas>=2.0.3,<3",
-    "peft>=0.15.0,<0.16",
+    "peft>=0.17.0,<0.18",
     "pexpect>=4.8.0,<4.9",       # Used by Polaris client
     "pillow>=11.1.0,<11.4",      # Used by image datasets
     "protobuf>=5.29.0",

--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Literal, Optional, Union, cast
+from typing import Optional, Union, cast
 
 import torch
 import torch.nn as nn
 import transformers
-from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+from peft import PeftModel, get_peft_model, prepare_model_for_kbit_training
 
-from oumi.core.configs import LoraWeightInitialization, ModelParams, PeftParams
+from oumi.core.configs import ModelParams, PeftParams
 from oumi.core.configs.internal.internal_model_config import InternalModelConfig
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config_using_model_name,
@@ -516,27 +516,6 @@ def build_tokenizer(
     return tokenizer
 
 
-def _convert_lora_init_weights_to_lora_config(
-    param: LoraWeightInitialization,
-) -> Union[
-    bool,
-    Literal[
-        "gaussian",
-        "eva",
-        "pissa",
-        "pissa_niter_[number of iters]",
-        "loftq",
-        "olora",
-    ],
-]:
-    if param == LoraWeightInitialization.RANDOM:
-        return False
-    if param == LoraWeightInitialization.DEFAULT:
-        return True
-
-    return param.value
-
-
 def build_peft_model(
     base_model, use_gradient_checkpointing: bool, peft_params: PeftParams
 ):
@@ -550,18 +529,7 @@ def build_peft_model(
     Returns:
         The built PEFT model.
     """
-    lora_config = LoraConfig(
-        r=peft_params.lora_r,
-        lora_alpha=peft_params.lora_alpha,
-        lora_dropout=peft_params.lora_dropout,
-        target_modules=peft_params.lora_target_modules,
-        modules_to_save=peft_params.lora_modules_to_save,
-        bias=peft_params.lora_bias,  # type: ignore
-        task_type=peft_params.lora_task_type,
-        init_lora_weights=(
-            _convert_lora_init_weights_to_lora_config(peft_params.lora_init_weights)
-        ),
-    )
+    lora_config = peft_params.to_lora()
 
     if peft_params.q_lora:
         model = prepare_model_for_kbit_training(

--- a/src/oumi/core/configs/params/peft_params.py
+++ b/src/oumi/core/configs/params/peft_params.py
@@ -129,7 +129,7 @@ class PeftParams(BaseParams):
         default=None,
         metadata={"help": "LoRA target modules."},
     )
-    """List of module names to apply LoRA to.
+    """List of module names/regexes to apply LoRA to.
 
     If None, LoRA will be applied to all linear layers in the model.
     Specify module names to selectively apply LoRA to certain parts of the model.
@@ -139,7 +139,12 @@ class PeftParams(BaseParams):
         default=None,
         metadata={"help": "LoRA target parameters."},
     )
-    """List of parameter names to apply LoRA to."""
+    """List of parameter names/regexes to apply LoRA to.
+
+    This is similar to `lora_target_modules` (which you should prefer using if possible)
+    but for parameters instead of modules. This is generally only useful for models like
+    MoEs that sometimes use nn.Parameter instead of nn.Module.
+    """
 
     lora_modules_to_save: Optional[list[str]] = field(
         default=None,


### PR DESCRIPTION
# Description

- Upgrade `peft` to the latest version, 0.17.0
- Add LoRA `target_parameters` field, which was added in 0.17.0. This is useful for MoE models, and is used in the gpt-oss cookbook: https://cookbook.openai.com/articles/gpt-oss/fine-tune-transfomers
- Move logic to create LoraConfig to PeftParams. This is a pattern we follow for other params as well (ex. to_bits_and_bytes)

## Related issues

Fixes OPE-1490

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
