### PR TITLE
Simplify github issue creation in cli

### DIFF
--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -38,7 +38,7 @@ from oumi.cli.launch import run as launcher_run
 from oumi.cli.quantize import quantize
 from oumi.cli.synth import synth
 from oumi.cli.train import train
-from oumi.utils.logging import _should_use_rich_logging
+from oumi.utils.logging import should_use_rich_logging
 
 _ASCII_LOGO = r"""
    ____  _    _ __  __ _____
@@ -171,7 +171,7 @@ def run():
         CONSOLE.print(
             "\n[red]If you believe this is a bug, please file an issue:[/red]"
         )
-        if _should_use_rich_logging():
+        if should_use_rich_logging():
             CONSOLE.print(
                 f"📝 [yellow]Templated issue:[/yellow] "
                 f"[link={issue_url}]Click here to report[/link]"

--- a/src/oumi/utils/logging.py
+++ b/src/oumi/utils/logging.py
@@ -87,7 +87,7 @@ def configure_logger(
 
     # Add a console handler to the logger for only global leader.
     if device_rank == 0:
-        if _should_use_rich_logging():
+        if should_use_rich_logging():
             console_handler = _configure_rich_handler(device_rank, level)
         else:
             console_handler = logging.StreamHandler(sys.stdout)
@@ -109,8 +109,15 @@ def configure_logger(
     logger.propagate = False
 
 
-def _should_use_rich_logging() -> bool:
-    """Determines if rich logging should be used based on environment variables."""
+def should_use_rich_logging() -> bool:
+    """Determines whether rich logging should be used.
+
+    Returns:
+        bool: True if rich logging should be used, False otherwise.
+
+    Rich logging is enabled if the output is a terminal (TTY) and not explicitly
+    disabled via the OUMI_DISABLE_RICH_LOGGING environment variable.
+    """
     # Check if explicitly disabled
     if os.environ.get("OUMI_DISABLE_RICH_LOGGING", "").lower() in (
         "1",


### PR DESCRIPTION
# Description

This PR addresses OPE-1510 by reducing friction in the GitHub issue reporting flow within the CLI.

Previously, users were presented with two options when an error occurred: a templated issue link and a generic "create your own" link. This change removes the redundant "create your own" option, guiding users directly to the templated issue creation, which is the preferred and most helpful method for bug reporting.

Additionally, the `sys.stdout.isatty()` check has been replaced with `_should_use_rich_logging()`. This ensures that the rich logging output for the issue link is displayed consistently based on our internal logging configuration, including environment variables, rather than solely relying on `isatty()`.

## Related issues

Fixes #OPE-1510

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

---
Linear Issue: [OPE-1510](https://linear.app/oumi/issue/OPE-1510)

<a href="https://cursor.com/background-agent?bcId=bc-570fefaf-67f8-4123-ad35-f9b387c76593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-570fefaf-67f8-4123-ad35-f9b387c76593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

