### PR TITLE
Add shell script for launching jobs on NERSC Perlmutter HPC cluster

### DIFF
--- a/scripts/frontier/launcher.sh
+++ b/scripts/frontier/launcher.sh
@@ -79,7 +79,7 @@ rsync -e "ssh -S ~/.ssh/control-%h-%p-%r" -avz --delete \
 echo "Setting up environment and submitting job on Frontier..."
 # Save the variables to pass to the remote script.
 printf -v varsStr '%q ' "$COPY_DIRECTORY" "$JOB_PATH" "$FRONTIER_NODES" "$FRONTIER_QUEUE"
-# We need to properly escape the remote script due to the qsub command substitution.
+# We need to properly escape the remote script due to the sbatch command substitution.
 ssh -S ~/.ssh/control-%h-%p-%r "${FRONTIER_USER}@frontier.olcf.ornl.gov" "bash -s $varsStr" <<'EOF'
   COPY_DIRECTORY=$1; JOB_PATH=$2; FRONTIER_NODES=$3; FRONTIER_QUEUE=$4
   cd "${COPY_DIRECTORY}"

--- a/scripts/perlmutter/README.md
+++ b/scripts/perlmutter/README.md
@@ -1,0 +1,59 @@
+# Perlmutter Scripts
+
+This directory contains scripts for running jobs on the Perlmutter supercomputer at the National Energy Research Scientific Computing Center (NERSC) in Lawrence Berkeley National Laboratory.
+
+https://docs.nersc.gov/getting-started/
+
+## Overview
+
+- `launcher.sh`: A utility script for launching jobs on Perlmutter. It handles copying your local files to Perlmutter and submitting jobs.
+- `perlmutter_init.sh`: Initialization script that sets up the environment on Perlmutter nodes before running your job.
+- `jobs/`: Directory containing specific job scripts for different tasks.
+
+## Usage
+
+Requirement: Set `export SBATCH_ACCOUNT=<your_project>` in your Perlmutter `.bashrc`.
+
+### Launching a Job
+
+Use the `launcher.sh` script to submit jobs to Perlmutter. The script handles:
+
+- Setting up an SSH tunnel
+- Copying your local files to Perlmutter
+- Creating and activating the Conda environment
+- Submitting your job
+
+Basic usage:
+
+```bash
+./launcher.sh -u username -q queue -n num_nodes -s source_dir -d dest_dir -j job_script
+```
+
+Arguments:
+
+- `-u`: Your Perlmutter username
+- `-q`: Queue/partition to use (options: batch, extended)
+- `-n`: Number of nodes to request
+- `-s`: Source directory to copy (defaults to current directory)
+- `-d`: Destination directory on Perlmutter
+- `-j`: Path to your job script
+
+## Example
+
+```bash
+./scripts/perlmutter/launcher.sh \
+    -u jdoe \
+    -q batch \
+    -n 4 \
+    -s . \
+    -d  $CFS/$SBATCH_ACCOUNT/jdoe/oumi/ \
+    -j ./scripts/perlmutter/jobs/example_job.sh
+```
+
+## Monitoring Jobs
+
+After submission, you can monitor your jobs:
+
+- View job status: `squeue -l -u username`
+- Check error logs: `tail -n200 -f $CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/jobid.ER`
+- Check output logs: `tail -n200 -f $CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/jobid.OU`

--- a/scripts/perlmutter/jobs/example_job.sh
+++ b/scripts/perlmutter/jobs/example_job.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH -J example_job
-#SBATCH -t 01:00:00
+#SBATCH -t 00:30:00
 
 PERLMUTTER_NODE_RANK=${PMI_RANK:=0}
 

--- a/scripts/perlmutter/jobs/example_job.sh
+++ b/scripts/perlmutter/jobs/example_job.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#SBATCH -J example_job
+#SBATCH -t 01:00:00
+
+PERLMUTTER_NODE_RANK=${PMI_RANK:=0}
+
+# Only necessary if submitting like: sbatch --export=NONE ... (recommended)
+# Do NOT include this line when submitting without --export=NONE
+# unset SLURM_EXPORT_ENV
+
+set -e
+
+# Various setup for running on NERSC Perlmutter.
+source "${SLURM_SUBMIT_DIR}/scripts/perlmutter/perlmutter_init.sh"
+
+# TODO: Populate this variable:
+# export OMP_NUM_THREADS=56 # 64
+
+LOG_PREFIX="Node: ${PERLMUTTER_NODE_RANK}:"
+echo "${LOG_PREFIX} ***ENV BEGIN***"
+echo "${LOG_PREFIX} SLURM_JOBID: $SLURM_JOBID"
+echo "${LOG_PREFIX} OUMI_JOBNUM: $OUMI_JOBNUM"
+echo "${LOG_PREFIX} USER: ${USER}"
+echo "${LOG_PREFIX} OUMI_MASTER_ADDR: $OUMI_MASTER_ADDR"
+echo "${LOG_PREFIX} OUMI_MASTER_PORT: $OUMI_MASTER_PORT"
+echo "${LOG_PREFIX} OUMI_NUM_NODES: $OUMI_NUM_NODES"
+echo "${LOG_PREFIX} PMI_LOCAL_RANK: $PMI_LOCAL_RANK"
+echo "${LOG_PREFIX} PMI_RANK: $PMI_RANK"
+echo "${LOG_PREFIX} NCCL_COLLNET_ENABLE: $NCCL_COLLNET_ENABLE"
+echo "${LOG_PREFIX} NCCL_NET_GDR_LEVEL: $NCCL_NET_GDR_LEVEL"
+echo "${LOG_PREFIX} NCCL_DEBUG: $NCCL_DEBUG"
+echo "${LOG_PREFIX} Nvidia info: $(nvidia-smi)"
+echo "${LOG_PREFIX} TMPDIR: ${TMPDIR}"
+echo "${LOG_PREFIX} CUDA_VISIBLE_DEVICES: ${CUDA_VISIBLE_DEVICES}"
+echo "${LOG_PREFIX} OMP_NUM_THREADS: ${OMP_NUM_THREADS}"
+echo "${LOG_PREFIX} HF_HOME: ${HF_HOME}"
+echo "${LOG_PREFIX} HF_HUB_CACHE: ${HF_HUB_CACHE}"
+echo "${LOG_PREFIX} HF_ASSETS_CACHE: ${HF_ASSETS_CACHE}"
+echo "${LOG_PREFIX} ***ENV END***"
+
+echo "Using this Python environment: $(which python3)"
+HF_HUB_ENABLE_HF_TRANSFER=1 hf download "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+
+# Log some context info and  verify that Oumi is usable in this environment:
+# python -c "from oumi.utils.torch_utils import log_devices_info, log_versioning_info; log_versioning_info(); log_devices_info();"
+
+oumi env
+
+set +x
+
+oumi distributed torchrun \
+  -m oumi train \
+  -c configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml \
+  --training.run_name="deepseek-r1.qwen1.5b.fft.${SLURM_JOBID}" \
+  --training.max_steps=50 \
+  --training.dataloader_num_workers=2 \
+  --training.dataloader_prefetch_factor=32 \
+  --training.enable_wandb=false

--- a/scripts/perlmutter/launcher.sh
+++ b/scripts/perlmutter/launcher.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+helpFunction() {
+    echo ""
+    echo "Usage: $0 -u username -q regular -n 1 -s . -d /home/username/copylocation/ -j ./local/path/to/your_job.sh"
+    echo -e "\t-u The username on NERSC Perlmutter cluster."
+    echo -e "\t-q The Perlmutter QoS to use. https://docs.nersc.gov/jobs/policy/#selecting-a-qos."
+    echo -e "\t-n The number of Perlmutter nodes to use."
+    echo -e "\t-s The source directory to copy. Defaults to the current directory."
+    echo -e "\t-d The destination directory on Perlmutter to copy local files."
+    echo -e "\t-j The local path to your job."
+    exit 1 # Exit script after printing help
+}
+
+# Default values.
+SOURCE_DIRECTORY="."
+
+PERLMUTTER_QOS=""
+PERLMUTTER_NODES=1
+
+while getopts "u:q:n:s:d:j:" opt; do
+    case "$opt" in
+    u) PERLMUTTER_USER="$OPTARG" ;;
+    q) PERLMUTTER_QOS="$OPTARG" ;;
+    n) PERLMUTTER_NODES="$OPTARG" ;;
+    s) SOURCE_DIRECTORY="$OPTARG" ;;
+    d) COPY_DIRECTORY="$OPTARG" ;;
+    j) JOB_PATH="$OPTARG" ;;
+    ?) helpFunction ;; # Print a help message for an unknown parameter.
+    esac
+done
+
+# Print a help message if parameters are empty.
+if [ -z "$PERLMUTTER_USER" ] || [ -z "$PERLMUTTER_NODES" ]; then
+    echo "Some or all required parameters are empty:"
+    echo -e "\tPERLMUTTER_USER: $PERLMUTTER_USER"
+    echo -e "\tPERLMUTTER_NODES: $PERLMUTTER_NODES"
+    helpFunction
+fi
+
+if ! test "$PERLMUTTER_NODES" -gt 0; then
+    echo "The number of Perlmutter nodes ($PERLMUTTER_NODES) must be positive"
+    helpFunction
+fi
+
+# Select default queue if unspecified.
+if [ -z "$PERLMUTTER_QOS" ]; then
+    PERLMUTTER_QOS="debug"
+fi
+
+if [ -z "$COPY_DIRECTORY" ] || [ -z "$JOB_PATH" ] || [ -z "$SOURCE_DIRECTORY" ]; then
+    echo "Some or all required parameters are empty:"
+    echo -e "\tCOPY_DIRECTORY: $COPY_DIRECTORY"
+    echo -e "\tJOB_PATH: $JOB_PATH"
+    echo -e "\tSOURCE_DIRECTORY: $SOURCE_DIRECTORY"
+    helpFunction
+fi
+
+SSH_TARGET="${PERLMUTTER_USER}@perlmutter.nersc.gov"
+
+# Start an SSH tunnel in the background so we only have to auth once.
+# This tunnel will close automatically after 5 minutes of inactivity.
+ssh -f -N -M -S ~/.ssh/control-%h-%p-%r -o "ControlPersist 15m" ${SSH_TARGET}
+
+# Copy files to Perlmutter over the same SSH tunnel, excluding unnecessary ones.
+echo "Copying files to Perlmutter... -----------------------------------------"
+rsync -e "ssh -S ~/.ssh/control-%h-%p-%r" -avz --delete \
+    --exclude-from "${SOURCE_DIRECTORY}/.gitignore" \
+    --exclude tests \
+    "${SOURCE_DIRECTORY}" "${SSH_TARGET}:${COPY_DIRECTORY}"
+
+# Submit a job on Perlmutter over the same SSH tunnel.
+echo "Setting up environment and submitting job on Perlmutter..."
+# Save the variables to pass to the remote script.
+printf -v varsStr '%q ' "$COPY_DIRECTORY" "$JOB_PATH" "$PERLMUTTER_NODES" "$PERLMUTTER_QOS"
+# We need to properly escape the remote script due to the sbatch command substitution.
+ssh -S ~/.ssh/control-%h-%p-%r "${SSH_TARGET}" "bash -s $varsStr" <<'EOF'
+  COPY_DIRECTORY=$1; JOB_PATH=$2; PERLMUTTER_NODES=$3; PERLMUTTER_QOS=$4
+  cd "${COPY_DIRECTORY}"
+
+  # Activate the Conda environment.
+  module load conda
+  echo "Installing packages... -----------------------------------------"
+  if [ ! -z "$CONDA_DEFAULT_ENV" ]; then
+    # Deactivate the previous environment (stacked env-s cause `pip install` problems).
+    conda deactivate
+  fi
+  conda activate oumi
+
+  if ! command -v uv >/dev/null 2>&1; then
+      pip install -U uv
+  fi
+
+  uv pip install -U -e '.[gpu]' 'huggingface_hub[cli]' hf_transfer
+
+  # Optional: print GPU count and GPU name.
+  python -c "import torch; print('GPU count: ', torch.cuda.device_count()); print(torch.cuda.get_device_name(0))"
+
+  echo "Submitting job... -----------------------------------------"
+  # Create a logs directory for the user if it doesn't exist.
+  # This directory must exist for the run to work, as Perlmutter won't create them.
+  mkdir -p $CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/
+
+  set -x
+
+  # Additional options are set by the job script in #SBATCH comments.
+  SBATCH_OUTPUT=$(sbatch \
+    -C=GPU \
+    --gpus-per-node=4 \
+    -N=${PERLMUTTER_NODES} \
+    -n=${PERLMUTTER_NODES} \
+    -q=${PERLMUTTER_QOS} \
+    -o="$CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/%j.OU" \
+    -e="$CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/%j.ER" ${JOB_PATH}
+  )
+  SBATCH_RESULT=$?
+  set +x  # Turn-off printing
+
+  if (test "$SBATCH_RESULT" -ne 0) || [ -z "$SBATCH_OUTPUT" ]
+  then
+      echo "Job submission ('sbatch') failed with error code: $SBATCH_RESULT"
+      exit 1
+  fi
+  JOB_ID=$(echo "${SBATCH_OUTPUT}" | grep -o -E '[0-9]+')
+  if [ -z "$JOB_ID" ]
+  then
+      echo "Failed to extract JOB_ID from: $SBATCH_OUTPUT"
+      exit 1
+  fi
+
+  echo "Job id: ${JOB_ID}"
+
+  echo
+  echo "All jobs:"
+  squeue -l -u $USER
+
+  echo
+  echo "To view error logs, run (on Perlmutter):"
+  echo "tail -n200 -f $CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/${JOB_ID}.ER"
+  echo "To view output logs, run (on Perlmutter):"
+  echo "tail -n200 -f $CFS/$SBATCH_ACCOUNT/$USER/jobs/logs/${JOB_ID}.OU"
+EOF

--- a/scripts/perlmutter/perlmutter_init.sh
+++ b/scripts/perlmutter/perlmutter_init.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+# Change to the directory where the job was submitted.
+echo "Changing directory to ${SLURM_SUBMIT_DIR} ..."
+cd "${SLURM_SUBMIT_DIR}"
+
+echo "Perlmutter job ID: ${SLURM_JOBID}"
+echo "Running on host: $(hostname)"
+echo "Current dir: $(pwd)"
+echo "Work dir: ${SLURM_SUBMIT_DIR}"
+echo "Perlmutter node file: ${SLURM_NODELIST}"
+echo ""
+echo "SLURM_NNODES         =" $SLURM_NNODES
+echo "SLURM_NTASKS         =" $SLURM_NTASKS
+echo "SLURM_TASKS_PER_NODE =" $SLURM_TASKS_PER_NODE
+echo "SLURM_CPUS_PER_TASK  =" $SLURM_CPUS_PER_TASK
+echo "SLURM_NPROCS         =" $SLURM_NPROCS
+echo "SLURM_NODELIST       =" $SLURM_NODELIST
+echo "SLURM_JOB_NODELIST   =" $SLURM_JOB_NODELIST
+echo ""
+
+export OUMI_NUM_NODES=$SLURM_NNODES
+export OUMI_PERLMUTTER_NUM_GPUS_PER_NODE=4
+export OUMI_TOTAL_NUM_GPUS=$((${OUMI_NUM_NODES} * ${OUMI_PERLMUTTER_NUM_GPUS_PER_NODE}))
+export OUMI_MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+echo "Master address: ${OUMI_MASTER_ADDR}"
+echo "Number of nodes: ${OUMI_NUM_NODES}"
+echo "All nodes: " $(scontrol show hostnames "$SLURM_JOB_NODELIST")
+
+if [[ -z "${OUMI_MASTER_ADDR}" ]]; then
+    echo "Master address is empty!"
+    exit 1
+fi
+
+# DELETE: export OUMI_JOBNUM=$(echo $SLURM_JOBID | cut -d'.' -f1)
+export OUMI_JOBNUM="${SLURM_JOBID}"
+if [[ -z "${OUMI_JOBNUM}" ]]; then
+    echo "Job number is empty for SLURM_JOBID: ${SLURM_JOBID}!"
+    exit 1
+fi
+
+export NCCL_DEBUG=WARN # INFO
+## export NCCL_DEBUG_SUBSYS=ALL
+
+# TODO: Append "/slurm_job_${SLURM_JOBID}" suffix in case of cache file lock contention.
+export HF_HOME="$SCRATCH/.cache/huggingface"
+export HF_HUB_CACHE="$HF_HOME/hub"
+export HF_ASSETS_CACHE="$HF_HOME/assets"
+
+echo "Loading Perlmutter modules..."
+
+# Set up default modules.
+module load conda
+
+# Activate the Oumi Conda environment.
+set +x
+conda activate oumi
+echo "Conda path: ${CONDA_PREFIX}"
+set -x
+
+echo "perlmutter_init.sh is done!"


### PR DESCRIPTION
# Description

This is similar to #1691, but for the Perlmutter cluster. Both use the Slurm scheduler, but Perlmutter has Nvidia GPUs and a slightly different setup for conda. Tested with `scripts/perlmutter/launcher.sh -u wizeng -d /global/homes/w/wizeng/oumi_launcher -j scripts/perlmutter/jobs/example_job.sh`.

## Related issues

Towards OPE-1507

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
