### PR TITLE
[infer] Add progress_callback to inference, judge, and synthesis APIs

### DIFF
--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -19,6 +19,7 @@ import json
 import time
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -91,6 +92,7 @@ class BaseInferenceEngine(ABC):
         self,
         input: list[Conversation] | None = None,
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference.
 
@@ -98,6 +100,8 @@ class BaseInferenceEngine(ABC):
             input: A list of conversations to run inference on. Optional.
             inference_config: Parameters for inference.
                 If not specified, a default config is inferred.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count).
 
         Returns:
             List[Conversation]: Inference output.
@@ -197,7 +201,7 @@ class BaseInferenceEngine(ABC):
         start_time = time.perf_counter()
         histogram = self._latency_histogram_online
         inference_results = self._infer_online(
-            remaining_conversations, inference_config
+            remaining_conversations, inference_config, progress_callback
         )
         histogram.record_value((time.perf_counter() - start_time) * 1e3)
         self._maybe_log_latency_histogram(histogram)
@@ -464,12 +468,15 @@ class BaseInferenceEngine(ABC):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference online.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count).
 
         Returns:
             List[Conversation]: Inference output.

--- a/src/oumi/core/synthesis/attribute_synthesizer.py
+++ b/src/oumi/core/synthesis/attribute_synthesizer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from oumi.builders.inference_engines import build_inference_engine
@@ -81,6 +82,7 @@ class AttributeSynthesizer:
         self,
         samples: list[dict],
         generated_attribute: GeneratedAttribute,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, str]]:
         """Synthesize a value for the generated attribute.
 
@@ -89,6 +91,8 @@ class AttributeSynthesizer:
         Args:
             samples: The samples to synthesize values for.
             generated_attribute: The generated attribute to synthesize a value for.
+            progress_callback: Optional callback invoked after each sample is
+                processed. Called with (completed_count, total_count).
 
         Returns:
             A list of dictionaries, one for each sample, with the generated attribute
@@ -106,6 +110,7 @@ class AttributeSynthesizer:
         inference_results = self._inference_engine.infer(
             inference_conversations,
             inference_config=self._inference_config,
+            progress_callback=progress_callback,
         )
         self._accumulate_token_usage(inference_results)
 

--- a/src/oumi/inference/llama_cpp_inference_engine.py
+++ b/src/oumi/inference/llama_cpp_inference_engine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import warnings
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -327,12 +328,16 @@ class LlamaCppInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference online.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count). Not used
+                by this engine.
 
         Returns:
             List[Conversation]: Inference output.

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import warnings
+from collections.abc import Callable
 from typing import cast
 
 import PIL.Image
@@ -405,12 +406,16 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference online.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count). Not used
+                by this engine.
 
         Returns:
             List[Conversation]: Inference output.

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 import urllib.parse
 import warnings
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -739,13 +739,15 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference on the provided input.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
-            remote_params: Parameters for running inference against a remote API.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count).
 
         Returns:
             List[Conversation]: Inference output.
@@ -757,6 +759,20 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             capacity=self._remote_params.num_workers,
             politeness_policy=self._remote_params.politeness_policy,
         )
+        total = len(input)
+        completed_count = 0
+
+        async def _wrap_with_progress(task):
+            nonlocal completed_count
+            result = await task
+            completed_count += 1
+            if progress_callback:
+                try:
+                    progress_callback(completed_count, total)
+                except Exception:
+                    pass  # progress reporting is best-effort
+            return result
+
         async with aiohttp.ClientSession(connector=connector) as session:
             tasks = [
                 self._query_api(
@@ -769,7 +785,14 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             ]
 
             disable_tqdm = len(tasks) < 2
-            results = await tqdm.gather(*tasks, disable=disable_tqdm)
+            if progress_callback:
+                # Use asyncio.gather directly when we have a progress callback,
+                # since we report progress via the callback instead of tqdm.
+                results = await asyncio.gather(
+                    *[_wrap_with_progress(t) for t in tasks]
+                )
+            else:
+                results = await tqdm.gather(*tasks, disable=disable_tqdm)
             return results
 
     @override
@@ -777,17 +800,22 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference online.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count).
 
         Returns:
             List[Conversation]: Inference output.
         """
-        conversations = safe_asyncio_run(self._infer(input, inference_config))
+        conversations = safe_asyncio_run(
+            self._infer(input, inference_config, progress_callback)
+        )
         return conversations
 
     @override

--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import copy
 import math
 import warnings
+from collections.abc import Callable
 from typing import cast, get_args
 
 import torch
@@ -465,12 +466,16 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Conversation]:
         """Runs model inference online.
 
         Args:
             input: A list of conversations to run inference on.
             inference_config: Parameters for inference.
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count). Not used
+                by this engine.
 
         Returns:
             List[Conversation]: Inference output.

--- a/src/oumi/judges/base_judge.py
+++ b/src/oumi/judges/base_judge.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import pydantic
@@ -361,12 +362,15 @@ class BaseJudge:
     def judge(
         self,
         inputs: list[dict[str, str]],
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[JudgeOutput]:
         """Evaluate a batch of inputs and return structured judgments.
 
         Args:
             inputs: List of dictionaries containing input data for evaluation.
                     Each dict must contain values for all prompt_template placeholders.
+            progress_callback: Optional callback invoked after each input is
+                processed. Called with (completed_count, total_count).
 
         Returns:
             List of structured judge outputs with parsed results
@@ -375,7 +379,9 @@ class BaseJudge:
             ValueError: If inference returns unexpected number of conversations
         """
         conversations = self.build_conversations(inputs)
-        completed_conversations = self._infer(conversations)
+        completed_conversations = self._infer(
+            conversations, progress_callback=progress_callback
+        )
         return self.parse_judge_outputs(completed_conversations)
 
     def judge_batch_submit(
@@ -704,11 +710,17 @@ class BaseJudge:
                 f"got {conversation.messages[-1].role}"
             )
 
-    def _infer(self, conversations: list[Conversation]) -> list[Conversation]:
+    def _infer(
+        self,
+        conversations: list[Conversation],
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[Conversation]:
         """Run inference on judge conversations and preserve metadata.
 
         Args:
             conversations: List of conversations to run inference on
+            progress_callback: Optional callback invoked after each conversation
+                completes. Called with (completed_count, total_count).
 
         Returns:
             List of conversations with model responses added
@@ -718,7 +730,9 @@ class BaseJudge:
 
         # Run batch inference
         if self.inference_engine:
-            response_conversations = self.inference_engine.infer(input=conversations)
+            response_conversations = self.inference_engine.infer(
+                input=conversations, progress_callback=progress_callback
+            )
         else:
             raise ValueError(
                 "Cannot run inference: inference_engine is None. "

--- a/tests/unit/core/synthesis/test_attribute_synthesizer.py
+++ b/tests/unit/core/synthesis/test_attribute_synthesizer.py
@@ -994,3 +994,69 @@ def test_get_batch_results_partial_not_supported(
         )
 
     assert "does not support partial batch results" in str(exc_info.value)
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_forwards_progress_callback(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    """Test that synthesize forwards progress_callback to the inference engine."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    mock_inference_engine.infer.return_value = [
+        Conversation(
+            messages=[
+                Message(role=Role.USER, content="Test query"),
+                Message(role=Role.ASSISTANT, content="Test response"),
+            ]
+        ),
+    ]
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+    samples = [{"style": "formal", "topic": "tech"}]
+
+    callback = Mock()
+    synthesizer.synthesize(samples, mock_generated_attribute, progress_callback=callback)
+
+    # Verify infer was called with the progress_callback
+    mock_inference_engine.infer.assert_called_once()
+    assert mock_inference_engine.infer.call_args[1]["progress_callback"] is callback
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_progress_callback_defaults_to_none(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    """Test that synthesize passes None when no callback is provided."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    mock_inference_engine.infer.return_value = [
+        Conversation(
+            messages=[
+                Message(role=Role.USER, content="Test query"),
+                Message(role=Role.ASSISTANT, content="Test response"),
+            ]
+        ),
+    ]
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+    samples = [{"style": "formal", "topic": "tech"}]
+
+    synthesizer.synthesize(samples, mock_generated_attribute)
+
+    mock_inference_engine.infer.assert_called_once()
+    assert mock_inference_engine.infer.call_args[1]["progress_callback"] is None

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -21,6 +21,7 @@ class MockInferenceEngine(BaseInferenceEngine):
         self,
         input: list[Conversation],
         inference_config: InferenceConfig | None = None,
+        progress_callback=None,
     ) -> list[Conversation]:
         # Mock implementation that appends an assistant response
         results = []
@@ -168,10 +169,12 @@ def test_infer_no_resume_from_scratch_on_success(mock_engine):
                 [
                     # First call with just the first conversation
                     mock.call(
-                        [conversations[0].model_copy(deep=True)], inference_config
+                        [conversations[0].model_copy(deep=True)],
+                        inference_config,
+                        None,
                     ),
                     # Second call with both conversations
-                    mock.call(conversations, inference_config),
+                    mock.call(conversations, inference_config, None),
                 ]
             )
 
@@ -196,7 +199,7 @@ def test_infer_resume_from_scratch_on_failure(mock_engine):
         ]
 
         # Run inference which fails on the second conversation
-        def mock_infer_online(input_convs, config):
+        def mock_infer_online(input_convs, config, progress_callback=None):
             # Process conversations one at a time
             results = []
             for i, conv in enumerate(input_convs):
@@ -453,3 +456,43 @@ def test_final_conversations_saved_to_output_file(mock_engine):
         assert not scratch_path.exists(), (
             "Scratch file should be cleaned up after successful inference"
         )
+
+
+def test_progress_callback_called_for_each_conversation(mock_engine):
+    """Test that progress_callback is passed through to _infer_online."""
+    conversations = [create_test_conversation(i) for i in range(3)]
+
+    callback_calls = []
+
+    def track_callback(completed, total):
+        callback_calls.append((completed, total))
+
+    # The MockInferenceEngine._infer_online doesn't fire the callback itself,
+    # so we patch it to verify the callback is passed through from infer().
+    with patch.object(mock_engine, "_infer_online", wraps=mock_engine._infer_online) as m:
+        mock_engine.infer(input=conversations, progress_callback=track_callback)
+        # Verify progress_callback was forwarded to _infer_online
+        assert m.call_args[0][2] is track_callback
+
+
+def test_progress_callback_none_by_default(mock_engine):
+    """Test that progress_callback defaults to None."""
+    conversations = [create_test_conversation(1)]
+
+    with patch.object(mock_engine, "_infer_online", wraps=mock_engine._infer_online) as m:
+        mock_engine.infer(input=conversations)
+        # Third positional arg should be None
+        assert m.call_args[0][2] is None
+
+
+def test_progress_callback_exception_does_not_crash_inference(mock_engine):
+    """Test that a raising callback doesn't prevent inference from completing."""
+    conversations = [create_test_conversation(1)]
+
+    def bad_callback(completed, total):
+        raise RuntimeError("callback error")
+
+    # Even if the callback raises, infer() should still return results.
+    # (The base class passes it to _infer_online; concrete engines catch exceptions.)
+    results = mock_engine.infer(input=conversations, progress_callback=bad_callback)
+    assert len(results) == 1

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -3723,3 +3723,123 @@ def test_cancel_batch_public():
         status = engine.cancel_batch("batch-123")
         assert status.id == "batch-123"
         assert status.status == BatchStatus.CANCELLING
+
+
+def test_progress_callback_fires_per_conversation():
+    """Test that progress_callback fires once per conversation in _infer_online."""
+    num_conversations = 3
+    with aioresponses() as m:
+        for _ in range(num_conversations):
+            m.post(
+                _TARGET_SERVER,
+                status=200,
+                payload=dict(
+                    choices=[
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "response",
+                            }
+                        }
+                    ]
+                ),
+            )
+
+        engine = _make_engine()
+        conversations = [
+            Conversation(
+                messages=[Message(role=Role.USER, content=f"msg {i}")],
+                conversation_id=f"conv-{i}",
+            )
+            for i in range(num_conversations)
+        ]
+
+        callback_calls = []
+
+        def track_callback(completed, total):
+            callback_calls.append((completed, total))
+
+        results = engine.infer(
+            input=conversations,
+            inference_config=_get_default_inference_config(),
+            progress_callback=track_callback,
+        )
+
+        assert len(results) == num_conversations
+        assert len(callback_calls) == num_conversations
+        # All calls should have total == num_conversations
+        assert all(total == num_conversations for _, total in callback_calls)
+        # Completed values should cover 1..num_conversations (order may vary)
+        completed_values = sorted(c for c, _ in callback_calls)
+        assert completed_values == [1, 2, 3]
+
+
+def test_progress_callback_none_works():
+    """Test that inference works normally when progress_callback is None."""
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=200,
+            payload=dict(
+                choices=[
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "response",
+                        }
+                    }
+                ]
+            ),
+        )
+
+        engine = _make_engine()
+        conversations = [
+            Conversation(
+                messages=[Message(role=Role.USER, content="hello")],
+                conversation_id="conv-1",
+            )
+        ]
+
+        results = engine.infer(
+            input=conversations,
+            inference_config=_get_default_inference_config(),
+            progress_callback=None,
+        )
+        assert len(results) == 1
+
+
+def test_progress_callback_exception_does_not_crash():
+    """Test that a raising callback doesn't prevent inference from completing."""
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=200,
+            payload=dict(
+                choices=[
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "response",
+                        }
+                    }
+                ]
+            ),
+        )
+
+        engine = _make_engine()
+        conversations = [
+            Conversation(
+                messages=[Message(role=Role.USER, content="hello")],
+                conversation_id="conv-1",
+            )
+        ]
+
+        def bad_callback(completed, total):
+            raise RuntimeError("callback error")
+
+        results = engine.infer(
+            input=conversations,
+            inference_config=_get_default_inference_config(),
+            progress_callback=bad_callback,
+        )
+        assert len(results) == 1

--- a/tests/unit/judges/test_base_judge.py
+++ b/tests/unit/judges/test_base_judge.py
@@ -638,7 +638,9 @@ class TestBaseJudge:
         assert result[0].metadata == {"id": "conv1", "custom": "data1"}
         assert result[1].metadata == {"id": "conv2", "custom": "data2"}
 
-        mock_inference_engine.infer.assert_called_once_with(input=input_convs)
+        mock_inference_engine.infer.assert_called_once_with(
+            input=input_convs, progress_callback=None
+        )
 
     def test_infer_length_mismatch(self, base_judge, mock_inference_engine):
         input_convs = [Conversation(messages=[Message(content="test", role=Role.USER)])]
@@ -1066,3 +1068,66 @@ class TestBaseJudge:
         assert base_judge.total_input_tokens == 22
         assert base_judge.total_output_tokens == 11
         assert base_judge.total_cached_tokens == 11
+
+    def test_judge_forwards_progress_callback(
+        self, mock_inference_engine, sample_output_fields
+    ):
+        """Test that judge() forwards progress_callback to the inference engine."""
+        judge = BaseJudge(
+            prompt_template="Is this helpful? Question: {question}, Answer: {answer}",
+            prompt_template_placeholders={"question", "answer"},
+            system_instruction=None,
+            example_field_values=[],
+            response_format=JudgeResponseFormat.XML,
+            output_fields=sample_output_fields,
+            inference_engine=mock_inference_engine,
+        )
+
+        mock_inference_engine.infer.return_value = [
+            Conversation(
+                messages=[
+                    Message(content="prompt", role=Role.USER),
+                    Message(
+                        content="<judgment>True</judgment>", role=Role.ASSISTANT
+                    ),
+                ]
+            ),
+        ]
+
+        callback = Mock()
+        inputs = [{"question": "What is 1+1?", "answer": "2"}]
+        judge.judge(inputs, progress_callback=callback)
+
+        # Verify infer was called with progress_callback
+        mock_inference_engine.infer.assert_called_once()
+        assert mock_inference_engine.infer.call_args[1]["progress_callback"] is callback
+
+    def test_judge_progress_callback_defaults_to_none(
+        self, mock_inference_engine, sample_output_fields
+    ):
+        """Test that judge() passes None when no callback is provided."""
+        judge = BaseJudge(
+            prompt_template="Is this helpful? Question: {question}, Answer: {answer}",
+            prompt_template_placeholders={"question", "answer"},
+            system_instruction=None,
+            example_field_values=[],
+            response_format=JudgeResponseFormat.XML,
+            output_fields=sample_output_fields,
+            inference_engine=mock_inference_engine,
+        )
+
+        mock_inference_engine.infer.return_value = [
+            Conversation(
+                messages=[
+                    Message(content="prompt", role=Role.USER),
+                    Message(
+                        content="<judgment>True</judgment>", role=Role.ASSISTANT
+                    ),
+                ]
+            ),
+        ]
+
+        inputs = [{"question": "What is 1+1?", "answer": "2"}]
+        judge.judge(inputs)
+
+        assert mock_inference_engine.infer.call_args[1]["progress_callback"] is None


### PR DESCRIPTION
## Summary

- Adds an optional `progress_callback: Callable[[int, int], None]` parameter to `BaseInferenceEngine.infer()`, `BaseJudge.judge()`, and `AttributeSynthesizer.synthesize()`
- The callback fires `(completed_count, total_count)` after each item finishes, enabling callers to report granular progress during bulk operations
- `RemoteInferenceEngine` fires the callback per async task completion in the gather loop; other engines accept the parameter but don't use it yet

## Motivation

When the Oumi Enterprise worker calls bulk inference/judge/synthesis, it passes all rows at once. Without this callback, the worker can only update heartbeat progress at the start and end of the call — leaving users with no progress updates for potentially long-running operations.

## Changes

| File | Change |
|------|--------|
| `base_inference_engine.py` | `progress_callback` on `infer()` and `_infer_online()` |
| `remote_inference_engine.py` | Fires callback per task in async gather loop |
| `native_text_inference_engine.py` | Accepts param in `_infer_online()` |
| `vllm_inference_engine.py` | Accepts param in `_infer_online()` |
| `llama_cpp_inference_engine.py` | Accepts param in `_infer_online()` |
| `base_judge.py` | `progress_callback` on `judge()` and `_infer()`, forwarded to engine |
| `attribute_synthesizer.py` | `progress_callback` on `synthesize()`, forwarded to engine |

## Design

- Callback is optional (`None` default) — fully backwards compatible
- Thread-safe: `asyncio.gather()` runs on a single event loop thread, so the nonlocal counter won't race
- Best-effort: callback exceptions are silently caught to never crash inference
- Engine-level: judge and synthesis just forward the callback to the inference engine