### PR TITLE
feat(deploy): support uploads to Fireworks via FileResolver

### DIFF
--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -19,7 +19,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from pathlib import Path
+from typing import Any, AsyncContextManager
 
 
 class DeploymentProvider(str, Enum):
@@ -106,6 +107,11 @@ class Endpoint:
 # Async callback for upload/deploy progress updates.
 # Signature: ``async def callback(stage: str, message: str, details: dict)``
 ProgressCallback = Callable[[str, str, dict[str, Any]], Awaitable[None]]
+
+# Async context manager that yields a local Path for a given filename.
+# Used to provide model files one-at-a-time during upload so only one shard
+# is on disk at any moment (peak disk usage = size of one shard, not full model).
+FileResolver = Callable[[str], AsyncContextManager[Path]]
 
 
 class BaseDeploymentClient(ABC):

--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -15,7 +15,8 @@
 """Base types and interfaces for deployment clients."""
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncContextManager, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -111,7 +112,7 @@ ProgressCallback = Callable[[str, str, dict[str, Any]], Awaitable[None]]
 # Async context manager that yields a local Path for a given filename.
 # Used to provide model files one-at-a-time during upload so only one shard
 # is on disk at any moment (peak disk usage = size of one shard, not full model).
-FileResolver = Callable[[str], AsyncContextManager[Path]]
+FileResolver = Callable[[str], AbstractAsyncContextManager[Path]]
 
 
 class BaseDeploymentClient(ABC):

--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -15,12 +15,12 @@
 """Base types and interfaces for deployment clients."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncContextManager, Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, AsyncContextManager
+from typing import Any
 
 
 class DeploymentProvider(str, Enum):

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -442,11 +442,9 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         model_name: str,
         file_inventory: dict[str, int],
         file_resolver: FileResolver,
-        model_type: ModelType = ModelType.FULL,
-        base_model: str | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> UploadedModel:
-        """Uploads a model using a pre-computed file inventory and resolver.
+        """Uploads a full model using a pre-computed file inventory and resolver.
 
         Unlike ``upload_model()`` which requires all files on local disk, this
         method accepts a ``file_inventory`` (filenames → sizes in bytes) and a
@@ -454,26 +452,31 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         streaming from cloud storage one file at a time, keeping peak disk usage
         to the size of a single shard rather than the full model.
 
+        Only FULL model uploads are supported. Adapter (LoRA) uploads require
+        reading adapter_config.json and verifying the base model — see
+        ``upload_model()`` for that path.
+
         Args:
             model_name: Fireworks model ID (e.g., ``"my-custom-model"``).
             file_inventory: Mapping of relative filename to file size in bytes.
             file_resolver: Async context manager factory.  For each filename,
                 ``file_resolver(filename)`` must yield a local ``Path`` to the
                 file and clean up after the ``async with`` block exits.
-            model_type: FULL or ADAPTER (default: FULL).
-            base_model: Required for ADAPTER uploads.
             progress_callback: Optional async progress callback.
 
         Returns:
             ``UploadedModel`` with the Fireworks provider model ID.
         """
+        # TODO: Add adapter support. Requires accepting adapter_config dict
+        # and base_model, plus the same validation upload_model() does
+        # (_verify_base_model_exists, target_modules check).
         _validate_fireworks_model_id(model_name)
         hf_files = sorted(file_inventory.keys())
 
         create_payload = await self._create_model_resource(
             model_name,
-            model_type,
-            base_model,
+            ModelType.FULL,
+            None,
             progress_callback,
             huggingface_files=hf_files,
         )

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -392,7 +392,6 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             # which files to expect.  For adapter uploads, only PEFT files are
             # included (Fireworks rejects non-adapter files for HF_PEFT_ADDON).
             file_inventory = self._collect_file_inventory(model_dir, model_type)
-            hf_files = sorted(file_inventory.keys())
 
             # Step 2b: For adapters, read adapter_config.json so we can
             # populate peftDetails with the real r and target_modules.
@@ -537,6 +536,13 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         """
         total_bytes = sum(file_sizes.values())
         _MB = 1024 * 1024
+        if "config.json" in file_sizes:
+            logger.info("config.json found (%d bytes)", file_sizes["config.json"])
+        else:
+            logger.error(
+                "config.json NOT found in model files: %s",
+                list(file_sizes.keys()),
+            )
         logger.info(
             "Uploading %d files (%.1f MB) via resolver",
             len(file_sizes),

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -437,7 +437,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             request_payload=create_payload,
         )
 
-    async def upload_model_from_inventory(
+    async def upload_model_with_resolver(
         self,
         model_name: str,
         file_inventory: dict[str, int],

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -31,6 +31,7 @@ from oumi.deploy.base_client import (
     DeploymentProvider,
     Endpoint,
     EndpointState,
+    FileResolver,
     HardwareConfig,
     Model,
     ModelType,
@@ -434,6 +435,150 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             provider_model_id=f"accounts/{self.account_id}/models/{model_id}",
             status="validating",
             request_payload=create_payload,
+        )
+
+    async def upload_model_from_inventory(
+        self,
+        model_name: str,
+        file_inventory: dict[str, int],
+        file_resolver: FileResolver,
+        model_type: ModelType = ModelType.FULL,
+        base_model: str | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ) -> UploadedModel:
+        """Uploads a model using a pre-computed file inventory and resolver.
+
+        Unlike ``upload_model()`` which requires all files on local disk, this
+        method accepts a ``file_inventory`` (filenames → sizes in bytes) and a
+        ``file_resolver`` callback that yields each file on demand.  This enables
+        streaming from cloud storage one file at a time, keeping peak disk usage
+        to the size of a single shard rather than the full model.
+
+        Args:
+            model_name: Fireworks model ID (e.g., ``"my-custom-model"``).
+            file_inventory: Mapping of relative filename to file size in bytes.
+            file_resolver: Async context manager factory.  For each filename,
+                ``file_resolver(filename)`` must yield a local ``Path`` to the
+                file and clean up after the ``async with`` block exits.
+            model_type: FULL or ADAPTER (default: FULL).
+            base_model: Required for ADAPTER uploads.
+            progress_callback: Optional async progress callback.
+
+        Returns:
+            ``UploadedModel`` with the Fireworks provider model ID.
+        """
+        _validate_fireworks_model_id(model_name)
+        hf_files = sorted(file_inventory.keys())
+
+        create_payload = await self._create_model_resource(
+            model_name,
+            model_type,
+            base_model,
+            progress_callback,
+            huggingface_files=hf_files,
+        )
+
+        await self._upload_model_files_with_resolver(
+            model_name,
+            file_inventory,
+            file_resolver,
+            progress_callback,
+        )
+        await self._wait_and_validate(model_name, progress_callback)
+
+        return UploadedModel(
+            provider_model_id=f"accounts/{self.account_id}/models/{model_name}",
+            status="validating",
+            request_payload=create_payload,
+        )
+
+    async def _upload_model_files_with_resolver(
+        self,
+        model_id: str,
+        file_sizes: dict[str, int],
+        file_resolver: FileResolver,
+        progress_callback: ProgressCallback | None,
+    ) -> None:
+        """Upload files using a resolver that provides each file on demand.
+
+        Fetches signed upload URLs for all files, then iterates them in upload
+        order.  For each file, it calls ``file_resolver(filename)`` as an async
+        context manager to obtain a local path, uploads the file, and lets the
+        resolver clean up (e.g., delete the temp file) before moving on.
+
+        Args:
+            model_id: Fireworks model ID used to request signed upload URLs.
+            file_sizes: Mapping of relative filename to file size in bytes.
+            file_resolver: Async context manager factory yielding a local Path.
+            progress_callback: Optional async progress callback.
+        """
+        total_bytes = sum(file_sizes.values())
+        _MB = 1024 * 1024
+        logger.info(
+            "Uploading %d files (%.1f MB) via resolver",
+            len(file_sizes),
+            total_bytes / _MB,
+        )
+
+        upload_items = await self._get_signed_urls_ordered(model_id, file_sizes)
+        total_files = len(upload_items)
+
+        await self._notify(
+            progress_callback,
+            "uploading",
+            f"Starting upload of {total_files} files ({total_bytes / _MB:.1f} MB)",
+            {"total_files": total_files, "total_bytes": total_bytes},
+        )
+
+        uploaded_bytes = 0
+        for idx, (filename, signed_url) in enumerate(upload_items, 1):
+            file_size = file_sizes[filename]
+            logger.info(
+                "[%d/%d] Uploading %s (%.2f MB)",
+                idx,
+                total_files,
+                filename,
+                file_size / _MB,
+            )
+
+            async with file_resolver(filename) as file_path:
+                await self._upload_single_file(
+                    file_path, file_size, signed_url, filename, idx, total_files
+                )
+
+            uploaded_bytes += file_size
+            logger.info(
+                "[%d/%d] Uploaded %s (%.1f / %.1f MB)",
+                idx,
+                total_files,
+                filename,
+                uploaded_bytes / _MB,
+                total_bytes / _MB,
+            )
+            await self._notify(
+                progress_callback,
+                "uploading",
+                f"Uploaded {filename} ({idx}/{total_files}, "
+                f"{uploaded_bytes / _MB:.1f} / {total_bytes / _MB:.1f} MB)",
+                {
+                    "current_file": filename,
+                    "uploaded_count": idx,
+                    "total_files": total_files,
+                    "uploaded_bytes": uploaded_bytes,
+                    "total_bytes": total_bytes,
+                },
+            )
+
+        logger.info(
+            "All %d files uploaded via resolver (%.1f MB total)",
+            total_files,
+            total_bytes / _MB,
+        )
+        await self._notify(
+            progress_callback,
+            "uploading",
+            f"All {total_files} files uploaded ({total_bytes / _MB:.1f} MB total)",
+            {"status": "complete", "total_files": total_files},
         )
 
     # ------------------------------------------------------------------

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -492,6 +492,10 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             request_payload=create_payload,
         )
 
+    # ------------------------------------------------------------------
+    # upload_model — private helpers
+    # ------------------------------------------------------------------
+
     async def _upload_model_files_with_resolver(
         self,
         model_id: str,
@@ -580,10 +584,6 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             f"All {total_files} files uploaded ({total_bytes / _MB:.1f} MB total)",
             {"status": "complete", "total_files": total_files},
         )
-
-    # ------------------------------------------------------------------
-    # upload_model — private helpers
-    # ------------------------------------------------------------------
 
     async def _create_model_resource(
         self,

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import shutil
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, cast
 
@@ -412,30 +413,22 @@ class FireworksDeploymentClient(BaseDeploymentClient):
                     )
                 await self._verify_base_model_exists(base_model)
 
-            # Step 3: Create model resource on Fireworks
-            create_payload = await self._create_model_resource(
+            @asynccontextmanager
+            async def local_resolver(filename: str):
+                yield model_dir / filename
+
+            return await self._do_upload(
                 model_id,
+                file_inventory,
+                local_resolver,
                 model_type,
                 base_model,
+                adapter_config,
                 progress_callback,
-                huggingface_files=hf_files,
-                adapter_config=adapter_config,
             )
-
-            # Steps 4–5: Upload files, validate
-            await self._upload_model_files(
-                model_dir, model_id, progress_callback, file_inventory
-            )
-            await self._wait_and_validate(model_id, progress_callback)
         finally:
             if temp_dir and temp_dir.exists():
                 shutil.rmtree(temp_dir, ignore_errors=True)
-
-        return UploadedModel(
-            provider_model_id=f"accounts/{self.account_id}/models/{model_id}",
-            status="validating",
-            request_payload=create_payload,
-        )
 
     async def upload_model_with_resolver(
         self,
@@ -471,16 +464,44 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         # and base_model, plus the same validation upload_model() does
         # (_verify_base_model_exists, target_modules check).
         _validate_fireworks_model_id(model_name)
-        hf_files = sorted(file_inventory.keys())
-
-        create_payload = await self._create_model_resource(
+        return await self._do_upload(
             model_name,
+            file_inventory,
+            file_resolver,
             ModelType.FULL,
             None,
+            None,
             progress_callback,
-            huggingface_files=hf_files,
         )
 
+    # ------------------------------------------------------------------
+    # upload_model — private helpers
+    # ------------------------------------------------------------------
+
+    async def _do_upload(
+        self,
+        model_name: str,
+        file_inventory: dict[str, int],
+        file_resolver: FileResolver,
+        model_type: ModelType,
+        base_model: str | None,
+        adapter_config: dict[str, Any] | None,
+        progress_callback: ProgressCallback | None,
+    ) -> UploadedModel:
+        """Shared upload implementation: create model → upload files → validate.
+
+        Both ``upload_model`` and ``upload_model_with_resolver`` delegate here
+        after their own prep work (source resolution, adapter validation, etc.).
+        """
+        hf_files = sorted(file_inventory.keys())
+        create_payload = await self._create_model_resource(
+            model_name,
+            model_type,
+            base_model,
+            progress_callback,
+            huggingface_files=hf_files,
+            adapter_config=adapter_config,
+        )
         await self._upload_model_files_with_resolver(
             model_name,
             file_inventory,
@@ -488,16 +509,11 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             progress_callback,
         )
         await self._wait_and_validate(model_name, progress_callback)
-
         return UploadedModel(
             provider_model_id=f"accounts/{self.account_id}/models/{model_name}",
             status="validating",
             request_payload=create_payload,
         )
-
-    # ------------------------------------------------------------------
-    # upload_model — private helpers
-    # ------------------------------------------------------------------
 
     async def _upload_model_files_with_resolver(
         self,
@@ -954,117 +970,6 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             raise ValueError("No upload URLs received from Fireworks API.")
 
         return sorted(file_upload_urls.items(), key=self._upload_order_key)
-
-    async def _upload_model_files(
-        self,
-        model_dir: Path,
-        model_id: str,
-        progress_callback: ProgressCallback | None,
-        file_sizes: dict[str, int] | None = None,
-    ) -> None:
-        """Obtains signed URLs and uploads each file.
-
-        Follows the Fireworks REST API upload flow documented at
-        https://docs.fireworks.ai/models/uploading-custom-models-api:
-
-        1. Call ``getUploadEndpoint`` to obtain per-file signed URLs.
-        2. PUT each file to its signed URL (streamed from disk, with
-           retry and exponential back-off on transient failures).
-
-        Files are uploaded in deterministic order (config/tokenizer first) to
-        improve validation success (GCS propagation).
-
-        Args:
-            model_dir: Local directory containing model weight files.
-            model_id: Fireworks model ID used to request signed upload URLs.
-            progress_callback: Optional callback for upload progress events.
-            file_sizes: Pre-computed file inventory. When ``None`` the
-                inventory is collected from *model_dir* (backward compat).
-        """
-        if file_sizes is None:
-            file_sizes = self._collect_file_inventory(model_dir)
-        total_bytes = sum(file_sizes.values())
-        logger.info(
-            "Found %d files to upload (%.1f MB)",
-            len(file_sizes),
-            total_bytes / _MB,
-        )
-        if "config.json" in file_sizes:
-            logger.info("config.json found (%d bytes)", file_sizes["config.json"])
-        else:
-            logger.error(
-                "config.json NOT found in model files: %s", list(file_sizes.keys())
-            )
-
-        await self._notify(
-            progress_callback,
-            "extracting",
-            f"Found {len(file_sizes)} files ({total_bytes / _MB:.1f} MB total)",
-            {"file_count": len(file_sizes), "files": list(file_sizes.keys())},
-        )
-
-        upload_items = await self._get_signed_urls_ordered(model_id, file_sizes)
-        total_files = len(upload_items)
-        uploaded_bytes = 0
-
-        await self._notify(
-            progress_callback,
-            "uploading",
-            f"Starting upload of {total_files} files ({total_bytes / _MB:.1f} MB)",
-            {"total_files": total_files, "total_bytes": total_bytes},
-        )
-
-        for idx, (filename, signed_url) in enumerate(upload_items, 1):
-            file_path = model_dir / filename
-            file_size = file_sizes[filename]
-
-            logger.info(
-                "[%d/%d] Uploading %s (%.2f MB)",
-                idx,
-                total_files,
-                filename,
-                file_size / _MB,
-            )
-
-            await self._upload_single_file(
-                file_path, file_size, signed_url, filename, idx, total_files
-            )
-
-            uploaded_bytes += file_size
-            logger.info(
-                "[%d/%d] Uploaded %s (%.1f / %.1f MB)",
-                idx,
-                total_files,
-                filename,
-                uploaded_bytes / _MB,
-                total_bytes / _MB,
-            )
-
-            await self._notify(
-                progress_callback,
-                "uploading",
-                f"Uploaded {filename} ({idx}/{total_files}, "
-                f"{uploaded_bytes / _MB:.1f} / {total_bytes / _MB:.1f} MB)",
-                {
-                    "current_file": filename,
-                    "uploaded_count": idx,
-                    "total_files": total_files,
-                    "uploaded_bytes": uploaded_bytes,
-                    "total_bytes": total_bytes,
-                },
-            )
-
-        logger.info(
-            "All %d files uploaded (%.1f MB total)",
-            total_files,
-            total_bytes / _MB,
-        )
-        await self._notify(
-            progress_callback,
-            "uploading",
-            f"All {total_files} files uploaded ({total_bytes / _MB:.1f} MB total)",
-            {"status": "complete", "total_files": total_files},
-        )
 
     # ------------------------------------------------------------------
     # Per-file upload with retry

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -15,6 +15,7 @@
 """Unit tests for Fireworks.ai deployment client."""
 
 import os
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -698,8 +699,6 @@ class TestUploadModelFromInventory:
         async def mock_wait(*args, **kwargs) -> None:
             calls.append("validate")
 
-        from contextlib import asynccontextmanager
-
         @asynccontextmanager
         async def mock_resolver(filename: str):
             yield fake_file
@@ -736,13 +735,9 @@ class TestUploadModelFromInventory:
         """upload_model_from_inventory raises for names that violate Fireworks rules."""
         client = self._make_client()
 
-        from contextlib import asynccontextmanager
-
         @asynccontextmanager
         async def mock_resolver(filename: str):
             yield tmp_path / filename
-
-        from oumi.deploy.fireworks_client import FireworksInvalidModelIdError
 
         with pytest.raises(FireworksInvalidModelIdError):
             await client.upload_model_from_inventory(
@@ -769,8 +764,6 @@ class TestUploadModelFromInventory:
 
         # Map filename → temp file for the mock resolver
         files_map = {"config.json": file_a, "model.safetensors": file_b}
-
-        from contextlib import asynccontextmanager
 
         @asynccontextmanager
         async def mock_resolver(filename: str):

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -668,3 +668,140 @@ class TestCollectFileInventory:
             tmp_path, model_type=ModelType.FULL
         )
         assert len(inventory) == 4
+
+
+class TestUploadModelFromInventory:
+    """Tests for upload_model_from_inventory and _upload_model_files_with_resolver."""
+
+    @staticmethod
+    def _make_client() -> FireworksDeploymentClient:
+        return FireworksDeploymentClient(api_key="test-key", account_id="test-account")
+
+    @pytest.mark.asyncio
+    async def test_upload_model_from_inventory_calls_subflows(self, tmp_path):
+        """upload_model_from_inventory calls create, upload, and validate in order."""
+        client = self._make_client()
+
+        fake_file = tmp_path / "config.json"
+        fake_file.write_text("{}")
+
+        file_inventory = {"config.json": 2}
+        calls: list[str] = []
+
+        async def mock_create(*args, **kwargs) -> dict:
+            calls.append("create")
+            return {"modelId": "my-model"}
+
+        async def mock_upload_with_resolver(*args, **kwargs) -> None:
+            calls.append("upload")
+
+        async def mock_wait(*args, **kwargs) -> None:
+            calls.append("validate")
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_resolver(filename: str):
+            yield fake_file
+
+        with (
+            patch.object(
+                client,
+                "_create_model_resource",
+                side_effect=mock_create,
+            ),
+            patch.object(
+                client,
+                "_upload_model_files_with_resolver",
+                side_effect=mock_upload_with_resolver,
+            ),
+            patch.object(
+                client,
+                "_wait_and_validate",
+                side_effect=mock_wait,
+            ),
+        ):
+            result = await client.upload_model_from_inventory(
+                model_name="my-model",
+                file_inventory=file_inventory,
+                file_resolver=mock_resolver,
+            )
+
+        assert calls == ["create", "upload", "validate"]
+        assert result.provider_model_id == "accounts/test-account/models/my-model"
+        assert result.status == "validating"
+
+    @pytest.mark.asyncio
+    async def test_upload_model_from_inventory_rejects_invalid_name(self, tmp_path):
+        """upload_model_from_inventory raises for names that violate Fireworks rules."""
+        client = self._make_client()
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_resolver(filename: str):
+            yield tmp_path / filename
+
+        from oumi.deploy.fireworks_client import FireworksInvalidModelIdError
+
+        with pytest.raises(FireworksInvalidModelIdError):
+            await client.upload_model_from_inventory(
+                model_name="BadName",  # uppercase letters not allowed
+                file_inventory={"config.json": 10},
+                file_resolver=mock_resolver,
+            )
+
+    @pytest.mark.asyncio
+    async def test_upload_model_files_with_resolver_calls_resolver_per_file(
+        self, tmp_path
+    ):
+        """_upload_model_files_with_resolver calls file_resolver for each file."""
+        client = self._make_client()
+
+        file_a = tmp_path / "config.json"
+        file_a.write_text("{}")
+        file_b = tmp_path / "model.safetensors"
+        file_b.write_bytes(b"\x00" * 100)
+
+        file_inventory = {"config.json": 2, "model.safetensors": 100}
+        resolved: list[str] = []
+        uploaded: list[str] = []
+
+        # Map filename → temp file for the mock resolver
+        files_map = {"config.json": file_a, "model.safetensors": file_b}
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_resolver(filename: str):
+            resolved.append(filename)
+            yield files_map[filename]
+
+        async def mock_upload_single_file(file_path, file_size, signed_url, *args, **kwargs):
+            uploaded.append(str(file_path))
+
+        signed_urls = [("config.json", "https://gcs/config"), ("model.safetensors", "https://gcs/model")]
+        with (
+            patch.object(
+                client,
+                "_get_signed_urls_ordered",
+                new_callable=AsyncMock,
+                return_value=signed_urls,
+            ),
+            patch.object(
+                client,
+                "_upload_single_file",
+                side_effect=mock_upload_single_file,
+            ),
+        ):
+            await client._upload_model_files_with_resolver(
+                model_id="my-model",
+                file_sizes=file_inventory,
+                file_resolver=mock_resolver,
+                progress_callback=None,
+            )
+
+        # Resolver must be called for each file
+        assert sorted(resolved) == ["config.json", "model.safetensors"]
+        # Upload must be called for each resolved file
+        assert len(uploaded) == 2

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -770,10 +770,15 @@ class TestUploadModelFromInventory:
             resolved.append(filename)
             yield files_map[filename]
 
-        async def mock_upload_single_file(file_path, file_size, signed_url, *args, **kwargs):
+        async def mock_upload_single_file(
+            file_path, file_size, signed_url, *args, **kwargs
+        ):
             uploaded.append(str(file_path))
 
-        signed_urls = [("config.json", "https://gcs/config"), ("model.safetensors", "https://gcs/model")]
+        signed_urls = [
+            ("config.json", "https://gcs/config"),
+            ("model.safetensors", "https://gcs/model"),
+        ]
         with (
             patch.object(
                 client,

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -672,15 +672,15 @@ class TestCollectFileInventory:
 
 
 class TestUploadModelFromInventory:
-    """Tests for upload_model_from_inventory and _upload_model_files_with_resolver."""
+    """Tests for upload_model_with_resolver and _upload_model_files_with_resolver."""
 
     @staticmethod
     def _make_client() -> FireworksDeploymentClient:
         return FireworksDeploymentClient(api_key="test-key", account_id="test-account")
 
     @pytest.mark.asyncio
-    async def test_upload_model_from_inventory_calls_subflows(self, tmp_path):
-        """upload_model_from_inventory calls create, upload, and validate in order."""
+    async def test_upload_model_with_resolver_calls_subflows(self, tmp_path):
+        """upload_model_with_resolver calls create, upload, and validate in order."""
         client = self._make_client()
 
         fake_file = tmp_path / "config.json"
@@ -720,7 +720,7 @@ class TestUploadModelFromInventory:
                 side_effect=mock_wait,
             ),
         ):
-            result = await client.upload_model_from_inventory(
+            result = await client.upload_model_with_resolver(
                 model_name="my-model",
                 file_inventory=file_inventory,
                 file_resolver=mock_resolver,
@@ -731,8 +731,8 @@ class TestUploadModelFromInventory:
         assert result.status == "validating"
 
     @pytest.mark.asyncio
-    async def test_upload_model_from_inventory_rejects_invalid_name(self, tmp_path):
-        """upload_model_from_inventory raises for names that violate Fireworks rules."""
+    async def test_upload_model_with_resolver_rejects_invalid_name(self, tmp_path):
+        """upload_model_with_resolver raises for names that violate Fireworks rules."""
         client = self._make_client()
 
         @asynccontextmanager
@@ -740,7 +740,7 @@ class TestUploadModelFromInventory:
             yield tmp_path / filename
 
         with pytest.raises(FireworksInvalidModelIdError):
-            await client.upload_model_from_inventory(
+            await client.upload_model_with_resolver(
                 model_name="BadName",  # uppercase letters not allowed
                 file_inventory={"config.json": 10},
                 file_resolver=mock_resolver,


### PR DESCRIPTION
# Description

Add capability to yield files for uploading. This enables us to stream files from remote locations to Fireworks. The current upload_model function assumes everything is on local disk. Reworked it to yield its local directory.

Tested CLI locally to ensure no breaking changes.

## Related issues

Towards LOU-1161

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.