### PR TITLE
Run GitHub workflows in merge queue instead of on PR events

### DIFF
--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 */8 * * *' # Every 8 hours
   workflow_dispatch:
-  pull_request:
+  merge_group:
     paths:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/gpu_install_test.yaml
+++ b/.github/workflows/gpu_install_test.yaml
@@ -4,7 +4,7 @@ permissions:
     contents: 'read'
 
 on:
-  pull_request:
+  merge_group:
     paths:
       - 'pyproject.toml'
       - '.github/workflows/**'

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 */8 * * *' # Every 8 hours
   workflow_dispatch:
-  pull_request:
+  merge_group:
     paths-ignore:
       - 'docs/**'
       - 'notebooks/**'

--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -4,7 +4,7 @@ permissions:
     contents: 'read'
 
 on:
-  pull_request:
+  merge_group:
     paths:
       - 'pyproject.toml'
       - '.github/workflows/**'

--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 */8 * * *' # Every 8 hours
   workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'notebooks/**'
+      - 'scripts/**'
+      - 'README.md'
   merge_group:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 */8 * * *' # Every 8 hours
   workflow_dispatch:
-  pull_request:
+  merge_group:
     paths-ignore:
       - 'docs/**'
       - 'notebooks/**'

--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -9,7 +9,7 @@ on:
         description: 'Docker image tag (defaults to release tag or "manual")'
         required: false
         type: string
-  pull_request:
+  merge_group:
     paths:
       - 'Dockerfile'
 

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       index:
-        description: "Target index (pypi or testpypi)"
+        description: 'Target index (pypi or testpypi)'
         required: true
-        default: "testpypi"
+        default: 'testpypi'
         type: choice
         options:
           - testpypi
@@ -26,33 +26,33 @@ jobs:
       name: pypi
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build
 
-      - name: Build package
-        run: python -m build
+    - name: Build package
+      run: python -m build
 
-      - name: Check distribution
-        run: |
-          twine check dist/*
-          if [ $? -ne 0 ]; then
-            echo "Invalid distribution files"
-            exit 1
-          fi
+    - name: Check distribution
+      run: |
+        twine check dist/*
+        if [ $? -ne 0 ]; then
+          echo "Invalid distribution files"
+          exit 1
+        fi
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: ${{ github.event.inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
-          packages-dir: dist/
-          verbose: true
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ github.event.inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+        packages-dir: dist/
+        verbose: true

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       index:
-        description: 'Target index (pypi or testpypi)'
+        description: "Target index (pypi or testpypi)"
         required: true
-        default: 'testpypi'
+        default: "testpypi"
         type: choice
         options:
           - testpypi
@@ -26,33 +26,33 @@ jobs:
       name: pypi
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: "Set up Python"
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine build
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build
 
-    - name: Build package
-      run: python -m build
+      - name: Build package
+        run: python -m build
 
-    - name: Check distribution
-      run: |
-        twine check dist/*
-        if [ $? -ne 0 ]; then
-          echo "Invalid distribution files"
-          exit 1
-        fi
+      - name: Check distribution
+        run: |
+          twine check dist/*
+          if [ $? -ne 0 ]; then
+            echo "Invalid distribution files"
+            exit 1
+          fi
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: ${{ github.event.inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
-        packages-dir: dist/
-        verbose: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ github.event.inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          packages-dir: dist/
+          verbose: true


### PR DESCRIPTION
# Description

Currently, our test workflows are run whenever a PR is opened, synchronize, or reopened. This is eating into our quota. This PR instead has those tests run in a merge queue when the PR is submitted (with the exception of pretest.yaml, which we keep running for PR updates). The user is still able to run tests manually before the PR is submitted with the `workflow_dispatch` hook.

Documentation: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request

## Related issues

Fixes OPE-1512

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
