### PR TITLE
Add a parsable enum state field to the launcher to convey job status

### DIFF
--- a/docs/user_guides/launch/custom_cluster.md
+++ b/docs/user_guides/launch/custom_cluster.md
@@ -35,7 +35,7 @@ from enum import Enum
 from typing import Optional
 
 from oumi.core.configs import JobConfig
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobStatus, JobState
 
 
 class _JobState(Enum):
@@ -68,6 +68,7 @@ class CustomClient:
             cluster="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         self._jobs.append(job_status)
         return job_status

--- a/notebooks/Oumi - Launching Jobs on Custom Clusters.ipynb
+++ b/notebooks/Oumi - Launching Jobs on Custom Clusters.ipynb
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
     "from typing import Optional\n",
     "\n",
     "from oumi.core.configs import JobConfig\n",
-    "from oumi.core.launcher import JobStatus\n",
+    "from oumi.core.launcher import JobState, JobStatus\n",
     "\n",
     "\n",
     "class _JobState(Enum):\n",
@@ -146,6 +146,7 @@
     "            cluster=\"\",\n",
     "            metadata=\"\",\n",
     "            done=False,\n",
+    "            state=JobState.PENDING,\n",
     "        )\n",
     "        self._jobs.append(job_status)\n",
     "        return job_status\n",

--- a/src/oumi/core/launcher/__init__.py
+++ b/src/oumi/core/launcher/__init__.py
@@ -22,10 +22,11 @@ launchers for running machine learning jobs.
 """
 
 from oumi.core.launcher.base_cloud import BaseCloud
-from oumi.core.launcher.base_cluster import BaseCluster, JobStatus
+from oumi.core.launcher.base_cluster import BaseCluster, JobState, JobStatus
 
 __all__ = [
     "BaseCloud",
     "BaseCluster",
+    "JobState",
     "JobStatus",
 ]

--- a/src/oumi/core/launcher/base_cluster.py
+++ b/src/oumi/core/launcher/base_cluster.py
@@ -23,6 +23,7 @@ class JobState(Enum):
     """Enum to hold the state of a job."""
 
     PENDING = "pending"
+    RUNNING = "running"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     CANCELLED = "cancelled"

--- a/src/oumi/core/launcher/base_cluster.py
+++ b/src/oumi/core/launcher/base_cluster.py
@@ -14,8 +14,18 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 
 from oumi.core.configs import JobConfig
+
+
+class JobState(Enum):
+    """Enum to hold the state of a job."""
+
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 @dataclass
@@ -41,6 +51,10 @@ class JobStatus:
     #: True only if the job is in a terminal state (e.g. completed, failed, or
     #: canceled).
     done: bool
+
+    #: The state of the job.
+    #: For more fine-grained information about the job, see the status field.
+    state: JobState
 
 
 class BaseCluster(ABC):

--- a/src/oumi/launcher/clients/local_client.py
+++ b/src/oumi/launcher/clients/local_client.py
@@ -69,7 +69,7 @@ class LocalClient:
         if job_state == _JobState.QUEUED:
             return JobState.PENDING
         elif job_state == _JobState.RUNNING:
-            return JobState.PENDING
+            return JobState.RUNNING
         elif job_state == _JobState.COMPLETED:
             return JobState.SUCCEEDED
         elif job_state == _JobState.FAILED:

--- a/src/oumi/launcher/clients/local_client.py
+++ b/src/oumi/launcher/clients/local_client.py
@@ -23,7 +23,7 @@ from threading import Lock, Thread
 from typing import Optional
 
 from oumi.core.configs import JobConfig
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 
 
 @dataclass
@@ -64,11 +64,26 @@ class LocalClient:
         self._worker = Thread(target=self._worker_loop, daemon=True)
         self._worker.start()
 
+    def _get_job_state(self, job_state: _JobState) -> JobState:
+        """Gets the state of the job."""
+        if job_state == _JobState.QUEUED:
+            return JobState.PENDING
+        elif job_state == _JobState.RUNNING:
+            return JobState.PENDING
+        elif job_state == _JobState.COMPLETED:
+            return JobState.SUCCEEDED
+        elif job_state == _JobState.FAILED:
+            return JobState.FAILED
+        elif job_state == _JobState.CANCELED:
+            return JobState.CANCELLED
+        raise ValueError(f"Invalid job state: {job_state}")
+
     def _update_job_status(self, job_id: str, status: _JobState) -> None:
         """Updates the status of the job. Assumes the mutex is already acquired."""
         if job_id not in self._jobs:
             return
         self._jobs[job_id].status.status = status.value
+        self._jobs[job_id].status.state = self._get_job_state(status)
         is_done = status in (_JobState.COMPLETED, _JobState.FAILED, _JobState.CANCELED)
         self._jobs[job_id].status.done = is_done
 
@@ -188,6 +203,7 @@ class LocalClient:
                 cluster="",
                 metadata="",
                 done=False,
+                state=JobState.PENDING,
             )
             self._jobs[job_id] = _LocalJob(status=status, config=job)
             return status

--- a/src/oumi/launcher/clients/polaris_client.py
+++ b/src/oumi/launcher/clients/polaris_client.py
@@ -91,7 +91,7 @@ class PolarisClient:
 
     _FINISHED_STATUS = "F"
     _FAILED_STATUS = "E"
-
+    _RUNNING_STATUS = "R"
     _PROD_QUEUES = {
         "small",
         "medium",
@@ -123,6 +123,8 @@ class PolarisClient:
             return JobState.SUCCEEDED
         elif status == self._FAILED_STATUS:
             return JobState.FAILED
+        elif status == self._RUNNING_STATUS:
+            return JobState.RUNNING
         return JobState.PENDING
 
     def _split_status_line(self, line: str, metadata: str) -> JobStatus:

--- a/src/oumi/launcher/clients/polaris_client.py
+++ b/src/oumi/launcher/clients/polaris_client.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 import pexpect
 
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.utils.logging import logger
 
 _CTRL_PATH = "-S ~/.ssh/control-%h-%p-%r"
@@ -90,6 +90,7 @@ class PolarisClient:
         PROD = "prod"
 
     _FINISHED_STATUS = "F"
+    _FAILED_STATUS = "E"
 
     _PROD_QUEUES = {
         "small",
@@ -108,6 +109,21 @@ class PolarisClient:
         """
         self._user = user
         self._refresh_creds()
+
+    def _get_job_state(self, status: str) -> JobState:
+        """Gets the state of the job.
+
+        Args:
+            status: The status of the job.
+
+        Returns:
+            The state of the job.
+        """
+        if status == self._FINISHED_STATUS:
+            return JobState.SUCCEEDED
+        elif status == self._FAILED_STATUS:
+            return JobState.FAILED
+        return JobState.PENDING
 
     def _split_status_line(self, line: str, metadata: str) -> JobStatus:
         """Splits a status line into a JobStatus object.
@@ -138,13 +154,15 @@ class PolarisClient:
                 f"Invalid status line: {line}. "
                 f"Expected 11 fields, but found {len(fields)}."
             )
+        state = self._get_job_state(fields[9])
         return JobStatus(
             id=self._get_short_job_id(fields[0]),
             name=fields[3],
             status=fields[9],
             cluster=fields[2],
             metadata=metadata,
-            done=fields[9] == self._FINISHED_STATUS,
+            done=state in (JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELLED),
+            state=state,
         )
 
     def _get_short_job_id(self, job_id: str) -> str:

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
 
 from oumi.core.configs import JobConfig
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import try_str_to_bool
 
@@ -200,6 +200,7 @@ class SkyClient:
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
 
     def status(self) -> list[dict[str, Any]]:

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -81,6 +81,8 @@ def _get_job_state(job_state: str) -> JobState:
         return JobState.SUCCEEDED
     elif job_state == "CANCELLED":
         return JobState.CANCELLED
+    elif job_state == "RUNNING":
+        return JobState.RUNNING
     return JobState.PENDING
 
 

--- a/src/oumi/launcher/clusters/sky_cluster.py
+++ b/src/oumi/launcher/clusters/sky_cluster.py
@@ -15,7 +15,7 @@
 from typing import Any, Optional
 
 from oumi.core.configs import JobConfig
-from oumi.core.launcher import BaseCluster, JobStatus
+from oumi.core.launcher import BaseCluster, JobState, JobStatus
 from oumi.launcher.clients.sky_client import SkyClient
 
 
@@ -37,29 +37,42 @@ class SkyCluster(BaseCluster):
             return False
         return self.name() == other.name()
 
+    def _get_job_state(self, sky_job: dict) -> JobState:
+        """Gets the JobState from a sky job."""
+        # See sky job states here:
+        # https://skypilot.readthedocs.io/en/latest/reference/cli.html#sky-jobs-queue
+        status = str(sky_job["status"])
+        failed_states = {
+            "JobStatus.FAILED",
+            "JobStatus.FAILED_SETUP",
+            "JobStatus.FAILED_NO_RESOURCE",
+            "JobStatus.FAILED_CONTROLLER",
+        }
+        if status == "JobStatus.SUCCEEDED":
+            return JobState.SUCCEEDED
+        elif status == "JobStatus.CANCELLED":
+            return JobState.CANCELLED
+        elif status in failed_states:
+            return JobState.FAILED
+        return JobState.PENDING
+
     def _convert_sky_job_to_status(self, sky_job: dict) -> JobStatus:
         """Converts a sky job to a JobStatus."""
         required_fields = ["job_id", "job_name", "status"]
         for field in required_fields:
             if field not in sky_job:
                 raise ValueError(f"Missing required field: {field}")
+        state = self._get_job_state(sky_job)
         return JobStatus(
             id=str(sky_job["job_id"]),
             name=str(sky_job["job_name"]),
             status=str(sky_job["status"]),
             cluster=self.name(),
             metadata="",
-            # See sky job states here:
-            # https://skypilot.readthedocs.io/en/latest/reference/cli.html#sky-jobs-queue
-            done=str(sky_job["status"])
-            not in [
-                "JobStatus.PENDING",
-                "JobStatus.SUBMITTED",
-                "JobStatus.STARTING",
-                "JobStatus.RUNNING",
-                "JobStatus.RECOVERING",
-                "JobStatus.CANCELLING",
-            ],
+            done=state == JobState.SUCCEEDED
+            or state == JobState.FAILED
+            or state == JobState.CANCELLED,
+            state=state,
         )
 
     def name(self) -> str:

--- a/src/oumi/launcher/clusters/sky_cluster.py
+++ b/src/oumi/launcher/clusters/sky_cluster.py
@@ -52,6 +52,8 @@ class SkyCluster(BaseCluster):
             return JobState.SUCCEEDED
         elif status == "JobStatus.CANCELLED":
             return JobState.CANCELLED
+        elif status == "JobStatus.RUNNING":
+            return JobState.RUNNING
         elif status in failed_states:
             return JobState.FAILED
         return JobState.PENDING

--- a/tests/unit/cli/test_cli_launch.py
+++ b/tests/unit/cli/test_cli_launch.py
@@ -21,7 +21,7 @@ from oumi.core.configs import (
     TrainingConfig,
     TrainingParams,
 )
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher import JobConfig, JobResources
 from oumi.utils.logging import logger
 
@@ -195,6 +195,7 @@ def test_launch_up_job(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -204,6 +205,7 @@ def test_launch_up_job(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -240,6 +242,7 @@ def test_launch_up_job_with_alias(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -249,6 +252,7 @@ def test_launch_up_job_with_alias(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -287,6 +291,7 @@ def test_launch_up_job_dev_confirm(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -296,6 +301,7 @@ def test_launch_up_job_dev_confirm(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -331,6 +337,7 @@ def test_launch_up_job_dev_no_confirm(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -340,6 +347,7 @@ def test_launch_up_job_dev_no_confirm(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -375,6 +383,7 @@ def test_launch_up_job_dev_no_confirm_same_path(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -384,6 +393,7 @@ def test_launch_up_job_dev_no_confirm_same_path(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -417,6 +427,7 @@ def test_launch_up_job_no_working_dir(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -426,6 +437,7 @@ def test_launch_up_job_no_working_dir(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -459,6 +471,7 @@ def test_launch_up_job_existing_cluster(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.run.return_value = job_status
         mock_cluster.get_job.return_value = JobStatus(
@@ -468,6 +481,7 @@ def test_launch_up_job_existing_cluster(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         mock_cloud = Mock()
         mock_launcher.get_cloud.return_value = mock_cloud
@@ -505,6 +519,7 @@ def test_launch_up_job_detach(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -514,6 +529,7 @@ def test_launch_up_job_detach(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -547,6 +563,7 @@ def test_launch_up_job_detached_local(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -556,6 +573,7 @@ def test_launch_up_job_detached_local(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -595,6 +613,7 @@ def test_launch_up_job_sky_logs(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -604,6 +623,7 @@ def test_launch_up_job_sky_logs(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -635,6 +655,7 @@ def test_launch_up_job_not_found(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_launcher.up.return_value = (mock_cluster, job_status)
         mock_cluster.get_job.return_value = job_status = JobStatus(
@@ -644,6 +665,7 @@ def test_launch_up_job_not_found(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         with pytest.raises(FileNotFoundError) as exception_info:
             res = runner.invoke(
@@ -678,6 +700,7 @@ def test_launch_run_job(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -690,6 +713,7 @@ def test_launch_run_job(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -733,6 +757,7 @@ def test_launch_run_job_with_alias(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -745,6 +770,7 @@ def test_launch_run_job_with_alias(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -790,6 +816,7 @@ def test_launch_run_job_dev_confirm(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -802,6 +829,7 @@ def test_launch_run_job_dev_confirm(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -843,6 +871,7 @@ def test_launch_run_job_dev_no_confirm(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -855,6 +884,7 @@ def test_launch_run_job_dev_no_confirm(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -893,6 +923,7 @@ def test_launch_run_job_detached(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -905,6 +936,7 @@ def test_launch_run_job_detached(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -943,6 +975,7 @@ def test_launch_run_job_detached_local(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -955,6 +988,7 @@ def test_launch_run_job_detached_local(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         _ = runner.invoke(
             app,
@@ -991,6 +1025,7 @@ def test_launch_run_job_no_cluster(
             status="running",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud = Mock()
         mock_launcher.run.return_value = job_status
@@ -1003,6 +1038,7 @@ def test_launch_run_job_no_cluster(
             status="done",
             metadata="",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         with pytest.raises(
             ValueError, match="No cluster specified for the `run` action."

--- a/tests/unit/launcher/clients/data/qstat.txt
+++ b/tests/unit/launcher/clients/data/qstat.txt
@@ -9,7 +9,7 @@ Job ID                         Username        Queue           Jobname         S
    Not Running: Not enough free nodes available and terminated
 2017652.polaris-pbs-01.hsn.cm* matthew         debug           example_job.sh   2354947    1    64    --  00:10 F 00:00:43
    Job run at Wed Jul 10 at 23:28 on (x3006c0s19b1n0:ncpus=64) and failed
-2017654.polaris-pbs-01.hsn.cm* matthew         debug           example_job.sh   2356268    1    64    --  00:10 F 00:00:42
+2017654.polaris-pbs-01.hsn.cm* matthew         debug           example_job.sh   2356268    1    64    --  00:10 E 00:00:42
    Job run at Wed Jul 10 at 23:33 on (x3006c0s19b1n0:ncpus=64) and failed
 2018469.polaris-pbs-01.hsn.cm* matthew         debug           example_job.sh    504718    1    64    --  00:10 F 00:00:44
    Job run at Thu Jul 11 at 16:26 on (x3004c0s37b0n0:ncpus=64) and failed

--- a/tests/unit/launcher/clients/test_local_client.py
+++ b/tests/unit/launcher/clients/test_local_client.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.local_client import LocalClient
 
 
@@ -101,7 +101,13 @@ def test_local_client_submit_job(mock_thread):
     job = _get_default_job()
     job_status = client.submit_job(job)
     expected_status = JobStatus(
-        id="0", name=str(job.name), cluster="", status="QUEUED", metadata="", done=False
+        id="0",
+        name=str(job.name),
+        cluster="",
+        status="QUEUED",
+        metadata="",
+        done=False,
+        state=JobState.PENDING,
     )
     assert job_status == expected_status
     assert client.list_jobs() == [expected_status]
@@ -137,6 +143,7 @@ pip install -r requirements.txt
         status="COMPLETED",
         metadata=f"Job finished at {datetime.fromtimestamp(10).isoformat()} .",
         done=True,
+        state=JobState.SUCCEEDED,
     )
     assert job_status == expected_status
     assert client.list_jobs() == [expected_status]
@@ -188,6 +195,7 @@ pip install -r requirements.txt
             metadata=f"Job finished at {datetime.fromtimestamp(10).isoformat()} ."
             f" Logs available at: {output_temp_dir}/1970_01_01_00_00_10_123_0.stdout",
             done=True,
+            state=JobState.SUCCEEDED,
         )
         assert job_status == expected_status
         assert client.list_jobs() == [expected_status]
@@ -246,6 +254,7 @@ echo 'hello'"""
         status="COMPLETED",
         metadata=f"Job finished at {datetime.fromtimestamp(10).isoformat()} .",
         done=True,
+        state=JobState.SUCCEEDED,
     )
     second_expected_status = JobStatus(
         id="1",
@@ -254,6 +263,7 @@ echo 'hello'"""
         status="FAILED",
         metadata="a" * 1024,
         done=True,
+        state=JobState.FAILED,
     )
     assert job_status == expected_status
     assert second_job_status == second_expected_status

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.sky_client import (
     SkyClient,
     _convert_job_to_task,
@@ -169,6 +169,7 @@ def test_sky_client_launch(
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(
@@ -198,6 +199,7 @@ def test_sky_client_launch_no_stop(
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(
@@ -223,6 +225,7 @@ def test_sky_client_launch_kwarg(mock_sky_data_storage):
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(
@@ -248,6 +251,7 @@ def test_sky_client_launch_kwarg_value(mock_sky_data_storage):
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(
@@ -273,6 +277,7 @@ def test_sky_client_launch_unused_kwarg(mock_sky_data_storage):
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(
@@ -298,6 +303,7 @@ def test_sky_client_launch_with_cluster_name(mock_sky_data_storage):
             status="",
             metadata="",
             done=False,
+            state=JobState.PENDING,
         )
         assert job_status == expected_job_status
         mock_launch.assert_called_once_with(

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient
 
 _CTRL_PATH: str = "-S ~/.ssh/control-%h-%p-%r"
@@ -440,6 +440,7 @@ def test_slurm_client_get_job_success(mock_subprocess):
             "                             6                           test                         taenin                      COMPLETED                           None"  # noqa: E501
         ),
         done=True,
+        state=JobState.SUCCEEDED,
     )
     assert job_status == expected_status
 
@@ -476,6 +477,7 @@ def test_slurm_client_get_job_success_one_job(mock_subprocess):
             "                             6                           test                         taenin                      COMPLETED                           None"  # noqa: E501
         ),
         done=True,
+        state=JobState.SUCCEEDED,
     )
     assert job_status == expected_status
 
@@ -596,6 +598,7 @@ def test_slurm_client_cancel_success(mock_subprocess):
             "                       7.batch                          batch                                                       RUNNING"  # noqa: E501
         ),
         done=False,
+        state=JobState.PENDING,
     )
     assert job_status == expected_status
 

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -598,7 +598,7 @@ def test_slurm_client_cancel_success(mock_subprocess):
             "                       7.batch                          batch                                                       RUNNING"  # noqa: E501
         ),
         done=False,
-        state=JobState.PENDING,
+        state=JobState.RUNNING,
     )
     assert job_status == expected_status
 

--- a/tests/unit/launcher/clouds/test_frontier_cloud.py
+++ b/tests/unit/launcher/clouds/test_frontier_cloud.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.launcher.clients.slurm_client import SlurmClient
 from oumi.launcher.clouds.frontier_cloud import FrontierCloud
@@ -73,6 +73,7 @@ def test_frontier_cloud_up_cluster_extended(mock_slurm_client, mock_frontier_clu
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("frontier")
@@ -97,6 +98,7 @@ def test_frontier_cloud_up_cluster_batch(mock_slurm_client, mock_frontier_cluste
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("frontier")
@@ -133,6 +135,7 @@ def test_frontier_cloud_up_cluster_default_queue(
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("frontier")

--- a/tests/unit/launcher/clouds/test_local_cloud.py
+++ b/tests/unit/launcher/clouds/test_local_cloud.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.launcher.clients.local_client import LocalClient
 from oumi.launcher.clouds.local_cloud import LocalCloud
@@ -72,6 +72,7 @@ def test_local_cloud_up_cluster(mock_local_client, mock_local_cluster):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("local")
@@ -95,6 +96,7 @@ def test_local_cloud_up_cluster_no_name(mock_local_client, mock_local_cluster):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("local")

--- a/tests/unit/launcher/clouds/test_polaris_cloud.py
+++ b/tests/unit/launcher/clouds/test_polaris_cloud.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.launcher.clients.polaris_client import PolarisClient
 from oumi.launcher.clouds.polaris_cloud import PolarisCloud
@@ -73,6 +73,7 @@ def test_polaris_cloud_up_cluster_debug(mock_polaris_client, mock_polaris_cluste
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")
@@ -95,6 +96,7 @@ def test_polaris_cloud_up_cluster_demand(mock_polaris_client, mock_polaris_clust
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")
@@ -119,6 +121,7 @@ def test_polaris_cloud_up_cluster_debug_scaling(
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")
@@ -143,6 +146,7 @@ def test_polaris_cloud_up_cluster_preemptable(
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")
@@ -165,6 +169,7 @@ def test_polaris_cloud_up_cluster_prod(mock_polaris_client, mock_polaris_cluster
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")
@@ -197,6 +202,7 @@ def test_polaris_cloud_up_cluster_default_queue(
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("polaris")

--- a/tests/unit/launcher/clouds/test_sky_cloud.py
+++ b/tests/unit/launcher/clouds/test_sky_cloud.py
@@ -4,7 +4,7 @@ import pytest
 import sky
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.launcher.clients.sky_client import SkyClient
 from oumi.launcher.clouds.sky_cloud import SkyCloud
@@ -71,6 +71,7 @@ def test_sky_cloud_up_cluster(mock_sky_client, mock_sky_cluster):
         status="",
         metadata="",
         done=False,
+        state=JobState.PENDING,
     )
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
@@ -142,6 +143,7 @@ def test_sky_cloud_up_cluster_kwargs(mock_sky_client, mock_sky_cluster):
         status="",
         metadata="",
         done=False,
+        state=JobState.PENDING,
     )
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()
@@ -205,6 +207,7 @@ def test_sky_cloud_up_cluster_no_name(mock_sky_client, mock_sky_cluster):
         status="",
         metadata="",
         done=False,
+        state=JobState.PENDING,
     )
     mock_gcp_cluster = Mock(spec=sky.clouds.GCP)
     mock_gcp_handler = Mock()

--- a/tests/unit/launcher/clouds/test_slurm_cloud.py
+++ b/tests/unit/launcher/clouds/test_slurm_cloud.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.launcher.clients.slurm_client import SlurmClient
 from oumi.launcher.clouds.slurm_cloud import SlurmCloud
@@ -91,6 +91,7 @@ def test_slurm_cloud_up_cluster(mock_slurm_client, mock_slurm_cluster):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cluster.run_job.return_value = expected_job_status
     job = _get_default_job("slurm")

--- a/tests/unit/launcher/clusters/test_frontier_cluster.py
+++ b/tests/unit/launcher/clusters/test_frontier_cluster.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient
 from oumi.launcher.clusters.frontier_cluster import FrontierCluster
 
@@ -123,6 +123,7 @@ def test_frontier_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -131,6 +132,7 @@ def test_frontier_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -139,6 +141,7 @@ def test_frontier_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("myjob")
@@ -166,6 +169,7 @@ def test_frontier_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -174,6 +178,7 @@ def test_frontier_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -182,6 +187,7 @@ def test_frontier_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("wrong job")
@@ -199,6 +205,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -207,6 +214,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -215,6 +223,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     jobs = cluster.get_jobs()
@@ -227,6 +236,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -235,6 +245,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -243,6 +254,7 @@ def test_frontier_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     assert jobs == expected_jobs
@@ -267,6 +279,7 @@ def test_frontier_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -275,6 +288,7 @@ def test_frontier_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -283,6 +297,7 @@ def test_frontier_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job_status = cluster.cancel_job("job2")
@@ -293,6 +308,7 @@ def test_frontier_cluster_cancel_job(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="extended.name",
         done=False,
+        state=JobState.PENDING,
     )
     mock_slurm_client.cancel.assert_called_once_with("job2")
     assert job_status == expected_status
@@ -308,6 +324,7 @@ def test_frontier_cluster_cancel_job_fails(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="batch.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     with pytest.raises(RuntimeError):
@@ -328,6 +345,7 @@ def test_frontier_cluster_run_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -337,6 +355,7 @@ def test_frontier_cluster_run_job(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("frontier"))
     mock_slurm_client.put_recursive.assert_has_calls(
@@ -417,6 +436,7 @@ def test_frontier_cluster_run_job_with_conda_setup(mock_datetime, mock_slurm_cli
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -426,6 +446,7 @@ def test_frontier_cluster_run_job_with_conda_setup(mock_datetime, mock_slurm_cli
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("frontier"))
     mock_slurm_client.put_recursive.assert_has_calls(
@@ -497,6 +518,7 @@ def test_frontier_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -506,6 +528,7 @@ def test_frontier_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("frontier")
     job.name = None
@@ -588,6 +611,7 @@ def test_frontier_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -597,6 +621,7 @@ def test_frontier_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("frontier")
     job.file_mounts = {}
@@ -667,6 +692,7 @@ def test_frontier_cluster_run_job_no_sbatch(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -676,6 +702,7 @@ def test_frontier_cluster_run_job_no_sbatch(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("frontier")
     job.file_mounts = {}
@@ -738,6 +765,7 @@ def test_frontier_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -747,6 +775,7 @@ def test_frontier_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="batch.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("frontier")
     job.file_mounts = {}
@@ -806,6 +835,7 @@ def test_frontier_cluster_run_job_fails(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     with pytest.raises(RuntimeError):

--- a/tests/unit/launcher/clusters/test_local_cluster.py
+++ b/tests/unit/launcher/clusters/test_local_cluster.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.local_client import LocalClient
 from oumi.launcher.clusters.local_cluster import LocalCluster
 
@@ -74,6 +74,7 @@ def test_local_cluster_get_job_valid_id(mock_local_client):
             metadata="",
             cluster="",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -82,6 +83,7 @@ def test_local_cluster_get_job_valid_id(mock_local_client):
             metadata="",
             cluster="",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -90,6 +92,7 @@ def test_local_cluster_get_job_valid_id(mock_local_client):
             metadata="",
             cluster="",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("myjob")
@@ -101,6 +104,7 @@ def test_local_cluster_get_job_valid_id(mock_local_client):
         metadata="",
         cluster="name",
         done=False,
+        state=JobState.PENDING,
     )
 
 
@@ -122,6 +126,7 @@ def test_local_cluster_get_job_invalid_id_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -130,6 +135,7 @@ def test_local_cluster_get_job_invalid_id_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -138,6 +144,7 @@ def test_local_cluster_get_job_invalid_id_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("wrong job")
@@ -155,6 +162,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -163,6 +171,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -171,6 +180,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     jobs = cluster.get_jobs()
@@ -183,6 +193,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -191,6 +202,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -199,6 +211,7 @@ def test_local_cluster_get_jobs_nonempty(mock_local_client):
             metadata="",
             cluster="name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     assert jobs == expected_jobs
@@ -223,6 +236,7 @@ def test_local_cluster_cancel_job(mock_local_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -231,6 +245,7 @@ def test_local_cluster_cancel_job(mock_local_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -239,6 +254,7 @@ def test_local_cluster_cancel_job(mock_local_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job_status = cluster.cancel_job("job2")
@@ -249,6 +265,7 @@ def test_local_cluster_cancel_job(mock_local_client):
         metadata="",
         cluster="name",
         done=False,
+        state=JobState.PENDING,
     )
     mock_local_client.cancel.assert_called_once_with(
         "job2",
@@ -266,6 +283,7 @@ def test_local_cluster_cancel_job_fails(mock_local_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     with pytest.raises(RuntimeError, match="Job myjobid not found."):
@@ -281,6 +299,7 @@ def test_local_cluster_run_job(mock_local_client):
         metadata="",
         cluster="mycluster",
         done=False,
+        state=JobState.PENDING,
     )
     expected_status = JobStatus(
         id="1234",
@@ -289,6 +308,7 @@ def test_local_cluster_run_job(mock_local_client):
         metadata="",
         cluster="name",
         done=False,
+        state=JobState.PENDING,
     )
     expected_job = _get_default_job("local")
     job_status = cluster.run_job(expected_job)
@@ -307,6 +327,7 @@ def test_local_cluster_run_job_no_name(mock_local_client):
         metadata="",
         cluster="mycluster",
         done=False,
+        state=JobState.PENDING,
     )
     expected_status = JobStatus(
         id="1234",
@@ -315,6 +336,7 @@ def test_local_cluster_run_job_no_name(mock_local_client):
         metadata="",
         cluster="name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("local")
     job.name = None
@@ -342,6 +364,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -350,6 +373,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -358,6 +382,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -368,6 +393,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -376,6 +402,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -384,6 +411,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -394,6 +422,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -402,6 +431,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -410,6 +440,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -420,6 +451,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -428,6 +460,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -436,6 +469,7 @@ def test_local_cluster_down(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     ]
@@ -458,6 +492,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -466,6 +501,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -474,6 +510,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -484,6 +521,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -492,6 +530,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -500,6 +539,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -510,6 +550,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -518,6 +559,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -526,6 +568,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         [
@@ -536,6 +579,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="job2",
@@ -544,6 +588,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="final job",
@@ -552,6 +597,7 @@ def test_local_cluster_stop(mock_local_client):
                 metadata="",
                 cluster="",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     ]

--- a/tests/unit/launcher/clusters/test_polaris_cluster.py
+++ b/tests/unit/launcher/clusters/test_polaris_cluster.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.polaris_client import PolarisClient
 from oumi.launcher.clusters.polaris_cluster import PolarisCluster
 
@@ -101,6 +101,7 @@ def test_polaris_cluster_get_job_valid_id(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -109,6 +110,7 @@ def test_polaris_cluster_get_job_valid_id(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -117,6 +119,7 @@ def test_polaris_cluster_get_job_valid_id(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("myjob")
@@ -150,6 +153,7 @@ def test_polaris_cluster_get_job_invalid_id_nonempty(
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -158,6 +162,7 @@ def test_polaris_cluster_get_job_invalid_id_nonempty(
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -166,6 +171,7 @@ def test_polaris_cluster_get_job_invalid_id_nonempty(
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("wrong job")
@@ -185,6 +191,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -193,6 +200,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -201,6 +209,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     jobs = cluster.get_jobs()
@@ -215,6 +224,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -223,6 +233,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -231,6 +242,7 @@ def test_polaris_cluster_get_jobs_nonempty(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     assert jobs == expected_jobs
@@ -257,6 +269,7 @@ def test_polaris_cluster_cancel_job(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -265,6 +278,7 @@ def test_polaris_cluster_cancel_job(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -273,6 +287,7 @@ def test_polaris_cluster_cancel_job(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job_status = cluster.cancel_job("job2")
@@ -283,6 +298,7 @@ def test_polaris_cluster_cancel_job(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="prod.name",
         done=False,
+        state=JobState.PENDING,
     )
     mock_polaris_client.cancel.assert_called_once_with(
         "job2",
@@ -301,6 +317,7 @@ def test_polaris_cluster_cancel_job_fails(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="debug.name",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     with pytest.raises(RuntimeError):
@@ -321,6 +338,7 @@ def test_polaris_cluster_run_job(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -330,6 +348,7 @@ def test_polaris_cluster_run_job(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("polaris"))
     mock_polaris_client.put_recursive.assert_has_calls(
@@ -416,6 +435,7 @@ def test_polaris_cluster_run_job_no_working_dir(mock_datetime, mock_polaris_clie
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -425,6 +445,7 @@ def test_polaris_cluster_run_job_no_working_dir(mock_datetime, mock_polaris_clie
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job_config = _get_default_job("polaris")
     job_config.working_dir = None
@@ -507,6 +528,7 @@ def test_polaris_cluster_run_job_with_conda_setup(mock_datetime, mock_polaris_cl
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -516,6 +538,7 @@ def test_polaris_cluster_run_job_with_conda_setup(mock_datetime, mock_polaris_cl
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("polaris"))
     mock_polaris_client.put_recursive.assert_has_calls(
@@ -602,6 +625,7 @@ def test_polaris_cluster_run_job_no_name(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -611,6 +635,7 @@ def test_polaris_cluster_run_job_no_name(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("polaris")
     job.name = None
@@ -703,6 +728,7 @@ def test_polaris_cluster_run_job_no_mounts(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -712,6 +738,7 @@ def test_polaris_cluster_run_job_no_mounts(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("polaris")
     job.file_mounts = {}
@@ -792,6 +819,7 @@ def test_polaris_cluster_run_job_no_pbs(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -801,6 +829,7 @@ def test_polaris_cluster_run_job_no_pbs(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("polaris")
     job.file_mounts = {}
@@ -873,6 +902,7 @@ def test_polaris_cluster_run_job_no_setup(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -882,6 +912,7 @@ def test_polaris_cluster_run_job_no_setup(mock_datetime, mock_polaris_client):
         metadata="",
         cluster="debug.name",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("polaris")
     job.file_mounts = {}
@@ -951,6 +982,7 @@ def test_polaris_cluster_run_job_fails(mock_datetime, mock_polaris_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     with pytest.raises(RuntimeError):

--- a/tests/unit/launcher/clusters/test_sky_cluster.py
+++ b/tests/unit/launcher/clusters/test_sky_cluster.py
@@ -132,7 +132,7 @@ def test_sky_cluster_get_jobs_nonempty(mock_sky_client):
             metadata="",
             cluster="mycluster",
             done=False,
-            state=JobState.PENDING,
+            state=JobState.RUNNING,
         ),
         JobStatus(
             id="myjob",

--- a/tests/unit/launcher/clusters/test_sky_cluster.py
+++ b/tests/unit/launcher/clusters/test_sky_cluster.py
@@ -4,7 +4,7 @@ import pytest
 import sky.exceptions
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.sky_client import SkyClient
 from oumi.launcher.clusters.sky_cluster import SkyCluster
 
@@ -132,6 +132,7 @@ def test_sky_cluster_get_jobs_nonempty(mock_sky_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="myjob",
@@ -140,6 +141,7 @@ def test_sky_cluster_get_jobs_nonempty(mock_sky_client):
             metadata="",
             cluster="mycluster",
             done=True,
+            state=JobState.CANCELLED,
         ),
         JobStatus(
             id="myjob3",
@@ -148,6 +150,7 @@ def test_sky_cluster_get_jobs_nonempty(mock_sky_client):
             metadata="",
             cluster="mycluster",
             done=True,
+            state=JobState.FAILED,
         ),
     ]
     assert jobs == expected_jobs
@@ -190,6 +193,7 @@ def test_sky_cluster_cancel_job(mock_sky_client):
         metadata="",
         cluster="mycluster",
         done=True,
+        state=JobState.FAILED,
     )
     mock_sky_client.cancel.assert_called_once_with("mycluster", "myjobid")
     assert job_status == expected_status
@@ -225,6 +229,7 @@ def test_sky_cluster_run_job(mock_sky_client):
         metadata="",
         cluster="mycluster",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("gcp"))
     mock_sky_client.exec.assert_called_once_with(ANY, "mycluster")

--- a/tests/unit/launcher/clusters/test_slurm_cluster.py
+++ b/tests/unit/launcher/clusters/test_slurm_cluster.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import JobStatus
+from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient
 from oumi.launcher.clusters.slurm_cluster import SlurmCluster
 
@@ -171,6 +171,7 @@ def test_slurm_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -179,6 +180,7 @@ def test_slurm_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -187,6 +189,7 @@ def test_slurm_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("myjob")
@@ -214,6 +217,7 @@ def test_slurm_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_cli
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -222,6 +226,7 @@ def test_slurm_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_cli
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -230,6 +235,7 @@ def test_slurm_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_cli
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job = cluster.get_job("wrong job")
@@ -247,6 +253,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -255,6 +262,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -263,6 +271,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     jobs = cluster.get_jobs()
@@ -275,6 +284,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -283,6 +293,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -291,6 +302,7 @@ def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     assert jobs == expected_jobs
@@ -315,6 +327,7 @@ def test_slurm_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="job2",
@@ -323,6 +336,7 @@ def test_slurm_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="final job",
@@ -331,6 +345,7 @@ def test_slurm_cluster_cancel_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     job_status = cluster.cancel_job("job2")
@@ -341,6 +356,7 @@ def test_slurm_cluster_cancel_job(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="prod@host",
         done=False,
+        state=JobState.PENDING,
     )
     mock_slurm_client.cancel.assert_called_once_with(
         "job2",
@@ -358,6 +374,7 @@ def test_slurm_cluster_cancel_job_fails(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="debug@host",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     with pytest.raises(RuntimeError):
@@ -378,6 +395,7 @@ def test_slurm_cluster_run_job(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -387,6 +405,7 @@ def test_slurm_cluster_run_job(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("slurm"))
     mock_slurm_client.put_recursive.assert_has_calls(
@@ -442,6 +461,7 @@ def test_slurm_cluster_run_job_no_working_dir(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -451,6 +471,7 @@ def test_slurm_cluster_run_job_no_working_dir(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job_config = _get_default_job("slurm")
     job_config.working_dir = None
@@ -507,6 +528,7 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
                 metadata="",
                 cluster="mycluster",
                 done=False,
+                state=JobState.PENDING,
             )
         ],
         [
@@ -517,6 +539,7 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
                 metadata="",
                 cluster="mycluster",
                 done=False,
+                state=JobState.PENDING,
             )
         ],
     ]
@@ -527,6 +550,7 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job_status = cluster.run_job(_get_default_job("slurm"))
     mock_slurm_client.put_recursive.assert_has_calls(
@@ -583,6 +607,7 @@ def test_slurm_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -592,6 +617,7 @@ def test_slurm_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("slurm")
     job.name = None
@@ -653,6 +679,7 @@ def test_slurm_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -662,6 +689,7 @@ def test_slurm_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("slurm")
     job.file_mounts = {}
@@ -711,6 +739,7 @@ def test_slurm_cluster_run_job_no_pbs(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -720,6 +749,7 @@ def test_slurm_cluster_run_job_no_pbs(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("slurm")
     job.file_mounts = {}
@@ -767,6 +797,7 @@ def test_slurm_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     expected_status = JobStatus(
@@ -776,6 +807,7 @@ def test_slurm_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
         metadata="",
         cluster="debug@host",
         done=False,
+        state=JobState.PENDING,
     )
     job = _get_default_job("slurm")
     job.file_mounts = {}
@@ -820,6 +852,7 @@ def test_slurm_cluster_run_job_fails(mock_time, mock_datetime, mock_slurm_client
             metadata="",
             cluster="mycluster",
             done=False,
+            state=JobState.PENDING,
         )
     ]
     with pytest.raises(RuntimeError):

--- a/tests/unit/launcher/test_launcher.py
+++ b/tests/unit/launcher/test_launcher.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from oumi.core.configs import JobConfig, JobResources, StorageMount
-from oumi.core.launcher import BaseCloud, BaseCluster, JobStatus
+from oumi.core.launcher import BaseCloud, BaseCluster, JobState, JobStatus
 from oumi.launcher.launcher import (
     LAUNCHER,
     Launcher,
@@ -159,6 +159,7 @@ def test_launcher_up_succeeds(mock_registry):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cloud.up_cluster.return_value = expected_job_status
     mock_cloud.get_cluster.return_value = mock_cluster
@@ -187,6 +188,7 @@ def test_launcher_up_succeeds_kwargs(mock_registry):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cloud.up_cluster.return_value = expected_job_status
     mock_cloud.get_cluster.return_value = mock_cluster
@@ -215,6 +217,7 @@ def test_launcher_up_succeeds_no_name(mock_registry):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cloud.up_cluster.return_value = expected_job_status
     mock_cloud.get_cluster.return_value = mock_cluster
@@ -243,6 +246,7 @@ def test_launcher_up_inavlid_cluster(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         )
         mock_cloud.up_cluster.return_value = expected_job_status
         mock_cloud.get_cluster.return_value = None
@@ -269,6 +273,7 @@ def test_launcher_run_succeeds(mock_registry):
         status="running",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cloud.get_cluster.return_value = mock_cluster
     mock_cluster.run_job.return_value = expected_job_status
@@ -314,6 +319,7 @@ def test_launcher_cancel_succeeds(mock_registry):
         status="canceled",
         metadata="bar",
         done=False,
+        state=JobState.PENDING,
     )
     mock_cloud.get_cluster.return_value = mock_cluster
     mock_cluster.cancel_job.return_value = expected_job_status
@@ -401,6 +407,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -409,6 +416,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -420,6 +428,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -431,6 +440,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -444,6 +454,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -465,6 +476,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="2",
@@ -473,6 +485,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -481,6 +494,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         "polaris": [
@@ -491,6 +505,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -499,6 +514,7 @@ def test_launcher_status_multiple_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     }
@@ -533,6 +549,7 @@ def test_launcher_status_filters_clusters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -541,6 +558,7 @@ def test_launcher_status_filters_clusters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -553,6 +571,7 @@ def test_launcher_status_filters_clusters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -565,6 +584,7 @@ def test_launcher_status_filters_clusters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -580,6 +600,7 @@ def test_launcher_status_filters_clusters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -601,6 +622,7 @@ def test_launcher_status_filters_clusters(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="2",
@@ -609,6 +631,7 @@ def test_launcher_status_filters_clusters(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         "polaris": [],
@@ -643,6 +666,7 @@ def test_launcher_status_filters_jobs(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -651,6 +675,7 @@ def test_launcher_status_filters_jobs(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -662,6 +687,7 @@ def test_launcher_status_filters_jobs(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -673,6 +699,7 @@ def test_launcher_status_filters_jobs(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -686,6 +713,7 @@ def test_launcher_status_filters_jobs(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -707,6 +735,7 @@ def test_launcher_status_filters_jobs(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -715,6 +744,7 @@ def test_launcher_status_filters_jobs(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         "polaris": [
@@ -725,6 +755,7 @@ def test_launcher_status_filters_jobs(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -733,6 +764,7 @@ def test_launcher_status_filters_jobs(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     }
@@ -766,6 +798,7 @@ def test_launcher_status_filters_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -774,6 +807,7 @@ def test_launcher_status_filters_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -785,6 +819,7 @@ def test_launcher_status_filters_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -796,6 +831,7 @@ def test_launcher_status_filters_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -809,6 +845,7 @@ def test_launcher_status_filters_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -829,6 +866,7 @@ def test_launcher_status_filters_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="2",
@@ -837,6 +875,7 @@ def test_launcher_status_filters_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -845,6 +884,7 @@ def test_launcher_status_filters_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     }
@@ -879,6 +919,7 @@ def test_launcher_status_all_filters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -887,6 +928,7 @@ def test_launcher_status_all_filters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -899,6 +941,7 @@ def test_launcher_status_all_filters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -911,6 +954,7 @@ def test_launcher_status_all_filters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -926,6 +970,7 @@ def test_launcher_status_all_filters(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -946,6 +991,7 @@ def test_launcher_status_all_filters(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     }
@@ -983,6 +1029,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
         JobStatus(
             id="2",
@@ -991,6 +1038,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_sky_cluster2 = Mock(spec=BaseCluster)
@@ -1002,6 +1050,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster1 = Mock(spec=BaseCluster)
@@ -1013,6 +1062,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     mock_polaris_cluster2 = Mock(spec=BaseCluster)
@@ -1026,6 +1076,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
             status="running",
             metadata="bar",
             done=False,
+            state=JobState.PENDING,
         ),
     ]
     sky_mock.list_clusters.return_value = [mock_sky_cluster1, mock_sky_cluster2]
@@ -1051,6 +1102,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="2",
@@ -1059,6 +1111,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -1067,6 +1120,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
         "polaris": [
@@ -1077,6 +1131,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
             JobStatus(
                 id="1",
@@ -1085,6 +1140,7 @@ def test_launcher_status_inits_new_clouds(mock_registry):
                 status="running",
                 metadata="bar",
                 done=False,
+                state=JobState.PENDING,
             ),
         ],
     }


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

Previously the oumi launcher only exposed a `done` enum, as well as a string for status parsing. This PR adds an enum `state` to easily check if a job is `pending`, `failed`, `succeeded`, or `cancelled`.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
