### PR TITLE
Reorganize proto imports for consistency

### DIFF
--- a/src/oumi/core/types/proto/generated/conversation_pb2.pyi
+++ b/src/oumi/core/types/proto/generated/conversation_pb2.pyi
@@ -1,14 +1,19 @@
-from google.protobuf.internal import containers as _containers
-from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
-from google.protobuf import descriptor as _descriptor
-from google.protobuf import message as _message
+from collections.abc import Iterable as _Iterable
+from collections.abc import Mapping as _Mapping
 from typing import (
     ClassVar as _ClassVar,
-    Iterable as _Iterable,
-    Mapping as _Mapping,
+)
+from typing import (
     Optional as _Optional,
+)
+from typing import (
     Union as _Union,
 )
+
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 
 DESCRIPTOR: _descriptor.FileDescriptor
 


### PR DESCRIPTION
## Summary
- Update `conversation_pb2.pyi` to use modern Python import style
- Use `collections.abc` instead of `typing` module for `Iterable`/`Mapping`
- Organize imports alphabetically

🤖 Generated with [Claude Code](https://claude.com/claude-code)