### PR TITLE
Adding Verbose Flag

### DIFF
--- a/src/oumi/__init__.py
+++ b/src/oumi/__init__.py
@@ -239,6 +239,7 @@ def train(
     config: TrainingConfig,
     additional_model_kwargs: dict[str, Any] | None = None,
     additional_trainer_kwargs: dict[str, Any] | None = None,
+    verbose: bool = False,
 ) -> None:
     """Trains a model using the provided configuration."""
     import oumi.train
@@ -247,6 +248,7 @@ def train(
         config,
         additional_model_kwargs=additional_model_kwargs,
         additional_trainer_kwargs=additional_trainer_kwargs,
+        verbose=verbose,
     )
 
 

--- a/src/oumi/builders/training.py
+++ b/src/oumi/builders/training.py
@@ -28,13 +28,14 @@ from oumi.utils.logging import logger
 
 
 def build_trainer(
-    trainer_type: TrainerType, processor: Optional[BaseProcessor]
+    trainer_type: TrainerType, processor: Optional[BaseProcessor], verbose: bool = False
 ) -> Callable[..., BaseTrainer]:
     """Builds a trainer creator functor based on the provided configuration.
 
     Args:
         trainer_type (TrainerType): Enum indicating the type of training.
         processor: An optional processor.
+        verbose (bool): Whether to enable verbose logging of training arguments.
 
     Returns:
         A builder function that can create an appropriate trainer based on the trainer
@@ -58,7 +59,7 @@ def build_trainer(
                 training_args.finalize_and_validate()
 
             hf_args = training_args.to_hf()
-            if is_world_process_zero():
+            if verbose and is_world_process_zero():
                 logger.info(pformat(hf_args))
             trainer = HuggingFaceTrainer(cls(*args, **kwargs, args=hf_args), processor)
             if callbacks:

--- a/src/oumi/cli/cli_utils.py
+++ b/src/oumi/cli/cli_utils.py
@@ -160,6 +160,16 @@ LOG_LEVEL_TYPE = Annotated[
     ),
 ]
 
+VERBOSE_TYPE = Annotated[
+    bool,
+    typer.Option(
+        "--verbose",
+        "-v",
+        help="Enable verbose logging with additional debug information.",
+        show_default=True,
+    ),
+]
+
 
 def _resolve_oumi_prefix(
     config_path: str, output_dir: Optional[Path] = None

--- a/src/oumi/cli/evaluate.py
+++ b/src/oumi/cli/evaluate.py
@@ -31,6 +31,7 @@ def evaluate(
         ),
     ],
     level: cli_utils.LOG_LEVEL_TYPE = None,
+    verbose: cli_utils.VERBOSE_TYPE = False,
 ):
     """Evaluate a model.
 
@@ -38,6 +39,7 @@ def evaluate(
         ctx: The Typer context object.
         config: Path to the configuration file for evaluation.
         level: The logging level for the specified command.
+        verbose: Enable verbose logging with additional debug information.
     """
     extra_args = cli_utils.parse_extra_cli_args(ctx)
 
@@ -60,8 +62,9 @@ def evaluate(
     )
     parsed_config.finalize_and_validate()
 
-    # Print configuration for verification
-    parsed_config.print_config(logger)
+    if verbose:
+        # Print configuration for verification
+        parsed_config.print_config(logger)
 
     # Run evaluation
     with cli_utils.CONSOLE.status(

--- a/src/oumi/cli/infer.py
+++ b/src/oumi/cli/infer.py
@@ -59,6 +59,7 @@ def infer(
         ),
     ] = None,
     level: cli_utils.LOG_LEVEL_TYPE = None,
+    verbose: cli_utils.VERBOSE_TYPE = False,
 ):
     """Run inference on a model.
 
@@ -75,6 +76,7 @@ def infer(
         image: Path to the input image for `image+text` VLLMs.
         system_prompt: System prompt for task-specific instructions.
         level: The logging level for the specified command.
+        verbose: Enable verbose logging with additional debug information.
     """
     extra_args = cli_utils.parse_extra_cli_args(ctx)
 
@@ -102,8 +104,9 @@ def infer(
     )
     parsed_config.finalize_and_validate()
 
-    # Print configuration for verification
-    parsed_config.print_config(logger)
+    if verbose:
+        # Print configuration for verification
+        parsed_config.print_config(logger)
 
     # https://stackoverflow.com/questions/62691279/how-to-disable-tokenizers-parallelism-true-false-warning
     os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/src/oumi/cli/synth.py
+++ b/src/oumi/cli/synth.py
@@ -37,6 +37,7 @@ def synth(
         ),
     ],
     level: cli_utils.LOG_LEVEL_TYPE = None,
+    verbose: cli_utils.VERBOSE_TYPE = False,
 ):
     """Synthesize a dataset.
 
@@ -44,6 +45,7 @@ def synth(
         ctx: The Typer context object.
         config: Path to the configuration file for synthesis.
         level: The logging level for the specified command.
+        verbose: Enable verbose logging with additional debug information.
     """
     extra_args = cli_utils.parse_extra_cli_args(ctx)
 

--- a/src/oumi/cli/train.py
+++ b/src/oumi/cli/train.py
@@ -30,6 +30,7 @@ def train(
         ),
     ],
     level: cli_utils.LOG_LEVEL_TYPE = None,
+    verbose: cli_utils.VERBOSE_TYPE = False,
 ):
     """Train a model.
 
@@ -37,6 +38,7 @@ def train(
         ctx: The Typer context object.
         config: Path to the configuration file for training.
         level: The logging level for the specified command.
+        verbose: Enable verbose logging with additional debug information.
     """
     extra_args = cli_utils.parse_extra_cli_args(ctx)
 
@@ -72,6 +74,6 @@ def train(
     )
 
     # Run training
-    oumi_train(parsed_config)
+    oumi_train(parsed_config, verbose=verbose)
 
     device_cleanup()


### PR DESCRIPTION
# Description
By default, most configurations are displayed in the terminal during operations, which can create unnecessary noise for the average user. This PR introduces a --verbose flag, allowing users who want more detailed output to enable it, while keeping the default experience cleaner and easier to read.

# Usage

`oumi infer -i -c configs/recipes/smollm/inference/135m_infer.yaml **--verbose**`

# Tested With Flag On and Off

`oumi train -c configs/recipes/smollm/sft/135m/quickstart_train.yaml`
`oumi infer -i -c configs/recipes/smollm/inference/135m_infer.yaml`
`oumi evaluate -c configs/recipes/phi3/evaluation/eval.yaml`

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.