### PR TITLE
[tiny] Remove `add_special_tokens` kwarg from vision DPO dataset processor

### DIFF
--- a/src/oumi/core/datasets/vision_language_dpo_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dpo_dataset.py
@@ -257,9 +257,7 @@ class VisionLanguageDpoDataset(BaseDpoDataset):
         rejected = prompt_rejected[len(prompt) :]
 
         # Tokenize the prompt, chosen, and rejected turns.
-        processed_features = self._processor(
-            images=features["images"], text=[prompt], add_special_tokens=False
-        )
+        processed_features = self._processor(images=features["images"], text=[prompt])
 
         prompt_input_ids = self._drop_first_dim_if_needed(
             "input_ids", processed_features["input_ids"]


### PR DESCRIPTION
# Description

This causes an error for Phi3 DPO because it's not a kwarg for the Phi3 processor: https://huggingface.co/microsoft/Phi-3-vision-128k-instruct/blob/main/processing_phi3_v.py#L58. It's not in the Qwen2 VL processor either: https://github.com/huggingface/transformers/blob/e3d8fd730ed063a88edc49ed5f3c8acfabb53368/src/transformers/models/qwen2_vl/processing_qwen2_vl.py#L93

## Related issues

Towards OPE-1524

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
