### PR TITLE
Update builders to use hf_hub_transfer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "click<8.3.0",                # Used by CLI. 8.2.0 is currently unsupported by Typer.
     "datasets>=3.2,<3.3",         # breaking change for 4.0
     "hdrhistogram>=0.10,<0.11",
+    "hf_transfer>=0.1.8",         # Fast parallel downloads from HuggingFace Hub
     "jsonlines",
     "lm_eval[wandb]>=0.4,<0.5.0",
     "mlflow>=3.1",                # >=3.1.4 requires Python3.10>=

--- a/src/oumi/cli/cli_utils.py
+++ b/src/oumi/cli/cli_utils.py
@@ -127,6 +127,13 @@ def configure_common_env_vars() -> None:
         os.environ["ACCELERATE_LOG_LEVEL"] = "info"
     if "TOKENIZERS_PARALLELISM" not in os.environ:
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
+        # Enable hf_transfer for faster parallel downloads from HuggingFace Hub
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+        logger.debug(
+            "Enabled hf_transfer for parallel downloads from HuggingFace Hub. "
+            "To disable, set HF_HUB_ENABLE_HF_TRANSFER=0."
+        )
 
 
 class LogLevel(str, Enum):

--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -115,6 +115,7 @@ def test_configure_common_env_vars_empty():
         "FOO": "1",
         "ACCELERATE_LOG_LEVEL": "info",
         "TOKENIZERS_PARALLELISM": "false",
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",
     }
 
 
@@ -132,6 +133,7 @@ def test_configure_common_env_vars_partially_preconfigured():
         "FOO": "1",
         "ACCELERATE_LOG_LEVEL": "info",
         "TOKENIZERS_PARALLELISM": "true",
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",
     }
 
 
@@ -145,6 +147,26 @@ def test_configure_common_env_vars_fully_preconfigured():
     assert os.environ == {
         "ACCELERATE_LOG_LEVEL": "debug",
         "TOKENIZERS_PARALLELISM": "true",
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    }
+
+
+@patch.dict(
+    os.environ,
+    {
+        "TOKENIZERS_PARALLELISM": "true",
+        "ACCELERATE_LOG_LEVEL": "debug",
+        "HF_HUB_ENABLE_HF_TRANSFER": "0",
+    },
+    clear=True,
+)
+def test_configure_common_env_vars_with_hf_transfer_disabled():
+    configure_common_env_vars()
+    # Should not override user's explicit choice to disable hf_transfer
+    assert os.environ == {
+        "ACCELERATE_LOG_LEVEL": "debug",
+        "TOKENIZERS_PARALLELISM": "true",
+        "HF_HUB_ENABLE_HF_TRANSFER": "0",
     }
 
 


### PR DESCRIPTION
# Description

This PR addresses OPE-463 by integrating `hf_transfer` to automatically optimize downloads from HuggingFace Hub.

**Why this change?**
Downloads from HuggingFace Hub (for models and datasets) were previously sequential, which could lead to slower performance. By enabling `hf_transfer`, we leverage its ability to download files in parallel, significantly increasing download speeds and maximizing bandwidth utilization. This directly improves the performance and user experience when fetching resources from the HuggingFace Hub.

**How it works:**
1.  `hf_transfer` is added as a core dependency in `pyproject.toml`.
2.  The `HF_HUB_ENABLE_HF_TRANSFER` environment variable is automatically set to `1` within `configure_common_env_vars()` in `src/oumi/cli/cli_utils.py` if not already set. This activates the parallel download backend for all HuggingFace Hub operations.
3.  A debug log is added to inform users when `hf_transfer` is enabled.
4.  The change respects user preferences: if `HF_HUB_ENABLE_HF_TRANSFER` is explicitly set (e.g., to `0`), the automatic setting will not override it.
5.  Unit tests in `tests/unit/cli/test_cli_utils.py` have been updated and extended to cover this new behavior, including ensuring user overrides are respected.

This change is transparent to the end-user, providing faster downloads by default without requiring any manual configuration.

## Related issues

Fixes #OPE-463

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

---
Linear Issue: [OPE-463](https://linear.app/oumi/issue/OPE-463)

<a href="https://cursor.com/background-agent?bcId=bc-2ccb8f08-cb68-4c52-8511-7da771b2cd23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ccb8f08-cb68-4c52-8511-7da771b2cd23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

