### PR TITLE
Replace mentions of deprecated `huggingface-cli` tool with `hf`

### DIFF
--- a/configs/examples/berry_bench/evaluation/eval.yaml
+++ b/configs/examples/berry_bench/evaluation/eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/examples/berry_bench/evaluation/gcp_job.yaml
+++ b/configs/examples/berry_bench/evaluation/gcp_job.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/examples/bulk_inference/gcp_job.yaml
+++ b/configs/examples/bulk_inference/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Replace <your-input-bucket> and <your-output-bucket> with your GCS buckets.
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/examples/grpo_verl_countdown/gcp_job.yaml
+++ b/configs/examples/grpo_verl_countdown/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up -c configs/examples/grpo_verl_countdown/gcp_job.yaml --cluster grpo-verl-countdown

--- a/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
+++ b/configs/examples/grpo_verl_geometry3k/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up -c configs/examples/grpo_verl_geometry3k/gcp_job.yaml --cluster grpo-verl-vlm-geom3k

--- a/configs/examples/letter_counting/evaluation/eval.yaml
+++ b/configs/examples/letter_counting/evaluation/eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/examples/letter_counting/evaluation/gcp_job.yaml
+++ b/configs/examples/letter_counting/evaluation/gcp_job.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/examples/letter_counting/grpo/gcp_job.yaml
+++ b/configs/examples/letter_counting/grpo/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up -c oumi://configs/examples/letter_counting/grpo/gcp_job.yaml --cluster letter-counting-grpo
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/examples/letter_counting/grpo/train.yaml
+++ b/configs/examples/letter_counting/grpo/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/examples/misc/dev_gcp_job.yaml
+++ b/configs/examples/misc/dev_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - (optional) Mount a storage bucket below
 #   - (optional) Modify `resources.cloud` to run on a different cloud provider
 #
@@ -34,7 +34,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.

--- a/configs/projects/aya/evaluation/eval.yaml
+++ b/configs/projects/aya/evaluation/eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/projects/aya/evaluation/gcp_job.yaml
+++ b/configs/projects/aya/evaluation/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -21,7 +21,7 @@ resources:
   cloud: gcp
   accelerators: "A100:1"
   use_spot: false
-  disk_size: 200  # Disk size in GB
+  disk_size: 200 # Disk size in GB
 
 working_dir: .
 

--- a/configs/projects/aya/sft/gcp_job.yaml
+++ b/configs/projects/aya/sft/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -17,7 +17,7 @@
 
 name: llama3-8b-aya-sft
 
-num_nodes: 1  # Set it to N for multi-node training.
+num_nodes: 1 # Set it to N for multi-node training.
 
 resources:
   cloud: gcp
@@ -27,7 +27,7 @@ resources:
   # preemption. For more information, see:
   # https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#mount-cloud-storage
   use_spot: false
-  disk_size: 500  # Disk size in GB
+  disk_size: 500 # Disk size in GB
 
 working_dir: .
 

--- a/configs/projects/aya/sft/train.yaml
+++ b/configs/projects/aya/sft/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/projects/chatqa/gcp_job.yaml
+++ b/configs/projects/chatqa/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - (optional) Request access to Llama 3.1 if you want to use it: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -21,13 +21,13 @@ resources:
   cloud: gcp
   accelerators: "A100-80GB"
   use_spot: false
-  disk_size: 1000  # Disk size in GB
+  disk_size: 1000 # Disk size in GB
 
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
-  ~/.cache/huggingface/token: ~/.cache/huggingface/token  # HF credentials
+  ~/.netrc: ~/.netrc # WandB credentials
+  ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
   WANDB_PROJECT: oumi-train

--- a/configs/projects/dcvlr/README.md
+++ b/configs/projects/dcvlr/README.md
@@ -91,10 +91,10 @@ We provide configurations for three models; Molmo-D, Molmo-O, and QwenVL-2.5. Ot
 
 Depending on how `training: output_dir` is set in the config file, the model checkpoints will be saved in the base of the specified directory.
 
-We then recommend syncing the trained model to HuggingFace Hub using the `huggingface-cli` tool to enable version control and ease of future access. The repository need not exist in advance, it will be automatically created when you use this command.
+We then recommend syncing the trained model to HuggingFace Hub using the `hf` CLI tool to enable version control and ease of future access. The repository need not exist in advance, it will be automatically created when you use this command.
 
 ```bash
-huggingface-cli upload-large-folder <YOUR_HF_REPO> <YOUR_OUTPUT_DIRECTORY> --repo-type=model
+hf upload-large-folder <YOUR_HF_REPO> <YOUR_OUTPUT_DIRECTORY> --repo-type=model
 ```
 
 ### Model Evaluation

--- a/configs/projects/halloumi/8b_train.yaml
+++ b/configs/projects/halloumi/8b_train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -30,34 +30,38 @@ data:
     datasets:
       - dataset_name: "HuggingFaceDataset"
         split: "train"
-        dataset_kwargs: {
-          "hf_dataset_path": "oumi-ai/oumi-anli-subset",
-          "messages_column": "messages",
-        }
+        dataset_kwargs:
+          {
+            "hf_dataset_path": "oumi-ai/oumi-anli-subset",
+            "messages_column": "messages",
+          }
         shuffle: True
         seed: 42
       - dataset_name: "HuggingFaceDataset"
         split: "train"
-        dataset_kwargs: {
-          "hf_dataset_path": "oumi-ai/oumi-c2d-d2c-subset",
-          "messages_column": "messages",
-        }
+        dataset_kwargs:
+          {
+            "hf_dataset_path": "oumi-ai/oumi-c2d-d2c-subset",
+            "messages_column": "messages",
+          }
         shuffle: True
         seed: 42
       - dataset_name: "HuggingFaceDataset"
         split: "train"
-        dataset_kwargs: {
-          "hf_dataset_path": "oumi-ai/oumi-synthetic-claims",
-          "messages_column": "messages",
-        }
+        dataset_kwargs:
+          {
+            "hf_dataset_path": "oumi-ai/oumi-synthetic-claims",
+            "messages_column": "messages",
+          }
         shuffle: True
         seed: 42
       - dataset_name: "HuggingFaceDataset"
         split: "train"
-        dataset_kwargs: {
-          "hf_dataset_path": "oumi-ai/oumi-synthetic-document-claims",
-          "messages_column": "messages",
-        }
+        dataset_kwargs:
+          {
+            "hf_dataset_path": "oumi-ai/oumi-synthetic-document-claims",
+            "messages_column": "messages",
+          }
         shuffle: True
         seed: 42
 
@@ -68,15 +72,15 @@ data:
     datasets:
       - dataset_name: "HuggingFaceDataset"
         split: "validation"
-        dataset_kwargs: {
-          "hf_dataset_path": "oumi-ai/oumi-synthetic-document-claims",
-          "messages_column": "messages",
-        }
+        dataset_kwargs:
+          {
+            "hf_dataset_path": "oumi-ai/oumi-synthetic-document-claims",
+            "messages_column": "messages",
+          }
 
     collator_name: "text_completions_only_with_padding"
     target_col: "messages"
     seed: 42
-
 
 training:
   trainer_type: "TRL_SFT"

--- a/configs/projects/halloumi/gcp_job.yaml
+++ b/configs/projects/halloumi/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -27,7 +27,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/projects/wc50m/configs/gcp_base_ultrachat.yaml
+++ b/configs/projects/wc50m/configs/gcp_base_ultrachat.yaml
@@ -14,9 +14,9 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   # Mount HF token, which is needed to download locked-down models from HF Hub.
-  # This is created on the local machine by running `huggingface-cli login`.
+  # This is created on the local machine by running `hf auth login`.
   ~/.cache/huggingface/token: ~/.cache/huggingface/token
 
 envs:
@@ -31,7 +31,7 @@ setup: |
   pip install uv && uv pip install -e .[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Meta-Llama-3.1-8B --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Meta-Llama-3.1-8B --exclude original/*
   pip install -U flash-attn --no-build-isolation
 
 run: |

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_70b/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_llama_8b/gcp_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -38,7 +38,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/evaluation/distill_qwen_32b/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_gcp_job.yaml
@@ -31,7 +31,7 @@ num_nodes: 1 # Set it to N for multi-node training.
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.
 # For more details, see https://oumi.ai/docs/en/latest/user_guides/launch/launch.html.
@@ -49,7 +49,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_gcp_job.yaml
@@ -28,7 +28,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_gcp_job.yaml
@@ -28,7 +28,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_gcp_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -34,7 +34,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_gcp_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -34,7 +34,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_frontier_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_frontier_job.yaml
@@ -76,7 +76,7 @@ run: |
   echo "${LOG_PREFIX} ***ENV END***"
 
   echo "Using this Python environment: $(which python3)"
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 
   # Log some context info and  verify that Oumi is usable in this environment:
   python -c "from oumi.utils.torch_utils import log_devices_info, log_versioning_info; log_versioning_info(); log_devices_info();"

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_0_5b/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_0_5b/lambda_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -43,7 +43,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-0.5B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-0.5B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_1_5b/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_1_5b/lambda_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -43,7 +43,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-1.5B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-1.5B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_1_5b_deep/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_1_5b_deep/lambda_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -43,7 +43,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-1.5B-Deep-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-1.5B-Deep-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_34b/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_34b/lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -44,7 +44,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-34B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-34B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_3b/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_3b/lambda_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -43,7 +43,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-3B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-3B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/evaluation/falcon_h1_7b/lambda_job.yaml
+++ b/configs/recipes/falcon_h1/evaluation/falcon_h1_7b/lambda_job.yaml
@@ -23,7 +23,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -43,7 +43,7 @@ setup: |
   uv pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git@main
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-7B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-7B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_0_5b/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_0_5b/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-0.5B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-0.5B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_1_5b/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_1_5b/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-1.5B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-1.5B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_1_5b_deep/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_1_5b_deep/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-1.5B-Deep-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-1.5B-Deep-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_34b/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_34b/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-34B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-34B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_3b/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_3b/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-3B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-3B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/falcon_h1/sft/falcon_h1_7b/full_lambda_job.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_7b/full_lambda_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -41,7 +41,7 @@ setup: |
   uv pip install dill==0.3.8
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download tiiuae/Falcon-H1-7B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download tiiuae/Falcon-H1-7B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/glm4/inference/air_gguf_macos_infer.yaml
+++ b/configs/recipes/glm4/inference/air_gguf_macos_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # 1. Download the GGUF file to current working directory:
-#   huggingface-cli download unsloth/GLM-4.5-Air-GGUF \
+#   hf download unsloth/GLM-4.5-Air-GGUF \
 #     GLM-4.5-Air-UD-Q2_K_XL.gguf --local-dir .
 #
 #   # 2. Run inference:

--- a/configs/recipes/llama3_1/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/70b_polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/evaluation/8b_eval.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -41,7 +41,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
+++ b/configs/recipes/llama3_1/evaluation/8b_polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/70b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 70B Instruct.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/inference/8b_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 8B Instruct.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_rvllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
+++ b/configs/recipes/llama3_1/inference/8b_sglang_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Install SGLang: https://docs.sglang.ai/start/install.html
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -22,12 +22,12 @@ resources:
   cloud: gcp
   accelerators: "A100:4"
   use_spot: false
-  disk_size: 500  # in GB -> we can save the final model locally.
+  disk_size: 500 # in GB -> we can save the final model locally.
 
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -20,7 +20,7 @@ name: llama8b-pretrain
 # NOTE: Replace with your username.
 user: your_username
 
-num_nodes: 1  # Set it to N for multi-node training.
+num_nodes: 1 # Set it to N for multi-node training.
 resources:
   cloud: polaris
 

--- a/configs/recipes/llama3_1/pretraining/8b/train.yaml
+++ b/configs/recipes/llama3_1/pretraining/8b/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:
@@ -31,7 +31,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:
@@ -30,7 +30,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -44,7 +44,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Download the model from HF.
   # We exclude original/* because it contains two redundant copies of the model weights.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-405B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #   - (optional) Mount a storage bucket below
 #
@@ -31,7 +31,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.
@@ -50,7 +50,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -3,11 +3,11 @@
 # https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama3_1/70B_full.yaml
 #
 # Strongly recommend downloading the model first:
-# HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
+# HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -38,7 +38,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:
@@ -30,7 +30,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -5,7 +5,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -27,7 +27,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -20,7 +20,7 @@ name: llama8b-sft
 # NOTE: Replace with your username.
 user: your_username
 
-num_nodes: 1  # Set it to N for multi-node training.
+num_nodes: 1 # Set it to N for multi-node training.
 resources:
   cloud: polaris
 

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -37,7 +37,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -37,7 +37,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -20,7 +20,7 @@ name: llama8b-lora
 # NOTE: Replace with your username.
 user: your_username
 
-num_nodes: 1  # Set it to N for multi-node training.
+num_nodes: 1 # Set it to N for multi-node training.
 resources:
   cloud: polaris
 

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -37,7 +37,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.1-8B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.1: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/evaluation/1b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/1b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/evaluation/3b_eval.yaml
+++ b/configs/recipes/llama3_2/evaluation/3b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/1b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 1B Instruct.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_sglang_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Install SGLang: https://docs.sglang.ai/start/install.html
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/1b_vllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/3b_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3B Instruct.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_sglang_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Install SGLang: https://docs.sglang.ai/start/install.html
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
+++ b/configs/recipes/llama3_2/inference/3b_vllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/1b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/1b_full/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:

--- a/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/polaris_job.yaml
@@ -4,7 +4,7 @@
 #   - Set up your ALCF account (only available to Oumi core team)
 #   - Set `user` to your ALCF username
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/evaluation/70b_eval.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
+++ b/configs/recipes/llama3_3/evaluation/70b_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_3/inference/70b_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3.3 70B Instruct with a NATIVE engine.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
+++ b/configs/recipes/llama3_3/inference/70b_vllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/inference/nemotron_super_49b_gguf_macos_infer.yaml
+++ b/configs/recipes/llama3_3/inference/nemotron_super_49b_gguf_macos_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # 1. Download the GGUF file to current working directory:
-#   huggingface-cli download bartowski/nvidia_Llama-3_3-Nemotron-Super-49B-v1-GGUF \
+#   hf download bartowski/nvidia_Llama-3_3-Nemotron-Super-49B-v1-GGUF \
 #     nvidia_Llama-3_3-Nemotron-Super-49B-v1-Q4_K_M.gguf --local-dir .
 #
 #   # 2. Run inference:

--- a/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #   - (optional) Mount a storage bucket below
 #
@@ -33,7 +33,7 @@ num_nodes: 1 # Set it to N for multi-node training.
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.
@@ -52,7 +52,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:
@@ -30,7 +30,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -4,7 +4,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:
@@ -30,7 +30,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.3-70B-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -5,7 +5,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.3: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/evaluation/scout_instruct_eval.yaml
+++ b/configs/recipes/llama4/evaluation/scout_instruct_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/inference/scout_instruct_gguf_macos_infer.yaml
+++ b/configs/recipes/llama4/inference/scout_instruct_gguf_macos_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # 1. Download the GGUF file to current working directory:
-#   huggingface-cli download unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF \
+#   hf download unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF \
 #     Llama-4-Scout-17B-16E-Instruct-UD-Q2_K_XL.gguf --local-dir .
 #
 #   # 2. Run inference:

--- a/configs/recipes/llama4/inference/scout_instruct_infer.yaml
+++ b/configs/recipes/llama4/inference/scout_instruct_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 4 Scout-17B-16E Instruct with a NATIVE engine.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/inference/scout_instruct_vllm_infer.yaml
+++ b/configs/recipes/llama4/inference/scout_instruct_vllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/sft/scout_base_full/gcp_job.yaml
+++ b/configs/recipes/llama4/sft/scout_base_full/gcp_job.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E
 #   - (optional) Mount a storage bucket below
 #
@@ -48,7 +48,7 @@ setup: |
 
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-4-Scout-17B-16E --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-4-Scout-17B-16E --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama4/sft/scout_base_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_base_full/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E
 #
 # Usage:

--- a/configs/recipes/llama4/sft/scout_instruct_full/gcp_job.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_full/gcp_job.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #   - (optional) Mount a storage bucket below
 #
@@ -48,7 +48,7 @@ setup: |
 
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-4-Scout-17B-16E-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-4-Scout-17B-16E-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama4: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
 #
 # Usage:

--- a/configs/recipes/phi4/evaluation/reasoning_plus_gcp_job.yaml
+++ b/configs/recipes/phi4/evaluation/reasoning_plus_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-reasoning-plus
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-reasoning-plus
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/phi4/sft/reasoning_plus/full_gcp_job.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/full_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.
 # For more details, see https://oumi.ai/docs/en/latest/user_guides/launch/launch.html.
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-reasoning-plus
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-reasoning-plus
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/phi4/sft/reasoning_plus/lora_gcp_job.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/lora_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-reasoning-plus
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-reasoning-plus
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/phi4/sft/reasoning_plus/qlora_gcp_job.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/qlora_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-reasoning-plus
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-reasoning-plus
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/evaluation/14b_gcp_job.yaml
+++ b/configs/recipes/qwen3/evaluation/14b_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-14B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-14B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/evaluation/30b_a3b_gcp_job.yaml
+++ b/configs/recipes/qwen3/evaluation/30b_a3b_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-30B-A3B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-30B-A3B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/evaluation/32b_gcp_job.yaml
+++ b/configs/recipes/qwen3/evaluation/32b_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/evaluation/8b_gcp_job.yaml
+++ b/configs/recipes/qwen3/evaluation/8b_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/inference/30b_a3b_instruct_gguf_macos_infer.yaml
+++ b/configs/recipes/qwen3/inference/30b_a3b_instruct_gguf_macos_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # 1. Download the GGUF file to current working directory:
-#   huggingface-cli download unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
+#   hf download unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
 #     Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --local-dir .
 #
 #   # 2. Run inference:

--- a/configs/recipes/qwen3/sft/14b_lora/gcp_job.yaml
+++ b/configs/recipes/qwen3/sft/14b_lora/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-14B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-14B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/sft/30b_a3b_lora/gcp_job.yaml
+++ b/configs/recipes/qwen3/sft/30b_a3b_lora/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-30B-A3B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-30B-A3B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3/sft/8b_full/gcp_job.yaml
+++ b/configs/recipes/qwen3/sft/8b_full/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-8B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-8B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwen3_coder/inference/30b_a3b_instruct_gguf_macos_infer.yaml
+++ b/configs/recipes/qwen3_coder/inference/30b_a3b_instruct_gguf_macos_infer.yaml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   # 1. Download the GGUF file to current working directory:
-#   huggingface-cli download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
+#   hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
 #     Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --local-dir .
 #
 #   # 2. Run inference:

--- a/configs/recipes/qwq/evaluation/gcp_job.yaml
+++ b/configs/recipes/qwq/evaluation/gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   # NOTE: For SFT, update this to point to your model checkpoint.
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu,evaluation] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/QwQ-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/QwQ-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwq/sft/full_gcp_job.yaml
+++ b/configs/recipes/qwq/sft/full_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 # NOTE: Uncomment the following lines to mount a cloud bucket to your VM.
 # For more details, see https://oumi.ai/docs/en/latest/user_guides/launch/launch.html.
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/QwQ-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/QwQ-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwq/sft/lora_gcp_job.yaml
+++ b/configs/recipes/qwq/sft/lora_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/QwQ-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/QwQ-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/qwq/sft/qlora_gcp_job.yaml
+++ b/configs/recipes/qwq/sft/qlora_gcp_job.yaml
@@ -24,7 +24,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
 
 envs:
   WANDB_PROJECT: oumi-train
@@ -35,7 +35,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/QwQ-32B
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/QwQ-32B
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v1_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - (optional) Mount a storage bucket below
 #
 # Usage:

--- a/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
+++ b/configs/recipes/smollm/evaluation/135m/leaderboards/huggingface_leaderboard_v2_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to the GPQA dataset: https://huggingface.co/datasets/Idavidrein/gpqa
 #   - (optional) Mount a storage bucket below
 #

--- a/configs/recipes/vision/internvl3/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/internvl3/sft/full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/internvl3/sft/full/gcp_job.yaml --cluster internvl3
@@ -43,7 +43,7 @@ setup: |
 
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download OpenGVLab/InternVL3-1B-hf
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download OpenGVLab/InternVL3-1B-hf
 
   # Use transformers latest version (4.52.0.dev0)
   # Use this with caution, as it might break some of Oumi's features which is as of

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/evaluation/11b_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:
@@ -26,7 +26,7 @@ resources:
 working_dir: .
 
 file_mounts:
-  ~/.netrc: ~/.netrc  # WandB credentials
+  ~/.netrc: ~/.netrc # WandB credentials
   ~/.cache/huggingface/token: ~/.cache/huggingface/token # HF credentials
 
 envs:
@@ -42,7 +42,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_infer.yaml
@@ -1,7 +1,7 @@
 # Inference config for Llama 3.2 11B Vision Instruct.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_rvllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_sglang_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Install SGLang: https://docs.sglang.ai/start/install.html
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
+++ b/configs/recipes/vision/llama3_2_vision/inference/11b_vllm_infer.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Run `pip install oumi[gpu]`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:
@@ -48,7 +48,7 @@ setup: |
   uv pip install torch==2.5.0 torchvision==0.20.0
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_full/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:
@@ -46,7 +46,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.2-11B-Vision-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-90B-Vision-Instruct
 #
 # Usage:
@@ -46,7 +46,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download meta-llama/Llama-3.2-90B-Vision-Instruct --exclude original/*
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download meta-llama/Llama-3.2-90B-Vision-Instruct --exclude original/*
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Llama 3.2: https://huggingface.co/meta-llama/Llama-3.2-90B-Vision-Instruct
 #
 # Usage:

--- a/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/oumi_gcp_job.yaml
@@ -41,7 +41,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download llava-hf/llava-1.5-7b-hf
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download llava-hf/llava-1.5-7b-hf
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
+++ b/configs/recipes/vision/llava_7b/sft/trl_gcp_job.yaml
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download llava-hf/llava-1.5-7b-hf
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download llava-hf/llava-1.5-7b-hf
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/phi3/sft/full/oumi_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/full/oumi_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/phi3/sft/full/oumi_gcp_job.yaml --cluster phi3-vision
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-3-vision-128k-instruct
 
   pip install -U flash-attn --no-build-isolation
 

--- a/configs/recipes/vision/phi3/sft/full/trl_gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/full/trl_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/phi3/sft/full/trl_gcp_job.yaml --cluster phi3-vision
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-3-vision-128k-instruct
 
   pip install -U flash-attn --no-build-isolation
 

--- a/configs/recipes/vision/phi3/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/phi3/sft/lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/phi3/sft/lora/gcp_job.yaml --cluster phi3-vision
@@ -43,7 +43,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-3-vision-128k-instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-3-vision-128k-instruct
 
   pip install -U flash-attn --no-build-isolation
 

--- a/configs/recipes/vision/phi4/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/phi4/sft/full/gcp_job.yaml
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-multimodal-instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-multimodal-instruct
 
   # The model requires flash_attention_2! Install it here.
   pip install -U flash-attn --no-build-isolation

--- a/configs/recipes/vision/phi4/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/phi4/sft/lora/gcp_job.yaml
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download microsoft/Phi-4-multimodal-instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download microsoft/Phi-4-multimodal-instruct
 
   # The model requires flash_attention_2! Install it here.
   pip install -U flash-attn --no-build-isolation

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/qwen2_5_vl_3b/sft/full/gcp_job.yaml --cluster qwen2_5-vl-vision
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen2.5-VL-3B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen2.5-VL-3B-Instruct
 
   # Also, if you want to try it with a more efficient attention implementation,
   # you can install the `flash_attention_2` package and set `attn_implementation:

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/qwen2_5_vl_3b/sft/lora/gcp_job.yaml --cluster qwen2_5-vl-vision
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen2.5-VL-3B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen2.5-VL-3B-Instruct
 
   # Also, if you want to try it with a more efficient attention implementation,
   # you can install the `flash_attention_2` package and set `attn_implementation:

--- a/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/evaluation/gcp_job.yaml
@@ -42,7 +42,7 @@ setup: |
 
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during eval.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen2-VL-2B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen2-VL-2B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/qwen2_vl_2b/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/qwen2_vl_2b/sft/full/gcp_job.yaml --cluster qwen2-vl-vision
@@ -41,7 +41,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen2-VL-2B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen2-VL-2B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/qwen2_vl_2b/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/qwen2_vl_2b/sft/lora/gcp_job.yaml --cluster qwen2-vl-vision
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen2-VL-2B-Instruct
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen2-VL-2B-Instruct
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/vision/smolvlm/sft/full/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/full/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/smolvlm/sft/full/gcp_job.yaml --cluster smolvlm-vision
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
 
   pip install -U flash-attn --no-build-isolation
 

--- a/configs/recipes/vision/smolvlm/sft/lora/gcp_job.yaml
+++ b/configs/recipes/vision/smolvlm/sft/lora/gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #
 # Usage:
 #   oumi launch up --config configs/recipes/vision/smolvlm/sft/lora/gcp_job.yaml --cluster smolvlm-vision
@@ -39,7 +39,7 @@ setup: |
   pip install uv && uv pip install oumi[gpu] hf_transfer
   # Install model from HF Hub. This tool increases download speed compared to
   # downloading the model during training.
-  HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
+  HF_HUB_ENABLE_HF_TRANSFER=1 hf download HuggingFaceTB/SmolVLM-Instruct --exclude "onnx/*" "runs/*"
 
   pip install -U flash-attn --no-build-isolation
 

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -111,7 +111,7 @@ Oumi integrates with HuggingFace (HF) Hub for access to models and datasets. Whi
 3. Run the following to log in on your machine, using the token created in the previous step:
 
    ```shell
-   huggingface-cli login
+   hf auth login
    ```
 
    This will save your token in the HF cache directory at `~/.cache/huggingface/token`. Oumi jobs mount this file to remote clusters to access gated content there. See [this config](https://github.com/oumi-ai/oumi/blob/535f28b3c93a6423abc247e921a00d2b27de14df/configs/recipes/llama3_1/sft/8b_full/gcp_job.yaml#L19) for an example.

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -73,7 +73,7 @@ oumi train -c configs/recipes/smollm/sft/135m/quickstart_train.yaml \
 To run the same recipe on your own dataset (e.g., in our supported JSON or JSONL formats), you can override the dataset name and path. You can try this functionality out by downloading the `alpaca_cleaned` dataset manually via the huggingface CLI, then including that local path in your run.
 
 ```bash
-huggingface-cli download yahma/alpaca-cleaned --repo-type dataset --local-dir /path/to/local/dataset
+hf download yahma/alpaca-cleaned --repo-type dataset --local-dir /path/to/local/dataset
 
 oumi train -c configs/recipes/smollm/sft/135m/quickstart_train.yaml \
   --data.train.datasets "[{dataset_name: text_sft, dataset_path: /path/to/local/dataset}]" \

--- a/notebooks/Oumi - Distill a Large Model.ipynb
+++ b/notebooks/Oumi - Distill a Large Model.ipynb
@@ -135,7 +135,7 @@
    "outputs": [],
    "source": [
     "!HF_HUB_ENABLE_HF_TRANSFER=1 \\\n",
-    "    huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \\\n",
+    "    hf download deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \\\n",
     "    --exclude original/*"
    ]
   },
@@ -146,7 +146,7 @@
    "outputs": [],
    "source": [
     "!HF_HUB_ENABLE_HF_TRANSFER=1 \\\n",
-    "    huggingface-cli download deepseek-ai/DeepSeek-R1-Distill-Llama-70B \\\n",
+    "    hf download deepseek-ai/DeepSeek-R1-Distill-Llama-70B \\\n",
     "    --exclude original/*"
    ]
   },

--- a/notebooks/Oumi - MiniMath-R1-1.5B.ipynb
+++ b/notebooks/Oumi - MiniMath-R1-1.5B.ipynb
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \\\n",
+    "!HF_HUB_ENABLE_HF_TRANSFER=1 hf download \\\n",
     "    deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --exclude original/*"
    ]
   },
@@ -219,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download oumi-ai/MetaMathQA-R1 \\\n",
+    "!HF_HUB_ENABLE_HF_TRANSFER=1 hf download oumi-ai/MetaMathQA-R1 \\\n",
     "    --exclude original/* --repo-type dataset"
    ]
   },

--- a/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
+++ b/notebooks/Oumi - Using vLLM Engine for Inference.ipynb
@@ -109,7 +109,7 @@
    "source": [
     "%pip install hf_transfer\n",
     "os.environ[\"HF_HUB_ENABLE_HF_TRANSFER\"] = \"1\"\n",
-    "! huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --exclude original/*"
+    "! hf download meta-llama/Llama-3.3-70B-Instruct --exclude original/*"
    ]
   },
   {

--- a/scripts/frontier/jobs/example_job.sh
+++ b/scripts/frontier/jobs/example_job.sh
@@ -47,7 +47,7 @@ echo "${LOG_PREFIX} HF_ASSETS_CACHE: ${HF_ASSETS_CACHE}"
 echo "${LOG_PREFIX} ***ENV END***"
 
 echo "Using this Python environment: $(which python3)"
-HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+HF_HUB_ENABLE_HF_TRANSFER=1 hf download "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 
 # Log some context info and  verify that Oumi is usable in this environment:
 # python -c "from oumi.utils.torch_utils import log_devices_info, log_versioning_info; log_versioning_info(); log_devices_info();"

--- a/scripts/polaris/jobs/download_model_from_hf.sh
+++ b/scripts/polaris/jobs/download_model_from_hf.sh
@@ -29,6 +29,6 @@ source ${PBS_O_WORKDIR}/scripts/polaris/polaris_init.sh
 
 set -x
 
-huggingface-cli download "${MODEL_REPO}"
+hf download "${MODEL_REPO}"
 
 echo "Polaris job is all done!"

--- a/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
+++ b/src/experimental/configs/projects/zephyr/evaluation/eval.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Mistral: https://huggingface.co/mistralai/Mistral-7B-v0.1
 #
 # Usage:

--- a/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Mistral: https://huggingface.co/mistralai/Mistral-7B-v0.1
 #
 # Usage:
@@ -17,7 +17,7 @@
 
 name: zephyr-7b-fft
 
-num_nodes: 1  # Set it to N for multi-node training.
+num_nodes: 1 # Set it to N for multi-node training.
 
 resources:
   cloud: gcp
@@ -27,7 +27,7 @@ resources:
   # preemption. For more information, see:
   # https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#mount-cloud-storage
   use_spot: false
-  disk_size: 200  # Disk size in GB
+  disk_size: 200 # Disk size in GB
   # region: us-west1  # Uncomment this line to only consider a specific region.
 
 working_dir: .

--- a/src/experimental/configs/projects/zephyr/sft/full_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/full_train.yaml
@@ -5,7 +5,7 @@
 # Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Mistral: https://huggingface.co/mistralai/Mistral-7B-v0.1
 #
 # Usage:

--- a/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_gcp_job.yaml
@@ -3,7 +3,7 @@
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Mistral: https://huggingface.co/mistralai/Mistral-7B-v0.1
 #
 # Usage:
@@ -25,7 +25,7 @@ resources:
   # preemption. For more information, see:
   # https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#mount-cloud-storage
   use_spot: false
-  disk_size: 200  # Disk size in GB
+  disk_size: 200 # Disk size in GB
   # region: us-west3  # Uncomment this line to only consider a specific region.
 
 working_dir: .

--- a/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
+++ b/src/experimental/configs/projects/zephyr/sft/qlora_train.yaml
@@ -5,7 +5,7 @@
 # Adjust per_device_train_batch_size & gradient_accumulation_steps for your setup.
 #
 # Requirements:
-#   - Log into HF: `huggingface-cli login`
+#   - Log into HF: `hf auth login`
 #   - Request access to Mistral: https://huggingface.co/mistralai/Mistral-7B-v0.1
 #
 # Usage:

--- a/tests/scripts/predownload_for_github_gpu_tests.sh
+++ b/tests/scripts/predownload_for_github_gpu_tests.sh
@@ -5,5 +5,5 @@
 set -xe
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
-huggingface-cli download "HuggingFaceTB/SmolLM2-135M-Instruct" --exclude "onnx/*" "runs/*"
-huggingface-cli download "Qwen/Qwen2-VL-2B-Instruct"
+hf download "HuggingFaceTB/SmolLM2-135M-Instruct" --exclude "onnx/*" "runs/*"
+hf download "Qwen/Qwen2-VL-2B-Instruct"


### PR DESCRIPTION
# Description

Example warning message: 
```
⚠️  Warning: 'huggingface-cli download' is deprecated. Use 'hf download' instead.
```

I did the following find-replaces in our codebase:
- `huggingface-cli download` -> 'hf download'
- `huggingface-cli login` -> 'hf auth login'
- `huggingface-cli upload-large-folder` -> 'hf upload-large-folder'

Additional code changes were made by the linter, not me.

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
