### PR TITLE
[tiny] Cleanup redundant specifications of lora_dropout 0.0

### DIFF
--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -70,7 +70,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - q_proj
     - k_proj

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
@@ -12,7 +12,6 @@
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
 #   - Other training configs: configs/**/*train.yaml
 
-
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
   model_max_length: 2048
@@ -59,7 +58,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
@@ -12,7 +12,6 @@
 #   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
 #   - Other training configs: configs/**/*train.yaml
 
-
 model:
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
   model_max_length: 2048
@@ -65,7 +64,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
@@ -61,7 +61,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
@@ -58,7 +58,6 @@ peft:
   q_lora: False
   lora_r: 64
   lora_alpha: 128
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/falcon_h1/dpo/falcon_h1_0_5b/qlora_dpo.yaml
+++ b/configs/recipes/falcon_h1/dpo/falcon_h1_0_5b/qlora_dpo.yaml
@@ -38,7 +38,6 @@ peft:
     - "out_proj"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -63,7 +63,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -70,7 +70,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -61,7 +61,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -69,7 +69,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -65,7 +65,6 @@ peft:
   q_lora: False
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -64,7 +64,6 @@ training:
 peft:
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -71,7 +71,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_2/dpo/1b_qlora_dpo.yaml
+++ b/configs/recipes/llama3_2/dpo/1b_qlora_dpo.yaml
@@ -36,7 +36,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -63,7 +63,6 @@ peft:
   q_lora: False
   lora_r: 64
   lora_alpha: 128
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -63,7 +63,6 @@ peft:
   q_lora: False
   lora_r: 64
   lora_alpha: 128
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -69,7 +69,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 64
   lora_alpha: 128
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -66,7 +66,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 64
   lora_alpha: 128
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "v_proj"

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -63,7 +63,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -70,7 +70,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
@@ -67,7 +67,6 @@ peft:
   q_lora: False
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
@@ -73,7 +73,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "qkv_proj"
     - "o_proj"

--- a/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
@@ -64,7 +64,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 8
   lora_alpha: 16
-  lora_dropout: 0.0
   lora_target_modules:
     - "qkv_proj"
     - "o_proj"

--- a/configs/recipes/qwen3/sft/14b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/14b_lora/train.yaml
@@ -59,7 +59,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/qwen3/sft/32b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/qwq/sft/lora_train.yaml
+++ b/configs/recipes/qwq/sft/lora_train.yaml
@@ -57,7 +57,6 @@ training:
 peft:
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/configs/recipes/qwq/sft/qlora_train.yaml
+++ b/configs/recipes/qwq/sft/qlora_train.yaml
@@ -63,7 +63,6 @@ peft:
   bnb_4bit_compute_dtype: "bfloat16"
   lora_r: 16
   lora_alpha: 32
-  lora_dropout: 0.0
   lora_target_modules:
     - "q_proj"
     - "k_proj"

--- a/notebooks/Oumi - Finetuning Tutorial.ipynb
+++ b/notebooks/Oumi - Finetuning Tutorial.ipynb
@@ -291,7 +291,6 @@
     "peft:\n",
     "  lora_r: 16\n",
     "  lora_alpha: 32\n",
-    "  lora_dropout: 0.00\n",
     "  lora_target_modules:\n",
     "    - \"q_proj\"\n",
     "    - \"k_proj\"\n",


### PR DESCRIPTION
# Description

In https://github.com/oumi-ai/oumi/pull/1124, we changed the default value of `lora_dropout` from 0.05 to 0. We can now clean up this field from our yaml configs to reduce bloat.

## Related issues

Towards OPE-1490

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
