### PR TITLE
[tiny] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ coverage_html/
 notebooks/*tutorial*
 # Evaluation results
 results/
-# Local model checkpoints
-models/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
# Description

This is causing a bug with the Oumi launcher, because the oumi/src/oumi/models folder isn't being copied to remote clusters.

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?
