### PR TITLE
feat(deploy): support caller-supplied deploymentId in create_endpoint

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -189,6 +189,15 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             timeout=120.0,
         )
 
+    async def __aenter__(self) -> "FireworksDeploymentClient":
+        """Enters the async context manager.
+
+        Narrows the base ``__aenter__`` return type to this subclass so
+        callers using ``async with`` get full access to Fireworks-specific
+        methods without a cast.
+        """
+        return self
+
     async def close(self) -> None:
         """Closes the HTTP client and releases resources."""
         await self._client.aclose()
@@ -1216,6 +1225,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         hardware: HardwareConfig,
         autoscaling: AutoscalingConfig,
         display_name: str | None = None,
+        endpoint_id: str | None = None,
     ) -> Endpoint:
         """Creates an inference endpoint (deployment) for a model.
 
@@ -1224,6 +1234,12 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             hardware: Hardware configuration
             autoscaling: Autoscaling configuration
             display_name: Optional display name
+            endpoint_id: Optional caller-supplied deployment ID. When provided,
+                it is passed as the ``deploymentId`` query parameter so the
+                resulting deployment has a deterministic resource path
+                ``accounts/{account_id}/deployments/{endpoint_id}``. When
+                omitted, Fireworks generates a random ID (the default
+                behavior).
 
         Returns:
             Created Endpoint
@@ -1239,9 +1255,14 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             displayName=display_name,
         )
 
+        params: dict[str, Any] = {}
+        if endpoint_id is not None:
+            params["deploymentId"] = endpoint_id
+
         response = await self._client.post(
             f"/v1/accounts/{self.account_id}/deployments",
             json=deployment.model_dump(by_alias=True, exclude_none=True),
+            params=params,
         )
         self._check_response(response, f"create endpoint for model '{model_id}'")
 

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -230,6 +230,43 @@ class TestFireworksDeploymentClient:
             assert payload["minReplicaCount"] == 1
             assert payload["maxReplicaCount"] == 2
             assert payload["displayName"] == "test-deployment"
+            # No caller-supplied ID → no deploymentId query param.
+            assert call_args[1].get("params", {}) == {}
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint_with_endpoint_id(self):
+        """Test create_endpoint passes caller-supplied deploymentId as query param."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "name": "accounts/test-account/deployments/dep-42-m10-v1",
+            "baseModel": "model-456",
+            "state": "CREATING",
+            "acceleratorType": "NVIDIA_A100_80GB",
+            "acceleratorCount": 1,
+            "minReplicaCount": 1,
+            "maxReplicaCount": 2,
+        }
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            await client.create_endpoint(
+                model_id="model-456",
+                hardware=HardwareConfig(accelerator="nvidia_a100_80gb", count=1),
+                autoscaling=AutoscalingConfig(min_replicas=1, max_replicas=2),
+                endpoint_id="dep-42-m10-v1",
+            )
+
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            # deploymentId is a query param, not a body field.
+            assert call_args[1]["params"] == {"deploymentId": "dep-42-m10-v1"}
+            payload = call_args[1]["json"]
+            assert "deploymentId" not in payload
+            assert payload["baseModel"] == "model-456"
 
     @pytest.mark.asyncio
     async def test_get_endpoint(self):


### PR DESCRIPTION
## Summary

Adds an optional `endpoint_id` parameter to `FireworksDeploymentClient.create_endpoint`. When provided, it is passed as the `?deploymentId=...` [query parameter](https://docs.fireworks.ai/api-reference/create-deployment#parameter-deployment-id).

Also narrows `FireworksDeploymentClient.__aenter__` return type to `FireworksDeploymentClient` so consumers using `async with` get full access to subclass methods without a cast, needed now that callers reference the new `endpoint_id` kwarg via the context manager.

Towards LOU-1161.