### PR TITLE
Token-Based Rate Limiting for RemoteInferenceEngine

### DIFF
--- a/src/oumi/inference/rate_limiter.py
+++ b/src/oumi/inference/rate_limiter.py
@@ -1,0 +1,238 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TokenUsage:
+    """Token usage information from an API response."""
+
+    input_tokens: int = 0
+    """Number of input tokens used."""
+
+    output_tokens: int = 0
+    """Number of output tokens used."""
+
+    total_tokens: int = 0
+    """Total number of tokens used (input + output)."""
+
+
+@dataclass
+class UsageRecord:
+    """Record of a single request's usage."""
+
+    timestamp: float
+    """Time when the request was made."""
+
+    input_tokens: int
+    """Number of input tokens used."""
+
+    output_tokens: int
+    """Number of output tokens used."""
+
+
+class RateLimiter:
+    """Rate limiter for requests and tokens.
+
+    This class implements a sliding window rate limiter that tracks:
+    - Requests per minute (RPM)
+    - Input tokens per minute (TPM)
+    - Output tokens per minute (TPM)
+
+    It calculates the wait time needed to stay within all configured limits.
+    """
+
+    def __init__(
+        self,
+        requests_per_minute: Optional[int] = None,
+        input_tokens_per_minute: Optional[int] = None,
+        output_tokens_per_minute: Optional[int] = None,
+    ):
+        """Initialize the rate limiter.
+
+        Args:
+            requests_per_minute: Maximum requests per minute (None = no limit).
+            input_tokens_per_minute: Maximum input tokens per minute (None = no limit).
+            output_tokens_per_minute: Maximum output tokens per minute (None = no limit).
+        """
+        self.requests_per_minute = requests_per_minute
+        self.input_tokens_per_minute = input_tokens_per_minute
+        self.output_tokens_per_minute = output_tokens_per_minute
+
+        # Use deque for efficient O(1) append/pop operations
+        self._usage_history: deque[UsageRecord] = deque()
+        self._lock = asyncio.Lock()
+
+        # Window size in seconds (1 minute)
+        self._window_size = 60.0
+
+    def _remove_expired_records(self, current_time: float) -> None:
+        """Remove records outside the sliding window.
+
+        Args:
+            current_time: Current timestamp.
+        """
+        cutoff_time = current_time - self._window_size
+        while self._usage_history and self._usage_history[0].timestamp < cutoff_time:
+            self._usage_history.popleft()
+
+    def _get_current_usage(self, current_time: float) -> tuple[int, int, int]:
+        """Get current usage within the sliding window.
+
+        Args:
+            current_time: Current timestamp.
+
+        Returns:
+            Tuple of (requests, input_tokens, output_tokens) within the window.
+        """
+        self._remove_expired_records(current_time)
+
+        if not self._usage_history:
+            return 0, 0, 0
+
+        requests = len(self._usage_history)
+        input_tokens = sum(record.input_tokens for record in self._usage_history)
+        output_tokens = sum(record.output_tokens for record in self._usage_history)
+
+        return requests, input_tokens, output_tokens
+
+    def _calculate_wait_time(
+        self,
+        current_time: float,
+        estimated_input_tokens: int = 0,
+    ) -> float:
+        """Calculate how long to wait before making a request.
+
+        Args:
+            current_time: Current timestamp.
+            estimated_input_tokens: Estimated input tokens for the next request.
+
+        Returns:
+            Time in seconds to wait (0 if no wait needed).
+        """
+        requests, input_tokens, output_tokens = self._get_current_usage(current_time)
+
+        max_wait_time = 0.0
+
+        # Checking request limit
+        if self.requests_per_minute is not None:
+            # If we are at or over the limit, find when the oldest request expires
+            if requests >= self.requests_per_minute and self._usage_history:
+                oldest_request_time = self._usage_history[0].timestamp
+                wait_until = oldest_request_time + self._window_size
+                max_wait_time = max(max_wait_time, wait_until - current_time)
+
+        # Checking input token limit
+        if (
+            self.input_tokens_per_minute is not None
+            and estimated_input_tokens > 0
+        ):
+            projected_input_tokens = input_tokens + estimated_input_tokens
+            if projected_input_tokens > self.input_tokens_per_minute:
+                # Finding when enough tokens will expire to make room
+                needed_tokens = projected_input_tokens - self.input_tokens_per_minute
+                accumulated_tokens = 0
+                for record in self._usage_history:
+                    accumulated_tokens += record.input_tokens
+                    if accumulated_tokens >= needed_tokens:
+                        wait_until = record.timestamp + self._window_size
+                        max_wait_time = max(max_wait_time, wait_until - current_time)
+                        break
+
+        # Checking output token limit
+        if self.output_tokens_per_minute is not None:
+
+            # For output tokens, we can only check if we're already over the limit
+            # since we don't know the output size in advance
+            if output_tokens >= self.output_tokens_per_minute and self._usage_history:
+                # Find when enough tokens will expire
+                accumulated_tokens = 0
+                for record in self._usage_history:
+                    accumulated_tokens += record.output_tokens
+                    # Waiting for at least 10% of the limit to free up
+                    if accumulated_tokens >= self.output_tokens_per_minute * 0.1:
+                        wait_until = record.timestamp + self._window_size
+                        max_wait_time = max(max_wait_time, wait_until - current_time)
+                        break
+
+        return max(0.0, max_wait_time)
+
+    async def acquire(self, estimated_input_tokens: int = 0) -> None:
+        """Acquire permission to make a request.
+
+        This will wait if necessary to stay within rate limits.
+
+        Args:
+            estimated_input_tokens: Estimated number of input tokens for the request.
+        """
+        async with self._lock:
+            current_time = time.time()
+            wait_time = self._calculate_wait_time(current_time, estimated_input_tokens)
+
+            if wait_time > 0:
+                # Releasing the lock while sleeping
+                pass
+
+        # Sleeping outside the lock to allow other tasks to proceed
+        if wait_time > 0:
+            await asyncio.sleep(wait_time)
+
+    async def record_usage(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> None:
+        """Record usage after a request completes.
+
+        Args:
+            input_tokens: Number of input tokens used.
+            output_tokens: Number of output tokens used.
+        """
+        async with self._lock:
+            current_time = time.time()
+            self._remove_expired_records(current_time)
+
+            record = UsageRecord(
+                timestamp=current_time,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+            self._usage_history.append(record)
+
+    async def get_current_usage(self) -> tuple[int, int, int]:
+        """Get current usage statistics.
+
+        Returns:
+            Tuple of (requests, input_tokens, output_tokens) within the window.
+        """
+        async with self._lock:
+            current_time = time.time()
+            return self._get_current_usage(current_time)
+
+    def has_limits(self) -> bool:
+        """Check if any rate limits are configured.
+
+        Returns:
+            True if any rate limits are set, False otherwise.
+        """
+        return (
+            self.requests_per_minute is not None
+            or self.input_tokens_per_minute is not None
+            or self.output_tokens_per_minute is not None
+        )

--- a/tests/unit/inference/test_rate_limiter.py
+++ b/tests/unit/inference/test_rate_limiter.py
@@ -1,0 +1,210 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from oumi.inference.rate_limiter import RateLimiter, TokenUsage
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage dataclass."""
+
+    def test_token_usage_creation(self):
+        """Test creating a TokenUsage object."""
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150
+
+    def test_token_usage_defaults(self):
+        """Test TokenUsage with default values."""
+        usage = TokenUsage()
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+
+
+class TestRateLimiter:
+    """Tests for RateLimiter class."""
+
+    @pytest.mark.asyncio
+    async def test_no_limits(self):
+        """Test rate limiter with no limits configured."""
+        limiter = RateLimiter()
+        assert not limiter.has_limits()
+
+        # Should not wait when no limits are set
+        start_time = time.time()
+        await limiter.acquire()
+        elapsed = time.time() - start_time
+        assert elapsed < 0.1  # Should be nearly instant
+
+    @pytest.mark.asyncio
+    async def test_requests_per_minute_limit(self):
+        """Test request rate limiting."""
+        # Allow 10 requests per minute
+        limiter = RateLimiter(requests_per_minute=10)
+        assert limiter.has_limits()
+
+        # Make 10 requests - should all go through without waiting
+        for _ in range(10):
+            await limiter.acquire()
+            await limiter.record_usage(input_tokens=0, output_tokens=0)
+
+        # 11th request should wait
+        start_time = time.time()
+
+        # Mock time to simulate waiting
+        with patch('time.time') as mock_time:
+            # Set initial time
+            base_time = 1000.0
+            call_count = [0]
+
+            def time_side_effect():
+                call_count[0] += 1
+                # For the wait calculation, return time after 6 seconds
+                if call_count[0] > 20:
+                    return base_time + 6.1
+                return base_time
+
+            mock_time.side_effect = time_side_effect
+
+            # This should calculate a wait time
+            limiter_with_history = RateLimiter(requests_per_minute=10)
+            for _ in range(10):
+                await limiter_with_history.record_usage(input_tokens=0, output_tokens=0)
+
+            # Check current usage
+            requests, _, _ = await limiter_with_history.get_current_usage()
+            assert requests == 10
+
+    @pytest.mark.asyncio
+    async def test_input_tokens_per_minute_limit(self):
+        """Test input token rate limiting."""
+        # Allow 1000 input tokens per minute
+        limiter = RateLimiter(input_tokens_per_minute=1000)
+        assert limiter.has_limits()
+
+        # Use 900 tokens
+        await limiter.record_usage(input_tokens=900, output_tokens=0)
+
+        # Requesting 50 tokens should go through
+        await limiter.acquire(estimated_input_tokens=50)
+        await limiter.record_usage(input_tokens=50, output_tokens=0)
+
+        # Check usage
+        requests, input_tokens, output_tokens = await limiter.get_current_usage()
+        assert requests == 2
+        assert input_tokens == 950
+        assert output_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_output_tokens_per_minute_limit(self):
+        """Test output token rate limiting."""
+        # Allow 500 output tokens per minute
+        limiter = RateLimiter(output_tokens_per_minute=500)
+        assert limiter.has_limits()
+
+        # Use 400 tokens
+        await limiter.record_usage(input_tokens=0, output_tokens=400)
+
+        # Check usage
+        requests, input_tokens, output_tokens = await limiter.get_current_usage()
+        assert requests == 1
+        assert input_tokens == 0
+        assert output_tokens == 400
+
+    @pytest.mark.asyncio
+    async def test_combined_limits(self):
+        """Test rate limiter with multiple limits configured."""
+        limiter = RateLimiter(
+            requests_per_minute=10,
+            input_tokens_per_minute=1000,
+            output_tokens_per_minute=500,
+        )
+        assert limiter.has_limits()
+
+        # Make a few requests
+        for _ in range(5):
+            await limiter.acquire(estimated_input_tokens=100)
+            await limiter.record_usage(input_tokens=100, output_tokens=50)
+
+        # Check usage
+        requests, input_tokens, output_tokens = await limiter.get_current_usage()
+        assert requests == 5
+        assert input_tokens == 500
+        assert output_tokens == 250
+
+    @pytest.mark.asyncio
+    async def test_sliding_window(self):
+        """Test that old records are removed from the sliding window."""
+        limiter = RateLimiter(requests_per_minute=10)
+
+        # Mock time to simulate passage of time
+        with patch('time.time') as mock_time:
+            base_time = 1000.0
+            mock_time.return_value = base_time
+
+            # Record usage at base_time
+            await limiter.record_usage(input_tokens=100, output_tokens=50)
+
+            # Check usage immediately
+            requests, input_tokens, _ = await limiter.get_current_usage()
+            assert requests == 1
+            assert input_tokens == 100
+
+            # Move time forward by 61 seconds (past the 60-second window)
+            mock_time.return_value = base_time + 61
+
+            # Check usage again - should be 0 as the record expired
+            requests, input_tokens, _ = await limiter.get_current_usage()
+            assert requests == 0
+            assert input_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests(self):
+        """Test rate limiter with concurrent requests."""
+        limiter = RateLimiter(requests_per_minute=10)
+
+        # Create multiple concurrent tasks
+        async def make_request():
+            await limiter.acquire()
+            await limiter.record_usage(input_tokens=10, output_tokens=5)
+
+        # Run 5 concurrent requests
+        await asyncio.gather(*[make_request() for _ in range(5)])
+
+        # Check usage
+        requests, input_tokens, output_tokens = await limiter.get_current_usage()
+        assert requests == 5
+        assert input_tokens == 50
+        assert output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_record_usage_without_acquire(self):
+        """Test recording usage without acquiring (for error cases)."""
+        limiter = RateLimiter(requests_per_minute=10)
+
+        # Record usage directly
+        await limiter.record_usage(input_tokens=100, output_tokens=50)
+
+        # Check usage
+        requests, input_tokens, output_tokens = await limiter.get_current_usage()
+        assert requests == 1
+        assert input_tokens == 100
+        assert output_tokens == 50


### PR DESCRIPTION
# Description

 Implements a sliding window rate limiter that tracks and respects:
  - Requests per minute (RPM)
  - Input tokens per minute (input TPM)
  - Output tokens per minute (output TPM)

The system automatically throttles requests before hitting limits and tracks actual token usage from API responses.

## Changes
  - New Parameters in RemoteParams:
  - requests_per_minute: Optional[int] = None
  - input_tokens_per_minute: Optional[int] = None
  - output_tokens_per_minute: Optional[int] = None

 
Usage Example

```
  remote_params = RemoteParams(
      api_url="https://api.openai.com/v1/chat/completions",
      api_key_env_varname="OPENAI_API_KEY",
      requests_per_minute=500,      
      input_tokens_per_minute=80000,
      output_tokens_per_minute=16000,
      num_workers=50,
  )

  engine = RemoteInferenceEngine(model_params=model_params, remote_params=remote_params)
  results = engine.infer(conversations)  # Automatically respects rate limits
```

## Related issues

Fixes #1457 

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers
@oelachqar @wizeng23 
