### PR TITLE
Add masking_method enum for simplified masking control

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -263,9 +263,9 @@ def build_collator_from_config(
             )
         collator_kwargs = _build_masking_kwargs(masking_method, tokenizer)
     else:
-        collator_kwargs = dict(train_split.collator_kwargs or {})
+        collator_kwargs: dict = {}
 
-    # Vision collator auto-kwargs.
+    # 2. Vision collator auto-kwargs.
     if (
         collator_name in ("vision_language_with_padding", "vision_language_sft")
         and model_config is not None
@@ -291,6 +291,11 @@ def build_collator_from_config(
         collator_kwargs["trust_remote_code"] = collator_kwargs.get(
             "trust_remote_code", config.model.trust_remote_code
         )
+
+    # 3. Merge collator_kwargs from config with the existing kwargs.
+    # Config kwargs take precedence over automatically determined kwargs.
+    config_collator_kwargs = train_split.collator_kwargs or {}
+    collator_kwargs.update(config_collator_kwargs)
 
     return build_data_collator(
         collator_name=collator_name,

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import oumi.core.constants as constants
 from oumi.core.collators.text_collator_with_padding import TextCollatorWithPadding
@@ -27,11 +28,91 @@ from oumi.core.configs import DatasetSplit, TrainingConfig
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
 )
+from oumi.core.configs.params.data_params import MaskingMethod
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
 # This is used to set the max input length for a model with infinite size input
 _VERY_LARGE_INTEGER = int(1e30)
+
+
+@dataclass(frozen=True)
+class _CollatorTemplates:
+    """Model-specific token strings for SFT label masking."""
+
+    response_template: str
+    end_of_turn_template: str
+    tool_call_start_template: str | None = None
+
+
+_CHATML_TEMPLATES = _CollatorTemplates(
+    response_template="<|im_start|>assistant\n",
+    end_of_turn_template="<|im_end|>",
+    tool_call_start_template="<tool_call>",
+)
+
+_LLAMA3_TEMPLATES = _CollatorTemplates(
+    response_template="<|start_header_id|>assistant<|end_header_id|>\n\n",
+    end_of_turn_template="<|eot_id|>",
+    tool_call_start_template="<|python_tag|>",
+)
+
+# Each entry: (marker_token, templates).
+# Order matters: first marker found in the tokenizer's vocabulary wins.
+# Adding a new model family = adding one line here.
+_COLLATOR_TEMPLATE_DETECTORS: list[tuple[str, _CollatorTemplates]] = [
+    ("<|im_start|>", _CHATML_TEMPLATES),  # ChatML: Qwen, Yi, etc.
+    ("<|start_header_id|>", _LLAMA3_TEMPLATES),  # Llama 3
+]
+
+
+def _resolve_collator_templates(
+    tokenizer: BaseTokenizer,
+) -> _CollatorTemplates:
+    """Detect model family from tokenizer vocabulary and return templates."""
+    vocab = tokenizer.get_vocab()
+    for marker_token, templates in _COLLATOR_TEMPLATE_DETECTORS:
+        if marker_token in vocab:
+            return templates
+
+    raise ValueError(
+        "Cannot detect collator templates from tokenizer vocabulary. "
+        "Use collator_kwargs to provide response_template and "
+        "end_of_turn_template manually instead of masking_method."
+    )
+
+
+def _build_masking_kwargs(
+    masking_method: MaskingMethod,
+    tokenizer: BaseTokenizer,
+) -> dict:
+    """Build collator kwargs from a masking_method enum and tokenizer.
+
+    Resolves model-specific templates from the tokenizer vocabulary
+    and returns kwargs ready to pass to build_data_collator.
+    """
+    templates = _resolve_collator_templates(tokenizer)
+    kwargs: dict = {
+        "masking_method": masking_method.value,
+        "response_template": templates.response_template,
+    }
+
+    if masking_method in (
+        MaskingMethod.ASSISTANT_TURN,
+        MaskingMethod.ASSISTANT_TURN_NO_TOOLS,
+    ):
+        kwargs["end_of_turn_template"] = templates.end_of_turn_template
+
+    if masking_method == MaskingMethod.ASSISTANT_TURN_NO_TOOLS:
+        if templates.tool_call_start_template is None:
+            raise ValueError(
+                "masking_method='assistant_turn_no_tools' requires "
+                "tool_call_start_template, but none is registered "
+                "for this model's token family."
+            )
+        kwargs["tool_call_start_template"] = templates.tool_call_start_template
+
+    return kwargs
 
 
 def build_data_collator(
@@ -127,38 +208,26 @@ def build_data_collator(
             **kwargs,
         )
     elif collator_name == "text_completions_only_with_padding":
-        # Extract instruction and response templates from kwargs if provided
-        instruction_template = kwargs.pop("instruction_template", None)
-        response_template = kwargs.pop("response_template", None)
+        masking_method = kwargs.pop("masking_method", None)
         end_of_turn_template = kwargs.pop("end_of_turn_template", None)
-        mask_tool_calls = kwargs.pop("mask_tool_calls", False)
         tool_call_start_template = kwargs.pop("tool_call_start_template", None)
+        response_template = kwargs.pop("response_template", None)
+        instruction_template = kwargs.pop("instruction_template", None)
 
-        # Only default to Llama-style instruction template when NOT using
-        # span-based masking (end_of_turn_template makes instruction_prefix
-        # unnecessary since masking is handled by response/eot spans).
-        if end_of_turn_template is None:
-            instruction_prefix = (
-                instruction_template
-                if instruction_template
-                else "<|start_header_id|>user<|end_header_id|>\n\n"
+        if not response_template:
+            raise ValueError(
+                "response_template is required for "
+                "'text_completions_only_with_padding'. Provide it via "
+                "collator_kwargs or use masking_method for auto-resolution."
             )
-        else:
-            instruction_prefix = instruction_template  # may be None, that's fine
-
-        response_prefix = (
-            response_template
-            if response_template
-            else "<|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            instruction_prefix=instruction_prefix,
-            response_prefix=response_prefix,
+            response_template=response_template,
+            instruction_template=instruction_template,
             debug=debug,
+            masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            mask_tool_calls=mask_tool_calls,
             tool_call_start_template=tool_call_start_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
@@ -195,7 +264,22 @@ def build_collator_from_config(
         )
     )
 
-    collator_kwargs = {}
+    collator_kwargs: dict = {}
+    masking_method = train_split.masking_method
+
+    if masking_method is None:
+        # Legacy path: use collator_kwargs from config as-is.
+        collator_kwargs.update(train_split.collator_kwargs or {})
+    else:
+        if collator_name != "text_completions_only_with_padding":
+            raise ValueError(
+                f"masking_method is only supported for "
+                f"'text_completions_only_with_padding', "
+                f"got collator_name='{collator_name}'."
+            )
+        collator_kwargs.update(_build_masking_kwargs(masking_method, tokenizer))
+
+    # Vision collator auto-kwargs.
     if (
         collator_name in ("vision_language_with_padding", "vision_language_sft")
         and model_config is not None
@@ -221,11 +305,6 @@ def build_collator_from_config(
         collator_kwargs["trust_remote_code"] = collator_kwargs.get(
             "trust_remote_code", config.model.trust_remote_code
         )
-
-    # Merge collator_kwargs from config with the existing kwargs
-    # Config kwargs take precedence over automatically determined kwargs
-    config_collator_kwargs = train_split.collator_kwargs or {}
-    collator_kwargs.update(config_collator_kwargs)
 
     return build_data_collator(
         collator_name=collator_name,

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -208,27 +208,15 @@ def build_data_collator(
             **kwargs,
         )
     elif collator_name == "text_completions_only_with_padding":
-        masking_method = kwargs.pop("masking_method", None)
-        end_of_turn_template = kwargs.pop("end_of_turn_template", None)
-        tool_call_start_template = kwargs.pop("tool_call_start_template", None)
-        response_template = kwargs.pop("response_template", None)
-        instruction_template = kwargs.pop("instruction_template", None)
-
-        if not response_template:
+        if not kwargs.get("response_template"):
             raise ValueError(
                 "response_template is required for "
                 "'text_completions_only_with_padding'. Provide it via "
                 "collator_kwargs or use masking_method for auto-resolution."
             )
-
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_template=response_template,
-            instruction_template=instruction_template,
             debug=debug,
-            masking_method=masking_method,
-            end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
             ),
@@ -264,20 +252,18 @@ def build_collator_from_config(
         )
     )
 
-    collator_kwargs: dict = {}
+    # 1. Resolve kwargs — masking_method or raw collator_kwargs.
     masking_method = train_split.masking_method
-
-    if masking_method is None:
-        # Legacy path: use collator_kwargs from config as-is.
-        collator_kwargs.update(train_split.collator_kwargs or {})
-    else:
+    if masking_method is not None:
         if collator_name != "text_completions_only_with_padding":
             raise ValueError(
                 f"masking_method is only supported for "
                 f"'text_completions_only_with_padding', "
                 f"got collator_name='{collator_name}'."
             )
-        collator_kwargs.update(_build_masking_kwargs(masking_method, tokenizer))
+        collator_kwargs = _build_masking_kwargs(masking_method, tokenizer)
+    else:
+        collator_kwargs = dict(train_split.collator_kwargs or {})
 
     # Vision collator auto-kwargs.
     if (

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -27,11 +27,11 @@ class TextCompletionsCollatorWithPadding:
     def __init__(
         self,
         tokenizer: BaseTokenizer,
-        response_prefix: str | list[int],
-        instruction_prefix: str | list[int] | None = None,
+        response_template: str | list[int],
+        instruction_template: str | list[int] | None = None,
         debug: bool = False,
+        masking_method: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
-        mask_tool_calls: bool = False,
         tool_call_start_template: str | list[int] | None = None,
         ignore_index: int = -100,
     ):
@@ -39,24 +39,24 @@ class TextCompletionsCollatorWithPadding:
 
         Args:
         tokenizer: The tokenizer used for encoding the data.
-        response_prefix: The prefix marking the beginning of the assistant response.
-        instruction_prefix: The prefix marking the beginning of the user instruction.
-            Optional when using span-based masking via end_of_turn_template.
+        response_template: String or token-ID list marking assistant response start.
+        instruction_template: String or token-ID list marking user instruction start.
         debug: If True, enables debug mode for logging.
-        end_of_turn_template: String or token-ID list marking end of turn.
-            When provided, enables span-based masking for tool-aware conversations.
-        mask_tool_calls: When True, re-masks assistant spans containing tool calls.
+        masking_method: Masking strategy — ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
+        end_of_turn_template: String or token-ID list marking the end of a turn.
+            Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
         tool_call_start_template: String or token-ID list marking tool-call start.
-            Required when mask_tool_calls=True.
+            Required for ``assistant_turn_no_tools``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
-            instruction_template=instruction_prefix,
-            response_template=response_prefix,
+            instruction_template=instruction_template,
+            response_template=response_template,
+            masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            mask_tool_calls=mask_tool_calls,
             tool_call_start_template=tool_call_start_template,
             ignore_index=ignore_index,
         )

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -21,9 +21,48 @@ from transformers.data.data_collator import DataCollatorForLanguageModeling
 
 
 class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
-    """Data collator used for completion tasks.
+    """Data collator for completion-only training.
 
-    Copied from `trl`'s `DataCollatorForCompletionOnlyLM` class.
+    Masks input labels so that the loss is only computed on specific
+    tokens (typically assistant responses), while ignoring other tokens
+    (system prompts, user messages, padding).
+
+    The ``masking_method`` parameter selects the masking strategy:
+
+    **``assistant_turn``**:
+        Span-based masking for multi-turn and tool-calling conversations.
+        Masks everything, then unmarks each assistant response span bounded
+        by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
+        Correctly handles interleaved tool results and parallel tool calls.
+
+    **``assistant_turn_no_tools``**:
+        Same as ``assistant_turn``, but additionally re-masks assistant
+        turns that contain tool-call content. Requires
+        ``tool_call_start_template``. Only natural-language responses
+        contribute to the loss.
+
+    **``final_assistant_turn``**:
+        Masks all tokens before the *last* ``response_template`` occurrence.
+        Only the final assistant response is trained on. Suitable for
+        single-turn completions.
+
+    Args:
+        response_template: String or token IDs marking the start of an
+            assistant response. Required for all modes.
+        instruction_template: String or token IDs marking the start of a
+            user instruction. Legacy — only used with the instruction+response
+            fallback path.
+        masking_method: One of ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, ``"final_assistant_turn"``.
+            When None, inferred from template presence for backward compat.
+        end_of_turn_template: String or token IDs marking the end of a
+            conversational turn. Required for ``assistant_turn`` and
+            ``assistant_turn_no_tools`` modes.
+        tool_call_start_template: String or token IDs marking the start
+            of a tool-call block. Required for ``assistant_turn_no_tools``.
+        mlm: Whether to use masked language modeling. Default False.
+        ignore_index: Label value for masked tokens. Default -100.
+        padding_free: Remove padding and add position_ids. Default False.
     """
 
     def __init__(
@@ -31,8 +70,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
+        masking_method: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
-        mask_tool_calls: bool = False,
         tool_call_start_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
@@ -74,13 +113,38 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             self.end_of_turn_token_ids = None
 
-        self.mask_tool_calls = mask_tool_calls
+        _KNOWN_MASKING_METHODS = {
+            "assistant_turn",
+            "assistant_turn_no_tools",
+            "final_assistant_turn",
+            "_legacy_instruction_response",
+        }
+
+        # Infer masking_method from template presence for backward compatibility.
+        if masking_method is not None:
+            if masking_method not in _KNOWN_MASKING_METHODS:
+                valid_methods = sorted(
+                    _KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {valid_methods}"
+                )
+            self.masking_method = masking_method
+        elif end_of_turn_template is not None:
+            self.masking_method = "assistant_turn"
+        elif instruction_template is None:
+            self.masking_method = "final_assistant_turn"
+        else:
+            self.masking_method = "_legacy_instruction_response"
+
+        self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
         self.tool_call_start_token_ids: list[int] | None = None
-        if mask_tool_calls:
+        if self.mask_tool_calls:
             if tool_call_start_template is None:
                 raise ValueError(
                     "tool_call_start_template must be provided "
-                    "when mask_tool_calls=True"
+                    "when masking_method='assistant_turn_no_tools'"
                 )
             if isinstance(tool_call_start_template, str):
                 self.tool_call_start_token_ids = self.tokenizer.encode(
@@ -137,10 +201,12 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
     ) -> None:
-        """Apply span-based label masking for tool-aware conversations.
+        """Apply span-based masking for tool-aware conversations.
 
-        This masks everything, then selectively unmasks assistant response
-        spans delimited by response_template and end_of_turn_template.
+        Masks all labels, then unmarks assistant response spans bounded by
+        response_template and end_of_turn_template (inclusive — the EOT token
+        is unmasked so the model learns to produce it).  Optionally re-masks
+        spans that contain tool-call content.
         """
         resp_ids = self.response_token_ids
         eot_ids = self.end_of_turn_token_ids
@@ -199,9 +265,17 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     ):
                         continue
 
-                # Step 5: unmask this assistant response span.
-                batch["labels"][i, content_start:content_end] = batch["input_ids"][
-                    i, content_start:content_end
+                # Step 5: unmask this assistant response span, including the
+                # end-of-turn token so the model learns when to stop.
+                if eot_positions:
+                    eot_len = len(self.end_of_turn_token_ids)  # type: ignore
+                    unmask_end = content_end + eot_len
+                else:
+                    # No EOT found — content_end == n (end of real content).
+                    # Do NOT extend past n or we'd unmask into padding.
+                    unmask_end = content_end
+                batch["labels"][i, content_start:unmask_end] = batch["input_ids"][
+                    i, content_start:unmask_end
                 ]
 
     # ------------------------------------------------------------------
@@ -214,9 +288,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.end_of_turn_template is not None:
+        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
             self._apply_span_masking(batch, examples)
-        elif self.instruction_template is None:
+        elif self.masking_method == "final_assistant_turn":
+            # Response-only: unmask only the final assistant response.
             for i in range(len(examples)):
                 response_token_ids_start_idx = None
 

--- a/src/oumi/core/configs/__init__.py
+++ b/src/oumi/core/configs/__init__.py
@@ -93,6 +93,7 @@ from oumi.core.configs.params.data_params import (
     DatasetParams,
     DatasetSplit,
     DatasetSplitParams,
+    MaskingMethod,
     MixtureStrategy,
 )
 from oumi.core.configs.params.evaluation_params import (
@@ -190,6 +191,7 @@ __all__ = [
     "LMHarnessTaskParams",
     "LoraWeightInitialization",
     "MixedPrecisionDtype",
+    "MaskingMethod",
     "MixtureStrategy",
     "ModelParams",
     "PeftParams",

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -52,6 +52,33 @@ class MixtureStrategy(str, Enum):
             raise ValueError("Unsupported value for MixtureStrategy")
 
 
+class MaskingMethod(str, Enum):
+    """Controls which tokens contribute to the loss during SFT training.
+
+    Used with the ``text_completions_only_with_padding`` collator to
+    select the masking strategy. Template tokens are auto-resolved
+    from the tokenizer vocabulary.
+
+    Members:
+        ASSISTANT_TURN: Train on all assistant response turns including
+            tool calls. Uses span-based masking: system prompts, user
+            messages, and tool results are masked; everything between the
+            assistant header and the end-of-turn token (inclusive) is
+            unmasked.
+        ASSISTANT_TURN_NO_TOOLS: Same as ``ASSISTANT_TURN``, but
+            additionally masks assistant turns that contain tool-call
+            content. Only natural-language assistant responses contribute
+            to the loss.
+        FINAL_ASSISTANT_TURN: Train only on the final assistant response.
+            Masks all tokens before the last ``response_template``
+            occurrence. Suitable for single-turn completions.
+    """
+
+    ASSISTANT_TURN = "assistant_turn"
+    ASSISTANT_TURN_NO_TOOLS = "assistant_turn_no_tools"
+    FINAL_ASSISTANT_TURN = "final_assistant_turn"
+
+
 @dataclass
 class DatasetParams(BaseParams):
     dataset_name: str = MISSING
@@ -216,6 +243,24 @@ class DatasetSplitParams(BaseParams):
     and can be used to customize collator behavior beyond the default parameters.
     """
 
+    masking_method: MaskingMethod | None = None
+    """Masking strategy for the completions collator.
+
+    Only applies when ``collator_name`` is
+    ``text_completions_only_with_padding``. Defaults to ``assistant_turn``
+    when that collator is used.
+
+    When set, template tokens are auto-resolved from the tokenizer
+    vocabulary — ``collator_kwargs`` for templates are not needed.
+
+    Example YAML::
+
+        data:
+          train:
+            collator_name: "text_completions_only_with_padding"
+            masking_method: "assistant_turn"
+    """
+
     pack: bool = False
     """Whether to pack the text into constant-length chunks.
 
@@ -303,6 +348,15 @@ class DatasetSplitParams(BaseParams):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        if self.masking_method is not None:
+            if isinstance(self.masking_method, str):
+                self.masking_method = MaskingMethod(self.masking_method)
+            if self.collator_kwargs:
+                raise ValueError(
+                    "masking_method and collator_kwargs are mutually exclusive. "
+                    "masking_method auto-resolves all template tokens — remove "
+                    "collator_kwargs."
+                )
 
     def _is_sum_normalized(self, mix_sum) -> bool:
         # Note: the underlying interleave implementation requires

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -247,11 +247,12 @@ class DatasetSplitParams(BaseParams):
     """Masking strategy for the completions collator.
 
     Only applies when ``collator_name`` is
-    ``text_completions_only_with_padding``. Defaults to ``assistant_turn``
-    when that collator is used.
+    ``text_completions_only_with_padding``. When ``None`` (default),
+    template tokens must be provided manually via ``collator_kwargs``.
 
     When set, template tokens are auto-resolved from the tokenizer
     vocabulary — ``collator_kwargs`` for templates are not needed.
+    Mutually exclusive with ``collator_kwargs``.
 
     Example YAML::
 

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -9,6 +9,7 @@ from oumi.core.configs import (
     DataParams,
     DatasetParams,
     DatasetSplitParams,
+    MaskingMethod,
     ModelParams,
     TrainingConfig,
     TrainingParams,
@@ -176,14 +177,14 @@ def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
     )
     assert collator_custom._default_collator.ignore_index == -200
 
-    # With mask_tool_calls
+    # With masking_method=assistant_turn_no_tools
     collator_tc = build_data_collator(
         collator_name,
         mock_tokenizer,
         max_length=None,
         response_template=resp,
+        masking_method="assistant_turn_no_tools",
         end_of_turn_template=eot,
-        mask_tool_calls=True,
         tool_call_start_template="<tool_call>",
     )
     assert collator_tc is not None
@@ -293,3 +294,238 @@ def test_build_collator_from_config_collator_kwargs_override(mock_tokenizer):
     assert callable(collator)
     # Verify that the config kwargs override the model-determined kwargs
     assert collator._allow_multi_image_inputs is False
+
+
+# ---------------------------------------------------------------------------
+# masking_method tests
+# ---------------------------------------------------------------------------
+
+
+def test_masking_method_assistant_turn(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={"<|im_start|>": 1, "<|im_end|>": 2}
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="Qwen/Qwen2.5-1.5B",
+            model_max_length=64,
+            trust_remote_code=True,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.response_template == "<|im_start|>assistant\n"
+    assert inner.end_of_turn_template == "<|im_end|>"
+    assert inner.masking_method == "assistant_turn"
+    assert inner.mask_tool_calls is False
+
+
+def test_masking_method_no_tools(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={"<|im_start|>": 1, "<|im_end|>": 2}
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN_NO_TOOLS,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="Qwen/Qwen2.5-1.5B",
+            model_max_length=64,
+            trust_remote_code=True,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.mask_tool_calls is True
+    assert inner.tool_call_start_token_ids is not None
+
+
+def test_masking_method_final_assistant_turn(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={"<|im_start|>": 1, "<|im_end|>": 2}
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.FINAL_ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="Qwen/Qwen2.5-1.5B",
+            model_max_length=64,
+            trust_remote_code=True,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.masking_method == "final_assistant_turn"
+    assert inner.mask_tool_calls is False
+
+
+def test_masking_method_llama3(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={"<|start_header_id|>": 1, "<|eot_id|>": 2}
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_max_length=64,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.end_of_turn_template == "<|eot_id|>"
+
+
+def test_masking_method_unknown_tokenizer(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(return_value={"hello": 1})
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(model_name="MlpEncoder", model_max_length=64),
+    )
+    with pytest.raises(ValueError, match="Cannot detect collator templates"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)
+
+
+def test_masking_method_and_collator_kwargs_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        DatasetSplitParams(
+            masking_method=MaskingMethod.ASSISTANT_TURN,
+            collator_kwargs={"response_template": "foo"},
+            datasets=[DatasetParams(dataset_name="dummy", split="train")],
+        )
+
+
+def test_masking_method_on_wrong_collator(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={"<|im_start|>": 1, "<|im_end|>": 2}
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(model_name="MlpEncoder", model_max_length=64),
+    )
+    with pytest.raises(ValueError, match="only supported for"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)
+
+
+def test_no_masking_method_backward_compat(mock_tokenizer):
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|im_start|>assistant\n",
+                    "end_of_turn_template": "<|im_end|>",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="Qwen/Qwen2.5-1.5B",
+            model_max_length=64,
+            trust_remote_code=True,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+
+
+def test_masking_method_llama3_no_tools(mock_tokenizer):
+    mock_tokenizer.get_vocab = MagicMock(
+        return_value={
+            "<|start_header_id|>": 1,
+            "<|eot_id|>": 2,
+            "<|python_tag|>": 3,
+        }
+    )
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN_NO_TOOLS,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_max_length=64,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.mask_tool_calls is True
+    assert inner.tool_call_start_token_ids is not None
+
+
+def test_legacy_collator_kwargs_with_instruction_template(mock_tokenizer):
+    """Old configs that pass instruction_template via collator_kwargs use
+    the legacy instruction+response masking path."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": (
+                        "<|start_header_id|>assistant<|end_header_id|>\n\n"
+                    ),
+                    "instruction_template": (
+                        "<|start_header_id|>user<|end_header_id|>\n\n"
+                    ),
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_max_length=64,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.instruction_template == (
+        "<|start_header_id|>user<|end_header_id|>\n\n"
+    )
+    assert inner.response_template == (
+        "<|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+    # Verify it inferred the legacy instruction+response masking path
+    assert inner.masking_method == "_legacy_instruction_response"

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -391,7 +391,7 @@ def test_masking_method_llama3(mock_tokenizer):
             )
         ),
         model=ModelParams(
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_name="MlpEncoder",
             model_max_length=64,
         ),
     )
@@ -483,7 +483,7 @@ def test_masking_method_llama3_no_tools(mock_tokenizer):
             )
         ),
         model=ModelParams(
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_name="MlpEncoder",
             model_max_length=64,
         ),
     )
@@ -513,7 +513,7 @@ def test_legacy_collator_kwargs_with_instruction_template(mock_tokenizer):
             )
         ),
         model=ModelParams(
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_name="MlpEncoder",
             model_max_length=64,
         ),
     )

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -62,8 +62,8 @@ def test_success_basic():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
     )
     assert callable(collator)
 
@@ -186,8 +186,8 @@ def test_debug_logging(caplog):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
         debug=True,
     )
     assert callable(collator)
@@ -277,11 +277,12 @@ def make_span_collator(
 ) -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
     resp_ids, eot_ids, tc_ids = get_template_token_ids()
+    masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_prefix=resp_ids,
+        response_template=resp_ids,
+        masking_method=masking_method,
         end_of_turn_template=eot_ids,
-        mask_tool_calls=mask_tool_calls,
         tool_call_start_template=tc_ids if mask_tool_calls else None,
     )
 
@@ -313,7 +314,8 @@ def test_span_single_turn_content_is_unmasked():
     n_prefix = len(prefix) + len(resp)
     assert all(v == IGNORE for v in labels[:n_prefix])
     assert labels[n_prefix : n_prefix + len(content)] == content
-    assert all(v == IGNORE for v in labels[n_prefix + len(content) :])
+    # EOT tokens are unmasked (model learns to produce the stop token)
+    assert labels[n_prefix + len(content) : n_prefix + len(content) + len(eot)] == eot
 
 
 def test_span_single_turn_response_template_tokens_are_masked():
@@ -326,7 +328,7 @@ def test_span_single_turn_response_template_tokens_are_masked():
         assert labels[i] == IGNORE, f"resp template token {i} should be masked"
 
 
-def test_span_single_turn_eot_tokens_are_masked():
+def test_span_single_turn_eot_tokens_are_unmasked():
     resp, eot, _ = get_template_token_ids()
     content = [_SENTINELS[0]]
     seq = flat(resp, content, eot)
@@ -334,8 +336,7 @@ def test_span_single_turn_eot_tokens_are_masked():
     labels = get_span_labels(make_span_collator(), seq)
 
     eot_start = len(resp) + len(content)
-    for i in range(len(eot)):
-        assert labels[eot_start + i] == IGNORE, f"eot token {i} should be masked"
+    assert labels[eot_start : eot_start + len(eot)] == eot
 
 
 # ---------------------------------------------------------------------------
@@ -456,9 +457,9 @@ def test_span_mask_tool_calls_requires_template():
     with pytest.raises(ValueError, match="tool_call_start_template"):
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_prefix=resp_ids,
+            response_template=resp_ids,
+            masking_method="assistant_turn_no_tools",
             end_of_turn_template=eot_ids,
-            mask_tool_calls=True,
             tool_call_start_template=None,
         )
 
@@ -512,7 +513,7 @@ def test_span_padding_matching_eot_does_not_false_match():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_prefix=resp,
+        response_template=resp,
         end_of_turn_template=eot_ids,
     )
     batch = collator([{"input_ids": seq}])
@@ -592,5 +593,5 @@ def test_span_labels_numpy_values_match_expected():
     seq = flat(resp, content, eot)
 
     batch = make_span_collator()([{"input_ids": seq}])
-    expected = [IGNORE] * len(resp) + content + [IGNORE] * len(eot)
+    expected = [IGNORE] * len(resp) + content + eot
     assert np.all(batch["labels"].numpy() == np.array([expected], dtype=np.int32))

--- a/tests/unit/core/datasets/test_base_sft_dataset.py
+++ b/tests/unit/core/datasets/test_base_sft_dataset.py
@@ -26,8 +26,8 @@ def _get_hf_collator_result(conversation, tokenizer):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=_INSTRUCTION_PREFIX,
-        response_prefix=_RESPONSE_PREFIX,
+        instruction_template=_INSTRUCTION_PREFIX,
+        response_template=_RESPONSE_PREFIX,
     )
 
     return collator(batch)


### PR DESCRIPTION
# Description

Replace implicit masking mode detection (based on which template arguments are present) with an explicit `masking_method` enum parameter on the completions collator.

**Before** — users must provide model-specific token strings:
```yaml
collator_name: "text_completions_only_with_padding"
collator_kwargs:
  response_template: "<|im_start|>assistant\n"
  end_of_turn_template: "<|im_end|>"
  mask_tool_calls: false
  tool_call_start_template: "<tool_call>"
```

**After** — users express intent, templates auto-resolve from tokenizer:
```yaml
collator_name: "text_completions_only_with_padding"
masking_method: "assistant_turn"
```

### Changes

-`MaskingMethod` enum with three values: `ASSISTANT_TURN`, `ASSISTANT_TURN_NO_TOOLS`, `FINAL_ASSISTANT_TURN`
- Template auto-resolution from tokenizer vocabulary (Qwen/ChatML and Llama 3 via `_COLLATOR_TEMPLATE_DETECTORS` registry)
- `masking_method` is a parameter of the completions collator
- Backward compatible: legacy configs with `collator_kwargs` (including `instruction_template`) still work
- Validation: unknown `masking_method` strings raise `ValueError` at init time

## Related issues

Builds on shanghong/tool-aware-collator branch

## Before submitting

- [ ] This PR only changes documentation.
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.