### PR TITLE
Document oumi minimum storage requirements

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -11,8 +11,96 @@ Before installing Oumi, ensure you have the following:
 - Python 3.9 or later
 - pip (Python package installer)
 - Git (if cloning the repository; required for steps 1 and 2)
+- Adequate disk space (see [Storage Requirements](#storage-requirements) below)
 
 We recommend using a virtual environment to install Oumi. You can find instructions for setting up a Conda environment in the {doc}`/development/dev_setup` guide.
+
+### Storage Requirements
+
+Oumi requires sufficient disk space for models, datasets, checkpoints, and cache directories. The amount of storage needed depends on your specific use case, but here are general guidelines:
+
+#### Minimum Storage Requirements
+
+For basic usage (small model inference and evaluation):
+
+- **~50 GB minimum** - Enough for:
+  - Oumi installation and dependencies (~5-10 GB)
+  - Small models (1B-3B parameters) (~2-8 GB per model)
+  - Small datasets (~1-5 GB)
+  - Model cache and temporary files (~10-20 GB)
+
+#### Recommended Storage for Training
+
+For training and fine-tuning workflows:
+
+- **200-500 GB recommended** - Sufficient for:
+  - Multiple model checkpoints during training
+  - Medium-sized models (7B-13B parameters)
+  - Moderate-sized datasets
+  - Training artifacts and logs
+
+#### Large-Scale Usage
+
+For production deployments or large-scale training:
+
+- **1-5 TB recommended** - Required for:
+  - Large models (70B+ parameters)
+  - Multiple large model variants
+  - Large pre-training datasets (100GB+)
+  - Multiple training checkpoints
+  - Extensive experiment logs and artifacts
+
+#### Storage Breakdown by Component
+
+Here's what contributes to storage usage:
+
+**Model Weights** (cached at `~/.cache/huggingface/hub` by default):
+
+| Model Size | BF16/FP16 | FP32 | Q4 Quantized |
+|-----------|-----------|------|-------------|
+| 1B        | ~2 GB     | ~4 GB | ~0.5 GB |
+| 3B        | ~6 GB     | ~12 GB | ~1.5 GB |
+| 7B        | ~14 GB    | ~28 GB | ~3.5 GB |
+| 13B       | ~26 GB    | ~52 GB | ~6.5 GB |
+| 33B       | ~66 GB    | ~132 GB | ~16.5 GB |
+| 70B       | ~140 GB   | ~280 GB | ~35 GB |
+
+**Training Checkpoints**: Each checkpoint is approximately the same size as the model weights. By default, Oumi may save multiple checkpoints during training. Configure `training.save_total_limit` to control the number of checkpoints retained.
+
+**Datasets**: Varies widely based on use case:
+- Small fine-tuning datasets: 1-100 MB
+- Medium datasets: 100 MB - 10 GB  
+- Large pre-training datasets: 10 GB - 1 TB+
+
+**Cache and Temporary Files**: 10-50 GB for intermediate processing, compilation caches, and temporary artifacts.
+
+#### Managing Storage
+
+To manage storage effectively:
+
+1. **Configure cache directories**: Set `HF_HOME` or `TRANSFORMERS_CACHE` environment variables to control where models are cached:
+
+   ```bash
+   export HF_HOME=/path/to/large/disk/.cache/huggingface
+   ```
+
+2. **Clean up cache**: Use Oumi's cache management tools to remove unused models:
+
+   ```bash
+   oumi cache ls  # List cached models
+   oumi cache rm <model-name>  # Remove specific cached model
+   ```
+
+3. **Limit checkpoints**: Configure checkpoint retention in your training config:
+
+   ```yaml
+   training:
+     save_total_limit: 2  # Keep only the 2 most recent checkpoints
+   ```
+
+4. **Use cloud storage**: For remote training, mount cloud storage (GCS, S3, Azure Blob) to avoid filling local disks. See {doc}`/user_guides/launch/launch` for details.
+
+5. **Use quantization**: Employ quantized models (Q4, Q8) to reduce storage requirements by 2-4x with minimal quality impact.
 
 ## Installation Methods
 

--- a/docs/user_guides/train/environments/local.md
+++ b/docs/user_guides/train/environments/local.md
@@ -9,14 +9,14 @@ For cloud-based training options, see {doc}`/user_guides/launch/launch`.
 Before starting local training, ensure you have:
 
 1. **Hardware Requirements**
-   - CUDA-capable GPU(s) recommended
-   - Sufficient RAM (16GB minimum)
-   - Adequate disk space for storing your models and datasets
+   - CUDA-capable GPU(s) recommended (see {doc}`/faq/oom` for GPU memory guidance)
+   - Sufficient RAM (16GB minimum, 32GB+ recommended for training)
+   - Adequate disk space (minimum 50GB for basic usage, 200-500GB recommended for training; see {doc}`/get_started/installation` for detailed storage requirements)
 
 2. **Software Setup**
    - Python environment configured & `oumi` installed
 
-For detailed installation instructions, refer to our {doc}`/get_started/installation` guide.
+For detailed installation instructions and comprehensive storage requirements, refer to our {doc}`/get_started/installation` guide.
 
 ## Basic Usage
 


### PR DESCRIPTION
# Description

This PR addresses OPE-1451 by adding comprehensive documentation for Oumi's storage requirements. Users often encounter issues due to insufficient disk space, especially when working with larger models or training workflows. This change provides clear guidance on expected storage needs, helping users prepare their environments effectively.

Key additions include:
- A new "Storage Requirements" section in the installation guide (`docs/get_started/installation.md`).
- Detailed breakdowns for minimum, recommended, and large-scale usage scenarios.
- A table illustrating model weight sizes across different precisions.
- Guidance on managing storage for checkpoints, datasets, and cache.
- Cross-references to this new documentation from the local training guide (`docs/user_guides/train/environments/local.md`).

## Related issues

Fixes #OPE-1451

## Before submitting

- [x] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

---
Linear Issue: [OPE-1451](https://linear.app/oumi/issue/OPE-1451)

<a href="https://cursor.com/background-agent?bcId=bc-62971db8-4407-4c58-aa59-9301a48298e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62971db8-4407-4c58-aa59-9301a48298e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

