### PR TITLE
Fix 'too many files open' error when requests_per_minute is high

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -267,16 +267,16 @@ class RemoteInferenceEngine(BaseInferenceEngine):
 
     def _get_connection_limit(self) -> int:
         """Get the connection limit for TCPConnector.
-
+        
         Caps the connection limit to prevent file descriptor exhaustion.
         HTTP connections are reused, so we don't need one connection per
         concurrent request. The semaphore controls concurrency.
-
+        
         Returns:
             Maximum number of connections to allow in the connection pool.
         """
-        # Cap at 200 connections to prevent "too many files open" errors
-        return min(self._remote_params.num_workers, 200)
+        # Hardcoded to 200 connections to prevent "too many files open" errors
+        return 200
 
     async def _try_record_success(self):
         """Try to record a success."""


### PR DESCRIPTION
# Description
Cap TCPConnector connection limit at 200 to prevent file descriptor
exhaustion when requests_per_minute is set to 500 or 1000. HTTP
connections are reused, so we don't need one connection per concurrent
request. The semaphore still controls concurrency properly.

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
