### PR TITLE
Add span-based masking to DataCollatorForCompletionOnlyLM

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -132,7 +132,6 @@ def build_data_collator(
         response_template = kwargs.pop("response_template", None)
         end_of_turn_template = kwargs.pop("end_of_turn_template", None)
         masking_method = kwargs.pop("masking_method", None)
-        tool_call_start_template = kwargs.pop("tool_call_start_template", None)
 
         # Only default to Llama-style instruction template when NOT using
         # span-based masking (end_of_turn_template makes it unnecessary).
@@ -153,7 +152,6 @@ def build_data_collator(
             debug=debug,
             masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
             ),

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -127,31 +127,15 @@ def build_data_collator(
             **kwargs,
         )
     elif collator_name == "text_completions_only_with_padding":
-        # Extract instruction and response templates from kwargs if provided
-        instruction_template = kwargs.pop("instruction_template", None)
-        response_template = kwargs.pop("response_template", None)
-        end_of_turn_template = kwargs.pop("end_of_turn_template", None)
-        masking_method = kwargs.pop("masking_method", None)
-
-        # Only default to Llama-style instruction template when NOT using
-        # span-based masking (end_of_turn_template makes it unnecessary).
-        if end_of_turn_template is None:
-            instruction_template = (
-                instruction_template
-                if instruction_template
-                else "<|start_header_id|>user<|end_header_id|>\n\n"
+        if not kwargs.get("response_template"):
+            raise ValueError(
+                "'text_completions_only_with_padding' requires a "
+                "response_template. Provide it via collator_kwargs."
             )
-
-        if not response_template:
-            response_template = "<|start_header_id|>assistant<|end_header_id|>\n\n"
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_template=response_template,
-            instruction_template=instruction_template,
             debug=debug,
-            masking_method=masking_method,
-            end_of_turn_template=end_of_turn_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
             ),

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -51,7 +51,8 @@ def build_data_collator(
 
             - "text_with_padding": Uses `TextCollatorWithPadding`.
             - "text_completions_only_with_padding": Uses
-                `TextCompletionsCollatorWithPadding`.
+                `TextCompletionsCollatorWithPadding`. Supports optional
+                ``end_of_turn_template`` for tool-aware span-based masking.
             - "vision_language_with_padding": Uses `VisionLanguageCollatorWithPadding`.
             - "vision_language_sft": Uses `VisionLanguageSftCollator`.
 
@@ -129,24 +130,33 @@ def build_data_collator(
         # Extract instruction and response templates from kwargs if provided
         instruction_template = kwargs.pop("instruction_template", None)
         response_template = kwargs.pop("response_template", None)
+        end_of_turn_template = kwargs.pop("end_of_turn_template", None)
+        masking_method = kwargs.pop("masking_method", None)
+        tool_call_start_template = kwargs.pop("tool_call_start_template", None)
 
-        # Default to Llama-style templates if not provided
-        instruction_prefix = (
-            instruction_template
-            if instruction_template
-            else "<|start_header_id|>user<|end_header_id|>\n\n"
-        )
-        response_prefix = (
-            response_template
-            if response_template
-            else "<|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
+        # Only default to Llama-style instruction template when NOT using
+        # span-based masking (end_of_turn_template makes it unnecessary).
+        if end_of_turn_template is None:
+            instruction_template = (
+                instruction_template
+                if instruction_template
+                else "<|start_header_id|>user<|end_header_id|>\n\n"
+            )
+
+        if not response_template:
+            response_template = "<|start_header_id|>assistant<|end_header_id|>\n\n"
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            instruction_prefix=instruction_prefix,
-            response_prefix=response_prefix,
+            response_template=response_template,
+            instruction_template=instruction_template,
             debug=debug,
+            masking_method=masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            ignore_index=(
+                label_ignore_index if label_ignore_index is not None else -100
+            ),
             **kwargs,
         )
     raise ValueError(f"Unknown data collator name: '{collator_name}'")

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -63,11 +63,15 @@ class TextCompletionsCollatorWithPadding:
         self._debug = debug
         self._has_logged_example = False
 
+    def _collate(self, inputs: list[Any]) -> dict[str, Any]:
+        result = self._default_collator(inputs)
+        return result
+
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:
-        """Collates a batch, delegating to the underlying TRL collator.
+        """Pads to the longest length present in the batch.
 
         Args:
-            batch: List of batch items, each containing ``input_ids``.
+            batch: List of batch items.
 
         Returns:
             Dict[str, torch.Tensor]: Processed batch.
@@ -79,9 +83,11 @@ class TextCompletionsCollatorWithPadding:
                     f"Available keys: {item.keys()}"
                 )
 
-        collated_text_inputs = self._default_collator(batch)
+        # Collate batch prompts.
+        collated_text_inputs = self._collate(batch)
 
         if self._debug and not self._has_logged_example:
+            # Log an example of the data in the first step for debugging purposes.
             self._log_debug_example(batch, collated_text_inputs)
         return collated_text_inputs
 

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -27,26 +27,26 @@ class TextCompletionsCollatorWithPadding:
     def __init__(
         self,
         tokenizer: BaseTokenizer,
-        response_template: str | list[int],
-        instruction_template: str | list[int] | None = None,
+        response_template: str,
+        instruction_template: str | None = None,
         debug: bool = False,
         masking_method: str | None = None,
-        end_of_turn_template: str | list[int] | None = None,
-        tool_call_start_template: str | list[int] | None = None,
+        end_of_turn_template: str | None = None,
+        tool_call_start_template: str | None = None,
         ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
 
         Args:
         tokenizer: The tokenizer used for encoding the data.
-        response_template: String or token-ID list marking assistant response start.
-        instruction_template: String or token-ID list marking user instruction start.
+        response_template: String marking assistant response start.
+        instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
         masking_method: Masking strategy — ``"assistant_turn"``,
             ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
-        end_of_turn_template: String or token-ID list marking the end of a turn.
+        end_of_turn_template: String marking the end of a turn.
             Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
-        tool_call_start_template: String or token-ID list marking tool-call start.
+        tool_call_start_template: String marking tool-call start.
             Required for ``assistant_turn_no_tools``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -27,22 +27,38 @@ class TextCompletionsCollatorWithPadding:
     def __init__(
         self,
         tokenizer: BaseTokenizer,
-        instruction_prefix: str,
-        response_prefix: str,
+        response_template: str | list[int],
+        instruction_template: str | list[int] | None = None,
         debug: bool = False,
+        masking_method: str | None = None,
+        end_of_turn_template: str | list[int] | None = None,
+        tool_call_start_template: str | list[int] | None = None,
+        ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
 
         Args:
         tokenizer: The tokenizer used for encoding the data.
-        instruction_prefix: The prefix marking the beginning of the user instruction.
-        response_prefix: The prefix marking the beginning of the assistant response.
+        response_template: String or token-ID list marking assistant response start.
+        instruction_template: String or token-ID list marking user instruction start.
         debug: If True, enables debug mode for logging.
+        masking_method: Masking strategy — ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
+        end_of_turn_template: String or token-ID list marking the end of a turn.
+            Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
+        tool_call_start_template: String or token-ID list marking tool-call start.
+            Required for ``assistant_turn_no_tools``.
+        ignore_index: Value used for masked labels. Must match the ignore_index
+            of the loss function (default: -100).
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
-            instruction_template=instruction_prefix,
-            response_template=response_prefix,
+            instruction_template=instruction_template,
+            response_template=response_template,
+            masking_method=masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            ignore_index=ignore_index,
         )
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -30,7 +30,7 @@ class TextCompletionsCollatorWithPadding:
         response_template: str,
         instruction_template: str | None = None,
         debug: bool = False,
-        masking_method: str | None = None,
+        train_target: str | None = None,
         end_of_turn_template: str | None = None,
         ignore_index: int = -100,
     ):
@@ -41,10 +41,10 @@ class TextCompletionsCollatorWithPadding:
         response_template: String marking assistant response start.
         instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
-        masking_method: Masking strategy — ``"assistant_turn"``
+        train_target: Training target — ``"all_assistant_turns"``
             or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
-            Required for ``assistant_turn``.
+            Required for ``all_assistant_turns``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
@@ -52,7 +52,7 @@ class TextCompletionsCollatorWithPadding:
             tokenizer=tokenizer,
             instruction_template=instruction_template,
             response_template=response_template,
-            masking_method=masking_method,
+            train_target=train_target,
             end_of_turn_template=end_of_turn_template,
             ignore_index=ignore_index,
         )

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -32,7 +32,6 @@ class TextCompletionsCollatorWithPadding:
         debug: bool = False,
         masking_method: str | None = None,
         end_of_turn_template: str | None = None,
-        tool_call_start_template: str | None = None,
         ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
@@ -42,12 +41,10 @@ class TextCompletionsCollatorWithPadding:
         response_template: String marking assistant response start.
         instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
-        masking_method: Masking strategy — ``"assistant_turn"``,
-            ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
+        masking_method: Masking strategy — ``"assistant_turn"``
+            or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
-            Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
-        tool_call_start_template: String marking tool-call start.
-            Required for ``assistant_turn_no_tools``.
+            Required for ``assistant_turn``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
@@ -57,7 +54,6 @@ class TextCompletionsCollatorWithPadding:
             response_template=response_template,
             masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             ignore_index=ignore_index,
         )
 

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -63,15 +63,11 @@ class TextCompletionsCollatorWithPadding:
         self._debug = debug
         self._has_logged_example = False
 
-    def _collate(self, inputs: list[Any]) -> dict[str, Any]:
-        result = self._default_collator(inputs)
-        return result
-
-    def __call__(self, batch) -> dict[str, Any]:
-        """Pads to the longest length present in the batch.
+    def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:
+        """Collates a batch, delegating to the underlying TRL collator.
 
         Args:
-            batch: List of batch items.
+            batch: List of batch items, each containing ``input_ids``.
 
         Returns:
             Dict[str, torch.Tensor]: Processed batch.
@@ -83,11 +79,9 @@ class TextCompletionsCollatorWithPadding:
                     f"Available keys: {item.keys()}"
                 )
 
-        # Collate batch prompts.
-        collated_text_inputs = self._collate(batch)
+        collated_text_inputs = self._default_collator(batch)
 
         if self._debug and not self._has_logged_example:
-            # Log an example of the data in the first step for debugging purposes.
             self._log_debug_example(batch, collated_text_inputs)
         return collated_text_inputs
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -56,7 +56,11 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _VALID_TRAIN_TARGETS = {"all_assistant_turns", "final_assistant_turn"}
+    _VALID_TRAIN_TARGETS = {
+        "all_assistant_turns",
+        "final_assistant_turn",
+        "_legacy_instruction_response",
+    }
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -65,6 +69,48 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         if isinstance(template, str):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
+
+    @classmethod
+    def _resolve_train_target(
+        cls,
+        train_target: str | None,
+        *,
+        end_of_turn_template: str | list[int] | None,
+        instruction_template: str | list[int] | None,
+    ) -> str:
+        """Resolve train_target from explicit value or template presence.
+
+        Priority (first match wins):
+          1. Explicit train_target (validated)
+          2. end_of_turn only             → all_assistant_turns
+          3. no instruction_template      → final_assistant_turn
+          4. fallback                     → _legacy_instruction_response
+        """
+        if train_target is not None:
+            if train_target not in cls._VALID_TRAIN_TARGETS:
+                valid = sorted(
+                    cls._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown train_target='{train_target}'. Must be one of: {valid}"
+                )
+            return train_target
+
+        if end_of_turn_template is not None:
+            return "all_assistant_turns"
+        elif instruction_template is None:
+            return "final_assistant_turn"
+        else:
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use train_target='all_assistant_turns' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or train_target='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return "_legacy_instruction_response"
 
     def __init__(
         self,
@@ -89,35 +135,19 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Resolve train target: explicit value, or infer from templates.
-        if train_target is not None:
-            if train_target not in self._VALID_TRAIN_TARGETS:
-                raise ValueError(
-                    f"Unknown train_target='{train_target}'. "
-                    f"Must be one of: {sorted(self._VALID_TRAIN_TARGETS)}"
-                )
-            self.train_target = train_target
-        elif end_of_turn_template is not None:
-            self.train_target = "all_assistant_turns"
-        elif instruction_template is None:
-            self.train_target = "final_assistant_turn"
-        else:
-            warnings.warn(
-                "Instruction-based masking is deprecated. "
-                "Use train_target='all_assistant_turns' with "
-                "end_of_turn_template for multi-turn conversations, "
-                "or train_target='final_assistant_turn' "
-                "for single-turn completions.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.train_target = "_legacy_instruction_response"
+        self.train_target = self._resolve_train_target(
+            train_target,
+            end_of_turn_template=end_of_turn_template,
+            instruction_template=instruction_template,
+        )
 
-        if self.train_target == "all_assistant_turns" and end_of_turn_template is None:
-            raise ValueError(
-                "end_of_turn_template must be provided "
-                "when train_target='all_assistant_turns'"
-            )
+        # Validate required templates for each train target.
+        if self.train_target == "all_assistant_turns":
+            if end_of_turn_template is None:
+                raise ValueError(
+                    "end_of_turn_template must be provided "
+                    f"when train_target='{self.train_target}'"
+                )
 
         if (
             not self.mlm

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -35,12 +35,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
         Correctly handles interleaved tool results and parallel tool calls.
 
-    **``assistant_turn_no_tools``**:
-        Same as ``assistant_turn``, but additionally re-masks assistant
-        turns that contain tool-call content. Requires
-        ``tool_call_start_template``. Only natural-language responses
-        contribute to the loss.
-
     **``final_assistant_turn``**:
         Masks all tokens before the *last* ``response_template`` occurrence.
         Only the final assistant response is trained on. Suitable for
@@ -53,13 +47,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             user instruction. Legacy — only used with the instruction+response
             fallback path.
         masking_method: One of ``"assistant_turn"``,
-            ``"assistant_turn_no_tools"``, ``"final_assistant_turn"``.
+            ``"final_assistant_turn"``.
             When None, inferred from template presence for backward compat.
         end_of_turn_template: String or token IDs marking the end of a
-            conversational turn. Required for ``assistant_turn`` and
-            ``assistant_turn_no_tools`` modes.
-        tool_call_start_template: String or token IDs marking the start
-            of a tool-call block. Required for ``assistant_turn_no_tools``.
+            conversational turn. Required for ``assistant_turn`` mode.
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
@@ -67,7 +58,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
     _KNOWN_MASKING_METHODS = {
         "assistant_turn",
-        "assistant_turn_no_tools",
         "final_assistant_turn",
         "_legacy_instruction_response",
     }
@@ -86,17 +76,15 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         masking_method: str | None,
         *,
         end_of_turn_template: str | list[int] | None,
-        tool_call_start_template: str | list[int] | None,
         instruction_template: str | list[int] | None,
     ) -> str:
         """Resolve masking_method from explicit value or template presence.
 
         Priority (first match wins):
           1. Explicit masking_method (validated)
-          2. end_of_turn + tool_call_start → assistant_turn_no_tools
-          3. end_of_turn only             → assistant_turn
-          4. no instruction_template      → final_assistant_turn
-          5. fallback                     → _legacy_instruction_response
+          2. end_of_turn only             → assistant_turn
+          3. no instruction_template      → final_assistant_turn
+          4. fallback                     → _legacy_instruction_response
         """
         if masking_method is not None:
             if masking_method not in cls._KNOWN_MASKING_METHODS:
@@ -110,11 +98,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             return masking_method
 
         has_eot = end_of_turn_template is not None
-        has_tool = tool_call_start_template is not None
         has_inst = instruction_template is not None
 
-        if has_eot and has_tool:
-            return "assistant_turn_no_tools"
         if has_eot:
             return "assistant_turn"
         if not has_inst:
@@ -138,7 +123,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         *args,
         masking_method: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
-        tool_call_start_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -158,29 +142,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.masking_method = self._resolve_masking_method(
             masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             instruction_template=instruction_template,
         )
 
         # Validate required templates for each masking method.
-        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+        if self.masking_method == "assistant_turn":
             if end_of_turn_template is None:
                 raise ValueError(
                     "end_of_turn_template must be provided "
                     f"when masking_method='{self.masking_method}'"
                 )
-
-        self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
-        self.tool_call_start_token_ids: list[int] | None = None
-        if self.mask_tool_calls:
-            if tool_call_start_template is None:
-                raise ValueError(
-                    "tool_call_start_template must be provided "
-                    "when masking_method='assistant_turn_no_tools'"
-                )
-            self.tool_call_start_token_ids = self._tokenize_template(
-                tool_call_start_template
-            )
 
         if (
             not self.mlm
@@ -213,29 +184,14 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 positions.append(i)
         return positions
 
-    @staticmethod
-    def _span_contains(
-        seq: list[int], span_start: int, span_end: int, pattern: list[int]
-    ) -> bool:
-        """Return True if *pattern* appears anywhere in seq[span_start:span_end]."""
-        plen = len(pattern)
-        if plen == 0:
-            return False
-        first = pattern[0]
-        for i in range(span_start, span_end - plen + 1):
-            if seq[i] == first and seq[i : i + plen] == pattern:
-                return True
-        return False
-
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
     ) -> None:
-        """Apply span-based masking for tool-aware conversations.
+        """Apply span-based masking for multi-turn conversations.
 
         Masks all labels, then unmarks assistant response spans bounded by
         response_template and end_of_turn_template (inclusive — the EOT token
-        is unmasked so the model learns to produce it).  Optionally re-masks
-        spans that contain tool-call content.
+        is unmasked so the model learns to produce it).
         """
         resp_ids = self.response_token_ids
         eot_ids = self.end_of_turn_token_ids
@@ -284,17 +240,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 if content_start >= content_end:
                     continue
 
-                # Step 4: optionally skip tool-call spans.
-                if self.mask_tool_calls and self.tool_call_start_token_ids is not None:
-                    if self._span_contains(
-                        seq,
-                        content_start,
-                        content_end,
-                        self.tool_call_start_token_ids,
-                    ):
-                        continue
-
-                # Step 5: unmask this assistant response span, including the
+                # Step 4: unmask this assistant response span, including the
                 # end-of-turn token so the model learns when to stop.
                 if eot_positions:
                     eot_len = len(self.end_of_turn_token_ids)  # type: ignore
@@ -317,7 +263,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+        if self.masking_method == "assistant_turn":
             self._apply_span_masking(batch, examples)
         elif self.masking_method == "final_assistant_turn":
             # Response-only: unmask only the final assistant response.

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -121,6 +121,15 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             self.masking_method = "final_assistant_turn"
         else:
             self.masking_method = "_legacy_instruction_response"
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use masking_method='assistant_turn' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or masking_method='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -56,11 +56,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _KNOWN_MASKING_METHODS = {
-        "assistant_turn",
-        "final_assistant_turn",
-        "_legacy_instruction_response",
-    }
+    _VALID_MASKING_METHODS = {"assistant_turn", "final_assistant_turn"}
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -69,52 +65,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         if isinstance(template, str):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
-
-    @classmethod
-    def _resolve_masking_method(
-        cls,
-        masking_method: str | None,
-        *,
-        end_of_turn_template: str | list[int] | None,
-        instruction_template: str | list[int] | None,
-    ) -> str:
-        """Resolve masking_method from explicit value or template presence.
-
-        Priority (first match wins):
-          1. Explicit masking_method (validated)
-          2. end_of_turn only             → assistant_turn
-          3. no instruction_template      → final_assistant_turn
-          4. fallback                     → _legacy_instruction_response
-        """
-        if masking_method is not None:
-            if masking_method not in cls._KNOWN_MASKING_METHODS:
-                valid = sorted(
-                    cls._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
-                )
-                raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {valid}"
-                )
-            return masking_method
-
-        has_eot = end_of_turn_template is not None
-        has_inst = instruction_template is not None
-
-        if has_eot:
-            return "assistant_turn"
-        if not has_inst:
-            return "final_assistant_turn"
-
-        warnings.warn(
-            "Instruction-based masking is deprecated. "
-            "Use masking_method='assistant_turn' with "
-            "end_of_turn_template for multi-turn conversations, "
-            "or masking_method='final_assistant_turn' "
-            "for single-turn completions.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return "_legacy_instruction_response"
 
     def __init__(
         self,
@@ -139,19 +89,35 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        self.masking_method = self._resolve_masking_method(
-            masking_method,
-            end_of_turn_template=end_of_turn_template,
-            instruction_template=instruction_template,
-        )
-
-        # Validate required templates for each masking method.
-        if self.masking_method == "assistant_turn":
-            if end_of_turn_template is None:
+        # Resolve masking method: explicit value, or infer from templates.
+        if masking_method is not None:
+            if masking_method not in self._VALID_MASKING_METHODS:
                 raise ValueError(
-                    "end_of_turn_template must be provided "
-                    f"when masking_method='{self.masking_method}'"
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {sorted(self._VALID_MASKING_METHODS)}"
                 )
+            self.masking_method = masking_method
+        elif end_of_turn_template is not None:
+            self.masking_method = "assistant_turn"
+        elif instruction_template is None:
+            self.masking_method = "final_assistant_turn"
+        else:
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use masking_method='assistant_turn' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or masking_method='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.masking_method = "_legacy_instruction_response"
+
+        if self.masking_method == "assistant_turn" and end_of_turn_template is None:
+            raise ValueError(
+                "end_of_turn_template must be provided "
+                "when masking_method='assistant_turn'"
+            )
 
         if (
             not self.mlm

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -138,6 +138,13 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             self.masking_method = "_legacy_instruction_response"
 
+        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+            if end_of_turn_template is None:
+                raise ValueError(
+                    "end_of_turn_template must be provided "
+                    f"when masking_method='{self.masking_method}'"
+                )
+
         self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
         self.tool_call_start_token_ids: list[int] | None = None
         if self.mask_tool_calls:

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -80,6 +80,57 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
 
+    @classmethod
+    def _resolve_masking_method(
+        cls,
+        masking_method: str | None,
+        *,
+        end_of_turn_template: str | list[int] | None,
+        tool_call_start_template: str | list[int] | None,
+        instruction_template: str | list[int] | None,
+    ) -> str:
+        """Resolve masking_method from explicit value or template presence.
+
+        Priority (first match wins):
+          1. Explicit masking_method (validated)
+          2. end_of_turn + tool_call_start → assistant_turn_no_tools
+          3. end_of_turn only             → assistant_turn
+          4. no instruction_template      → final_assistant_turn
+          5. fallback                     → _legacy_instruction_response
+        """
+        if masking_method is not None:
+            if masking_method not in cls._KNOWN_MASKING_METHODS:
+                valid = sorted(
+                    cls._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {valid}"
+                )
+            return masking_method
+
+        has_eot = end_of_turn_template is not None
+        has_tool = tool_call_start_template is not None
+        has_inst = instruction_template is not None
+
+        if has_eot and has_tool:
+            return "assistant_turn_no_tools"
+        if has_eot:
+            return "assistant_turn"
+        if not has_inst:
+            return "final_assistant_turn"
+
+        warnings.warn(
+            "Instruction-based masking is deprecated. "
+            "Use masking_method='assistant_turn' with "
+            "end_of_turn_template for multi-turn conversations, "
+            "or masking_method='final_assistant_turn' "
+            "for single-turn completions.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return "_legacy_instruction_response"
+
     def __init__(
         self,
         response_template: str | list[int],
@@ -104,35 +155,12 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Infer masking_method from template presence for backward compatibility.
-        if masking_method is not None:
-            if masking_method not in self._KNOWN_MASKING_METHODS:
-                valid_methods = sorted(
-                    self._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
-                )
-                raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {valid_methods}"
-                )
-            self.masking_method = masking_method
-        elif end_of_turn_template is not None:
-            if tool_call_start_template is not None:
-                self.masking_method = "assistant_turn_no_tools"
-            else:
-                self.masking_method = "assistant_turn"
-        elif instruction_template is None:
-            self.masking_method = "final_assistant_turn"
-        else:
-            self.masking_method = "_legacy_instruction_response"
-            warnings.warn(
-                "Instruction-based masking is deprecated. "
-                "Use masking_method='assistant_turn' with "
-                "end_of_turn_template for multi-turn conversations, "
-                "or masking_method='final_assistant_turn' "
-                "for single-turn completions.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        self.masking_method = self._resolve_masking_method(
+            masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            instruction_template=instruction_template,
+        )
 
         # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -27,9 +27,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     tokens (typically assistant responses), while ignoring other tokens
     (system prompts, user messages, padding).
 
-    The ``masking_method`` parameter selects the masking strategy:
+    The ``train_target`` parameter selects the training target:
 
-    **``assistant_turn``**:
+    **``all_assistant_turns``**:
         Span-based masking for multi-turn and tool-calling conversations.
         Masks everything, then unmarks each assistant response span bounded
         by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
@@ -46,17 +46,17 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         instruction_template: String or token IDs marking the start of a
             user instruction. Legacy — only used with the instruction+response
             fallback path.
-        masking_method: One of ``"assistant_turn"``,
+        train_target: One of ``"all_assistant_turns"``,
             ``"final_assistant_turn"``.
             When None, inferred from template presence for backward compat.
         end_of_turn_template: String or token IDs marking the end of a
-            conversational turn. Required for ``assistant_turn`` mode.
+            conversational turn. Required for ``all_assistant_turns`` mode.
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _VALID_MASKING_METHODS = {"assistant_turn", "final_assistant_turn"}
+    _VALID_TRAIN_TARGETS = {"all_assistant_turns", "final_assistant_turn"}
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -71,7 +71,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
-        masking_method: str | None = None,
+        train_target: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
@@ -89,34 +89,34 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Resolve masking method: explicit value, or infer from templates.
-        if masking_method is not None:
-            if masking_method not in self._VALID_MASKING_METHODS:
+        # Resolve train target: explicit value, or infer from templates.
+        if train_target is not None:
+            if train_target not in self._VALID_TRAIN_TARGETS:
                 raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {sorted(self._VALID_MASKING_METHODS)}"
+                    f"Unknown train_target='{train_target}'. "
+                    f"Must be one of: {sorted(self._VALID_TRAIN_TARGETS)}"
                 )
-            self.masking_method = masking_method
+            self.train_target = train_target
         elif end_of_turn_template is not None:
-            self.masking_method = "assistant_turn"
+            self.train_target = "all_assistant_turns"
         elif instruction_template is None:
-            self.masking_method = "final_assistant_turn"
+            self.train_target = "final_assistant_turn"
         else:
             warnings.warn(
                 "Instruction-based masking is deprecated. "
-                "Use masking_method='assistant_turn' with "
+                "Use train_target='all_assistant_turns' with "
                 "end_of_turn_template for multi-turn conversations, "
-                "or masking_method='final_assistant_turn' "
+                "or train_target='final_assistant_turn' "
                 "for single-turn completions.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.masking_method = "_legacy_instruction_response"
+            self.train_target = "_legacy_instruction_response"
 
-        if self.masking_method == "assistant_turn" and end_of_turn_template is None:
+        if self.train_target == "all_assistant_turns" and end_of_turn_template is None:
             raise ValueError(
                 "end_of_turn_template must be provided "
-                "when masking_method='assistant_turn'"
+                "when train_target='all_assistant_turns'"
             )
 
         if (
@@ -229,9 +229,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.masking_method == "assistant_turn":
+        if self.train_target == "all_assistant_turns":
             self._apply_span_masking(batch, examples)
-        elif self.masking_method == "final_assistant_turn":
+        elif self.train_target == "final_assistant_turn":
             # Response-only: unmask only the final assistant response.
             for i in range(len(examples)):
                 response_token_ids_start_idx = None

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -116,7 +116,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 )
             self.masking_method = masking_method
         elif end_of_turn_template is not None:
-            self.masking_method = "assistant_turn"
+            if tool_call_start_template is not None:
+                self.masking_method = "assistant_turn_no_tools"
+            else:
+                self.masking_method = "assistant_turn"
         elif instruction_template is None:
             self.masking_method = "final_assistant_turn"
         else:

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -21,9 +21,48 @@ from transformers.data.data_collator import DataCollatorForLanguageModeling
 
 
 class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
-    """Data collator used for completion tasks.
+    """Data collator for completion-only training.
 
-    Copied from `trl`'s `DataCollatorForCompletionOnlyLM` class.
+    Masks input labels so that the loss is only computed on specific
+    tokens (typically assistant responses), while ignoring other tokens
+    (system prompts, user messages, padding).
+
+    The ``masking_method`` parameter selects the masking strategy:
+
+    **``assistant_turn``**:
+        Span-based masking for multi-turn and tool-calling conversations.
+        Masks everything, then unmarks each assistant response span bounded
+        by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
+        Correctly handles interleaved tool results and parallel tool calls.
+
+    **``assistant_turn_no_tools``**:
+        Same as ``assistant_turn``, but additionally re-masks assistant
+        turns that contain tool-call content. Requires
+        ``tool_call_start_template``. Only natural-language responses
+        contribute to the loss.
+
+    **``final_assistant_turn``**:
+        Masks all tokens before the *last* ``response_template`` occurrence.
+        Only the final assistant response is trained on. Suitable for
+        single-turn completions.
+
+    Args:
+        response_template: String or token IDs marking the start of an
+            assistant response. Required for all modes.
+        instruction_template: String or token IDs marking the start of a
+            user instruction. Legacy — only used with the instruction+response
+            fallback path.
+        masking_method: One of ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, ``"final_assistant_turn"``.
+            When None, inferred from template presence for backward compat.
+        end_of_turn_template: String or token IDs marking the end of a
+            conversational turn. Required for ``assistant_turn`` and
+            ``assistant_turn_no_tools`` modes.
+        tool_call_start_template: String or token IDs marking the start
+            of a tool-call block. Required for ``assistant_turn_no_tools``.
+        mlm: Whether to use masked language modeling. Default False.
+        ignore_index: Label value for masked tokens. Default -100.
+        padding_free: Remove padding and add position_ids. Default False.
     """
 
     def __init__(
@@ -31,6 +70,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
+        masking_method: str | None = None,
+        end_of_turn_template: str | list[int] | None = None,
+        tool_call_start_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -60,6 +102,57 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             # The user already provides the token ids
             self.response_token_ids = response_template
 
+        # Tool-aware span-based masking parameters
+        self.end_of_turn_template = end_of_turn_template
+        if isinstance(end_of_turn_template, str):
+            self.end_of_turn_token_ids: list[int] | None = self.tokenizer.encode(
+                end_of_turn_template, add_special_tokens=False
+            )
+        elif end_of_turn_template is not None:
+            self.end_of_turn_token_ids = list(end_of_turn_template)
+        else:
+            self.end_of_turn_token_ids = None
+
+        _KNOWN_MASKING_METHODS = {
+            "assistant_turn",
+            "assistant_turn_no_tools",
+            "final_assistant_turn",
+            "_legacy_instruction_response",
+        }
+
+        # Infer masking_method from template presence for backward compatibility.
+        if masking_method is not None:
+            if masking_method not in _KNOWN_MASKING_METHODS:
+                valid_methods = sorted(
+                    _KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {valid_methods}"
+                )
+            self.masking_method = masking_method
+        elif end_of_turn_template is not None:
+            self.masking_method = "assistant_turn"
+        elif instruction_template is None:
+            self.masking_method = "final_assistant_turn"
+        else:
+            self.masking_method = "_legacy_instruction_response"
+
+        self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
+        self.tool_call_start_token_ids: list[int] | None = None
+        if self.mask_tool_calls:
+            if tool_call_start_template is None:
+                raise ValueError(
+                    "tool_call_start_template must be provided "
+                    "when masking_method='assistant_turn_no_tools'"
+                )
+            if isinstance(tool_call_start_template, str):
+                self.tool_call_start_token_ids = self.tokenizer.encode(
+                    tool_call_start_template, add_special_tokens=False
+                )
+            else:
+                self.tool_call_start_token_ids = list(tool_call_start_template)
+
         if (
             not self.mlm
             and self.instruction_template
@@ -78,13 +171,127 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.ignore_index = ignore_index
         self.padding_free = padding_free
 
+    @staticmethod
+    def _find_pattern(seq: list[int], pattern: list[int]) -> list[int]:
+        """Return all start positions where *pattern* appears in *seq*."""
+        plen = len(pattern)
+        if plen == 0:
+            return []
+        first = pattern[0]
+        positions = []
+        for i in range(len(seq) - plen + 1):
+            if seq[i] == first and seq[i : i + plen] == pattern:
+                positions.append(i)
+        return positions
+
+    @staticmethod
+    def _span_contains(
+        seq: list[int], span_start: int, span_end: int, pattern: list[int]
+    ) -> bool:
+        """Return True if *pattern* appears anywhere in seq[span_start:span_end]."""
+        plen = len(pattern)
+        if plen == 0:
+            return False
+        first = pattern[0]
+        for i in range(span_start, span_end - plen + 1):
+            if seq[i] == first and seq[i : i + plen] == pattern:
+                return True
+        return False
+
+    def _apply_span_masking(
+        self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
+    ) -> None:
+        """Apply span-based masking for tool-aware conversations.
+
+        Masks all labels, then unmarks assistant response spans bounded by
+        response_template and end_of_turn_template (inclusive — the EOT token
+        is unmasked so the model learns to produce it).  Optionally re-masks
+        spans that contain tool-call content.
+        """
+        resp_ids = self.response_token_ids
+        eot_ids = self.end_of_turn_token_ids
+        assert eot_ids is not None  # Caller checks end_of_turn_template is not None
+        resp_len = len(resp_ids)
+        pad_token_id = self.tokenizer.pad_token_id
+
+        for i in range(len(examples)):
+            # Step 1: mask everything.
+            batch["labels"][i, :] = self.ignore_index
+
+            seq: list[int] = batch["input_ids"][i].tolist()
+
+            # Compute effective sequence length excluding trailing padding.
+            # Prevents false matches when end_of_turn_token_ids overlaps
+            # with the pad token (common: e.g. <|im_end|> = eos = pad).
+            if pad_token_id is not None:
+                n = len(seq)
+                while n > 0 and seq[n - 1] == pad_token_id:
+                    n -= 1
+            else:
+                n = len(seq)
+
+            # Step 2: find every assistant response start position.
+            resp_positions = self._find_pattern(seq[:n], resp_ids)
+
+            if len(resp_positions) == 0:
+                warnings.warn(
+                    f"Could not find response template in the following instance: "
+                    f"{self.tokenizer.decode(batch['input_ids'][i])}. "
+                    "This instance will be ignored in loss calculation.",
+                    UserWarning,
+                )
+                continue
+
+            for resp_pos in resp_positions:
+                content_start = resp_pos + resp_len
+
+                # Step 3: find the next end_of_turn after content_start.
+                eot_positions = self._find_pattern(seq[content_start:n], eot_ids)
+                if eot_positions:
+                    content_end = content_start + eot_positions[0]
+                else:
+                    content_end = n
+
+                if content_start >= content_end:
+                    continue
+
+                # Step 4: optionally skip tool-call spans.
+                if self.mask_tool_calls and self.tool_call_start_token_ids is not None:
+                    if self._span_contains(
+                        seq,
+                        content_start,
+                        content_end,
+                        self.tool_call_start_token_ids,
+                    ):
+                        continue
+
+                # Step 5: unmask this assistant response span, including the
+                # end-of-turn token so the model learns when to stop.
+                if eot_positions:
+                    eot_len = len(self.end_of_turn_token_ids)  # type: ignore
+                    unmask_end = content_end + eot_len
+                else:
+                    # No EOT found — content_end == n (end of real content).
+                    # Do NOT extend past n or we'd unmask into padding.
+                    unmask_end = content_end
+                batch["labels"][i, content_start:unmask_end] = batch["input_ids"][
+                    i, content_start:unmask_end
+                ]
+
+    # ------------------------------------------------------------------
+    # Main collation
+    # ------------------------------------------------------------------
+
     def torch_call(
         self, examples: list[list[int] | Any | dict[str, Any]]
     ) -> dict[str, Any]:
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.instruction_template is None:
+        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+            self._apply_span_masking(batch, examples)
+        elif self.masking_method == "final_assistant_turn":
+            # Response-only: unmask only the final assistant response.
             for i in range(len(examples)):
                 response_token_ids_start_idx = None
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -65,6 +65,21 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
+    _KNOWN_MASKING_METHODS = {
+        "assistant_turn",
+        "assistant_turn_no_tools",
+        "final_assistant_turn",
+        "_legacy_instruction_response",
+    }
+
+    def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
+        """Encode a template string into token IDs, or pass through if already IDs."""
+        if template is None:
+            return None
+        if isinstance(template, str):
+            return self.tokenizer.encode(template, add_special_tokens=False)
+        return list(template)
+
     def __init__(
         self,
         response_template: str | list[int],
@@ -81,50 +96,19 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Initializes the DataCollatorForCompletionOnlyLM."""
         super().__init__(*args, mlm=mlm, **kwargs)
 
+        # Tokenize templates.
         self.instruction_template = instruction_template
-        if isinstance(instruction_template, str):
-            # The user provides a string, must tokenize
-            self.instruction_token_ids = self.tokenizer.encode(
-                self.instruction_template,  # type: ignore
-                add_special_tokens=False,
-            )
-        else:
-            # The user already provides the token ids
-            self.instruction_token_ids = instruction_template
-
+        self.instruction_token_ids = self._tokenize_template(instruction_template)
         self.response_template = response_template
-        if isinstance(response_template, str):
-            # The user provides a string, must tokenize
-            self.response_token_ids = self.tokenizer.encode(
-                self.response_template, add_special_tokens=False
-            )
-        else:
-            # The user already provides the token ids
-            self.response_token_ids = response_template
-
-        # Tool-aware span-based masking parameters
+        self.response_token_ids: list[int] = self._tokenize_template(response_template)  # type: ignore[assignment]
         self.end_of_turn_template = end_of_turn_template
-        if isinstance(end_of_turn_template, str):
-            self.end_of_turn_token_ids: list[int] | None = self.tokenizer.encode(
-                end_of_turn_template, add_special_tokens=False
-            )
-        elif end_of_turn_template is not None:
-            self.end_of_turn_token_ids = list(end_of_turn_template)
-        else:
-            self.end_of_turn_token_ids = None
-
-        _KNOWN_MASKING_METHODS = {
-            "assistant_turn",
-            "assistant_turn_no_tools",
-            "final_assistant_turn",
-            "_legacy_instruction_response",
-        }
+        self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
         # Infer masking_method from template presence for backward compatibility.
         if masking_method is not None:
-            if masking_method not in _KNOWN_MASKING_METHODS:
+            if masking_method not in self._KNOWN_MASKING_METHODS:
                 valid_methods = sorted(
-                    _KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                    self._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
                 )
                 raise ValueError(
                     f"Unknown masking_method='{masking_method}'. "
@@ -138,6 +122,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             self.masking_method = "_legacy_instruction_response"
 
+        # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
             if end_of_turn_template is None:
                 raise ValueError(
@@ -153,12 +138,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     "tool_call_start_template must be provided "
                     "when masking_method='assistant_turn_no_tools'"
                 )
-            if isinstance(tool_call_start_template, str):
-                self.tool_call_start_token_ids = self.tokenizer.encode(
-                    tool_call_start_template, add_special_tokens=False
-                )
-            else:
-                self.tool_call_start_token_ids = list(tool_call_start_template)
+            self.tool_call_start_token_ids = self._tokenize_template(
+                tool_call_start_template
+            )
 
         if (
             not self.mlm

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -200,8 +200,8 @@ class DatasetSplitParams(BaseParams):
         - "text_completions_only_with_padding": Uses template matching to
             mask non-assistant tokens. Works for simple user/assistant turns.
             Supports optional ``end_of_turn_template`` in ``collator_kwargs``
-            for tool-aware span-based masking. When set, also supports
-            ``mask_tool_calls=True`` and ``tool_call_start_template``.
+            for span-based masking. Use
+            ``masking_method="assistant_turn_no_tools"`` to mask tool calls.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
         - "vision_language_sft": Uses VisionLanguageSftCollator.

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -197,8 +197,14 @@ class DatasetSplitParams(BaseParams):
 
         - "text_with_padding": Dynamically pads the inputs received to
             the longest length.
+        - "text_completions_only_with_padding": Uses template matching to
+            mask non-assistant tokens. Works for simple user/assistant turns.
+            Supports optional ``end_of_turn_template`` in ``collator_kwargs``
+            for tool-aware span-based masking. When set, also supports
+            ``mask_tool_calls=True`` and ``tool_call_start_template``.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
+        - "vision_language_sft": Uses VisionLanguageSftCollator.
 
     If None, then a default collator will be assigned.
     """

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -200,8 +200,7 @@ class DatasetSplitParams(BaseParams):
         - "text_completions_only_with_padding": Uses template matching to
             mask non-assistant tokens. Works for simple user/assistant turns.
             Supports optional ``end_of_turn_template`` in ``collator_kwargs``
-            for span-based masking. Use
-            ``masking_method="assistant_turn_no_tools"`` to mask tool calls.
+            for span-based masking.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
         - "vision_language_sft": Uses VisionLanguageSftCollator.

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -275,7 +275,7 @@ def make_span_collator() -> TextCompletionsCollatorWithPadding:
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
-        masking_method="assistant_turn",
+        train_target="all_assistant_turns",
         end_of_turn_template=_EOT_STR,
     )
 
@@ -409,7 +409,7 @@ def test_span_masking_requires_end_of_turn_template():
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
             response_template=_RESP_STR,
-            masking_method="assistant_turn",
+            train_target="all_assistant_turns",
             end_of_turn_template=None,
         )
 

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -1,10 +1,12 @@
 import functools
+import warnings
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
 
+import oumi.core.constants as constants
 from oumi.builders import build_tokenizer
 from oumi.core.collators.text_completions_collator_with_padding import (
     TextCompletionsCollatorWithPadding,
@@ -12,6 +14,16 @@ from oumi.core.collators.text_completions_collator_with_padding import (
 from oumi.core.configs import ModelParams
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils import logging
+
+IGNORE = constants.LABEL_IGNORE_INDEX
+
+# Template strings for span-masking tests — chosen to be unambiguous in GPT-2's vocab.
+_RESP_STR = " ASSISTANT_RESPONSE_START"
+_EOT_STR = " TURN_ENDS_HERE"
+_TC_STR = " TOOL_CALL_BEGINS"
+
+# Arbitrary token IDs used as "content" that must not appear in any template.
+_SENTINELS = [601, 602, 603, 604, 605, 606, 607, 608]
 
 
 @pytest.fixture
@@ -50,8 +62,8 @@ def test_success_basic():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
     )
     assert callable(collator)
 
@@ -174,8 +186,8 @@ def test_debug_logging(caplog):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
         debug=True,
     )
     assert callable(collator)
@@ -238,3 +250,348 @@ def test_debug_logging(caplog):
     assert "'input_ids':" in log_text
     assert "'attention_mask':" in log_text
     assert "'labels':" in log_text
+
+
+# ===========================================================================
+# Span-based masking tests (tool-aware collation)
+# ===========================================================================
+
+
+@functools.cache
+def get_template_token_ids() -> tuple[list[int], list[int], list[int]]:
+    """Return (resp_ids, eot_ids, tc_ids) encoded once and cached."""
+    tokenizer, _ = create_test_tokenizer()
+    resp = tokenizer.encode(_RESP_STR, add_special_tokens=False)
+    eot = tokenizer.encode(_EOT_STR, add_special_tokens=False)
+    tc = tokenizer.encode(_TC_STR, add_special_tokens=False)
+    forbidden = set(resp) | set(eot) | set(tc)
+    for sentinel in _SENTINELS:
+        assert sentinel not in forbidden, (
+            f"Sentinel {sentinel} collides with a template token ID. Adjust _SENTINELS."
+        )
+    return resp, eot, tc
+
+
+def make_span_collator(
+    mask_tool_calls: bool = False,
+) -> TextCompletionsCollatorWithPadding:
+    tokenizer, _ = create_test_tokenizer()
+    resp_ids, eot_ids, tc_ids = get_template_token_ids()
+    masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
+    return TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=resp_ids,
+        masking_method=masking_method,
+        end_of_turn_template=eot_ids,
+        tool_call_start_template=tc_ids if mask_tool_calls else None,
+    )
+
+
+def get_span_labels(collator, seq: list[int]) -> list[int]:
+    return collator([{"input_ids": seq}])["labels"][0].tolist()
+
+
+def flat(*parts: list[int]) -> list[int]:
+    result = []
+    for p in parts:
+        result.extend(p)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single assistant turn
+# ---------------------------------------------------------------------------
+
+
+def test_span_single_turn_content_is_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    prefix = [_SENTINELS[0], _SENTINELS[1]]
+    content = [_SENTINELS[2], _SENTINELS[3]]
+    seq = flat(prefix, resp, content, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    n_prefix = len(prefix) + len(resp)
+    assert all(v == IGNORE for v in labels[:n_prefix])
+    assert labels[n_prefix : n_prefix + len(content)] == content
+    # EOT tokens are unmasked (model learns to produce the stop token)
+    assert labels[n_prefix + len(content) : n_prefix + len(content) + len(eot)] == eot
+
+
+def test_span_single_turn_response_template_tokens_are_masked():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0]], eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    for i in range(len(resp)):
+        assert labels[i] == IGNORE, f"resp template token {i} should be masked"
+
+
+def test_span_single_turn_eot_tokens_are_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    content = [_SENTINELS[0]]
+    seq = flat(resp, content, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    eot_start = len(resp) + len(content)
+    assert labels[eot_start : eot_start + len(eot)] == eot
+
+
+# ---------------------------------------------------------------------------
+# Multiple assistant turns
+# ---------------------------------------------------------------------------
+
+
+def test_span_two_turns_both_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    turn1 = [_SENTINELS[0], _SENTINELS[1]]
+    middle = [_SENTINELS[2]]
+    turn2 = [_SENTINELS[3], _SENTINELS[4]]
+    seq = flat(resp, turn1, eot, middle, resp, turn2, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    t1_start = len(resp)
+    t1_end = t1_start + len(turn1)
+    assert labels[t1_start:t1_end] == turn1
+
+    t2_start = t1_end + len(eot) + len(middle) + len(resp)
+    t2_end = t2_start + len(turn2)
+    assert labels[t2_start:t2_end] == turn2
+
+
+def test_span_content_between_turns_is_masked():
+    resp, eot, _ = get_template_token_ids()
+    turn1 = [_SENTINELS[0]]
+    between = [_SENTINELS[1], _SENTINELS[2]]
+    turn2 = [_SENTINELS[3]]
+    seq = flat(resp, turn1, eot, between, resp, turn2, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    between_start = len(resp) + len(turn1) + len(eot)
+    for i in range(len(between)):
+        assert labels[between_start + i] == IGNORE
+
+
+# ---------------------------------------------------------------------------
+# Tool result masking
+# ---------------------------------------------------------------------------
+
+
+def test_span_tool_result_is_masked():
+    resp, eot, _ = get_template_token_ids()
+    tool_call_content = [_SENTINELS[0], _SENTINELS[1]]
+    tool_result = [_SENTINELS[2], _SENTINELS[3]]
+    final_answer = [_SENTINELS[4], _SENTINELS[5]]
+    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    tool_result_start = len(resp) + len(tool_call_content) + len(eot)
+    for i in range(len(tool_result)):
+        assert labels[tool_result_start + i] == IGNORE
+
+
+def test_span_final_answer_after_tool_result_is_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    tool_call_content = [_SENTINELS[0]]
+    tool_result = [_SENTINELS[1]]
+    final_answer = [_SENTINELS[2], _SENTINELS[3]]
+    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    final_start = (
+        len(resp) + len(tool_call_content) + len(eot) + len(tool_result) + len(resp)
+    )
+    assert labels[final_start : final_start + len(final_answer)] == final_answer
+
+
+# ---------------------------------------------------------------------------
+# mask_tool_calls option
+# ---------------------------------------------------------------------------
+
+
+def test_span_tool_call_turn_unmasked_by_default():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    seq = flat(resp, tc_content, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=False), seq)
+
+    content_start = len(resp)
+    assert labels[content_start : content_start + len(tc_content)] == tc_content
+
+
+def test_span_tool_call_turn_masked_when_option_set():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    seq = flat(resp, tc_content, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
+
+    content_start = len(resp)
+    assert all(
+        v == IGNORE for v in labels[content_start : content_start + len(tc_content)]
+    )
+
+
+def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    final_answer = [_SENTINELS[1], _SENTINELS[2]]
+    seq = flat(resp, tc_content, eot, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
+
+    final_start = len(resp) + len(tc_content) + len(eot) + len(resp)
+    assert labels[final_start : final_start + len(final_answer)] == final_answer
+
+
+def test_span_mask_tool_calls_requires_template():
+    tokenizer, _ = create_test_tokenizer()
+    resp_ids, eot_ids, _ = get_template_token_ids()
+    with pytest.raises(ValueError, match="tool_call_start_template"):
+        TextCompletionsCollatorWithPadding(
+            tokenizer=tokenizer,
+            response_template=resp_ids,
+            masking_method="assistant_turn_no_tools",
+            end_of_turn_template=eot_ids,
+            tool_call_start_template=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_span_no_response_template_all_masked():
+    seq = [_SENTINELS[0], _SENTINELS[1], _SENTINELS[2]]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        labels = get_span_labels(make_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels)
+    assert any("response template" in str(w.message).lower() for w in caught)
+
+
+def test_span_no_eot_unmasked_to_end_of_sequence():
+    resp, _, _ = get_template_token_ids()
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    seq = flat(resp, content)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert labels[len(resp) :] == content
+
+
+def test_span_empty_content_span():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels)
+
+
+def test_span_padding_matching_eot_does_not_false_match():
+    """When pad_token_id matches the EOT token, padding must not be treated as
+    a real end-of-turn boundary."""
+    tokenizer, pad_token_id = create_test_tokenizer()
+    resp, _, _ = get_template_token_ids()
+
+    # Use pad_token_id itself as the EOT template — worst case scenario.
+    eot_ids = [pad_token_id]
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    # Sequence: [RESP] content (no real EOT), then padding
+    seq = flat(resp, content) + [pad_token_id] * 5
+
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=resp,
+        end_of_turn_template=eot_ids,
+    )
+    batch = collator([{"input_ids": seq}])
+    labels = batch["labels"][0].tolist()
+
+    # Content should be unmasked — the padding should not act as an EOT.
+    content_start = len(resp)
+    assert labels[content_start : content_start + len(content)] == content
+    # Padding should be masked.
+    assert all(v == IGNORE for v in labels[content_start + len(content) :])
+
+
+# ---------------------------------------------------------------------------
+# Batch processing
+# ---------------------------------------------------------------------------
+
+
+def test_span_batch_two_examples_processed_independently():
+    resp, eot, _ = get_template_token_ids()
+    _, pad_token_id = create_test_tokenizer()
+    content_a = [_SENTINELS[0], _SENTINELS[1]]
+    content_b = [_SENTINELS[2]]
+    seq_a = flat(resp, content_a, eot)
+    seq_b = flat(resp, content_b, eot)
+
+    max_len = max(len(seq_a), len(seq_b))
+    pad_a = [pad_token_id] * (max_len - len(seq_a))
+    pad_b = [pad_token_id] * (max_len - len(seq_b))
+
+    collator = make_span_collator()
+    batch = collator([{"input_ids": seq_a + pad_a}, {"input_ids": seq_b + pad_b}])
+    labels_a = batch["labels"][0].tolist()
+    labels_b = batch["labels"][1].tolist()
+
+    assert labels_a[len(resp) : len(resp) + len(content_a)] == content_a
+    assert labels_b[len(resp) : len(resp) + len(content_b)] == content_b
+
+
+def test_span_batch_bad_example_does_not_affect_others():
+    resp, eot, _ = get_template_token_ids()
+    _, pad_token_id = create_test_tokenizer()
+    good_seq = flat(resp, [_SENTINELS[0]], eot)
+    bad_seq = [_SENTINELS[1], _SENTINELS[2]]
+
+    max_len = max(len(good_seq), len(bad_seq))
+    pad_good = [pad_token_id] * (max_len - len(good_seq))
+    pad_bad = [pad_token_id] * (max_len - len(bad_seq))
+
+    collator = make_span_collator()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        batch = collator(
+            [{"input_ids": good_seq + pad_good}, {"input_ids": bad_seq + pad_bad}]
+        )
+
+    assert batch["labels"][0].tolist()[len(resp)] == _SENTINELS[0]
+    assert all(v == IGNORE for v in batch["labels"][1].tolist())
+
+
+def test_span_output_labels_is_torch_tensor():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0]], eot)
+    batch = make_span_collator()([{"input_ids": seq}])
+    assert isinstance(batch["labels"], torch.Tensor)
+
+
+def test_span_labels_shape_matches_input_ids():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
+    batch = make_span_collator()([{"input_ids": seq}])
+    assert batch["labels"].shape == batch["input_ids"].shape
+
+
+def test_span_labels_numpy_values_match_expected():
+    resp, eot, _ = get_template_token_ids()
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    seq = flat(resp, content, eot)
+
+    batch = make_span_collator()([{"input_ids": seq}])
+    expected = [IGNORE] * len(resp) + content + eot
+    assert np.all(batch["labels"].numpy() == np.array([expected], dtype=np.int32))

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -20,7 +20,6 @@ IGNORE = constants.LABEL_IGNORE_INDEX
 # Template strings for span-masking tests — chosen to be unambiguous in GPT-2's vocab.
 _RESP_STR = " ASSISTANT_RESPONSE_START"
 _EOT_STR = " TURN_ENDS_HERE"
-_TC_STR = " TOOL_CALL_BEGINS"
 
 # Arbitrary token IDs used as "content" that must not appear in any template.
 _SENTINELS = [601, 602, 603, 604, 605, 606, 607, 608]
@@ -258,31 +257,26 @@ def test_debug_logging(caplog):
 
 
 @functools.cache
-def get_template_token_ids() -> tuple[list[int], list[int], list[int]]:
-    """Return (resp_ids, eot_ids, tc_ids) encoded once and cached."""
+def get_template_token_ids() -> tuple[list[int], list[int]]:
+    """Return (resp_ids, eot_ids) encoded once and cached."""
     tokenizer, _ = create_test_tokenizer()
     resp = tokenizer.encode(_RESP_STR, add_special_tokens=False)
     eot = tokenizer.encode(_EOT_STR, add_special_tokens=False)
-    tc = tokenizer.encode(_TC_STR, add_special_tokens=False)
-    forbidden = set(resp) | set(eot) | set(tc)
+    forbidden = set(resp) | set(eot)
     for sentinel in _SENTINELS:
         assert sentinel not in forbidden, (
             f"Sentinel {sentinel} collides with a template token ID. Adjust _SENTINELS."
         )
-    return resp, eot, tc
+    return resp, eot
 
 
-def make_span_collator(
-    mask_tool_calls: bool = False,
-) -> TextCompletionsCollatorWithPadding:
+def make_span_collator() -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
-    masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
-        masking_method=masking_method,
+        masking_method="assistant_turn",
         end_of_turn_template=_EOT_STR,
-        tool_call_start_template=_TC_STR if mask_tool_calls else None,
     )
 
 
@@ -303,7 +297,7 @@ def flat(*parts: list[int]) -> list[int]:
 
 
 def test_span_single_turn_content_is_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     prefix = [_SENTINELS[0], _SENTINELS[1]]
     content = [_SENTINELS[2], _SENTINELS[3]]
     seq = flat(prefix, resp, content, eot)
@@ -318,7 +312,7 @@ def test_span_single_turn_content_is_unmasked():
 
 
 def test_span_single_turn_response_template_tokens_are_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0]], eot)
 
     labels = get_span_labels(make_span_collator(), seq)
@@ -328,7 +322,7 @@ def test_span_single_turn_response_template_tokens_are_masked():
 
 
 def test_span_single_turn_eot_tokens_are_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     content = [_SENTINELS[0]]
     seq = flat(resp, content, eot)
 
@@ -344,7 +338,7 @@ def test_span_single_turn_eot_tokens_are_unmasked():
 
 
 def test_span_two_turns_both_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     turn1 = [_SENTINELS[0], _SENTINELS[1]]
     middle = [_SENTINELS[2]]
     turn2 = [_SENTINELS[3], _SENTINELS[4]]
@@ -362,7 +356,7 @@ def test_span_two_turns_both_unmasked():
 
 
 def test_span_content_between_turns_is_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     turn1 = [_SENTINELS[0]]
     between = [_SENTINELS[1], _SENTINELS[2]]
     turn2 = [_SENTINELS[3]]
@@ -381,7 +375,7 @@ def test_span_content_between_turns_is_masked():
 
 
 def test_span_tool_result_is_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     tool_call_content = [_SENTINELS[0], _SENTINELS[1]]
     tool_result = [_SENTINELS[2], _SENTINELS[3]]
     final_answer = [_SENTINELS[4], _SENTINELS[5]]
@@ -395,7 +389,7 @@ def test_span_tool_result_is_masked():
 
 
 def test_span_final_answer_after_tool_result_is_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     tool_call_content = [_SENTINELS[0]]
     tool_result = [_SENTINELS[1]]
     final_answer = [_SENTINELS[2], _SENTINELS[3]]
@@ -409,69 +403,15 @@ def test_span_final_answer_after_tool_result_is_unmasked():
     assert labels[final_start : final_start + len(final_answer)] == final_answer
 
 
-# ---------------------------------------------------------------------------
-# mask_tool_calls option
-# ---------------------------------------------------------------------------
-
-
-def test_span_tool_call_turn_unmasked_by_default():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    seq = flat(resp, tc_content, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=False), seq)
-
-    content_start = len(resp)
-    assert labels[content_start : content_start + len(tc_content)] == tc_content
-
-
-def test_span_tool_call_turn_masked_when_option_set():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    seq = flat(resp, tc_content, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
-
-    content_start = len(resp)
-    assert all(
-        v == IGNORE for v in labels[content_start : content_start + len(tc_content)]
-    )
-
-
-def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    final_answer = [_SENTINELS[1], _SENTINELS[2]]
-    seq = flat(resp, tc_content, eot, resp, final_answer, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
-
-    final_start = len(resp) + len(tc_content) + len(eot) + len(resp)
-    assert labels[final_start : final_start + len(final_answer)] == final_answer
-
-
-def test_span_mask_tool_calls_requires_template():
+def test_span_masking_requires_end_of_turn_template():
     tokenizer, _ = create_test_tokenizer()
-    with pytest.raises(ValueError, match="tool_call_start_template"):
+    with pytest.raises(ValueError, match="end_of_turn_template"):
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
             response_template=_RESP_STR,
-            masking_method="assistant_turn_no_tools",
-            end_of_turn_template=_EOT_STR,
-            tool_call_start_template=None,
+            masking_method="assistant_turn",
+            end_of_turn_template=None,
         )
-
-
-def test_span_masking_requires_end_of_turn_template():
-    tokenizer, _ = create_test_tokenizer()
-    for method in ("assistant_turn", "assistant_turn_no_tools"):
-        with pytest.raises(ValueError, match="end_of_turn_template"):
-            TextCompletionsCollatorWithPadding(
-                tokenizer=tokenizer,
-                response_template=_RESP_STR,
-                masking_method=method,
-                end_of_turn_template=None,
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +431,7 @@ def test_span_no_response_template_all_masked():
 
 
 def test_span_no_eot_unmasked_to_end_of_sequence():
-    resp, _, _ = get_template_token_ids()
+    resp, _ = get_template_token_ids()
     content = [_SENTINELS[0], _SENTINELS[1]]
     seq = flat(resp, content)
 
@@ -501,7 +441,7 @@ def test_span_no_eot_unmasked_to_end_of_sequence():
 
 
 def test_span_empty_content_span():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, eot)
 
     labels = get_span_labels(make_span_collator(), seq)
@@ -513,7 +453,7 @@ def test_span_padding_matching_eot_does_not_false_match():
     """When pad_token_id matches the EOT token, padding must not be treated as
     a real end-of-turn boundary."""
     tokenizer, pad_token_id = create_test_tokenizer()
-    resp, _, _ = get_template_token_ids()
+    resp, _ = get_template_token_ids()
 
     # Use pad_token_id itself as the EOT template — worst case scenario.
     eot_ids = [pad_token_id]
@@ -542,7 +482,7 @@ def test_span_padding_matching_eot_does_not_false_match():
 
 
 def test_span_batch_two_examples_processed_independently():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     _, pad_token_id = create_test_tokenizer()
     content_a = [_SENTINELS[0], _SENTINELS[1]]
     content_b = [_SENTINELS[2]]
@@ -563,7 +503,7 @@ def test_span_batch_two_examples_processed_independently():
 
 
 def test_span_batch_bad_example_does_not_affect_others():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     _, pad_token_id = create_test_tokenizer()
     good_seq = flat(resp, [_SENTINELS[0]], eot)
     bad_seq = [_SENTINELS[1], _SENTINELS[2]]
@@ -584,21 +524,21 @@ def test_span_batch_bad_example_does_not_affect_others():
 
 
 def test_span_output_labels_is_torch_tensor():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert isinstance(batch["labels"], torch.Tensor)
 
 
 def test_span_labels_shape_matches_input_ids():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert batch["labels"].shape == batch["input_ids"].shape
 
 
 def test_span_labels_numpy_values_match_expected():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     content = [_SENTINELS[0], _SENTINELS[1]]
     seq = flat(resp, content, eot)
 

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -276,14 +276,13 @@ def make_span_collator(
     mask_tool_calls: bool = False,
 ) -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
-    resp_ids, eot_ids, tc_ids = get_template_token_ids()
     masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_template=resp_ids,
+        response_template=_RESP_STR,
         masking_method=masking_method,
-        end_of_turn_template=eot_ids,
-        tool_call_start_template=tc_ids if mask_tool_calls else None,
+        end_of_turn_template=_EOT_STR,
+        tool_call_start_template=_TC_STR if mask_tool_calls else None,
     )
 
 
@@ -453,13 +452,12 @@ def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
 
 def test_span_mask_tool_calls_requires_template():
     tokenizer, _ = create_test_tokenizer()
-    resp_ids, eot_ids, _ = get_template_token_ids()
     with pytest.raises(ValueError, match="tool_call_start_template"):
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_template=resp_ids,
+            response_template=_RESP_STR,
             masking_method="assistant_turn_no_tools",
-            end_of_turn_template=eot_ids,
+            end_of_turn_template=_EOT_STR,
             tool_call_start_template=None,
         )
 
@@ -513,8 +511,8 @@ def test_span_padding_matching_eot_does_not_false_match():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_template=resp,
-        end_of_turn_template=eot_ids,
+        response_template=_RESP_STR,
+        end_of_turn_template=str(tokenizer.decode(eot_ids)),
     )
     batch = collator([{"input_ids": seq}])
     labels = batch["labels"][0].tolist()

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -462,6 +462,18 @@ def test_span_mask_tool_calls_requires_template():
         )
 
 
+def test_span_masking_requires_end_of_turn_template():
+    tokenizer, _ = create_test_tokenizer()
+    for method in ("assistant_turn", "assistant_turn_no_tools"):
+        with pytest.raises(ValueError, match="end_of_turn_template"):
+            TextCompletionsCollatorWithPadding(
+                tokenizer=tokenizer,
+                response_template=_RESP_STR,
+                masking_method=method,
+                end_of_turn_template=None,
+            )
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/datasets/test_base_sft_dataset.py
+++ b/tests/unit/core/datasets/test_base_sft_dataset.py
@@ -26,8 +26,8 @@ def _get_hf_collator_result(conversation, tokenizer):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=_INSTRUCTION_PREFIX,
-        response_prefix=_RESPONSE_PREFIX,
+        instruction_template=_INSTRUCTION_PREFIX,
+        response_template=_RESPONSE_PREFIX,
     )
 
     return collator(batch)


### PR DESCRIPTION
## Description

Extend `DataCollatorForCompletionOnlyLM` with span-based masking (detecting assistant turn boundaries via response + end-of-turn tokens) beyond instruction based masking (matching instruction/response string pairs) supported currently. Additionally, allow explicit control of which part of response to train on using `train_target` parameter:

- **`assistant_turn`**: Masks everything, then unmasks each assistant response bounded by `response_template` .. `end_of_turn_template` (inclusive of EOT). 
- **`final_assistant_turn`**: Masks all tokens before the last `response_template` occurrence. 

When `train_target` is not set, the mode is inferred from template presence. `train_target` ultimately has the final say on which template is used. Existing configs using `collator_kwargs` with `instruction_template` + `response_template` continue to work via the legacy path (with a deprecation warning). New configs should use `train_target` explicitly.

## Related issues

N/A
Part 1 of 2 — part 2 is #2369 (adds the `MaskingMethod` enum for YAML config).

## Before submitting

- [ ] This PR only changes documentation.
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.