### PR TITLE
Fix default train configs save final model

### DIFF
--- a/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/ddp/train.yaml
@@ -38,6 +38,7 @@ data:
     target_col: "text"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # or OUMI
   save_steps: 500
   # If gradient checkpointing is enabled: use 12 (~94% of 40GB VRAM)

--- a/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
+++ b/configs/examples/fineweb_ablation_pretraining/fsdp/train.yaml
@@ -38,6 +38,7 @@ data:
     target_col: "text"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 500
   per_device_train_batch_size: 14

--- a/configs/examples/gkd/train.yaml
+++ b/configs/examples/gkd/train.yaml
@@ -19,6 +19,7 @@ data:
           return_conversations_format: "dict" # required for TRL_GKD trainer
 
 training:
+  save_final_model: True
   trainer_type: "TRL_GKD"
   output_dir: "output/gkd_smollm_test_responses"
 

--- a/configs/examples/grpo_tldr/train.yaml
+++ b/configs/examples/grpo_tldr/train.yaml
@@ -25,6 +25,7 @@ data:
         split: "train"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_GRPO"
   save_steps: 500
   per_device_train_batch_size: 2 # 1 for GPUs with 24GB VRAM

--- a/configs/examples/grpo_verl_countdown/train.yaml
+++ b/configs/examples/grpo_verl_countdown/train.yaml
@@ -26,6 +26,7 @@ data:
         split: "test"
 
 training:
+  save_final_model: True
   trainer_type: "VERL_GRPO"
   num_train_epochs: 1
   save_steps: -1

--- a/configs/examples/grpo_verl_geometry3k/train.yaml
+++ b/configs/examples/grpo_verl_geometry3k/train.yaml
@@ -41,6 +41,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   trainer_type: "VERL_GRPO"
   num_train_epochs: 5
   save_steps: 150

--- a/configs/examples/grpo_verl_gsm8k/train.yaml
+++ b/configs/examples/grpo_verl_gsm8k/train.yaml
@@ -25,6 +25,7 @@ data:
         split: "test"
 
 training:
+  save_final_model: True
   trainer_type: "VERL_GRPO"
   num_train_epochs: 15
   save_steps: 10

--- a/configs/examples/letter_counting/grpo/train.yaml
+++ b/configs/examples/letter_counting/grpo/train.yaml
@@ -27,6 +27,7 @@ data:
         split: "train"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_GRPO"
   save_steps: 500
   max_steps: 500

--- a/configs/projects/aya/sft/train.yaml
+++ b/configs/projects/aya/sft/train.yaml
@@ -38,6 +38,7 @@ data:
     target_col: ${data.train.target_col}
 
 training:
+  save_final_model: True
   optimizer: "adafactor"
   use_peft: False
   output_dir: "output/llama3.8b.aya.fft"

--- a/configs/projects/chatqa/chatqa_stage1_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage1_train.yaml
@@ -34,6 +34,7 @@ data:
     stream: False
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
 
   output_dir: "output/chatqa.stage1"

--- a/configs/projects/chatqa/chatqa_stage2_train.yaml
+++ b/configs/projects/chatqa/chatqa_stage2_train.yaml
@@ -65,6 +65,7 @@ data:
         mixture_proportion: 0.1  # Original: 0.2
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
 
   output_dir: "output/chatqa.stage2"

--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -29,6 +29,7 @@ data:
     seed: 42
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 500

--- a/configs/projects/coalm/70b_train.yaml
+++ b/configs/projects/coalm/70b_train.yaml
@@ -29,6 +29,7 @@ data:
     seed: 42
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 688
   num_train_epochs: 1

--- a/configs/projects/coalm/8b_train.yaml
+++ b/configs/projects/coalm/8b_train.yaml
@@ -29,6 +29,7 @@ data:
     seed: 42
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 300

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/full_train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_70b/qlora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/full_train.yaml
@@ -29,6 +29,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 50

--- a/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_llama_8b/qlora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 50

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/full_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_1_5b/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 800

--- a/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
+++ b/configs/recipes/deepseek_r1/sft/distill_qwen_32b/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_1b/full_train.yaml
@@ -29,6 +29,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # Could also be TRL_DPO.
   save_steps: 800
 

--- a/configs/recipes/falcon_e/sft/falcon_e_1b_instruct/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_1b_instruct/full_train.yaml
@@ -29,6 +29,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # Could also be TRL_DPO.
   save_steps: 800
 

--- a/configs/recipes/falcon_e/sft/falcon_e_3b/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_3b/full_train.yaml
@@ -29,6 +29,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # Could also be TRL_DPO.
   save_steps: 800
 

--- a/configs/recipes/falcon_e/sft/falcon_e_3b_instruct/full_train.yaml
+++ b/configs/recipes/falcon_e/sft/falcon_e_3b_instruct/full_train.yaml
@@ -29,6 +29,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # Could also be TRL_DPO.
   save_steps: 800
 

--- a/configs/recipes/falcon_h1/sft/falcon_h1_0_5b/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_0_5b/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT" # Could also be TRL_DPO.
   save_steps: 800
 

--- a/configs/recipes/falcon_h1/sft/falcon_h1_1_5b/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_1_5b/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/falcon_h1/sft/falcon_h1_1_5b_deep/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_1_5b_deep/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/falcon_h1/sft/falcon_h1_34b/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_34b/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/falcon_h1/sft/falcon_h1_3b/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_3b/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/falcon_h1/sft/falcon_h1_7b/full_train.yaml
+++ b/configs/recipes/falcon_h1/sft/falcon_h1_7b/full_train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/gpt2/pretraining/macos_train.yaml
+++ b/configs/recipes/gpt2/pretraining/macos_train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "text"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   per_device_train_batch_size: 2
   max_steps: 10

--- a/configs/recipes/gpt2/pretraining/train.yaml
+++ b/configs/recipes/gpt2/pretraining/train.yaml
@@ -34,6 +34,7 @@ data:
     target_col: "text"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   per_device_train_batch_size: 64 # Use 64 for A100-80GB

--- a/configs/recipes/gpt_oss/sft/20b_lora_single_gpu_train.yaml
+++ b/configs/recipes/gpt_oss/sft/20b_lora_single_gpu_train.yaml
@@ -44,6 +44,7 @@ data:
     target_col: "messages"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: true
   ddp_find_unused_parameters: false

--- a/configs/recipes/llama3_1/sft/405b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_full/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/llama3_1/sft/405b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_lora/train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 20

--- a/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/405b_qlora/train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 100

--- a/configs/recipes/llama3_1/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_full/train.yaml
@@ -37,6 +37,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/llama3_1/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_lora/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/70b_qlora/train.yaml
@@ -32,6 +32,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/llama3_1/sft/8b_full/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_full/train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/fsdp_train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 50

--- a/configs/recipes/llama3_1/sft/8b_lora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_lora/train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 50

--- a/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
+++ b/configs/recipes/llama3_1/sft/8b_qlora/train.yaml
@@ -33,6 +33,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 50

--- a/configs/recipes/llama3_2/sft/1b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/1b_full/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 100
   num_train_epochs: 3

--- a/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/fsdp_train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/llama3_2/sft/3b_full/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_full/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 800
   num_train_epochs: 3

--- a/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/fsdp_train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 800

--- a/configs/recipes/llama3_2/sft/3b_lora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_lora/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 800

--- a/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/fsdp_train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 800

--- a/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
+++ b/configs/recipes/llama3_2/sft/3b_qlora/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 800

--- a/configs/recipes/llama3_3/sft/70b_full/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_full/train.yaml
@@ -32,6 +32,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/llama3_3/sft/70b_lora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_lora/train.yaml
@@ -31,6 +31,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
+++ b/configs/recipes/llama3_3/sft/70b_qlora/train.yaml
@@ -32,6 +32,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/llama4/sft/scout_base_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_base_full/train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_full/train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_lora/train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
+++ b/configs/recipes/llama4/sft/scout_instruct_qlora/train.yaml
@@ -27,6 +27,7 @@ data:
       - dataset_name: "yahma/alpaca-cleaned"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/phi3/dpo/macos_train.yaml
+++ b/configs/recipes/phi3/dpo/macos_train.yaml
@@ -20,6 +20,7 @@ data:
       - dataset_name: "mlabonne/orpo-dpo-mix-40k"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3.dpo"

--- a/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_24g_train.yaml
@@ -20,6 +20,7 @@ data:
       - dataset_name: "mlabonne/orpo-dpo-mix-40k"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch_fused"
   use_peft: true
   output_dir: "output/phi3.dpo"

--- a/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
+++ b/configs/recipes/phi3/dpo/nvidia_80g_train.yaml
@@ -20,6 +20,7 @@ data:
       - dataset_name: "mlabonne/orpo-dpo-mix-40k"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3.dpo"

--- a/configs/recipes/phi3/dpo/train.yaml
+++ b/configs/recipes/phi3/dpo/train.yaml
@@ -19,6 +19,7 @@ data:
       - dataset_name: "mlabonne/orpo-dpo-mix-40k"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3.dpo"

--- a/configs/recipes/phi3/kto/train.yaml
+++ b/configs/recipes/phi3/kto/train.yaml
@@ -19,6 +19,7 @@ data:
       - dataset_name: "trl-lib/kto-mix-14k"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3.kto"

--- a/configs/recipes/phi3/sft/lora_macos_train.yaml
+++ b/configs/recipes/phi3/sft/lora_macos_train.yaml
@@ -20,6 +20,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   trainer_type: "TRL_SFT"

--- a/configs/recipes/phi3/sft/lora_train.yaml
+++ b/configs/recipes/phi3/sft/lora_train.yaml
@@ -21,6 +21,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3.lora"

--- a/configs/recipes/phi4/sft/reasoning_plus/full_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/full_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
+++ b/configs/recipes/phi4/sft/reasoning_plus/qlora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/qwen3/sft/0.6b_full/train.yaml
+++ b/configs/recipes/qwen3/sft/0.6b_full/train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/qwen3/sft/1.7b_full/train.yaml
+++ b/configs/recipes/qwen3/sft/1.7b_full/train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/qwen3/sft/14b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/14b_lora/train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/30b_a3b_lora/train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/qwen3/sft/32b_lora/train.yaml
+++ b/configs/recipes/qwen3/sft/32b_lora/train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/qwen3/sft/4b_full/train.yaml
+++ b/configs/recipes/qwen3/sft/4b_full/train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/qwen3/sft/8b_full/train.yaml
+++ b/configs/recipes/qwen3/sft/8b_full/train.yaml
@@ -28,6 +28,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 1

--- a/configs/recipes/qwq/sft/full_train.yaml
+++ b/configs/recipes/qwq/sft/full_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   save_steps: 200
   num_train_epochs: 3

--- a/configs/recipes/qwq/sft/lora_train.yaml
+++ b/configs/recipes/qwq/sft/lora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/qwq/sft/qlora_train.yaml
+++ b/configs/recipes/qwq/sft/qlora_train.yaml
@@ -26,6 +26,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: "TRL_SFT"
   use_peft: True
   save_steps: 200

--- a/configs/recipes/smollm/sft/135m/train.yaml
+++ b/configs/recipes/smollm/sft/135m/train.yaml
@@ -27,6 +27,7 @@ data:
     target_col: "prompt"
 
 training:
+  save_final_model: True
   trainer_type: TRL_SFT
   save_steps: 100
   num_train_epochs: 1

--- a/configs/recipes/vision/internvl3/sft/full/train.yaml
+++ b/configs/recipes/vision/internvl3/sft/full/train.yaml
@@ -58,6 +58,7 @@ data:
       #     return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # or "OUMI"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/11b_lora/train.yaml
@@ -39,6 +39,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   # TODO: OPE-875 - Re-enable. Currently broken at `transformers==4.48.2`.

--- a/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
+++ b/configs/recipes/vision/llama3_2_vision/sft/90b_full/train.yaml
@@ -39,6 +39,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   # TODO: OPE-875 - Re-enable. Currently broken at `transformers==4.48.2`.

--- a/configs/recipes/vision/llava_7b/dpo/train.yaml
+++ b/configs/recipes/vision/llava_7b/dpo/train.yaml
@@ -29,6 +29,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_DPO"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/llava_7b/sft/train.yaml
+++ b/configs/recipes/vision/llava_7b/sft/train.yaml
@@ -61,6 +61,7 @@ data:
       #     processor_name: "llava-hf/llava-1.5-7b-hf"
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/molmo/grpo/train.yaml
+++ b/configs/recipes/vision/molmo/grpo/train.yaml
@@ -49,6 +49,7 @@ data:
           return_conversations: True
 
 training:
+  save_final_model: True
   output_dir: "output/grpo-verl-molmo-o"
   enable_wandb: True
 

--- a/configs/recipes/vision/molmo/sft/molmo_d_full/train.yaml
+++ b/configs/recipes/vision/molmo/sft/molmo_d_full/train.yaml
@@ -40,6 +40,7 @@ data:
           return_conversation: True
 
 training:
+  save_final_model: True
   output_dir: "output/molmo_sft"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: False # Note: Molmo does not support gradient checkpointing

--- a/configs/recipes/vision/molmo/sft/molmo_o_full/train.yaml
+++ b/configs/recipes/vision/molmo/sft/molmo_o_full/train.yaml
@@ -41,6 +41,7 @@ data:
           return_conversation: True
 
 training:
+  save_final_model: True
   output_dir: "output/molmo_sft"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: False # Note: Molmo does not support gradient checkpointing

--- a/configs/recipes/vision/phi3/dpo/train.yaml
+++ b/configs/recipes/vision/phi3/dpo/train.yaml
@@ -27,6 +27,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   use_peft: true
   output_dir: "output/phi3_vision.vision_dpo"

--- a/configs/recipes/vision/phi3/sft/full/completions_only_train.yaml
+++ b/configs/recipes/vision/phi3/sft/full/completions_only_train.yaml
@@ -49,6 +49,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_completions_only_finetuned"
   # Note: with phi3.5, the latest version of transformers/trl have a bug
   # preventing saving the model. https://github.com/microsoft/PhiCookBook/issues/223

--- a/configs/recipes/vision/phi3/sft/full/train.yaml
+++ b/configs/recipes/vision/phi3/sft/full/train.yaml
@@ -61,6 +61,7 @@ data:
       #     processor_name: "microsoft/Phi-3-vision-128k-instruct"
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   # Note: with phi3.5, the latest version of transformers/trl have a bug
   # preventing saving the model. https://github.com/microsoft/PhiCookBook/issues/223

--- a/configs/recipes/vision/phi3/sft/lora/train.yaml
+++ b/configs/recipes/vision/phi3/sft/lora/train.yaml
@@ -59,6 +59,7 @@ data:
       #     processor_name: "microsoft/Phi-3-vision-128k-instruct"
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/phi4/sft/full/train.yaml
+++ b/configs/recipes/vision/phi4/sft/full/train.yaml
@@ -68,6 +68,7 @@ data:
       #     processor_name: "microsoft/Phi-4-multimodal-instruct"
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/phi4/sft/lora/train.yaml
+++ b/configs/recipes/vision/phi4/sft/lora/train.yaml
@@ -65,6 +65,7 @@ data:
       #     processor_name: "microsoft/Phi-4-multimodal-instruct"
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/qwen2_5_vl_3b/dpo/train.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/dpo/train.yaml
@@ -23,6 +23,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   # use_peft: true
   output_dir: "output/qwen2_5_vl_3b.vision_dpo"

--- a/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml
+++ b/configs/recipes/vision/qwen2_5_vl_3b/sft/lora/train.yaml
@@ -48,6 +48,7 @@ data:
       # Consider resizing the images or using GPUs with more memory.
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/qwen2_vl_2b/dpo/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/dpo/train.yaml
@@ -23,6 +23,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   optimizer: "adamw_torch"
   # use_peft: true
   output_dir: "output/qwen2_vl_2b.vision_dpo"

--- a/configs/recipes/vision/qwen2_vl_2b/sft/full/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/full/train.yaml
@@ -49,6 +49,7 @@ data:
       #     return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # or "OUMI"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/qwen2_vl_2b/sft/lora/train.yaml
+++ b/configs/recipes/vision/qwen2_vl_2b/sft/lora/train.yaml
@@ -49,6 +49,7 @@ data:
       #     return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # or "OUMI"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/qwen3_vl/sft/4b_instruct_fft_train.yaml
+++ b/configs/recipes/vision/qwen3_vl/sft/4b_instruct_fft_train.yaml
@@ -49,6 +49,7 @@ data:
       #     return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # or "OUMI"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/qwen3_vl/sft/4b_instruct_lora_train.yaml
+++ b/configs/recipes/vision/qwen3_vl/sft/4b_instruct_lora_train.yaml
@@ -50,6 +50,7 @@ data:
       #     return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # or "OUMI"
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/smolvlm/sft/full/train.yaml
+++ b/configs/recipes/vision/smolvlm/sft/full/train.yaml
@@ -40,6 +40,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # Or "OUMI".
   enable_gradient_checkpointing: True

--- a/configs/recipes/vision/smolvlm/sft/lora/train.yaml
+++ b/configs/recipes/vision/smolvlm/sft/lora/train.yaml
@@ -40,6 +40,7 @@ data:
           return_tensors: True
 
 training:
+  save_final_model: True
   output_dir: "output/vlm_finetuned"
   trainer_type: "TRL_SFT" # Or, "OUMI"
   enable_gradient_checkpointing: True


### PR DESCRIPTION
# Description

This PR addresses issue OPE-1323 by adding `save_final_model: True` to all default training configurations. This ensures that essential files, such as processor configurations and chat templates, are consistently saved after training, preventing user confusion about missing artifacts.

The change was applied to 104 YAML files across `configs/recipes/`, `configs/examples/`, and `configs/projects/`.

## Related issues

Fixes #OPE-1323

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

---
Linear Issue: [OPE-1323](https://linear.app/oumi/issue/OPE-1323)

<a href="https://cursor.com/background-agent?bcId=bc-299c0b1d-beef-4095-9e2b-de74712c9dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-299c0b1d-beef-4095-9e2b-de74712c9dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

