### PR TITLE
Add Pre-Populated GitHub Issue Link On Failures

### DIFF
--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -170,15 +170,20 @@ def run():
         CONSOLE.print(
             "\n[red]If you believe this is a bug, please file an issue:[/red]"
         )
-        CONSOLE.print(
-            f"📝 [yellow]Templated issue:[/yellow] "
-            f"[link={issue_url}]Click here to report[/link]"
-        )
-        CONSOLE.print(
-            "🔗 [dim]Or create your own:[/dim] "
-            "[link=https://github.com/oumi-ai/oumi/issues/new]"
-            "github.com/oumi-ai/oumi/issues/new[/link]"
-        )
+        if sys.stdout.isatty():
+            CONSOLE.print(
+                f"📝 [yellow]Templated issue:[/yellow] "
+                f"[link={issue_url}]Click here to report[/link]"
+            )
+            CONSOLE.print(
+                "🔗 [dim]Or create your own:[/dim] "
+                "[link=https://github.com/oumi-ai/oumi/issues/new]"
+                "github.com/oumi-ai/oumi/issues/new[/link]"
+            )
+        else:
+            CONSOLE.print(
+                "https://github.com/oumi-ai/oumi/issues/new?template=bug-report.yaml"
+            )
 
         sys.exit(1)
 

--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -165,7 +165,7 @@ def run():
         return app()
     except Exception as e:
         tb_str = traceback.format_exc()
-
+        CONSOLE.print(tb_str)
         issue_url = create_github_issue_url(e, tb_str)
         CONSOLE.print(
             "\n[red]If you believe this is a bug, please file an issue:[/red]"

--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -171,7 +171,7 @@ def run():
             "\n[red]If you believe this is a bug, please file an issue:[/red]"
         )
         CONSOLE.print(
-            f"📝 [yellow]Prefilled issue:[/yellow] "
+            f"📝 [yellow]Templated issue:[/yellow] "
             f"[link={issue_url}]Click here to report[/link]"
         )
         CONSOLE.print(

--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import traceback
 
 import typer
 
@@ -21,7 +22,11 @@ from oumi.cli.cache import card as cache_card
 from oumi.cli.cache import get as cache_get
 from oumi.cli.cache import ls as cache_ls
 from oumi.cli.cache import rm as cache_rm
-from oumi.cli.cli_utils import CONSOLE, CONTEXT_ALLOW_EXTRA_ARGS
+from oumi.cli.cli_utils import (
+    CONSOLE,
+    CONTEXT_ALLOW_EXTRA_ARGS,
+    create_github_issue_url,
+)
 from oumi.cli.distributed_run import accelerate, torchrun
 from oumi.cli.env import env
 from oumi.cli.evaluate import evaluate
@@ -156,7 +161,26 @@ def get_app() -> typer.Typer:
 def run():
     """The entrypoint for the CLI."""
     app = get_app()
-    return app()
+    try:
+        return app()
+    except Exception as e:
+        tb_str = traceback.format_exc()
+
+        issue_url = create_github_issue_url(e, tb_str)
+        CONSOLE.print(
+            "\n[red]If you believe this is a bug, please file an issue:[/red]"
+        )
+        CONSOLE.print(
+            f"📝 [yellow]Prefilled issue:[/yellow] "
+            f"[link={issue_url}]Click here to report[/link]"
+        )
+        CONSOLE.print(
+            "🔗 [dim]Or create your own:[/dim] "
+            "[link=https://github.com/oumi-ai/oumi/issues/new]"
+            "github.com/oumi-ai/oumi/issues/new[/link]"
+        )
+
+        sys.exit(1)
 
 
 if "sphinx" in sys.modules:


### PR DESCRIPTION
# Description

We want to make users more aware that when they run into any types of issues they should open an issue. This PR appends a pre-populated Github issue link after any type of failure occurs for the user to optionally open if they feel it should be tracked by the team.

Example: `oumi launch up -c configs/examples/grpo_verl_countdown/gcp_job.yaml --cluster grpo-verl-countdown`
**BEFORE CHANGES**
<img width="754" height="271" alt="image" src="https://github.com/user-attachments/assets/dae83685-f0b1-4492-a593-b2fb25ce730f" />

**AFTER CHANGERS**
<img width="1053" height="295" alt="Screenshot 2025-08-19 at 10 23 32 AM" src="https://github.com/user-attachments/assets/988c9ad9-378b-4465-a415-efcdc391bc45" />
<img width="668" height="720" alt="Screenshot 2025-08-20 at 9 22 05 AM" src="https://github.com/user-attachments/assets/f23e852c-83a7-4790-b275-745a9eefeda2" />

**LONGER ERROR EXAMPLE**
<img width="737" height="683" alt="Screenshot 2025-08-20 at 9 21 05 AM" src="https://github.com/user-attachments/assets/4b4b3e0e-4484-4004-9e7b-dcdc2906bdad" />
<img width="692" height="764" alt="Screenshot 2025-08-20 at 9 21 27 AM" src="https://github.com/user-attachments/assets/4c6773db-6b41-4015-969a-ac861c4a5c8d" />

NOTE: For any jobs used with the launcher, rich console logs that leverage links won't work. Instead a check is made and if its a remote job we just display the template for the user to use instead of populating any fields

<img width="792" height="521" alt="Screenshot 2025-08-20 at 11 15 19 AM" src="https://github.com/user-attachments/assets/a70a65d6-adde-466c-b870-d8b353590494" />

## Before submitting
- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?