### PR TITLE
Extend DataCollatorForCompletionOnlyLM to support correct tool result masking

### DIFF
--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -18,12 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
 
 training:

--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
 
 training:

--- a/configs/projects/coalm/405b_train.yaml
+++ b/configs/projects/coalm/405b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
 
 training:

--- a/configs/projects/coalm/70b_train.yaml
+++ b/configs/projects/coalm/70b_train.yaml
@@ -18,12 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
 
 training:

--- a/configs/projects/coalm/70b_train.yaml
+++ b/configs/projects/coalm/70b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
 
 training:

--- a/configs/projects/coalm/70b_train.yaml
+++ b/configs/projects/coalm/70b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
 
 training:

--- a/configs/projects/coalm/8b_train.yaml
+++ b/configs/projects/coalm/8b_train.yaml
@@ -18,12 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
 
 training:

--- a/configs/projects/coalm/8b_train.yaml
+++ b/configs/projects/coalm/8b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
 
 training:

--- a/configs/projects/coalm/8b_train.yaml
+++ b/configs/projects/coalm/8b_train.yaml
@@ -18,14 +18,14 @@ data:
         shuffle: True
         seed: 42
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
   validation:
     datasets:
       - dataset_name: "text_sft_jsonl"
         dataset_path: "/path/to/validation/dataset.jsonl"
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
 
 training:

--- a/configs/projects/halloumi/8b_train.yaml
+++ b/configs/projects/halloumi/8b_train.yaml
@@ -66,6 +66,7 @@ data:
         seed: 42
 
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
   validation:
     datasets:
@@ -78,6 +79,7 @@ data:
           }
 
     collator_name: "text_completions_only_with_padding"
+    masking_method: "assistant_turn"
     seed: 42
 
 training:

--- a/configs/projects/halloumi/8b_train.yaml
+++ b/configs/projects/halloumi/8b_train.yaml
@@ -66,7 +66,7 @@ data:
         seed: 42
 
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
   validation:
     datasets:
@@ -79,7 +79,7 @@ data:
           }
 
     collator_name: "text_completions_only_with_padding"
-    train_target: "all_assistant_turns"
+    train_target: "ALL_ASSISTANT_TURNS"
     seed: 42
 
 training:

--- a/configs/projects/halloumi/8b_train.yaml
+++ b/configs/projects/halloumi/8b_train.yaml
@@ -66,7 +66,7 @@ data:
         seed: 42
 
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
   validation:
     datasets:
@@ -79,7 +79,7 @@ data:
           }
 
     collator_name: "text_completions_only_with_padding"
-    masking_method: "assistant_turn"
+    train_target: "all_assistant_turns"
     seed: 42
 
 training:

--- a/src/oumi/builders/__init__.py
+++ b/src/oumi/builders/__init__.py
@@ -23,7 +23,11 @@ allowing for easier setup and configuration of machine learning experiments.
 """
 
 from oumi.builders.callbacks import build_training_callbacks
-from oumi.builders.collators import build_collator_from_config, build_data_collator
+from oumi.builders.collators import (
+    build_collator_from_config,
+    build_data_collator,
+    resolve_collator_templates,
+)
 from oumi.builders.data import (
     build_dataset,
     build_dataset_mixture,
@@ -63,4 +67,5 @@ __all__ = [
     "build_training_callbacks",
     "is_image_text_llm",
     "build_collator_from_config",
+    "resolve_collator_templates",
 ]

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -302,12 +302,15 @@ def build_data_collator(
                 "train_target in collator_kwargs."
             )
 
+        ignore_index = kwargs.pop(
+            "ignore_index",
+            label_ignore_index if label_ignore_index is not None else -100,
+        )
+
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
             debug=debug,
-            ignore_index=(
-                label_ignore_index if label_ignore_index is not None else -100
-            ),
+            ignore_index=ignore_index,
             **kwargs,
         )
     raise ValueError(f"Unknown data collator name: '{collator_name}'")

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -115,6 +115,7 @@ def _detect_response_template(
                 f"Extracted response_template is only a <think> block.\n{_FIX_HINT}"
             )
 
+    response_template = response_template.rstrip("\n")
     return response_template
 
 

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -292,12 +292,6 @@ def build_collator_from_config(
 
     # --- TrainTarget auto-resolution ---
     if train_split.train_target is not None:
-        if collator_name != "text_completions_only_with_padding":
-            raise ValueError(
-                f"`train_target` is only supported with the "
-                f"'text_completions_only_with_padding' collator, "
-                f"got '{collator_name}'."
-            )
         if tokenizer is None:
             raise ValueError("Tokenizer is required for `train_target` auto-detection.")
         response_template, end_of_turn_template = _resolve_collator_templates(tokenizer)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import oumi.core.constants as constants
 from oumi.core.collators.text_collator_with_padding import TextCollatorWithPadding
@@ -27,11 +28,81 @@ from oumi.core.configs import DatasetSplit, TrainingConfig
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
 )
+from oumi.core.configs.params.data_params import MaskingMethod
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
 # This is used to set the max input length for a model with infinite size input
 _VERY_LARGE_INTEGER = int(1e30)
+
+
+# ---------------------------------------------------------------------------
+# Template auto-detection for MaskingMethod
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CollatorTemplates:
+    """Chat-format template strings used by the completions collator."""
+
+    response_template: str
+    end_of_turn_template: str
+
+
+_CHATML_TEMPLATES = _CollatorTemplates(
+    response_template="<|im_start|>assistant\n",
+    end_of_turn_template="<|im_end|>",
+)
+
+_LLAMA3_TEMPLATES = _CollatorTemplates(
+    response_template="<|start_header_id|>assistant<|end_header_id|>\n\n",
+    end_of_turn_template="<|eot_id|>",
+)
+
+
+# Each entry is (detector_fn, templates).  The detector receives the
+# tokenizer vocabulary (dict[str, int]) and returns True when the format
+# matches.
+_COLLATOR_TEMPLATE_DETECTORS: list[
+    tuple[Callable[[dict[str, int]], bool], _CollatorTemplates]
+] = [
+    (lambda vocab: "<|im_start|>" in vocab, _CHATML_TEMPLATES),
+    (lambda vocab: "<|start_header_id|>" in vocab, _LLAMA3_TEMPLATES),
+]
+
+
+def _resolve_collator_templates(
+    tokenizer: "BaseTokenizer",
+) -> _CollatorTemplates:
+    """Auto-detect collator templates from the tokenizer vocabulary.
+
+    Raises:
+        ValueError: If no known chat format is detected.
+    """
+    vocab: dict[str, int] = tokenizer.get_vocab()
+    for detector, templates in _COLLATOR_TEMPLATE_DETECTORS:
+        if detector(vocab):
+            return templates
+    raise ValueError(
+        "Cannot auto-detect chat template format from the tokenizer "
+        "vocabulary. Please use `collator_kwargs` to specify templates "
+        "manually instead of `masking_method`."
+    )
+
+
+def _build_masking_kwargs(
+    masking_method: MaskingMethod,
+    templates: _CollatorTemplates,
+) -> dict:
+    """Build collator keyword arguments for the given masking method."""
+    kwargs: dict = {
+        "response_template": templates.response_template,
+        "masking_method": masking_method.value,
+    }
+    if masking_method == MaskingMethod.ASSISTANT_TURN:
+        kwargs["end_of_turn_template"] = templates.end_of_turn_template
+    # FINAL_ASSISTANT_TURN needs no extra kwargs beyond response_template
+    return kwargs
 
 
 def build_data_collator(
@@ -130,7 +201,9 @@ def build_data_collator(
         if not kwargs.get("response_template"):
             raise ValueError(
                 "'text_completions_only_with_padding' requires a "
-                "response_template. Provide it via collator_kwargs."
+                "response_template. Either set train_target in your config "
+                "(which auto-resolves templates from the tokenizer) or "
+                "provide response_template via collator_kwargs."
             )
 
         return TextCompletionsCollatorWithPadding(
@@ -197,6 +270,22 @@ def build_collator_from_config(
         collator_kwargs["trust_remote_code"] = collator_kwargs.get(
             "trust_remote_code", config.model.trust_remote_code
         )
+
+    # --- MaskingMethod auto-resolution ---
+    if train_split.masking_method is not None:
+        if collator_name != "text_completions_only_with_padding":
+            raise ValueError(
+                f"`masking_method` is only supported with the "
+                f"'text_completions_only_with_padding' collator, "
+                f"got '{collator_name}'."
+            )
+        if tokenizer is None:
+            raise ValueError(
+                "Tokenizer is required for `masking_method` auto-detection."
+            )
+        templates = _resolve_collator_templates(tokenizer)
+        masking_kwargs = _build_masking_kwargs(train_split.masking_method, templates)
+        collator_kwargs.update(masking_kwargs)
 
     # Merge collator_kwargs from config with the existing kwargs
     # Config kwargs take precedence over automatically determined kwargs

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -33,6 +33,7 @@ from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
 _VERY_LARGE_INTEGER = int(1e30)
+_SENTINEL_SYS = "<<__S__>>"
 _SENTINEL_USER = "<<__U__>>"
 _SENTINEL_ASST = "<<__A__>>"
 _FIX_HINT = (
@@ -131,21 +132,28 @@ def resolve_collator_templates(
     Raises:
         ValueError: If templates cannot be extracted.
     """
-    msgs = [
+    msgs_with_sys = [
+        {"role": "system", "content": _SENTINEL_SYS},
         {"role": "user", "content": _SENTINEL_USER},
         {"role": "assistant", "content": _SENTINEL_ASST},
         {"role": "user", "content": _SENTINEL_USER},
         {"role": "assistant", "content": _SENTINEL_ASST},
     ]
+    msgs_no_sys = msgs_with_sys[1:]
 
-    try:
-        rendered = tokenizer.apply_chat_template(
-            msgs, tokenize=False, add_generation_prompt=False
-        )
-    except Exception as exc:
+    rendered = None
+    for msgs in (msgs_with_sys, msgs_no_sys):
+        try:
+            rendered = tokenizer.apply_chat_template(
+                msgs, tokenize=False, add_generation_prompt=False
+            )
+            break
+        except Exception:
+            continue
+    if rendered is None:
         raise ValueError(
             f"Tokenizer has no chat template or it failed to render.\n{_FIX_HINT}"
-        ) from exc
+        )
 
     if not isinstance(rendered, str):
         raise ValueError(

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -295,6 +295,12 @@ def build_data_collator(
                 "Fix: set train_target in your data config (auto-resolves templates "
                 "from the tokenizer), or provide response_template in collator_kwargs."
             )
+        if not kwargs.get("train_target"):
+            raise ValueError(
+                "'text_completions_only_with_padding' requires a train_target.\n"
+                "Fix: set train_target in your data config, or provide "
+                "train_target in collator_kwargs."
+            )
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -96,7 +96,7 @@ def _resolve_collator_templates(
             break
         eot_len += 1
     eot_ids = after_ids[:eot_len]
-    end_of_turn = tokenizer.decode(eot_ids, skip_special_tokens=False)
+    end_of_turn_template = tokenizer.decode(eot_ids, skip_special_tokens=False)
 
     # Response template: strip the EOT prefix to get just the assistant header.
     resp_ids = tokenizer.encode(
@@ -121,7 +121,7 @@ def _resolve_collator_templates(
             "response_template manually."
         )
 
-    return response_template, end_of_turn
+    return response_template, end_of_turn_template
 
 
 def build_data_collator(

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -111,7 +111,7 @@ def _resolve_collator_templates(
     assert isinstance(_resp_decoded, str)
     response_template = _resp_decoded
 
-    if not response_template.strip():
+    if not response_template.strip() or not end_of_turn_template.strip():
         raise ValueError(_FALLBACK_MSG)
 
     # Qwen3 and similar reasoning models inject <think>...</think> into
@@ -315,6 +315,17 @@ def build_collator_from_config(
             except ValueError:
                 if config_collator_kwargs.get("response_template") is None:
                     raise
+
+            if (
+                train_split.train_target == TrainTarget.ALL_ASSISTANT_TURNS
+                and "end_of_turn_template" not in collator_kwargs
+                and config_collator_kwargs.get("end_of_turn_template") is None
+            ):
+                raise ValueError(
+                    "train_target='all_assistant_turns' requires an "
+                    "end_of_turn_template, but auto-detection failed and "
+                    "none was provided in collator_kwargs."
+                )
 
         elif config_collator_kwargs.get("response_template") is not None:
             # Path 2: train_target not set, templates provided manually

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -35,10 +35,9 @@ from oumi.utils.logging import logger
 _VERY_LARGE_INTEGER = int(1e30)
 _SENTINEL_USER = "<<__U__>>"
 _SENTINEL_ASST = "<<__A__>>"
-_FALLBACK_MSG = (
-    "Cannot auto-detect collator templates from the chat template. "
-    "Provide response_template (and end_of_turn_template for "
-    "all_assistant_turns) via collator_kwargs."
+_FIX_HINT = (
+    "Fix: provide response_template (and end_of_turn_template for "
+    "all_assistant_turns) in collator_kwargs."
 )
 
 
@@ -68,10 +67,15 @@ def _resolve_collator_templates(
             msgs, tokenize=False, add_generation_prompt=False
         )
     except Exception as exc:
-        raise ValueError(_FALLBACK_MSG) from exc
+        raise ValueError(
+            f"Tokenizer has no chat template or it failed to render.\n{_FIX_HINT}"
+        ) from exc
 
     if not isinstance(rendered, str):
-        raise ValueError(_FALLBACK_MSG)
+        raise ValueError(
+            f"Chat template returned a non-string type ({type(rendered).__name__}).\n"
+            f"{_FIX_HINT}"
+        )
 
     # Locate boundaries around the second turn pair
     # to avoid system-prompt effects on the first turn.
@@ -83,7 +87,10 @@ def _resolve_collator_templates(
         second_asst = rendered.index(_SENTINEL_ASST, second_user_end)
         second_asst_end = second_asst + len(_SENTINEL_ASST)
     except ValueError:
-        raise ValueError(_FALLBACK_MSG)
+        raise ValueError(
+            "Could not locate assistant turn boundaries in the rendered "
+            f"chat template.\n{_FIX_HINT}"
+        )
 
     # End-of-turn: common token-ID prefix of the two strings that
     # follow assistant content (mid-conversation vs. end-of-sequence).
@@ -111,8 +118,10 @@ def _resolve_collator_templates(
     assert isinstance(_resp_decoded, str)
     response_template = _resp_decoded
 
-    if not response_template.strip() or not end_of_turn_template.strip():
-        raise ValueError(_FALLBACK_MSG)
+    if not response_template.strip():
+        raise ValueError(f"Extracted response_template is empty.\n{_FIX_HINT}")
+    if not end_of_turn_template.strip():
+        raise ValueError(f"Extracted end_of_turn_template is empty.\n{_FIX_HINT}")
 
     # Qwen3 and similar reasoning models inject <think>...</think> into
     # every assistant turn via their chat template.  If training data was
@@ -224,10 +233,9 @@ def build_data_collator(
     elif collator_name == "text_completions_only_with_padding":
         if not kwargs.get("response_template"):
             raise ValueError(
-                "'text_completions_only_with_padding' requires a "
-                "response_template. Either set train_target in your config "
-                "(which auto-resolves templates from the tokenizer) or "
-                "provide response_template via collator_kwargs."
+                "'text_completions_only_with_padding' requires a response_template.\n"
+                "Fix: set train_target in your data config (auto-resolves templates "
+                "from the tokenizer), or provide response_template in collator_kwargs."
             )
 
         return TextCompletionsCollatorWithPadding(
@@ -322,9 +330,9 @@ def build_collator_from_config(
                 and config_collator_kwargs.get("end_of_turn_template") is None
             ):
                 raise ValueError(
-                    "train_target='all_assistant_turns' requires an "
-                    "end_of_turn_template, but auto-detection failed and "
-                    "none was provided in collator_kwargs."
+                    "train_target='all_assistant_turns' requires end_of_turn_template, "
+                    "but auto-detection failed.\n"
+                    "Fix: provide end_of_turn_template in collator_kwargs."
                 )
 
         elif config_collator_kwargs.get("response_template") is not None:
@@ -337,11 +345,9 @@ def build_collator_from_config(
                 collator_kwargs["train_target"] = "all_assistant_turns"
             elif has_inst:
                 warnings.warn(
-                    "Instruction-based masking is deprecated. "
-                    "Use train_target='all_assistant_turns' with "
-                    "end_of_turn_template for multi-turn conversations, "
-                    "or train_target='final_assistant_turn' "
-                    "for single-turn completions.",
+                    "Instruction-based masking is deprecated.\n"
+                    "Use train_target='all_assistant_turns'"
+                    "or train_target='final_assistant_turn' instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -350,8 +356,10 @@ def build_collator_from_config(
                 collator_kwargs["train_target"] = "final_assistant_turn"
         else:
             raise ValueError(
-                "'text_completions_only_with_padding' requires either "
-                "train_target or response_template in collator_kwargs."
+                "'text_completions_only_with_padding' collator requires"
+                " configuration.\n"
+                "Fix: set train_target in your data config, "
+                "or provide response_template in collator_kwargs."
             )
 
     # User-provided collator_kwargs override auto-resolved values

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -28,7 +28,7 @@ from oumi.core.configs import DatasetSplit, TrainingConfig
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
 )
-from oumi.core.configs.params.data_params import MaskingMethod
+from oumi.core.configs.params.data_params import TrainTarget
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
@@ -37,7 +37,7 @@ _VERY_LARGE_INTEGER = int(1e30)
 
 
 # ---------------------------------------------------------------------------
-# Template auto-detection for MaskingMethod
+# Template auto-detection for TrainTarget
 # ---------------------------------------------------------------------------
 
 
@@ -86,20 +86,20 @@ def _resolve_collator_templates(
     raise ValueError(
         "Cannot auto-detect chat template format from the tokenizer "
         "vocabulary. Please use `collator_kwargs` to specify templates "
-        "manually instead of `masking_method`."
+        "manually instead of `train_target`."
     )
 
 
-def _build_masking_kwargs(
-    masking_method: MaskingMethod,
+def _build_train_target_kwargs(
+    train_target: TrainTarget,
     templates: _CollatorTemplates,
 ) -> dict:
-    """Build collator keyword arguments for the given masking method."""
+    """Build collator keyword arguments for the given train target."""
     kwargs: dict = {
         "response_template": templates.response_template,
-        "masking_method": masking_method.value,
+        "train_target": train_target.value,
     }
-    if masking_method == MaskingMethod.ASSISTANT_TURN:
+    if train_target == TrainTarget.ALL_ASSISTANT_TURNS:
         kwargs["end_of_turn_template"] = templates.end_of_turn_template
     # FINAL_ASSISTANT_TURN needs no extra kwargs beyond response_template
     return kwargs
@@ -271,21 +271,21 @@ def build_collator_from_config(
             "trust_remote_code", config.model.trust_remote_code
         )
 
-    # --- MaskingMethod auto-resolution ---
-    if train_split.masking_method is not None:
+    # --- TrainTarget auto-resolution ---
+    if train_split.train_target is not None:
         if collator_name != "text_completions_only_with_padding":
             raise ValueError(
-                f"`masking_method` is only supported with the "
+                f"`train_target` is only supported with the "
                 f"'text_completions_only_with_padding' collator, "
                 f"got '{collator_name}'."
             )
         if tokenizer is None:
-            raise ValueError(
-                "Tokenizer is required for `masking_method` auto-detection."
-            )
+            raise ValueError("Tokenizer is required for `train_target` auto-detection.")
         templates = _resolve_collator_templates(tokenizer)
-        masking_kwargs = _build_masking_kwargs(train_split.masking_method, templates)
-        collator_kwargs.update(masking_kwargs)
+        train_target_kwargs = _build_train_target_kwargs(
+            train_split.train_target, templates
+        )
+        collator_kwargs.update(train_target_kwargs)
 
     # Merge collator_kwargs from config with the existing kwargs
     # Config kwargs take precedence over automatically determined kwargs

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -97,7 +97,9 @@ def _resolve_collator_templates(
             break
         eot_len += 1
     eot_ids = after_ids[:eot_len]
-    end_of_turn_template: str = tokenizer.decode(eot_ids, skip_special_tokens=False)
+    _eot_decoded = tokenizer.decode(eot_ids, skip_special_tokens=False)
+    assert isinstance(_eot_decoded, str)
+    end_of_turn_template = _eot_decoded
 
     # Response template: strip the EOT prefix to get just the assistant header.
     resp_ids = tokenizer.encode(
@@ -105,7 +107,9 @@ def _resolve_collator_templates(
     )
     if eot_len > 0 and resp_ids[:eot_len] == eot_ids:
         resp_ids = resp_ids[eot_len:]
-    response_template: str = tokenizer.decode(resp_ids, skip_special_tokens=False)
+    _resp_decoded = tokenizer.decode(resp_ids, skip_special_tokens=False)
+    assert isinstance(_resp_decoded, str)
+    response_template = _resp_decoded
 
     if not response_template.strip():
         raise ValueError(_FALLBACK_MSG)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -97,7 +97,7 @@ def _resolve_collator_templates(
             break
         eot_len += 1
     eot_ids = after_ids[:eot_len]
-    end_of_turn_template = tokenizer.decode(eot_ids, skip_special_tokens=False)
+    end_of_turn_template: str = tokenizer.decode(eot_ids, skip_special_tokens=False)
 
     # Response template: strip the EOT prefix to get just the assistant header.
     resp_ids = tokenizer.encode(
@@ -105,7 +105,7 @@ def _resolve_collator_templates(
     )
     if eot_len > 0 and resp_ids[:eot_len] == eot_ids:
         resp_ids = resp_ids[eot_len:]
-    response_template = tokenizer.decode(resp_ids, skip_special_tokens=False)
+    response_template: str = tokenizer.decode(resp_ids, skip_special_tokens=False)
 
     if not response_template.strip():
         raise ValueError(_FALLBACK_MSG)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -132,7 +132,6 @@ def build_data_collator(
         response_template = kwargs.pop("response_template", None)
         end_of_turn_template = kwargs.pop("end_of_turn_template", None)
         masking_method = kwargs.pop("masking_method", None)
-        tool_call_start_template = kwargs.pop("tool_call_start_template", None)
 
         # Only default to Llama-style instruction template when NOT using
         # span-based masking (end_of_turn_template makes it unnecessary).
@@ -153,7 +152,6 @@ def build_data_collator(
             debug=debug,
             masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
             ),

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -41,7 +41,83 @@ _FIX_HINT = (
 )
 
 
-def _resolve_collator_templates(
+def _detect_eot_template(
+    tokenizer: "BaseTokenizer",
+    after_text: str,
+    between_text: str,
+) -> tuple[list[int], str]:
+    """Detect end-of-turn token IDs and template string.
+
+    Compares token-ID prefixes of the text after the last assistant turn
+    (end-of-sequence) with the text between assistant turns (mid-conversation).
+
+    Primary: longest common token-ID prefix.
+    Fallback: first token of between_text (for models like GPT OSS
+    that use different mid-conversation vs end-of-sequence tokens).
+
+    Returns:
+        (eot_ids, end_of_turn_template)
+    """
+    after_ids = tokenizer.encode(after_text, add_special_tokens=False)
+    between_ids = tokenizer.encode(between_text, add_special_tokens=False)
+
+    prefix_len = 0
+    for a, b in zip(after_ids, between_ids):
+        if a != b:
+            break
+        prefix_len += 1
+    eot_ids = after_ids[:prefix_len]
+
+    if not eot_ids and between_ids:
+        eot_ids = between_ids[:1]
+
+    eot_decoded = tokenizer.decode(eot_ids, skip_special_tokens=False)
+    assert isinstance(eot_decoded, str)
+    return eot_ids, eot_decoded
+
+
+def _detect_response_template(
+    tokenizer: "BaseTokenizer",
+    header_text: str,
+    eot_ids: list[int],
+) -> str:
+    """Detect the assistant response header from the user-to-assistant boundary.
+
+    Strips the leading end-of-turn prefix (which belongs to the previous
+    turn, not the response header) and any ``<think>`` blocks injected
+    by reasoning-model chat templates (e.g. Qwen3).
+
+    Returns:
+        response_template string
+    """
+    resp_ids = tokenizer.encode(header_text, add_special_tokens=False)
+    eot_len = len(eot_ids)
+    if eot_len > 0 and resp_ids[:eot_len] == eot_ids:
+        resp_ids = resp_ids[eot_len:]
+
+    resp_decoded = tokenizer.decode(resp_ids, skip_special_tokens=False)
+    assert isinstance(resp_decoded, str)
+    response_template = resp_decoded
+
+    if "<think>" in response_template:
+        idx = response_template.index("<think>")
+        stripped = response_template[:idx].rstrip()
+        if stripped:
+            logger.info(
+                "Stripped <think> block from auto-detected response_template: %r -> %r",
+                response_template,
+                stripped,
+            )
+            response_template = stripped
+        else:
+            raise ValueError(
+                f"Extracted response_template is only a <think> block.\n{_FIX_HINT}"
+            )
+
+    return response_template
+
+
+def resolve_collator_templates(
     tokenizer: "BaseTokenizer",
 ) -> tuple[str, str]:
     """Auto-detect response_template and end_of_turn_template.
@@ -80,8 +156,8 @@ def _resolve_collator_templates(
     # Locate boundaries around the second turn pair
     # to avoid system-prompt effects on the first turn.
     try:
-        a1 = rendered.index(_SENTINEL_ASST)
-        first_asst_end = a1 + len(_SENTINEL_ASST)
+        first_asst = rendered.index(_SENTINEL_ASST)
+        first_asst_end = first_asst + len(_SENTINEL_ASST)
         second_user = rendered.index(_SENTINEL_USER, first_asst_end)
         second_user_end = second_user + len(_SENTINEL_USER)
         second_asst = rendered.index(_SENTINEL_ASST, second_user_end)
@@ -92,48 +168,21 @@ def _resolve_collator_templates(
             f"chat template.\n{_FIX_HINT}"
         )
 
-    # End-of-turn: common token-ID prefix of the two strings that
-    # follow assistant content (mid-conversation vs. end-of-sequence).
-    after_ids = tokenizer.encode(rendered[second_asst_end:], add_special_tokens=False)
-    between_ids = tokenizer.encode(
-        rendered[first_asst_end:second_user], add_special_tokens=False
+    eot_ids, end_of_turn_template = _detect_eot_template(
+        tokenizer,
+        after_text=rendered[second_asst_end:],
+        between_text=rendered[first_asst_end:second_user],
     )
-    eot_len = 0
-    for a, b in zip(after_ids, between_ids):
-        if a != b:
-            break
-        eot_len += 1
-    eot_ids = after_ids[:eot_len]
-    _eot_decoded = tokenizer.decode(eot_ids, skip_special_tokens=False)
-    assert isinstance(_eot_decoded, str)
-    end_of_turn_template = _eot_decoded
-
-    # Response template: strip the EOT prefix to get just the assistant header.
-    resp_ids = tokenizer.encode(
-        rendered[second_user_end:second_asst], add_special_tokens=False
+    response_template = _detect_response_template(
+        tokenizer,
+        header_text=rendered[second_user_end:second_asst],
+        eot_ids=eot_ids,
     )
-    if eot_len > 0 and resp_ids[:eot_len] == eot_ids:
-        resp_ids = resp_ids[eot_len:]
-    _resp_decoded = tokenizer.decode(resp_ids, skip_special_tokens=False)
-    assert isinstance(_resp_decoded, str)
-    response_template = _resp_decoded
 
     if not response_template.strip():
         raise ValueError(f"Extracted response_template is empty.\n{_FIX_HINT}")
     if not end_of_turn_template.strip():
         raise ValueError(f"Extracted end_of_turn_template is empty.\n{_FIX_HINT}")
-
-    # Qwen3 and similar reasoning models inject <think>...</think> into
-    # every assistant turn via their chat template.  If training data was
-    # formatted without thinking tokens the response_template won't match
-    # and every example will be silently masked.
-    if "<think>" in response_template:
-        logger.warning(
-            "The extracted response_template contains <think> tokens "
-            "(from the model's chat template). If you're training without "
-            "thinking tokens, use collator_kwargs to specify "
-            "response_template manually."
-        )
 
     return response_template, end_of_turn_template
 
@@ -314,7 +363,7 @@ def build_collator_from_config(
             collator_kwargs["train_target"] = train_split.train_target.value
 
             try:
-                response_template, end_of_turn_template = _resolve_collator_templates(
+                response_template, end_of_turn_template = resolve_collator_templates(
                     tokenizer
                 )
                 collator_kwargs["response_template"] = response_template

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from collections.abc import Callable
 
 import oumi.core.constants as constants
@@ -290,17 +291,55 @@ def build_collator_from_config(
             "trust_remote_code", config.model.trust_remote_code
         )
 
-    # --- TrainTarget auto-resolution ---
-    if train_split.train_target is not None:
-        response_template, end_of_turn_template = _resolve_collator_templates(tokenizer)
-        collator_kwargs["response_template"] = response_template
-        collator_kwargs["train_target"] = train_split.train_target.value
-        if train_split.train_target == TrainTarget.ALL_ASSISTANT_TURNS:
-            collator_kwargs["end_of_turn_template"] = end_of_turn_template
-
-    # Merge collator_kwargs from config with the existing kwargs
-    # Config kwargs take precedence over automatically determined kwargs
+    # --- Resolve train_target and templates ---
     config_collator_kwargs = train_split.collator_kwargs or {}
+
+    if collator_name == "text_completions_only_with_padding":
+        if train_split.train_target is not None:
+            # Path 1: train_target is set, auto-detect templates from
+            # the tokenizer's chat template. Falls back to user-provided
+            # response_template in collator_kwargs if auto-detection fails.
+            collator_kwargs["train_target"] = train_split.train_target.value
+
+            try:
+                response_template, end_of_turn_template = _resolve_collator_templates(
+                    tokenizer
+                )
+                collator_kwargs["response_template"] = response_template
+                if train_split.train_target == TrainTarget.ALL_ASSISTANT_TURNS:
+                    collator_kwargs["end_of_turn_template"] = end_of_turn_template
+            except ValueError:
+                if config_collator_kwargs.get("response_template") is None:
+                    raise
+
+        elif config_collator_kwargs.get("response_template") is not None:
+            # Path 2: train_target not set, templates provided manually
+            # via collator_kwargs. Infer train_target from which templates
+            # are present.
+            has_eot = config_collator_kwargs.get("end_of_turn_template") is not None
+            has_inst = config_collator_kwargs.get("instruction_template") is not None
+            if has_eot:
+                collator_kwargs["train_target"] = "all_assistant_turns"
+            elif has_inst:
+                warnings.warn(
+                    "Instruction-based masking is deprecated. "
+                    "Use train_target='all_assistant_turns' with "
+                    "end_of_turn_template for multi-turn conversations, "
+                    "or train_target='final_assistant_turn' "
+                    "for single-turn completions.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                collator_kwargs["train_target"] = "_legacy_instruction_response"
+            else:
+                collator_kwargs["train_target"] = "final_assistant_turn"
+        else:
+            raise ValueError(
+                "'text_completions_only_with_padding' requires either "
+                "train_target or response_template in collator_kwargs."
+            )
+
+    # User-provided collator_kwargs override auto-resolved values
     collator_kwargs.update(config_collator_kwargs)
 
     return build_data_collator(

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -46,7 +46,8 @@ def _resolve_collator_templates(
 ) -> tuple[str, str]:
     """Auto-detect response_template and end_of_turn_template.
 
-    Renders the tokenizer's chat template with sentinel content.
+    Applies the chat template to a known test conversation, then finds
+    the assistant boundary strings in the rendered output.
 
     Returns:
         (response_template, end_of_turn_template)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from dataclasses import dataclass
 
 import oumi.core.constants as constants
 from oumi.core.collators.text_collator_with_padding import TextCollatorWithPadding
@@ -32,77 +31,96 @@ from oumi.core.configs.params.data_params import TrainTarget
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
-# This is used to set the max input length for a model with infinite size input
 _VERY_LARGE_INTEGER = int(1e30)
-
-
-# ---------------------------------------------------------------------------
-# Template auto-detection for TrainTarget
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _CollatorTemplates:
-    """Chat-format template strings used by the completions collator."""
-
-    response_template: str
-    end_of_turn_template: str
-
-
-_CHATML_TEMPLATES = _CollatorTemplates(
-    response_template="<|im_start|>assistant\n",
-    end_of_turn_template="<|im_end|>",
+_SENTINEL_USER = "<<__U__>>"
+_SENTINEL_ASST = "<<__A__>>"
+_FALLBACK_MSG = (
+    "Cannot auto-detect collator templates from the chat template. "
+    "Use collator_kwargs to specify response_template and "
+    "end_of_turn_template manually instead of train_target."
 )
-
-_LLAMA3_TEMPLATES = _CollatorTemplates(
-    response_template="<|start_header_id|>assistant<|end_header_id|>\n\n",
-    end_of_turn_template="<|eot_id|>",
-)
-
-
-# Each entry is (detector_fn, templates).  The detector receives the
-# tokenizer vocabulary (dict[str, int]) and returns True when the format
-# matches.
-_COLLATOR_TEMPLATE_DETECTORS: list[
-    tuple[Callable[[dict[str, int]], bool], _CollatorTemplates]
-] = [
-    (lambda vocab: "<|im_start|>" in vocab, _CHATML_TEMPLATES),
-    (lambda vocab: "<|start_header_id|>" in vocab, _LLAMA3_TEMPLATES),
-]
 
 
 def _resolve_collator_templates(
     tokenizer: "BaseTokenizer",
-) -> _CollatorTemplates:
-    """Auto-detect collator templates from the tokenizer vocabulary.
+) -> tuple[str, str]:
+    """Auto-detect response_template and end_of_turn_template.
+
+    Renders the tokenizer's chat template with sentinel content.
+
+    Returns:
+        (response_template, end_of_turn_template)
 
     Raises:
-        ValueError: If no known chat format is detected.
+        ValueError: If templates cannot be extracted.
     """
-    vocab: dict[str, int] = tokenizer.get_vocab()
-    for detector, templates in _COLLATOR_TEMPLATE_DETECTORS:
-        if detector(vocab):
-            return templates
-    raise ValueError(
-        "Cannot auto-detect chat template format from the tokenizer "
-        "vocabulary. Please use `collator_kwargs` to specify templates "
-        "manually instead of `train_target`."
+    msgs = [
+        {"role": "user", "content": _SENTINEL_USER},
+        {"role": "assistant", "content": _SENTINEL_ASST},
+        {"role": "user", "content": _SENTINEL_USER},
+        {"role": "assistant", "content": _SENTINEL_ASST},
+    ]
+
+    try:
+        rendered = tokenizer.apply_chat_template(
+            msgs, tokenize=False, add_generation_prompt=False
+        )
+    except Exception as exc:
+        raise ValueError(_FALLBACK_MSG) from exc
+
+    if not isinstance(rendered, str):
+        raise ValueError(_FALLBACK_MSG)
+
+    # Locate boundaries around the second turn pair
+    # to avoid system-prompt effects on the first turn.
+    try:
+        a1 = rendered.index(_SENTINEL_ASST)
+        first_asst_end = a1 + len(_SENTINEL_ASST)
+        second_user = rendered.index(_SENTINEL_USER, first_asst_end)
+        second_user_end = second_user + len(_SENTINEL_USER)
+        second_asst = rendered.index(_SENTINEL_ASST, second_user_end)
+        second_asst_end = second_asst + len(_SENTINEL_ASST)
+    except ValueError:
+        raise ValueError(_FALLBACK_MSG)
+
+    # End-of-turn: common token-ID prefix of the two strings that
+    # follow assistant content (mid-conversation vs. end-of-sequence).
+    after_ids = tokenizer.encode(rendered[second_asst_end:], add_special_tokens=False)
+    between_ids = tokenizer.encode(
+        rendered[first_asst_end:second_user], add_special_tokens=False
     )
+    eot_len = 0
+    for a, b in zip(after_ids, between_ids):
+        if a != b:
+            break
+        eot_len += 1
+    eot_ids = after_ids[:eot_len]
+    end_of_turn = tokenizer.decode(eot_ids, skip_special_tokens=False)
 
+    # Response template: strip the EOT prefix to get just the assistant header.
+    resp_ids = tokenizer.encode(
+        rendered[second_user_end:second_asst], add_special_tokens=False
+    )
+    if eot_len > 0 and resp_ids[:eot_len] == eot_ids:
+        resp_ids = resp_ids[eot_len:]
+    response_template = tokenizer.decode(resp_ids, skip_special_tokens=False)
 
-def _build_train_target_kwargs(
-    train_target: TrainTarget,
-    templates: _CollatorTemplates,
-) -> dict:
-    """Build collator keyword arguments for the given train target."""
-    kwargs: dict = {
-        "response_template": templates.response_template,
-        "train_target": train_target.value,
-    }
-    if train_target == TrainTarget.ALL_ASSISTANT_TURNS:
-        kwargs["end_of_turn_template"] = templates.end_of_turn_template
-    # FINAL_ASSISTANT_TURN needs no extra kwargs beyond response_template
-    return kwargs
+    if not response_template.strip():
+        raise ValueError(_FALLBACK_MSG)
+
+    # Qwen3 and similar reasoning models inject <think>...</think> into
+    # every assistant turn via their chat template.  If training data was
+    # formatted without thinking tokens the response_template won't match
+    # and every example will be silently masked.
+    if "<think>" in response_template:
+        logger.warning(
+            "The extracted response_template contains <think> tokens "
+            "(from the model's chat template). If you're training without "
+            "thinking tokens, use collator_kwargs to specify "
+            "response_template manually."
+        )
+
+    return response_template, end_of_turn
 
 
 def build_data_collator(
@@ -281,11 +299,11 @@ def build_collator_from_config(
             )
         if tokenizer is None:
             raise ValueError("Tokenizer is required for `train_target` auto-detection.")
-        templates = _resolve_collator_templates(tokenizer)
-        train_target_kwargs = _build_train_target_kwargs(
-            train_split.train_target, templates
-        )
-        collator_kwargs.update(train_target_kwargs)
+        response_template, end_of_turn_template = _resolve_collator_templates(tokenizer)
+        collator_kwargs["response_template"] = response_template
+        collator_kwargs["train_target"] = train_split.train_target.value
+        if train_split.train_target == TrainTarget.ALL_ASSISTANT_TURNS:
+            collator_kwargs["end_of_turn_template"] = end_of_turn_template
 
     # Merge collator_kwargs from config with the existing kwargs
     # Config kwargs take precedence over automatically determined kwargs

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -292,8 +292,6 @@ def build_collator_from_config(
 
     # --- TrainTarget auto-resolution ---
     if train_split.train_target is not None:
-        if tokenizer is None:
-            raise ValueError("Tokenizer is required for `train_target` auto-detection.")
         response_template, end_of_turn_template = _resolve_collator_templates(tokenizer)
         collator_kwargs["response_template"] = response_template
         collator_kwargs["train_target"] = train_split.train_target.value

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -36,8 +36,8 @@ _SENTINEL_USER = "<<__U__>>"
 _SENTINEL_ASST = "<<__A__>>"
 _FALLBACK_MSG = (
     "Cannot auto-detect collator templates from the chat template. "
-    "Use collator_kwargs to specify response_template and "
-    "end_of_turn_template manually instead of train_target."
+    "Provide response_template (and end_of_turn_template for "
+    "all_assistant_turns) via collator_kwargs."
 )
 
 

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -127,31 +127,15 @@ def build_data_collator(
             **kwargs,
         )
     elif collator_name == "text_completions_only_with_padding":
-        # Extract instruction and response templates from kwargs if provided
-        instruction_template = kwargs.pop("instruction_template", None)
-        response_template = kwargs.pop("response_template", None)
-        end_of_turn_template = kwargs.pop("end_of_turn_template", None)
-        masking_method = kwargs.pop("masking_method", None)
-
-        # Only default to Llama-style instruction template when NOT using
-        # span-based masking (end_of_turn_template makes it unnecessary).
-        if end_of_turn_template is None:
-            instruction_template = (
-                instruction_template
-                if instruction_template
-                else "<|start_header_id|>user<|end_header_id|>\n\n"
+        if not kwargs.get("response_template"):
+            raise ValueError(
+                "'text_completions_only_with_padding' requires a "
+                "response_template. Provide it via collator_kwargs."
             )
-
-        if not response_template:
-            response_template = "<|start_header_id|>assistant<|end_header_id|>\n\n"
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_template=response_template,
-            instruction_template=instruction_template,
             debug=debug,
-            masking_method=masking_method,
-            end_of_turn_template=end_of_turn_template,
             ignore_index=(
                 label_ignore_index if label_ignore_index is not None else -100
             ),

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -51,7 +51,8 @@ def build_data_collator(
 
             - "text_with_padding": Uses `TextCollatorWithPadding`.
             - "text_completions_only_with_padding": Uses
-                `TextCompletionsCollatorWithPadding`.
+                `TextCompletionsCollatorWithPadding`. Supports optional
+                ``end_of_turn_template`` for tool-aware span-based masking.
             - "vision_language_with_padding": Uses `VisionLanguageCollatorWithPadding`.
             - "vision_language_sft": Uses `VisionLanguageSftCollator`.
 
@@ -129,24 +130,33 @@ def build_data_collator(
         # Extract instruction and response templates from kwargs if provided
         instruction_template = kwargs.pop("instruction_template", None)
         response_template = kwargs.pop("response_template", None)
+        end_of_turn_template = kwargs.pop("end_of_turn_template", None)
+        masking_method = kwargs.pop("masking_method", None)
+        tool_call_start_template = kwargs.pop("tool_call_start_template", None)
 
-        # Default to Llama-style templates if not provided
-        instruction_prefix = (
-            instruction_template
-            if instruction_template
-            else "<|start_header_id|>user<|end_header_id|>\n\n"
-        )
-        response_prefix = (
-            response_template
-            if response_template
-            else "<|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
+        # Only default to Llama-style instruction template when NOT using
+        # span-based masking (end_of_turn_template makes it unnecessary).
+        if end_of_turn_template is None:
+            instruction_template = (
+                instruction_template
+                if instruction_template
+                else "<|start_header_id|>user<|end_header_id|>\n\n"
+            )
+
+        if not response_template:
+            response_template = "<|start_header_id|>assistant<|end_header_id|>\n\n"
 
         return TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            instruction_prefix=instruction_prefix,
-            response_prefix=response_prefix,
+            response_template=response_template,
+            instruction_template=instruction_template,
             debug=debug,
+            masking_method=masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            ignore_index=(
+                label_ignore_index if label_ignore_index is not None else -100
+            ),
             **kwargs,
         )
     raise ValueError(f"Unknown data collator name: '{collator_name}'")

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -63,11 +63,15 @@ class TextCompletionsCollatorWithPadding:
         self._debug = debug
         self._has_logged_example = False
 
+    def _collate(self, inputs: list[Any]) -> dict[str, Any]:
+        result = self._default_collator(inputs)
+        return result
+
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:
-        """Collates a batch, delegating to the underlying TRL collator.
+        """Pads to the longest length present in the batch.
 
         Args:
-            batch: List of batch items, each containing ``input_ids``.
+            batch: List of batch items.
 
         Returns:
             Dict[str, torch.Tensor]: Processed batch.
@@ -79,9 +83,11 @@ class TextCompletionsCollatorWithPadding:
                     f"Available keys: {item.keys()}"
                 )
 
-        collated_text_inputs = self._default_collator(batch)
+        # Collate batch prompts.
+        collated_text_inputs = self._collate(batch)
 
         if self._debug and not self._has_logged_example:
+            # Log an example of the data in the first step for debugging purposes.
             self._log_debug_example(batch, collated_text_inputs)
         return collated_text_inputs
 

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -28,9 +28,9 @@ class TextCompletionsCollatorWithPadding:
         self,
         tokenizer: BaseTokenizer,
         response_template: str,
+        train_target: str,
         instruction_template: str | None = None,
         debug: bool = False,
-        train_target: str | None = None,
         end_of_turn_template: str | None = None,
         ignore_index: int = -100,
     ):

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -27,26 +27,26 @@ class TextCompletionsCollatorWithPadding:
     def __init__(
         self,
         tokenizer: BaseTokenizer,
-        response_template: str | list[int],
-        instruction_template: str | list[int] | None = None,
+        response_template: str,
+        instruction_template: str | None = None,
         debug: bool = False,
         masking_method: str | None = None,
-        end_of_turn_template: str | list[int] | None = None,
-        tool_call_start_template: str | list[int] | None = None,
+        end_of_turn_template: str | None = None,
+        tool_call_start_template: str | None = None,
         ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
 
         Args:
         tokenizer: The tokenizer used for encoding the data.
-        response_template: String or token-ID list marking assistant response start.
-        instruction_template: String or token-ID list marking user instruction start.
+        response_template: String marking assistant response start.
+        instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
         masking_method: Masking strategy — ``"assistant_turn"``,
             ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
-        end_of_turn_template: String or token-ID list marking the end of a turn.
+        end_of_turn_template: String marking the end of a turn.
             Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
-        tool_call_start_template: String or token-ID list marking tool-call start.
+        tool_call_start_template: String marking tool-call start.
             Required for ``assistant_turn_no_tools``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -27,22 +27,38 @@ class TextCompletionsCollatorWithPadding:
     def __init__(
         self,
         tokenizer: BaseTokenizer,
-        instruction_prefix: str,
-        response_prefix: str,
+        response_template: str | list[int],
+        instruction_template: str | list[int] | None = None,
         debug: bool = False,
+        masking_method: str | None = None,
+        end_of_turn_template: str | list[int] | None = None,
+        tool_call_start_template: str | list[int] | None = None,
+        ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
 
         Args:
         tokenizer: The tokenizer used for encoding the data.
-        instruction_prefix: The prefix marking the beginning of the user instruction.
-        response_prefix: The prefix marking the beginning of the assistant response.
+        response_template: String or token-ID list marking assistant response start.
+        instruction_template: String or token-ID list marking user instruction start.
         debug: If True, enables debug mode for logging.
+        masking_method: Masking strategy — ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
+        end_of_turn_template: String or token-ID list marking the end of a turn.
+            Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
+        tool_call_start_template: String or token-ID list marking tool-call start.
+            Required for ``assistant_turn_no_tools``.
+        ignore_index: Value used for masked labels. Must match the ignore_index
+            of the loss function (default: -100).
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
-            instruction_template=instruction_prefix,
-            response_template=response_prefix,
+            instruction_template=instruction_template,
+            response_template=response_template,
+            masking_method=masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            ignore_index=ignore_index,
         )
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -30,7 +30,7 @@ class TextCompletionsCollatorWithPadding:
         response_template: str,
         instruction_template: str | None = None,
         debug: bool = False,
-        masking_method: str | None = None,
+        train_target: str | None = None,
         end_of_turn_template: str | None = None,
         ignore_index: int = -100,
     ):
@@ -41,10 +41,10 @@ class TextCompletionsCollatorWithPadding:
         response_template: String marking assistant response start.
         instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
-        masking_method: Masking strategy — ``"assistant_turn"``
+        train_target: Training target — ``"all_assistant_turns"``
             or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
-            Required for ``assistant_turn``.
+            Required for ``all_assistant_turns``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
@@ -52,7 +52,7 @@ class TextCompletionsCollatorWithPadding:
             tokenizer=tokenizer,
             instruction_template=instruction_template,
             response_template=response_template,
-            masking_method=masking_method,
+            train_target=train_target,
             end_of_turn_template=end_of_turn_template,
             ignore_index=ignore_index,
         )

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -32,7 +32,6 @@ class TextCompletionsCollatorWithPadding:
         debug: bool = False,
         masking_method: str | None = None,
         end_of_turn_template: str | None = None,
-        tool_call_start_template: str | None = None,
         ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
@@ -42,12 +41,10 @@ class TextCompletionsCollatorWithPadding:
         response_template: String marking assistant response start.
         instruction_template: String marking user instruction start.
         debug: If True, enables debug mode for logging.
-        masking_method: Masking strategy — ``"assistant_turn"``,
-            ``"assistant_turn_no_tools"``, or ``"final_assistant_turn"``.
+        masking_method: Masking strategy — ``"assistant_turn"``
+            or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
-            Required for ``assistant_turn`` and ``assistant_turn_no_tools``.
-        tool_call_start_template: String marking tool-call start.
-            Required for ``assistant_turn_no_tools``.
+            Required for ``assistant_turn``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
@@ -57,7 +54,6 @@ class TextCompletionsCollatorWithPadding:
             response_template=response_template,
             masking_method=masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             ignore_index=ignore_index,
         )
 

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -63,15 +63,11 @@ class TextCompletionsCollatorWithPadding:
         self._debug = debug
         self._has_logged_example = False
 
-    def _collate(self, inputs: list[Any]) -> dict[str, Any]:
-        result = self._default_collator(inputs)
-        return result
-
-    def __call__(self, batch) -> dict[str, Any]:
-        """Pads to the longest length present in the batch.
+    def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:
+        """Collates a batch, delegating to the underlying TRL collator.
 
         Args:
-            batch: List of batch items.
+            batch: List of batch items, each containing ``input_ids``.
 
         Returns:
             Dict[str, torch.Tensor]: Processed batch.
@@ -83,11 +79,9 @@ class TextCompletionsCollatorWithPadding:
                     f"Available keys: {item.keys()}"
                 )
 
-        # Collate batch prompts.
-        collated_text_inputs = self._collate(batch)
+        collated_text_inputs = self._default_collator(batch)
 
         if self._debug and not self._has_logged_example:
-            # Log an example of the data in the first step for debugging purposes.
             self._log_debug_example(batch, collated_text_inputs)
         return collated_text_inputs
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -56,7 +56,11 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _VALID_TRAIN_TARGETS = {"all_assistant_turns", "final_assistant_turn"}
+    _VALID_TRAIN_TARGETS = {
+        "all_assistant_turns",
+        "final_assistant_turn",
+        "_legacy_instruction_response",
+    }
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -65,6 +69,48 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         if isinstance(template, str):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
+
+    @classmethod
+    def _resolve_train_target(
+        cls,
+        train_target: str | None,
+        *,
+        end_of_turn_template: str | list[int] | None,
+        instruction_template: str | list[int] | None,
+    ) -> str:
+        """Resolve train_target from explicit value or template presence.
+
+        Priority (first match wins):
+          1. Explicit train_target (validated)
+          2. end_of_turn only             → all_assistant_turns
+          3. no instruction_template      → final_assistant_turn
+          4. fallback                     → _legacy_instruction_response
+        """
+        if train_target is not None:
+            if train_target not in cls._VALID_TRAIN_TARGETS:
+                valid = sorted(
+                    cls._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown train_target='{train_target}'. Must be one of: {valid}"
+                )
+            return train_target
+
+        if end_of_turn_template is not None:
+            return "all_assistant_turns"
+        elif instruction_template is None:
+            return "final_assistant_turn"
+        else:
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use train_target='all_assistant_turns' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or train_target='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return "_legacy_instruction_response"
 
     def __init__(
         self,
@@ -89,35 +135,19 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Resolve train target: explicit value, or infer from templates.
-        if train_target is not None:
-            if train_target not in self._VALID_TRAIN_TARGETS:
-                raise ValueError(
-                    f"Unknown train_target='{train_target}'. "
-                    f"Must be one of: {sorted(self._VALID_TRAIN_TARGETS)}"
-                )
-            self.train_target = train_target
-        elif end_of_turn_template is not None:
-            self.train_target = "all_assistant_turns"
-        elif instruction_template is None:
-            self.train_target = "final_assistant_turn"
-        else:
-            warnings.warn(
-                "Instruction-based masking is deprecated. "
-                "Use train_target='all_assistant_turns' with "
-                "end_of_turn_template for multi-turn conversations, "
-                "or train_target='final_assistant_turn' "
-                "for single-turn completions.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.train_target = "_legacy_instruction_response"
+        self.train_target = self._resolve_train_target(
+            train_target,
+            end_of_turn_template=end_of_turn_template,
+            instruction_template=instruction_template,
+        )
 
-        if self.train_target == "all_assistant_turns" and end_of_turn_template is None:
-            raise ValueError(
-                "end_of_turn_template must be provided "
-                "when train_target='all_assistant_turns'"
-            )
+        # Validate required templates for each train target.
+        if self.train_target == "all_assistant_turns":
+            if end_of_turn_template is None:
+                raise ValueError(
+                    "end_of_turn_template must be provided "
+                    f"when train_target='{self.train_target}'"
+                )
 
         if (
             not self.mlm

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -35,12 +35,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
         Correctly handles interleaved tool results and parallel tool calls.
 
-    **``assistant_turn_no_tools``**:
-        Same as ``assistant_turn``, but additionally re-masks assistant
-        turns that contain tool-call content. Requires
-        ``tool_call_start_template``. Only natural-language responses
-        contribute to the loss.
-
     **``final_assistant_turn``**:
         Masks all tokens before the *last* ``response_template`` occurrence.
         Only the final assistant response is trained on. Suitable for
@@ -53,13 +47,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             user instruction. Legacy — only used with the instruction+response
             fallback path.
         masking_method: One of ``"assistant_turn"``,
-            ``"assistant_turn_no_tools"``, ``"final_assistant_turn"``.
+            ``"final_assistant_turn"``.
             When None, inferred from template presence for backward compat.
         end_of_turn_template: String or token IDs marking the end of a
-            conversational turn. Required for ``assistant_turn`` and
-            ``assistant_turn_no_tools`` modes.
-        tool_call_start_template: String or token IDs marking the start
-            of a tool-call block. Required for ``assistant_turn_no_tools``.
+            conversational turn. Required for ``assistant_turn`` mode.
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
@@ -67,7 +58,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
     _KNOWN_MASKING_METHODS = {
         "assistant_turn",
-        "assistant_turn_no_tools",
         "final_assistant_turn",
         "_legacy_instruction_response",
     }
@@ -86,17 +76,15 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         masking_method: str | None,
         *,
         end_of_turn_template: str | list[int] | None,
-        tool_call_start_template: str | list[int] | None,
         instruction_template: str | list[int] | None,
     ) -> str:
         """Resolve masking_method from explicit value or template presence.
 
         Priority (first match wins):
           1. Explicit masking_method (validated)
-          2. end_of_turn + tool_call_start → assistant_turn_no_tools
-          3. end_of_turn only             → assistant_turn
-          4. no instruction_template      → final_assistant_turn
-          5. fallback                     → _legacy_instruction_response
+          2. end_of_turn only             → assistant_turn
+          3. no instruction_template      → final_assistant_turn
+          4. fallback                     → _legacy_instruction_response
         """
         if masking_method is not None:
             if masking_method not in cls._KNOWN_MASKING_METHODS:
@@ -110,11 +98,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             return masking_method
 
         has_eot = end_of_turn_template is not None
-        has_tool = tool_call_start_template is not None
         has_inst = instruction_template is not None
 
-        if has_eot and has_tool:
-            return "assistant_turn_no_tools"
         if has_eot:
             return "assistant_turn"
         if not has_inst:
@@ -138,7 +123,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         *args,
         masking_method: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
-        tool_call_start_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -158,29 +142,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.masking_method = self._resolve_masking_method(
             masking_method,
             end_of_turn_template=end_of_turn_template,
-            tool_call_start_template=tool_call_start_template,
             instruction_template=instruction_template,
         )
 
         # Validate required templates for each masking method.
-        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+        if self.masking_method == "assistant_turn":
             if end_of_turn_template is None:
                 raise ValueError(
                     "end_of_turn_template must be provided "
                     f"when masking_method='{self.masking_method}'"
                 )
-
-        self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
-        self.tool_call_start_token_ids: list[int] | None = None
-        if self.mask_tool_calls:
-            if tool_call_start_template is None:
-                raise ValueError(
-                    "tool_call_start_template must be provided "
-                    "when masking_method='assistant_turn_no_tools'"
-                )
-            self.tool_call_start_token_ids = self._tokenize_template(
-                tool_call_start_template
-            )
 
         if (
             not self.mlm
@@ -213,29 +184,14 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 positions.append(i)
         return positions
 
-    @staticmethod
-    def _span_contains(
-        seq: list[int], span_start: int, span_end: int, pattern: list[int]
-    ) -> bool:
-        """Return True if *pattern* appears anywhere in seq[span_start:span_end]."""
-        plen = len(pattern)
-        if plen == 0:
-            return False
-        first = pattern[0]
-        for i in range(span_start, span_end - plen + 1):
-            if seq[i] == first and seq[i : i + plen] == pattern:
-                return True
-        return False
-
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
     ) -> None:
-        """Apply span-based masking for tool-aware conversations.
+        """Apply span-based masking for multi-turn conversations.
 
         Masks all labels, then unmarks assistant response spans bounded by
         response_template and end_of_turn_template (inclusive — the EOT token
-        is unmasked so the model learns to produce it).  Optionally re-masks
-        spans that contain tool-call content.
+        is unmasked so the model learns to produce it).
         """
         resp_ids = self.response_token_ids
         eot_ids = self.end_of_turn_token_ids
@@ -284,17 +240,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 if content_start >= content_end:
                     continue
 
-                # Step 4: optionally skip tool-call spans.
-                if self.mask_tool_calls and self.tool_call_start_token_ids is not None:
-                    if self._span_contains(
-                        seq,
-                        content_start,
-                        content_end,
-                        self.tool_call_start_token_ids,
-                    ):
-                        continue
-
-                # Step 5: unmask this assistant response span, including the
+                # Step 4: unmask this assistant response span, including the
                 # end-of-turn token so the model learns when to stop.
                 if eot_positions:
                     eot_len = len(self.end_of_turn_token_ids)  # type: ignore
@@ -317,7 +263,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+        if self.masking_method == "assistant_turn":
             self._apply_span_masking(batch, examples)
         elif self.masking_method == "final_assistant_turn":
             # Response-only: unmask only the final assistant response.

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -121,6 +121,15 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             self.masking_method = "final_assistant_turn"
         else:
             self.masking_method = "_legacy_instruction_response"
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use masking_method='assistant_turn' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or masking_method='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -56,11 +56,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _KNOWN_MASKING_METHODS = {
-        "assistant_turn",
-        "final_assistant_turn",
-        "_legacy_instruction_response",
-    }
+    _VALID_MASKING_METHODS = {"assistant_turn", "final_assistant_turn"}
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -69,52 +65,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         if isinstance(template, str):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
-
-    @classmethod
-    def _resolve_masking_method(
-        cls,
-        masking_method: str | None,
-        *,
-        end_of_turn_template: str | list[int] | None,
-        instruction_template: str | list[int] | None,
-    ) -> str:
-        """Resolve masking_method from explicit value or template presence.
-
-        Priority (first match wins):
-          1. Explicit masking_method (validated)
-          2. end_of_turn only             → assistant_turn
-          3. no instruction_template      → final_assistant_turn
-          4. fallback                     → _legacy_instruction_response
-        """
-        if masking_method is not None:
-            if masking_method not in cls._KNOWN_MASKING_METHODS:
-                valid = sorted(
-                    cls._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
-                )
-                raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {valid}"
-                )
-            return masking_method
-
-        has_eot = end_of_turn_template is not None
-        has_inst = instruction_template is not None
-
-        if has_eot:
-            return "assistant_turn"
-        if not has_inst:
-            return "final_assistant_turn"
-
-        warnings.warn(
-            "Instruction-based masking is deprecated. "
-            "Use masking_method='assistant_turn' with "
-            "end_of_turn_template for multi-turn conversations, "
-            "or masking_method='final_assistant_turn' "
-            "for single-turn completions.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return "_legacy_instruction_response"
 
     def __init__(
         self,
@@ -139,19 +89,35 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        self.masking_method = self._resolve_masking_method(
-            masking_method,
-            end_of_turn_template=end_of_turn_template,
-            instruction_template=instruction_template,
-        )
-
-        # Validate required templates for each masking method.
-        if self.masking_method == "assistant_turn":
-            if end_of_turn_template is None:
+        # Resolve masking method: explicit value, or infer from templates.
+        if masking_method is not None:
+            if masking_method not in self._VALID_MASKING_METHODS:
                 raise ValueError(
-                    "end_of_turn_template must be provided "
-                    f"when masking_method='{self.masking_method}'"
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {sorted(self._VALID_MASKING_METHODS)}"
                 )
+            self.masking_method = masking_method
+        elif end_of_turn_template is not None:
+            self.masking_method = "assistant_turn"
+        elif instruction_template is None:
+            self.masking_method = "final_assistant_turn"
+        else:
+            warnings.warn(
+                "Instruction-based masking is deprecated. "
+                "Use masking_method='assistant_turn' with "
+                "end_of_turn_template for multi-turn conversations, "
+                "or masking_method='final_assistant_turn' "
+                "for single-turn completions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.masking_method = "_legacy_instruction_response"
+
+        if self.masking_method == "assistant_turn" and end_of_turn_template is None:
+            raise ValueError(
+                "end_of_turn_template must be provided "
+                "when masking_method='assistant_turn'"
+            )
 
         if (
             not self.mlm

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -138,6 +138,13 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             self.masking_method = "_legacy_instruction_response"
 
+        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+            if end_of_turn_template is None:
+                raise ValueError(
+                    "end_of_turn_template must be provided "
+                    f"when masking_method='{self.masking_method}'"
+                )
+
         self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
         self.tool_call_start_token_ids: list[int] | None = None
         if self.mask_tool_calls:

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -80,6 +80,57 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
 
+    @classmethod
+    def _resolve_masking_method(
+        cls,
+        masking_method: str | None,
+        *,
+        end_of_turn_template: str | list[int] | None,
+        tool_call_start_template: str | list[int] | None,
+        instruction_template: str | list[int] | None,
+    ) -> str:
+        """Resolve masking_method from explicit value or template presence.
+
+        Priority (first match wins):
+          1. Explicit masking_method (validated)
+          2. end_of_turn + tool_call_start → assistant_turn_no_tools
+          3. end_of_turn only             → assistant_turn
+          4. no instruction_template      → final_assistant_turn
+          5. fallback                     → _legacy_instruction_response
+        """
+        if masking_method is not None:
+            if masking_method not in cls._KNOWN_MASKING_METHODS:
+                valid = sorted(
+                    cls._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {valid}"
+                )
+            return masking_method
+
+        has_eot = end_of_turn_template is not None
+        has_tool = tool_call_start_template is not None
+        has_inst = instruction_template is not None
+
+        if has_eot and has_tool:
+            return "assistant_turn_no_tools"
+        if has_eot:
+            return "assistant_turn"
+        if not has_inst:
+            return "final_assistant_turn"
+
+        warnings.warn(
+            "Instruction-based masking is deprecated. "
+            "Use masking_method='assistant_turn' with "
+            "end_of_turn_template for multi-turn conversations, "
+            "or masking_method='final_assistant_turn' "
+            "for single-turn completions.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return "_legacy_instruction_response"
+
     def __init__(
         self,
         response_template: str | list[int],
@@ -104,35 +155,12 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Infer masking_method from template presence for backward compatibility.
-        if masking_method is not None:
-            if masking_method not in self._KNOWN_MASKING_METHODS:
-                valid_methods = sorted(
-                    self._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
-                )
-                raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {valid_methods}"
-                )
-            self.masking_method = masking_method
-        elif end_of_turn_template is not None:
-            if tool_call_start_template is not None:
-                self.masking_method = "assistant_turn_no_tools"
-            else:
-                self.masking_method = "assistant_turn"
-        elif instruction_template is None:
-            self.masking_method = "final_assistant_turn"
-        else:
-            self.masking_method = "_legacy_instruction_response"
-            warnings.warn(
-                "Instruction-based masking is deprecated. "
-                "Use masking_method='assistant_turn' with "
-                "end_of_turn_template for multi-turn conversations, "
-                "or masking_method='final_assistant_turn' "
-                "for single-turn completions.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        self.masking_method = self._resolve_masking_method(
+            masking_method,
+            end_of_turn_template=end_of_turn_template,
+            tool_call_start_template=tool_call_start_template,
+            instruction_template=instruction_template,
+        )
 
         # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -27,9 +27,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     tokens (typically assistant responses), while ignoring other tokens
     (system prompts, user messages, padding).
 
-    The ``masking_method`` parameter selects the masking strategy:
+    The ``train_target`` parameter selects the training target:
 
-    **``assistant_turn``**:
+    **``all_assistant_turns``**:
         Span-based masking for multi-turn and tool-calling conversations.
         Masks everything, then unmarks each assistant response span bounded
         by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
@@ -46,17 +46,17 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         instruction_template: String or token IDs marking the start of a
             user instruction. Legacy — only used with the instruction+response
             fallback path.
-        masking_method: One of ``"assistant_turn"``,
+        train_target: One of ``"all_assistant_turns"``,
             ``"final_assistant_turn"``.
             When None, inferred from template presence for backward compat.
         end_of_turn_template: String or token IDs marking the end of a
-            conversational turn. Required for ``assistant_turn`` mode.
+            conversational turn. Required for ``all_assistant_turns`` mode.
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _VALID_MASKING_METHODS = {"assistant_turn", "final_assistant_turn"}
+    _VALID_TRAIN_TARGETS = {"all_assistant_turns", "final_assistant_turn"}
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
         """Encode a template string into token IDs, or pass through if already IDs."""
@@ -71,7 +71,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
-        masking_method: str | None = None,
+        train_target: str | None = None,
         end_of_turn_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
@@ -89,34 +89,34 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        # Resolve masking method: explicit value, or infer from templates.
-        if masking_method is not None:
-            if masking_method not in self._VALID_MASKING_METHODS:
+        # Resolve train target: explicit value, or infer from templates.
+        if train_target is not None:
+            if train_target not in self._VALID_TRAIN_TARGETS:
                 raise ValueError(
-                    f"Unknown masking_method='{masking_method}'. "
-                    f"Must be one of: {sorted(self._VALID_MASKING_METHODS)}"
+                    f"Unknown train_target='{train_target}'. "
+                    f"Must be one of: {sorted(self._VALID_TRAIN_TARGETS)}"
                 )
-            self.masking_method = masking_method
+            self.train_target = train_target
         elif end_of_turn_template is not None:
-            self.masking_method = "assistant_turn"
+            self.train_target = "all_assistant_turns"
         elif instruction_template is None:
-            self.masking_method = "final_assistant_turn"
+            self.train_target = "final_assistant_turn"
         else:
             warnings.warn(
                 "Instruction-based masking is deprecated. "
-                "Use masking_method='assistant_turn' with "
+                "Use train_target='all_assistant_turns' with "
                 "end_of_turn_template for multi-turn conversations, "
-                "or masking_method='final_assistant_turn' "
+                "or train_target='final_assistant_turn' "
                 "for single-turn completions.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.masking_method = "_legacy_instruction_response"
+            self.train_target = "_legacy_instruction_response"
 
-        if self.masking_method == "assistant_turn" and end_of_turn_template is None:
+        if self.train_target == "all_assistant_turns" and end_of_turn_template is None:
             raise ValueError(
                 "end_of_turn_template must be provided "
-                "when masking_method='assistant_turn'"
+                "when train_target='all_assistant_turns'"
             )
 
         if (
@@ -229,9 +229,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.masking_method == "assistant_turn":
+        if self.train_target == "all_assistant_turns":
             self._apply_span_masking(batch, examples)
-        elif self.masking_method == "final_assistant_turn":
+        elif self.train_target == "final_assistant_turn":
             # Response-only: unmask only the final assistant response.
             for i in range(len(examples)):
                 response_token_ids_start_idx = None

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -116,7 +116,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 )
             self.masking_method = masking_method
         elif end_of_turn_template is not None:
-            self.masking_method = "assistant_turn"
+            if tool_call_start_template is not None:
+                self.masking_method = "assistant_turn_no_tools"
+            else:
+                self.masking_method = "assistant_turn"
         elif instruction_template is None:
             self.masking_method = "final_assistant_turn"
         else:

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -21,9 +21,48 @@ from transformers.data.data_collator import DataCollatorForLanguageModeling
 
 
 class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
-    """Data collator used for completion tasks.
+    """Data collator for completion-only training.
 
-    Copied from `trl`'s `DataCollatorForCompletionOnlyLM` class.
+    Masks input labels so that the loss is only computed on specific
+    tokens (typically assistant responses), while ignoring other tokens
+    (system prompts, user messages, padding).
+
+    The ``masking_method`` parameter selects the masking strategy:
+
+    **``assistant_turn``**:
+        Span-based masking for multi-turn and tool-calling conversations.
+        Masks everything, then unmarks each assistant response span bounded
+        by ``response_template`` .. ``end_of_turn_template`` (inclusive of EOT).
+        Correctly handles interleaved tool results and parallel tool calls.
+
+    **``assistant_turn_no_tools``**:
+        Same as ``assistant_turn``, but additionally re-masks assistant
+        turns that contain tool-call content. Requires
+        ``tool_call_start_template``. Only natural-language responses
+        contribute to the loss.
+
+    **``final_assistant_turn``**:
+        Masks all tokens before the *last* ``response_template`` occurrence.
+        Only the final assistant response is trained on. Suitable for
+        single-turn completions.
+
+    Args:
+        response_template: String or token IDs marking the start of an
+            assistant response. Required for all modes.
+        instruction_template: String or token IDs marking the start of a
+            user instruction. Legacy — only used with the instruction+response
+            fallback path.
+        masking_method: One of ``"assistant_turn"``,
+            ``"assistant_turn_no_tools"``, ``"final_assistant_turn"``.
+            When None, inferred from template presence for backward compat.
+        end_of_turn_template: String or token IDs marking the end of a
+            conversational turn. Required for ``assistant_turn`` and
+            ``assistant_turn_no_tools`` modes.
+        tool_call_start_template: String or token IDs marking the start
+            of a tool-call block. Required for ``assistant_turn_no_tools``.
+        mlm: Whether to use masked language modeling. Default False.
+        ignore_index: Label value for masked tokens. Default -100.
+        padding_free: Remove padding and add position_ids. Default False.
     """
 
     def __init__(
@@ -31,6 +70,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
+        masking_method: str | None = None,
+        end_of_turn_template: str | list[int] | None = None,
+        tool_call_start_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -60,6 +102,57 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             # The user already provides the token ids
             self.response_token_ids = response_template
 
+        # Tool-aware span-based masking parameters
+        self.end_of_turn_template = end_of_turn_template
+        if isinstance(end_of_turn_template, str):
+            self.end_of_turn_token_ids: list[int] | None = self.tokenizer.encode(
+                end_of_turn_template, add_special_tokens=False
+            )
+        elif end_of_turn_template is not None:
+            self.end_of_turn_token_ids = list(end_of_turn_template)
+        else:
+            self.end_of_turn_token_ids = None
+
+        _KNOWN_MASKING_METHODS = {
+            "assistant_turn",
+            "assistant_turn_no_tools",
+            "final_assistant_turn",
+            "_legacy_instruction_response",
+        }
+
+        # Infer masking_method from template presence for backward compatibility.
+        if masking_method is not None:
+            if masking_method not in _KNOWN_MASKING_METHODS:
+                valid_methods = sorted(
+                    _KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                )
+                raise ValueError(
+                    f"Unknown masking_method='{masking_method}'. "
+                    f"Must be one of: {valid_methods}"
+                )
+            self.masking_method = masking_method
+        elif end_of_turn_template is not None:
+            self.masking_method = "assistant_turn"
+        elif instruction_template is None:
+            self.masking_method = "final_assistant_turn"
+        else:
+            self.masking_method = "_legacy_instruction_response"
+
+        self.mask_tool_calls = self.masking_method == "assistant_turn_no_tools"
+        self.tool_call_start_token_ids: list[int] | None = None
+        if self.mask_tool_calls:
+            if tool_call_start_template is None:
+                raise ValueError(
+                    "tool_call_start_template must be provided "
+                    "when masking_method='assistant_turn_no_tools'"
+                )
+            if isinstance(tool_call_start_template, str):
+                self.tool_call_start_token_ids = self.tokenizer.encode(
+                    tool_call_start_template, add_special_tokens=False
+                )
+            else:
+                self.tool_call_start_token_ids = list(tool_call_start_template)
+
         if (
             not self.mlm
             and self.instruction_template
@@ -78,13 +171,127 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.ignore_index = ignore_index
         self.padding_free = padding_free
 
+    @staticmethod
+    def _find_pattern(seq: list[int], pattern: list[int]) -> list[int]:
+        """Return all start positions where *pattern* appears in *seq*."""
+        plen = len(pattern)
+        if plen == 0:
+            return []
+        first = pattern[0]
+        positions = []
+        for i in range(len(seq) - plen + 1):
+            if seq[i] == first and seq[i : i + plen] == pattern:
+                positions.append(i)
+        return positions
+
+    @staticmethod
+    def _span_contains(
+        seq: list[int], span_start: int, span_end: int, pattern: list[int]
+    ) -> bool:
+        """Return True if *pattern* appears anywhere in seq[span_start:span_end]."""
+        plen = len(pattern)
+        if plen == 0:
+            return False
+        first = pattern[0]
+        for i in range(span_start, span_end - plen + 1):
+            if seq[i] == first and seq[i : i + plen] == pattern:
+                return True
+        return False
+
+    def _apply_span_masking(
+        self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
+    ) -> None:
+        """Apply span-based masking for tool-aware conversations.
+
+        Masks all labels, then unmarks assistant response spans bounded by
+        response_template and end_of_turn_template (inclusive — the EOT token
+        is unmasked so the model learns to produce it).  Optionally re-masks
+        spans that contain tool-call content.
+        """
+        resp_ids = self.response_token_ids
+        eot_ids = self.end_of_turn_token_ids
+        assert eot_ids is not None  # Caller checks end_of_turn_template is not None
+        resp_len = len(resp_ids)
+        pad_token_id = self.tokenizer.pad_token_id
+
+        for i in range(len(examples)):
+            # Step 1: mask everything.
+            batch["labels"][i, :] = self.ignore_index
+
+            seq: list[int] = batch["input_ids"][i].tolist()
+
+            # Compute effective sequence length excluding trailing padding.
+            # Prevents false matches when end_of_turn_token_ids overlaps
+            # with the pad token (common: e.g. <|im_end|> = eos = pad).
+            if pad_token_id is not None:
+                n = len(seq)
+                while n > 0 and seq[n - 1] == pad_token_id:
+                    n -= 1
+            else:
+                n = len(seq)
+
+            # Step 2: find every assistant response start position.
+            resp_positions = self._find_pattern(seq[:n], resp_ids)
+
+            if len(resp_positions) == 0:
+                warnings.warn(
+                    f"Could not find response template in the following instance: "
+                    f"{self.tokenizer.decode(batch['input_ids'][i])}. "
+                    "This instance will be ignored in loss calculation.",
+                    UserWarning,
+                )
+                continue
+
+            for resp_pos in resp_positions:
+                content_start = resp_pos + resp_len
+
+                # Step 3: find the next end_of_turn after content_start.
+                eot_positions = self._find_pattern(seq[content_start:n], eot_ids)
+                if eot_positions:
+                    content_end = content_start + eot_positions[0]
+                else:
+                    content_end = n
+
+                if content_start >= content_end:
+                    continue
+
+                # Step 4: optionally skip tool-call spans.
+                if self.mask_tool_calls and self.tool_call_start_token_ids is not None:
+                    if self._span_contains(
+                        seq,
+                        content_start,
+                        content_end,
+                        self.tool_call_start_token_ids,
+                    ):
+                        continue
+
+                # Step 5: unmask this assistant response span, including the
+                # end-of-turn token so the model learns when to stop.
+                if eot_positions:
+                    eot_len = len(self.end_of_turn_token_ids)  # type: ignore
+                    unmask_end = content_end + eot_len
+                else:
+                    # No EOT found — content_end == n (end of real content).
+                    # Do NOT extend past n or we'd unmask into padding.
+                    unmask_end = content_end
+                batch["labels"][i, content_start:unmask_end] = batch["input_ids"][
+                    i, content_start:unmask_end
+                ]
+
+    # ------------------------------------------------------------------
+    # Main collation
+    # ------------------------------------------------------------------
+
     def torch_call(
         self, examples: list[list[int] | Any | dict[str, Any]]
     ) -> dict[str, Any]:
         """Collates a list of examples into a batch."""
         batch = super().torch_call(examples)
 
-        if self.instruction_template is None:
+        if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
+            self._apply_span_masking(batch, examples)
+        elif self.masking_method == "final_assistant_turn":
+            # Response-only: unmask only the final assistant response.
             for i in range(len(examples)):
                 response_token_ids_start_idx = None
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -19,6 +19,8 @@ import numpy as np
 import torch
 from transformers.data.data_collator import DataCollatorForLanguageModeling
 
+from oumi.core.configs.params.data_params import TrainTarget
+
 
 class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     """Data collator for completion-only training.
@@ -47,8 +49,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             user instruction. Legacy — only used with the instruction+response
             fallback path.
         train_target: One of ``"all_assistant_turns"``,
-            ``"final_assistant_turn"``.
-            When None, inferred from template presence for backward compat.
+            ``"final_assistant_turn"``, ``"_legacy_instruction_response"``.
+            Resolved by the builder before construction.
         end_of_turn_template: String or token IDs marking the end of a
             conversational turn. Required for ``all_assistant_turns`` mode.
         mlm: Whether to use masked language modeling. Default False.
@@ -56,9 +58,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
-    _VALID_TRAIN_TARGETS = {
-        "all_assistant_turns",
-        "final_assistant_turn",
+    _VALID_TRAIN_TARGETS = {t.value for t in TrainTarget} | {
         "_legacy_instruction_response",
     }
 
@@ -70,54 +70,12 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             return self.tokenizer.encode(template, add_special_tokens=False)
         return list(template)
 
-    @classmethod
-    def _resolve_train_target(
-        cls,
-        train_target: str | None,
-        *,
-        end_of_turn_template: str | list[int] | None,
-        instruction_template: str | list[int] | None,
-    ) -> str:
-        """Resolve train_target from explicit value or template presence.
-
-        Priority (first match wins):
-          1. Explicit train_target (validated)
-          2. end_of_turn only             → all_assistant_turns
-          3. no instruction_template      → final_assistant_turn
-          4. fallback                     → _legacy_instruction_response
-        """
-        if train_target is not None:
-            if train_target not in cls._VALID_TRAIN_TARGETS:
-                valid = sorted(
-                    cls._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"}
-                )
-                raise ValueError(
-                    f"Unknown train_target='{train_target}'. Must be one of: {valid}"
-                )
-            return train_target
-
-        if end_of_turn_template is not None:
-            return "all_assistant_turns"
-        elif instruction_template is None:
-            return "final_assistant_turn"
-        else:
-            warnings.warn(
-                "Instruction-based masking is deprecated. "
-                "Use train_target='all_assistant_turns' with "
-                "end_of_turn_template for multi-turn conversations, "
-                "or train_target='final_assistant_turn' "
-                "for single-turn completions.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            return "_legacy_instruction_response"
-
     def __init__(
         self,
         response_template: str | list[int],
         instruction_template: str | list[int] | None = None,
         *args,
-        train_target: str | None = None,
+        train_target: str,
         end_of_turn_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
@@ -135,17 +93,23 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
-        self.train_target = self._resolve_train_target(
-            train_target,
-            end_of_turn_template=end_of_turn_template,
-            instruction_template=instruction_template,
-        )
+        if train_target not in self._VALID_TRAIN_TARGETS:
+            valid = sorted(self._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"})
+            raise ValueError(
+                f"Unknown train_target='{train_target}'. Must be one of: {valid}"
+            )
+        self.train_target = train_target
 
-        # Validate required templates for each train target.
         if self.train_target == "all_assistant_turns":
             if end_of_turn_template is None:
                 raise ValueError(
                     "end_of_turn_template must be provided "
+                    f"when train_target='{self.train_target}'"
+                )
+        if self.train_target == "_legacy_instruction_response":
+            if instruction_template is None:
+                raise ValueError(
+                    "instruction_template must be provided "
                     f"when train_target='{self.train_target}'"
                 )
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -65,6 +65,21 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         padding_free: Remove padding and add position_ids. Default False.
     """
 
+    _KNOWN_MASKING_METHODS = {
+        "assistant_turn",
+        "assistant_turn_no_tools",
+        "final_assistant_turn",
+        "_legacy_instruction_response",
+    }
+
+    def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
+        """Encode a template string into token IDs, or pass through if already IDs."""
+        if template is None:
+            return None
+        if isinstance(template, str):
+            return self.tokenizer.encode(template, add_special_tokens=False)
+        return list(template)
+
     def __init__(
         self,
         response_template: str | list[int],
@@ -81,50 +96,19 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         """Initializes the DataCollatorForCompletionOnlyLM."""
         super().__init__(*args, mlm=mlm, **kwargs)
 
+        # Tokenize templates.
         self.instruction_template = instruction_template
-        if isinstance(instruction_template, str):
-            # The user provides a string, must tokenize
-            self.instruction_token_ids = self.tokenizer.encode(
-                self.instruction_template,  # type: ignore
-                add_special_tokens=False,
-            )
-        else:
-            # The user already provides the token ids
-            self.instruction_token_ids = instruction_template
-
+        self.instruction_token_ids = self._tokenize_template(instruction_template)
         self.response_template = response_template
-        if isinstance(response_template, str):
-            # The user provides a string, must tokenize
-            self.response_token_ids = self.tokenizer.encode(
-                self.response_template, add_special_tokens=False
-            )
-        else:
-            # The user already provides the token ids
-            self.response_token_ids = response_template
-
-        # Tool-aware span-based masking parameters
+        self.response_token_ids: list[int] = self._tokenize_template(response_template)  # type: ignore[assignment]
         self.end_of_turn_template = end_of_turn_template
-        if isinstance(end_of_turn_template, str):
-            self.end_of_turn_token_ids: list[int] | None = self.tokenizer.encode(
-                end_of_turn_template, add_special_tokens=False
-            )
-        elif end_of_turn_template is not None:
-            self.end_of_turn_token_ids = list(end_of_turn_template)
-        else:
-            self.end_of_turn_token_ids = None
-
-        _KNOWN_MASKING_METHODS = {
-            "assistant_turn",
-            "assistant_turn_no_tools",
-            "final_assistant_turn",
-            "_legacy_instruction_response",
-        }
+        self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
 
         # Infer masking_method from template presence for backward compatibility.
         if masking_method is not None:
-            if masking_method not in _KNOWN_MASKING_METHODS:
+            if masking_method not in self._KNOWN_MASKING_METHODS:
                 valid_methods = sorted(
-                    _KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
+                    self._KNOWN_MASKING_METHODS - {"_legacy_instruction_response"}
                 )
                 raise ValueError(
                     f"Unknown masking_method='{masking_method}'. "
@@ -138,6 +122,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             self.masking_method = "_legacy_instruction_response"
 
+        # Validate required templates for each masking method.
         if self.masking_method in ("assistant_turn", "assistant_turn_no_tools"):
             if end_of_turn_template is None:
                 raise ValueError(
@@ -153,12 +138,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     "tool_call_start_template must be provided "
                     "when masking_method='assistant_turn_no_tools'"
                 )
-            if isinstance(tool_call_start_template, str):
-                self.tool_call_start_token_ids = self.tokenizer.encode(
-                    tool_call_start_template, add_special_tokens=False
-                )
-            else:
-                self.tool_call_start_token_ids = list(tool_call_start_template)
+            self.tool_call_start_token_ids = self._tokenize_template(
+                tool_call_start_template
+            )
 
         if (
             not self.mlm

--- a/src/oumi/core/configs/__init__.py
+++ b/src/oumi/core/configs/__init__.py
@@ -93,6 +93,7 @@ from oumi.core.configs.params.data_params import (
     DatasetParams,
     DatasetSplit,
     DatasetSplitParams,
+    MaskingMethod,
     MixtureStrategy,
 )
 from oumi.core.configs.params.evaluation_params import (
@@ -190,6 +191,7 @@ __all__ = [
     "LMHarnessTaskParams",
     "LoraWeightInitialization",
     "MixedPrecisionDtype",
+    "MaskingMethod",
     "MixtureStrategy",
     "ModelParams",
     "PeftParams",

--- a/src/oumi/core/configs/__init__.py
+++ b/src/oumi/core/configs/__init__.py
@@ -93,8 +93,8 @@ from oumi.core.configs.params.data_params import (
     DatasetParams,
     DatasetSplit,
     DatasetSplitParams,
-    MaskingMethod,
     MixtureStrategy,
+    TrainTarget,
 )
 from oumi.core.configs.params.evaluation_params import (
     EvaluationBackend,
@@ -191,7 +191,7 @@ __all__ = [
     "LMHarnessTaskParams",
     "LoraWeightInitialization",
     "MixedPrecisionDtype",
-    "MaskingMethod",
+    "TrainTarget",
     "MixtureStrategy",
     "ModelParams",
     "PeftParams",

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -307,6 +307,16 @@ class DatasetSplitParams(BaseParams):
         if isinstance(self.train_target, str):
             self.train_target = TrainTarget(self.train_target)
 
+        if self.train_target is not None and self.collator_name not in (
+            None,
+            "text_completions_only_with_padding",
+        ):
+            raise ValueError(
+                "`train_target` is only supported with the "
+                "'text_completions_only_with_padding' collator, "
+                f"got '{self.collator_name}'."
+            )
+
         if any([dataset.mixture_proportion is not None for dataset in self.datasets]):
             if not all(
                 [dataset.mixture_proportion is not None for dataset in self.datasets]

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -200,8 +200,8 @@ class DatasetSplitParams(BaseParams):
         - "text_completions_only_with_padding": Uses template matching to
             mask non-assistant tokens. Works for simple user/assistant turns.
             Supports optional ``end_of_turn_template`` in ``collator_kwargs``
-            for tool-aware span-based masking. When set, also supports
-            ``mask_tool_calls=True`` and ``tool_call_start_template``.
+            for span-based masking. Use
+            ``masking_method="assistant_turn_no_tools"`` to mask tool calls.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
         - "vision_language_sft": Uses VisionLanguageSftCollator.

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -52,6 +52,28 @@ class MixtureStrategy(str, Enum):
             raise ValueError("Unsupported value for MixtureStrategy")
 
 
+class MaskingMethod(str, Enum):
+    """Controls which tokens contribute to the loss during SFT training.
+
+    Used with the ``text_completions_only_with_padding`` collator to
+    select the masking strategy. Template tokens are auto-resolved
+    from the tokenizer vocabulary.
+
+    Members:
+        ASSISTANT_TURN: Train on all assistant response turns including
+            tool calls. Uses span-based masking: system prompts, user
+            messages, and tool results are masked; everything between the
+            assistant header and the end-of-turn token (inclusive) is
+            unmasked.
+        FINAL_ASSISTANT_TURN: Train only on the final assistant response.
+            Masks all tokens before the last ``response_template``
+            occurrence. Suitable for single-turn completions.
+    """
+
+    ASSISTANT_TURN = "assistant_turn"
+    FINAL_ASSISTANT_TURN = "final_assistant_turn"
+
+
 @dataclass
 class DatasetParams(BaseParams):
     dataset_name: str = MISSING
@@ -215,6 +237,16 @@ class DatasetSplitParams(BaseParams):
     and can be used to customize collator behavior beyond the default parameters.
     """
 
+    masking_method: MaskingMethod | None = None
+    """High-level masking strategy for ``text_completions_only_with_padding``.
+
+    When set, the builder auto-detects ``response_template`` and
+    ``end_of_turn_template`` from the tokenizer vocabulary.  Mutually
+    exclusive with ``collator_kwargs`` -- use one or the other.
+
+    See :class:`MaskingMethod` for available options.
+    """
+
     pack: bool = False
     """Whether to pack the text into constant-length chunks.
 
@@ -271,6 +303,18 @@ class DatasetSplitParams(BaseParams):
 
     def __post_init__(self):
         """Verifies params."""
+        # Convert string masking_method to enum if needed
+        if isinstance(self.masking_method, str):
+            self.masking_method = MaskingMethod(self.masking_method)
+
+        # masking_method and collator_kwargs are mutually exclusive
+        if self.masking_method is not None and self.collator_kwargs:
+            raise ValueError(
+                "Cannot specify both `masking_method` and `collator_kwargs`. "
+                "`masking_method` auto-resolves all collator keyword arguments; "
+                "use one or the other."
+            )
+
         if any([dataset.mixture_proportion is not None for dataset in self.datasets]):
             if not all(
                 [dataset.mixture_proportion is not None for dataset in self.datasets]

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -197,8 +197,14 @@ class DatasetSplitParams(BaseParams):
 
         - "text_with_padding": Dynamically pads the inputs received to
             the longest length.
+        - "text_completions_only_with_padding": Uses template matching to
+            mask non-assistant tokens. Works for simple user/assistant turns.
+            Supports optional ``end_of_turn_template`` in ``collator_kwargs``
+            for tool-aware span-based masking. When set, also supports
+            ``mask_tool_calls=True`` and ``tool_call_start_template``.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
+        - "vision_language_sft": Uses VisionLanguageSftCollator.
 
     If None, then a default collator will be assigned.
     """

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -307,13 +307,13 @@ class DatasetSplitParams(BaseParams):
         if isinstance(self.train_target, str):
             self.train_target = TrainTarget(self.train_target)
 
-        if self.train_target is not None and self.collator_name not in (
-            None,
-            "text_completions_only_with_padding",
+        if (
+            self.train_target is not None
+            and self.collator_name != "text_completions_only_with_padding"
         ):
             raise ValueError(
-                "`train_target` is only supported with the "
-                "'text_completions_only_with_padding' collator, "
+                "`train_target` requires "
+                "collator_name='text_completions_only_with_padding', "
                 f"got '{self.collator_name}'."
             )
 

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -52,15 +52,15 @@ class MixtureStrategy(str, Enum):
             raise ValueError("Unsupported value for MixtureStrategy")
 
 
-class MaskingMethod(str, Enum):
+class TrainTarget(str, Enum):
     """Controls which tokens contribute to the loss during SFT training.
 
     Used with the ``text_completions_only_with_padding`` collator to
-    select the masking strategy. Template tokens are auto-resolved
+    select the training target. Template tokens are auto-resolved
     from the tokenizer vocabulary.
 
     Members:
-        ASSISTANT_TURN: Train on all assistant response turns including
+        ALL_ASSISTANT_TURNS: Train on all assistant response turns including
             tool calls. Uses span-based masking: system prompts, user
             messages, and tool results are masked; everything between the
             assistant header and the end-of-turn token (inclusive) is
@@ -70,7 +70,7 @@ class MaskingMethod(str, Enum):
             occurrence. Suitable for single-turn completions.
     """
 
-    ASSISTANT_TURN = "assistant_turn"
+    ALL_ASSISTANT_TURNS = "all_assistant_turns"
     FINAL_ASSISTANT_TURN = "final_assistant_turn"
 
 
@@ -237,14 +237,14 @@ class DatasetSplitParams(BaseParams):
     and can be used to customize collator behavior beyond the default parameters.
     """
 
-    masking_method: MaskingMethod | None = None
-    """High-level masking strategy for ``text_completions_only_with_padding``.
+    train_target: TrainTarget | None = None
+    """High-level training target for ``text_completions_only_with_padding``.
 
     When set, the builder auto-detects ``response_template`` and
     ``end_of_turn_template`` from the tokenizer vocabulary.  Mutually
     exclusive with ``collator_kwargs`` -- use one or the other.
 
-    See :class:`MaskingMethod` for available options.
+    See :class:`TrainTarget` for available options.
     """
 
     pack: bool = False
@@ -303,15 +303,15 @@ class DatasetSplitParams(BaseParams):
 
     def __post_init__(self):
         """Verifies params."""
-        # Convert string masking_method to enum if needed
-        if isinstance(self.masking_method, str):
-            self.masking_method = MaskingMethod(self.masking_method)
+        # Convert string train_target to enum if needed
+        if isinstance(self.train_target, str):
+            self.train_target = TrainTarget(self.train_target)
 
-        # masking_method and collator_kwargs are mutually exclusive
-        if self.masking_method is not None and self.collator_kwargs:
+        # train_target and collator_kwargs are mutually exclusive
+        if self.train_target is not None and self.collator_kwargs:
             raise ValueError(
-                "Cannot specify both `masking_method` and `collator_kwargs`. "
-                "`masking_method` auto-resolves all collator keyword arguments; "
+                "Cannot specify both `train_target` and `collator_kwargs`. "
+                "`train_target` auto-resolves all collator keyword arguments; "
                 "use one or the other."
             )
 

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -53,7 +53,7 @@ class MixtureStrategy(str, Enum):
 
 
 class TrainTarget(str, Enum):
-    """Controls which tokens contribute to the loss during SFT training.
+    """Controls which tokens contribute to the loss during training.
 
     Used with the ``text_completions_only_with_padding`` collator to
     select the training target. Template tokens are auto-resolved

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -241,8 +241,8 @@ class DatasetSplitParams(BaseParams):
     """High-level training target for ``text_completions_only_with_padding``.
 
     When set, the builder auto-detects ``response_template`` and
-    ``end_of_turn_template`` from the tokenizer vocabulary.  Mutually
-    exclusive with ``collator_kwargs`` -- use one or the other.
+    ``end_of_turn_template`` from the tokenizer's chat template.
+    Use ``collator_kwargs`` to override individual auto-resolved values.
 
     See :class:`TrainTarget` for available options.
     """
@@ -306,14 +306,6 @@ class DatasetSplitParams(BaseParams):
         # Convert string train_target to enum if needed
         if isinstance(self.train_target, str):
             self.train_target = TrainTarget(self.train_target)
-
-        # train_target and collator_kwargs are mutually exclusive
-        if self.train_target is not None and self.collator_kwargs:
-            raise ValueError(
-                "Cannot specify both `train_target` and `collator_kwargs`. "
-                "`train_target` auto-resolves all collator keyword arguments; "
-                "use one or the other."
-            )
 
         if any([dataset.mixture_proportion is not None for dataset in self.datasets]):
             if not all(

--- a/src/oumi/core/configs/params/data_params.py
+++ b/src/oumi/core/configs/params/data_params.py
@@ -200,8 +200,7 @@ class DatasetSplitParams(BaseParams):
         - "text_completions_only_with_padding": Uses template matching to
             mask non-assistant tokens. Works for simple user/assistant turns.
             Supports optional ``end_of_turn_template`` in ``collator_kwargs``
-            for span-based masking. Use
-            ``masking_method="assistant_turn_no_tools"`` to mask tool calls.
+            for span-based masking.
         - "vision_language_with_padding": Uses VisionLanguageCollator
             for image+text multi-modal data.
         - "vision_language_sft": Uses VisionLanguageSftCollator.

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -1,0 +1,240 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import pytest
+import transformers
+from huggingface_hub import hf_hub_download
+
+from oumi.builders.collators import resolve_collator_templates
+from tests.markers import requires_hf_token
+
+
+def _normalize(s: str) -> str:
+    """Normalize sentencepiece ▁ (U+2581) to space for cross-version comparison."""
+    return s.replace("\u2581", " ")
+
+
+@functools.cache
+def _load_tokenizer(
+    model_name: str, trust_remote_code: bool = False
+) -> transformers.PreTrainedTokenizerBase:
+    tok = transformers.AutoTokenizer.from_pretrained(
+        model_name, trust_remote_code=trust_remote_code
+    )
+    if not tok.chat_template:
+        try:
+            jinja_path = hf_hub_download(model_name, "chat_template.jinja")
+            with open(jinja_path) as f:
+                tok.chat_template = f.read()
+        except Exception:
+            pass
+    return tok
+
+
+# -- Public models (no HF token required) ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code,expected_response,expected_eot",
+    [
+        pytest.param(
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            False,
+            "<|im_start|>assistant\n",
+            "<|im_end|>\n",
+            id="qwen2.5-chatml",
+        ),
+        pytest.param(
+            "Qwen/Qwen3-0.6B",
+            False,
+            "<|im_start|>assistant",
+            "<|im_end|>\n",
+            id="qwen3-chatml-think",
+        ),
+        pytest.param(
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            False,
+            "<｜Assistant｜>",
+            "<｜end▁of▁sentence｜>",
+            id="deepseek-r1-qwen",
+        ),
+        pytest.param(
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+            False,
+            "<｜Assistant｜>",
+            "<｜end▁of▁sentence｜>",
+            id="deepseek-r1-llama",
+        ),
+        pytest.param(
+            "allenai/Olmo-3-7B-Instruct",
+            True,
+            "\n<|im_start|>assistant\n",
+            "<|im_end|>",
+            id="olmo3",
+        ),
+        pytest.param(
+            "HuggingFaceTB/SmolLM2-135M-Instruct",
+            False,
+            "<|im_start|>assistant\n",
+            "<|im_end|>\n",
+            id="smollm2",
+        ),
+        pytest.param(
+            "HuggingFaceTB/SmolLM3-3B",
+            False,
+            "<|im_start|>assistant\n",
+            "<|im_end|>\n",
+            id="smollm3",
+        ),
+        pytest.param(
+            "Qwen/Qwen3.5-0.8B",
+            True,
+            "<|im_start|>assistant",
+            "<|im_end|>\n",
+            id="qwen3.5",
+        ),
+        pytest.param(
+            "Qwen/Qwen3.6-35B-A3B",
+            True,
+            "<|im_start|>assistant",
+            "<|im_end|>\n",
+            id="qwen3.6",
+        ),
+        pytest.param(
+            "MiniMaxAI/MiniMax-M2.5",
+            True,
+            "]~b]ai\n",
+            "[e~[\n",
+            id="minimax-m2.5",
+        ),
+    ],
+)
+def test_template_detection_public(
+    model_name, trust_remote_code, expected_response, expected_eot
+):
+    tokenizer = _load_tokenizer(model_name, trust_remote_code)
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    assert _normalize(response_template) == _normalize(expected_response)
+    assert _normalize(end_of_turn_template) == _normalize(expected_eot)
+    assert response_template.strip()
+    assert end_of_turn_template.strip()
+    assert "<think>" not in response_template
+
+
+# -- Gated models (require HF token) -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code,expected_response,expected_eot",
+    [
+        pytest.param(
+            "meta-llama/Llama-3.2-1B-Instruct",
+            False,
+            "<|start_header_id|>assistant<|end_header_id|>\n\n",
+            "<|eot_id|>",
+            id="llama3",
+        ),
+        pytest.param(
+            "google/gemma-3-4b-it",
+            False,
+            "<start_of_turn>model\n",
+            "<end_of_turn>\n",
+            id="gemma3",
+        ),
+        pytest.param(
+            "microsoft/Phi-4-reasoning-plus",
+            True,
+            "<|im_start|>assistant<|im_sep|>",
+            "<|im_end|>",
+            id="phi4-reasoning",
+        ),
+        pytest.param(
+            "openai/gpt-oss-20b",
+            True,
+            "<|start|>assistant<|channel|>final<|message|>",
+            "<|end|>",
+            id="gpt-oss",
+        ),
+        pytest.param(
+            "mistralai/Mistral-7B-Instruct-v0.3",
+            False,
+            "[/INST] ",
+            "</s>",
+            id="mistral",
+        ),
+        pytest.param(
+            "Qwen/Qwen3-Next-80B-A3B-Instruct",
+            True,
+            "<|im_start|>assistant\n",
+            "<|im_end|>\n",
+            id="qwen3-next",
+        ),
+    ],
+)
+@requires_hf_token()
+def test_template_detection_gated(
+    model_name, trust_remote_code, expected_response, expected_eot
+):
+    tokenizer = _load_tokenizer(model_name, trust_remote_code)
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    assert _normalize(response_template) == _normalize(expected_response)
+    assert _normalize(end_of_turn_template) == _normalize(expected_eot)
+    assert response_template.strip()
+    assert end_of_turn_template.strip()
+    assert "<think>" not in response_template
+
+
+# -- Models requiring newer transformers --------------------------------------
+# These tokenizers need transformers >= 5.3.
+# Tests skip gracefully if the tokenizer cannot be loaded.
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code,expected_response,expected_eot",
+    [
+        pytest.param(
+            "google/gemma-4-E2B-it",
+            True,
+            "<|turn>model\n",
+            "<turn|>\n",
+            id="gemma4",
+        ),
+        pytest.param(
+            "mistralai/Mistral-Small-4-119B-2603",
+            True,
+            "[/INST]",
+            "</s>",
+            id="mistral-small-4",
+        ),
+    ],
+)
+@requires_hf_token()
+def test_template_detection_newer_transformers(
+    model_name, trust_remote_code, expected_response, expected_eot
+):
+    try:
+        tokenizer = _load_tokenizer(model_name, trust_remote_code)
+    except (AttributeError, ValueError, KeyError) as e:
+        pytest.skip(
+            f"Tokenizer for {model_name} not loadable with "
+            f"transformers {transformers.__version__}: {e}"
+        )
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    assert _normalize(response_template) == _normalize(expected_response)
+    assert _normalize(end_of_turn_template) == _normalize(expected_eot)
+    assert response_template.strip()
+    assert end_of_turn_template.strip()
+    assert "<think>" not in response_template

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -44,7 +44,7 @@ def _load_tokenizer(
         pytest.param(
             "Qwen/Qwen2.5-0.5B-Instruct",
             False,
-            "<|im_start|>assistant\n",
+            "<|im_start|>assistant",
             "<|im_end|>\n",
             id="qwen2.5-chatml",
         ),
@@ -72,21 +72,21 @@ def _load_tokenizer(
         pytest.param(
             "allenai/Olmo-3-7B-Instruct",
             True,
-            "\n<|im_start|>assistant\n",
+            "\n<|im_start|>assistant",
             "<|im_end|>",
             id="olmo3",
         ),
         pytest.param(
             "HuggingFaceTB/SmolLM2-135M-Instruct",
             False,
-            "<|im_start|>assistant\n",
+            "<|im_start|>assistant",
             "<|im_end|>\n",
             id="smollm2",
         ),
         pytest.param(
             "HuggingFaceTB/SmolLM3-3B",
             False,
-            "<|im_start|>assistant\n",
+            "<|im_start|>assistant",
             "<|im_end|>\n",
             id="smollm3",
         ),
@@ -107,7 +107,7 @@ def _load_tokenizer(
         pytest.param(
             "MiniMaxAI/MiniMax-M2.5",
             True,
-            "]~b]ai\n",
+            "]~b]ai",
             "[e~[\n",
             id="minimax-m2.5",
         ),
@@ -134,14 +134,14 @@ def test_template_detection_public(
         pytest.param(
             "meta-llama/Llama-3.2-1B-Instruct",
             False,
-            "<|start_header_id|>assistant<|end_header_id|>\n\n",
+            "<|start_header_id|>assistant<|end_header_id|>",
             "<|eot_id|>",
             id="llama3",
         ),
         pytest.param(
             "google/gemma-3-4b-it",
             False,
-            "<start_of_turn>model\n",
+            "<start_of_turn>model",
             "<end_of_turn>\n",
             id="gemma3",
         ),
@@ -169,7 +169,7 @@ def test_template_detection_public(
         pytest.param(
             "Qwen/Qwen3-Next-80B-A3B-Instruct",
             True,
-            "<|im_start|>assistant\n",
+            "<|im_start|>assistant",
             "<|im_end|>\n",
             id="qwen3-next",
         ),
@@ -199,7 +199,7 @@ def test_template_detection_gated(
         pytest.param(
             "google/gemma-4-E2B-it",
             True,
-            "<|turn>model\n",
+            "<|turn>model",
             "<turn|>\n",
             id="gemma4",
         ),

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -16,7 +16,6 @@ import functools
 
 import pytest
 import transformers
-from huggingface_hub import hf_hub_download
 
 from oumi.builders.collators import resolve_collator_templates
 from tests.markers import requires_hf_token
@@ -31,17 +30,9 @@ def _normalize(s: str) -> str:
 def _load_tokenizer(
     model_name: str, trust_remote_code: bool = False
 ) -> transformers.PreTrainedTokenizerBase:
-    tok = transformers.AutoTokenizer.from_pretrained(
+    return transformers.AutoTokenizer.from_pretrained(
         model_name, trust_remote_code=trust_remote_code
     )
-    if not tok.chat_template:
-        try:
-            jinja_path = hf_hub_download(model_name, "chat_template.jinja")
-            with open(jinja_path) as f:
-                tok.chat_template = f.read()
-        except Exception:
-            pass
-    return tok
 
 
 # -- Public models (no HF token required) ------------------------------------

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -453,7 +453,7 @@ def test_train_target_unknown_tokenizer():
             model_max_length=512,
         ),
     )
-    with pytest.raises(ValueError, match="Cannot auto-detect collator templates"):
+    with pytest.raises(ValueError, match="no chat template"):
         build_collator_from_config(config, tokenizer=tok)
 
 

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -457,15 +457,29 @@ def test_train_target_unknown_tokenizer():
         build_collator_from_config(config, tokenizer=tok)
 
 
-def test_train_target_and_collator_kwargs_exclusive():
-    """train_target and collator_kwargs are mutually exclusive."""
-    with pytest.raises(ValueError, match="Cannot specify both"):
-        DatasetSplitParams(
-            collator_name="text_completions_only_with_padding",
-            train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-            collator_kwargs={"response_template": "<|assistant|>"},
-            datasets=[DatasetParams(dataset_name="dummy", split="train")],
-        )
+def test_train_target_with_collator_kwargs_override():
+    """collator_kwargs overrides auto-resolved templates when train_target is set."""
+    tok = _chatml_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
+                collator_kwargs={"response_template": "<|im_end|>\n"},
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=tok)
+    assert collator is not None
+    inner = collator._default_collator
+    # Auto-resolved would be "<|im_start|>assistant\n"; user override wins
+    assert inner.response_template == "<|im_end|>\n"
 
 
 def test_train_target_on_wrong_collator():

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -492,83 +492,8 @@ def test_train_target_on_wrong_collator():
         )
 
 
-def test_no_train_target_backward_compat(mock_tokenizer):
-    """collator_kwargs still work when train_target is not set."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                collator_kwargs={
-                    "response_template": "<|assistant|>",
-                    "instruction_template": "<|user|>",
-                },
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
-    assert collator is not None
-    inner = collator._default_collator
-    assert inner.response_template == "<|assistant|>"
-    assert inner.instruction_template == "<|user|>"
-
-
-def test_bare_collator_name_raises_without_templates(mock_tokenizer):
-    """Bare collator_name without kwargs or train_target raises an error."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    with pytest.raises(ValueError, match="response_template"):
-        build_collator_from_config(config, tokenizer=mock_tokenizer)
-
-
-def test_legacy_collator_kwargs_with_instruction_template(mock_tokenizer):
-    """Legacy path: collator_kwargs with instruction_template still works."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                collator_kwargs={
-                    "response_template": "<|start_header_id|>assistant"
-                    "<|end_header_id|>\n\n",
-                    "instruction_template": "<|start_header_id|>user"
-                    "<|end_header_id|>\n\n",
-                },
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
-    assert collator is not None
-    inner = collator._default_collator
-    assert (
-        inner.response_template == "<|start_header_id|>assistant<|end_header_id|>\n\n"
-    )
-    assert inner.instruction_template == "<|start_header_id|>user<|end_header_id|>\n\n"
-
-
-def test_old_recipe_instruction_template_sets_legacy(mock_tokenizer):
-    """Old recipe: instruction_template + response_template → _legacy + warning."""
+def test_legacy_instruction_template_backward_compat(mock_tokenizer):
+    """Legacy path: instruction_template + response_template → _legacy + warning."""
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
@@ -591,7 +516,29 @@ def test_old_recipe_instruction_template_sets_legacy(mock_tokenizer):
     ):
         collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
     assert collator is not None
-    assert collator._default_collator.train_target == "_legacy_instruction_response"
+    inner = collator._default_collator
+    assert inner.response_template == "<|assistant|>"
+    assert inner.instruction_template == "<|user|>"
+    assert inner.train_target == "_legacy_instruction_response"
+
+
+def test_bare_collator_name_raises_without_templates(mock_tokenizer):
+    """Bare collator_name without kwargs or train_target raises an error."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    with pytest.raises(ValueError, match="response_template"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)
 
 
 def test_old_recipe_response_only_sets_final(mock_tokenizer):

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -484,7 +484,7 @@ def test_train_target_with_collator_kwargs_override():
 
 def test_train_target_on_wrong_collator():
     """train_target is only valid for text_completions_only_with_padding."""
-    with pytest.raises(ValueError, match="only supported with"):
+    with pytest.raises(ValueError, match="train_target.*requires"):
         DatasetSplitParams(
             collator_name="text_with_padding",
             train_target=TrainTarget.ALL_ASSISTANT_TURNS,

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -258,36 +258,93 @@ def test_build_collator_from_config_collator_kwargs_override(mock_tokenizer):
 
 
 def _chatml_tokenizer():
-    """Return a mock tokenizer whose vocab contains ChatML special tokens."""
+    """Mock tokenizer that renders ChatML format."""
     tok = MagicMock()
     tok.pad_token_id = 0
     tok.model_max_length = 2048
-    tok.get_vocab.return_value = {
-        "<|im_start|>": 100,
-        "<|im_end|>": 101,
+
+    def _apply(messages, **kw):
+        out = "".join(
+            f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages
+        )
+        if kw.get("add_generation_prompt"):
+            out += "<|im_start|>assistant\n"
+        return out
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    # The production code encodes/decodes three substrings from the
+    # rendered template.  Map each to stable token IDs so the
+    # common-prefix logic works.
+    _encode_map = {
+        "<|im_end|>\n": [101, 10],
+        "<|im_end|>\n<|im_start|>user\n": [101, 10, 100, 20],
+        "<|im_end|>\n<|im_start|>assistant\n": [101, 10, 100, 30],
+        "<|im_start|>assistant\n": [100, 30],
     }
+    _decode_map = {
+        (101, 10): "<|im_end|>\n",
+        (100, 30): "<|im_start|>assistant\n",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
     return tok
 
 
 def _llama3_tokenizer():
-    """Return a mock tokenizer whose vocab contains Llama-3 special tokens."""
+    """Mock tokenizer that renders Llama-3 format."""
     tok = MagicMock()
     tok.pad_token_id = 0
     tok.model_max_length = 2048
-    tok.get_vocab.return_value = {
-        "<|start_header_id|>": 200,
-        "<|end_header_id|>": 201,
-        "<|eot_id|>": 202,
+
+    def _apply(messages, **kw):
+        parts = ["<|begin_of_text|>"]
+        for m in messages:
+            parts.append(
+                f"<|start_header_id|>{m['role']}<|end_header_id|>\n\n"
+                f"{m['content']}<|eot_id|>"
+            )
+        if kw.get("add_generation_prompt"):
+            parts.append("<|start_header_id|>assistant<|end_header_id|>\n\n")
+        return "".join(parts)
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    _encode_map = {
+        "<|eot_id|>": [203],
+        "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n": [
+            203,
+            201,
+            20,
+            202,
+            10,
+        ],
+        "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n": [
+            203,
+            201,
+            30,
+            202,
+            10,
+        ],
+        "<|start_header_id|>assistant<|end_header_id|>\n\n": [201, 30, 202, 10],
     }
+    _decode_map = {
+        (203,): "<|eot_id|>",
+        (201, 30, 202, 10): "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
     return tok
 
 
 def _unknown_tokenizer():
-    """Return a mock tokenizer with no recognisable chat tokens."""
+    """Mock tokenizer with no chat template."""
     tok = MagicMock()
     tok.pad_token_id = 0
     tok.model_max_length = 2048
-    tok.get_vocab.return_value = {"hello": 1, "world": 2}
+    tok.apply_chat_template = MagicMock(
+        side_effect=Exception("No chat template configured")
+    )
     return tok
 
 
@@ -396,7 +453,7 @@ def test_train_target_unknown_tokenizer():
             model_max_length=512,
         ),
     )
-    with pytest.raises(ValueError, match="Cannot auto-detect chat template format"):
+    with pytest.raises(ValueError, match="Cannot auto-detect collator templates"):
         build_collator_from_config(config, tokenizer=tok)
 
 

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -565,3 +565,77 @@ def test_legacy_collator_kwargs_with_instruction_template(mock_tokenizer):
         inner.response_template == "<|start_header_id|>assistant<|end_header_id|>\n\n"
     )
     assert inner.instruction_template == "<|start_header_id|>user<|end_header_id|>\n\n"
+
+
+def test_old_recipe_instruction_template_sets_legacy(mock_tokenizer):
+    """Old recipe: instruction_template + response_template → _legacy + warning."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|assistant|>",
+                    "instruction_template": "<|user|>",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    with pytest.warns(
+        DeprecationWarning, match="Instruction-based masking is deprecated"
+    ):
+        collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    assert collator._default_collator.train_target == "_legacy_instruction_response"
+
+
+def test_old_recipe_response_only_sets_final(mock_tokenizer):
+    """Old recipe: response_template only → final_assistant_turn."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|assistant|>",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    assert collator._default_collator.train_target == "final_assistant_turn"
+
+
+def test_old_recipe_eot_sets_all_assistant(mock_tokenizer):
+    """Old recipe: response_template + end_of_turn_template → all_assistant_turns."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|assistant|>",
+                    "end_of_turn_template": "<|end|>",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    assert collator._default_collator.train_target == "all_assistant_turns"

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -9,6 +9,7 @@ from oumi.core.configs import (
     DataParams,
     DatasetParams,
     DatasetSplitParams,
+    MaskingMethod,
     ModelParams,
     TrainingConfig,
     TrainingParams,
@@ -249,3 +250,258 @@ def test_build_collator_from_config_collator_kwargs_override(mock_tokenizer):
     assert callable(collator)
     # Verify that the config kwargs override the model-determined kwargs
     assert collator._allow_multi_image_inputs is False
+
+
+# ---------------------------------------------------------------------------
+# MaskingMethod / builder auto-detection tests
+# ---------------------------------------------------------------------------
+
+
+def _chatml_tokenizer():
+    """Return a mock tokenizer whose vocab contains ChatML special tokens."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+    tok.get_vocab.return_value = {
+        "<|im_start|>": 100,
+        "<|im_end|>": 101,
+    }
+    return tok
+
+
+def _llama3_tokenizer():
+    """Return a mock tokenizer whose vocab contains Llama-3 special tokens."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+    tok.get_vocab.return_value = {
+        "<|start_header_id|>": 200,
+        "<|end_header_id|>": 201,
+        "<|eot_id|>": 202,
+    }
+    return tok
+
+
+def _unknown_tokenizer():
+    """Return a mock tokenizer with no recognisable chat tokens."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+    tok.get_vocab.return_value = {"hello": 1, "world": 2}
+    return tok
+
+
+def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
+    """Build completions collator with end_of_turn_template + custom ignore index."""
+    collator = build_data_collator(
+        "text_completions_only_with_padding",
+        mock_tokenizer,
+        max_length=512,
+        label_ignore_index=-200,
+        response_template="<|assistant|>",
+        end_of_turn_template="<|end|>",
+        masking_method="assistant_turn",
+    )
+    assert collator is not None
+    assert callable(collator)
+    inner = collator._default_collator
+    assert inner.ignore_index == -200
+
+
+def test_masking_method_assistant_turn():
+    """ChatML auto-detection with ASSISTANT_TURN masking method."""
+    tok = _chatml_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=tok)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.response_template == "<|im_start|>assistant\n"
+
+
+def test_masking_method_final_assistant_turn():
+    """ChatML auto-detection with FINAL_ASSISTANT_TURN masking method."""
+    tok = _chatml_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.FINAL_ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=tok)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.response_template == "<|im_start|>assistant\n"
+
+
+def test_masking_method_llama3():
+    """Llama-3 auto-detection with ASSISTANT_TURN masking method."""
+    tok = _llama3_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=tok)
+    assert collator is not None
+    inner = collator._default_collator
+    assert (
+        inner.response_template == "<|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+
+def test_masking_method_unknown_tokenizer():
+    """Error when tokenizer vocab does not match any known chat format."""
+    tok = _unknown_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    with pytest.raises(ValueError, match="Cannot auto-detect chat template format"):
+        build_collator_from_config(config, tokenizer=tok)
+
+
+def test_masking_method_and_collator_kwargs_exclusive():
+    """masking_method and collator_kwargs are mutually exclusive."""
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        DatasetSplitParams(
+            collator_name="text_completions_only_with_padding",
+            masking_method=MaskingMethod.ASSISTANT_TURN,
+            collator_kwargs={"response_template": "<|assistant|>"},
+            datasets=[DatasetParams(dataset_name="dummy", split="train")],
+        )
+
+
+def test_masking_method_on_wrong_collator():
+    """masking_method is only valid for text_completions_only_with_padding."""
+    tok = _chatml_tokenizer()
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_with_padding",
+                masking_method=MaskingMethod.ASSISTANT_TURN,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    with pytest.raises(ValueError, match="only supported with"):
+        build_collator_from_config(config, tokenizer=tok)
+
+
+def test_no_masking_method_backward_compat(mock_tokenizer):
+    """collator_kwargs still work when masking_method is not set."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|assistant|>",
+                    "instruction_template": "<|user|>",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.response_template == "<|assistant|>"
+    assert inner.instruction_template == "<|user|>"
+
+
+def test_bare_collator_name_raises_without_templates(mock_tokenizer):
+    """Bare collator_name without kwargs or masking_method raises an error."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    with pytest.raises(ValueError, match="requires a `response_template`"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)
+
+
+def test_legacy_collator_kwargs_with_instruction_template(mock_tokenizer):
+    """Legacy path: collator_kwargs with instruction_template still works."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs={
+                    "response_template": "<|start_header_id|>assistant"
+                    "<|end_header_id|>\n\n",
+                    "instruction_template": "<|start_header_id|>user"
+                    "<|end_header_id|>\n\n",
+                },
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
+    assert collator is not None
+    inner = collator._default_collator
+    assert (
+        inner.response_template == "<|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+    assert inner.instruction_template == "<|start_header_id|>user<|end_header_id|>\n\n"

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 import oumi.core.constants as constants
-from oumi.builders.collators import build_collator_from_config, build_data_collator
+from oumi.builders.collators import (
+    build_collator_from_config,
+    build_data_collator,
+    resolve_collator_templates,
+)
 from oumi.core.configs import (
     DataParams,
     DatasetParams,
@@ -253,88 +257,9 @@ def test_build_collator_from_config_collator_kwargs_override(mock_tokenizer):
 
 
 # ---------------------------------------------------------------------------
-# TrainTarget / builder auto-detection tests
+# Mock tokenizer factories for resolve_collator_templates error paths
+# (Happy-path coverage is in integration tests with real tokenizers.)
 # ---------------------------------------------------------------------------
-
-
-def _chatml_tokenizer():
-    """Mock tokenizer that renders ChatML format."""
-    tok = MagicMock()
-    tok.pad_token_id = 0
-    tok.model_max_length = 2048
-
-    def _apply(messages, **kw):
-        out = "".join(
-            f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages
-        )
-        if kw.get("add_generation_prompt"):
-            out += "<|im_start|>assistant\n"
-        return out
-
-    tok.apply_chat_template = MagicMock(side_effect=_apply)
-
-    # The production code encodes/decodes three substrings from the
-    # rendered template.  Map each to stable token IDs so the
-    # common-prefix logic works.
-    _encode_map = {
-        "<|im_end|>\n": [101, 10],
-        "<|im_end|>\n<|im_start|>user\n": [101, 10, 100, 20],
-        "<|im_end|>\n<|im_start|>assistant\n": [101, 10, 100, 30],
-        "<|im_start|>assistant\n": [100, 30],
-    }
-    _decode_map = {
-        (101, 10): "<|im_end|>\n",
-        (100, 30): "<|im_start|>assistant\n",
-    }
-    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
-    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
-    return tok
-
-
-def _llama3_tokenizer():
-    """Mock tokenizer that renders Llama-3 format."""
-    tok = MagicMock()
-    tok.pad_token_id = 0
-    tok.model_max_length = 2048
-
-    def _apply(messages, **kw):
-        parts = ["<|begin_of_text|>"]
-        for m in messages:
-            parts.append(
-                f"<|start_header_id|>{m['role']}<|end_header_id|>\n\n"
-                f"{m['content']}<|eot_id|>"
-            )
-        if kw.get("add_generation_prompt"):
-            parts.append("<|start_header_id|>assistant<|end_header_id|>\n\n")
-        return "".join(parts)
-
-    tok.apply_chat_template = MagicMock(side_effect=_apply)
-
-    _encode_map = {
-        "<|eot_id|>": [203],
-        "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n": [
-            203,
-            201,
-            20,
-            202,
-            10,
-        ],
-        "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n": [
-            203,
-            201,
-            30,
-            202,
-            10,
-        ],
-        "<|start_header_id|>assistant<|end_header_id|>\n\n": [201, 30, 202, 10],
-    }
-    _decode_map = {
-        (203,): "<|eot_id|>",
-        (201, 30, 202, 10): "<|start_header_id|>assistant<|end_header_id|>\n\n",
-    }
-    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
-    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
-    return tok
 
 
 def _unknown_tokenizer():
@@ -348,8 +273,158 @@ def _unknown_tokenizer():
     return tok
 
 
+def _non_string_template_tokenizer():
+    """Mock tokenizer whose apply_chat_template returns a list instead of str."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+    tok.apply_chat_template = MagicMock(return_value=[101, 102, 103])
+    return tok
+
+
+def _no_sentinels_tokenizer():
+    """Mock tokenizer that renders a template but drops message content."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+    tok.apply_chat_template = MagicMock(
+        return_value=(
+            "<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\nhi<|im_end|>\n"
+        )
+    )
+    return tok
+
+
+def _think_only_tokenizer():
+    """Mock where the assistant header is only a <think> block (no role prefix)."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+
+    def _apply(messages, **kw):
+        last_asst_idx = max(
+            i for i, m in enumerate(messages) if m["role"] == "assistant"
+        )
+        parts = []
+        for i, m in enumerate(messages):
+            if m["role"] == "assistant" and i == last_asst_idx:
+                parts.append(f"<think>{m['content']}<|im_end|>\n")
+            else:
+                parts.append(f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n")
+        return "".join(parts)
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    _encode_map = {
+        "<|im_end|>\n": [101, 10],
+        "<|im_end|>\n<|im_start|>user\n": [101, 10, 100, 20],
+        "<|im_end|>\n<think>": [101, 10, 600],
+    }
+    _decode_map = {
+        (101, 10): "<|im_end|>\n",
+        (600,): "<think>",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
+    return tok
+
+
+def _empty_response_template_tokenizer():
+    """Mock where header_text equals the EOT, so response_template is empty."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+
+    def _apply(messages, **kw):
+        return "<|e|>".join(m["content"] for m in messages) + "<|e|>"
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    _encode_map = {
+        "<|e|>": [200],
+        "<|e|><<__U__>>": [200, 300],
+        "<|e|><<__A__>>": [200, 400],
+    }
+    _decode_map = {
+        (200,): "<|e|>",
+        (): " ",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
+    return tok
+
+
+def _empty_eot_template_tokenizer():
+    """Mock where between/after texts are empty, producing whitespace-only EOT."""
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+
+    def _apply(messages, **kw):
+        parts = []
+        for m in messages:
+            prefix = "[A]" if m["role"] == "assistant" else ""
+            parts.append(f"{prefix}{m['content']}")
+        return "".join(parts)
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    _encode_map = {
+        "": [],
+        "[A]": [500],
+    }
+    _decode_map = {
+        (): " ",
+        (500,): "[A]",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
+    return tok
+
+
+@pytest.mark.parametrize(
+    "make_tok,match",
+    [
+        (_unknown_tokenizer, "no chat template"),
+        (_non_string_template_tokenizer, "non-string type"),
+        (_no_sentinels_tokenizer, "Could not locate assistant turn boundaries"),
+        (_think_only_tokenizer, "only a <think> block"),
+        (_empty_response_template_tokenizer, "response_template is empty"),
+        (_empty_eot_template_tokenizer, "end_of_turn_template is empty"),
+    ],
+)
+def test_resolve_templates_error(make_tok, match):
+    with pytest.raises(ValueError, match=match):
+        resolve_collator_templates(make_tok())
+
+
+# ---------------------------------------------------------------------------
+# build_collator_from_config with train_target
+# ---------------------------------------------------------------------------
+
+
+def _completions_config(
+    train_target: TrainTarget | None = None,
+    collator_kwargs: dict | None = None,
+) -> TrainingConfig:
+    return TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                train_target=train_target,
+                collator_kwargs=collator_kwargs or {},
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=512,
+        ),
+    )
+
+
 def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
-    """Build completions collator with end_of_turn_template + custom ignore index."""
     collator = build_data_collator(
         "text_completions_only_with_padding",
         mock_tokenizer,
@@ -361,129 +436,10 @@ def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
     )
     assert collator is not None
     assert callable(collator)
-    inner = collator._default_collator
-    assert inner.ignore_index == -200
-
-
-def test_train_target_all_assistant_turns():
-    """ChatML auto-detection with ALL_ASSISTANT_TURNS train target."""
-    tok = _chatml_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=tok)
-    assert collator is not None
-    inner = collator._default_collator
-    assert inner.response_template == "<|im_start|>assistant\n"
-
-
-def test_train_target_final_assistant_turn():
-    """ChatML auto-detection with FINAL_ASSISTANT_TURN train target."""
-    tok = _chatml_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=TrainTarget.FINAL_ASSISTANT_TURN,
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=tok)
-    assert collator is not None
-    inner = collator._default_collator
-    assert inner.response_template == "<|im_start|>assistant\n"
-
-
-def test_train_target_llama3():
-    """Llama-3 auto-detection with ALL_ASSISTANT_TURNS train target."""
-    tok = _llama3_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=tok)
-    assert collator is not None
-    inner = collator._default_collator
-    assert (
-        inner.response_template == "<|start_header_id|>assistant<|end_header_id|>\n\n"
-    )
-
-
-def test_train_target_unknown_tokenizer():
-    """Error when tokenizer vocab does not match any known chat format."""
-    tok = _unknown_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    with pytest.raises(ValueError, match="no chat template"):
-        build_collator_from_config(config, tokenizer=tok)
-
-
-def test_train_target_with_collator_kwargs_override():
-    """collator_kwargs overrides auto-resolved templates when train_target is set."""
-    tok = _chatml_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-                collator_kwargs={"response_template": "<|im_end|>\n"},
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    collator = build_collator_from_config(config, tokenizer=tok)
-    assert collator is not None
-    inner = collator._default_collator
-    # Auto-resolved would be "<|im_start|>assistant\n"; user override wins
-    assert inner.response_template == "<|im_end|>\n"
+    assert collator._default_collator.ignore_index == -200
 
 
 def test_train_target_on_wrong_collator():
-    """train_target is only valid for text_completions_only_with_padding."""
     with pytest.raises(ValueError, match="train_target.*requires"):
         DatasetSplitParams(
             collator_name="text_with_padding",
@@ -492,24 +448,23 @@ def test_train_target_on_wrong_collator():
         )
 
 
+def test_bare_collator_name_raises_without_templates(mock_tokenizer):
+    config = _completions_config()
+    with pytest.raises(ValueError, match="response_template"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)
+
+
+# ---------------------------------------------------------------------------
+# Legacy / old-recipe backward compatibility
+# ---------------------------------------------------------------------------
+
+
 def test_legacy_instruction_template_backward_compat(mock_tokenizer):
-    """Legacy path: instruction_template + response_template → _legacy + warning."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                collator_kwargs={
-                    "response_template": "<|assistant|>",
-                    "instruction_template": "<|user|>",
-                },
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
+    config = _completions_config(
+        collator_kwargs={
+            "response_template": "<|assistant|>",
+            "instruction_template": "<|user|>",
+        },
     )
     with pytest.warns(
         DeprecationWarning, match="Instruction-based masking is deprecated"
@@ -522,42 +477,9 @@ def test_legacy_instruction_template_backward_compat(mock_tokenizer):
     assert inner.train_target == "_legacy_instruction_response"
 
 
-def test_bare_collator_name_raises_without_templates(mock_tokenizer):
-    """Bare collator_name without kwargs or train_target raises an error."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
-    with pytest.raises(ValueError, match="response_template"):
-        build_collator_from_config(config, tokenizer=mock_tokenizer)
-
-
 def test_old_recipe_response_only_sets_final(mock_tokenizer):
-    """Old recipe: response_template only → final_assistant_turn."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                collator_kwargs={
-                    "response_template": "<|assistant|>",
-                },
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
+    config = _completions_config(
+        collator_kwargs={"response_template": "<|assistant|>"},
     )
     collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
     assert collator is not None
@@ -565,23 +487,11 @@ def test_old_recipe_response_only_sets_final(mock_tokenizer):
 
 
 def test_old_recipe_eot_sets_all_assistant(mock_tokenizer):
-    """Old recipe: response_template + end_of_turn_template → all_assistant_turns."""
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                collator_kwargs={
-                    "response_template": "<|assistant|>",
-                    "end_of_turn_template": "<|end|>",
-                },
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
+    config = _completions_config(
+        collator_kwargs={
+            "response_template": "<|assistant|>",
+            "end_of_turn_template": "<|end|>",
+        },
     )
     collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
     assert collator is not None

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -9,10 +9,10 @@ from oumi.core.configs import (
     DataParams,
     DatasetParams,
     DatasetSplitParams,
-    MaskingMethod,
     ModelParams,
     TrainingConfig,
     TrainingParams,
+    TrainTarget,
 )
 
 
@@ -253,7 +253,7 @@ def test_build_collator_from_config_collator_kwargs_override(mock_tokenizer):
 
 
 # ---------------------------------------------------------------------------
-# MaskingMethod / builder auto-detection tests
+# TrainTarget / builder auto-detection tests
 # ---------------------------------------------------------------------------
 
 
@@ -300,7 +300,7 @@ def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
         label_ignore_index=-200,
         response_template="<|assistant|>",
         end_of_turn_template="<|end|>",
-        masking_method="assistant_turn",
+        train_target="all_assistant_turns",
     )
     assert collator is not None
     assert callable(collator)
@@ -308,14 +308,14 @@ def test_build_data_collator_text_completions_with_tool_kwargs(mock_tokenizer):
     assert inner.ignore_index == -200
 
 
-def test_masking_method_assistant_turn():
-    """ChatML auto-detection with ASSISTANT_TURN masking method."""
+def test_train_target_all_assistant_turns():
+    """ChatML auto-detection with ALL_ASSISTANT_TURNS train target."""
     tok = _chatml_tokenizer()
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
                 collator_name="text_completions_only_with_padding",
-                masking_method=MaskingMethod.ASSISTANT_TURN,
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
                 datasets=[DatasetParams(dataset_name="dummy", split="train")],
             )
         ),
@@ -331,14 +331,14 @@ def test_masking_method_assistant_turn():
     assert inner.response_template == "<|im_start|>assistant\n"
 
 
-def test_masking_method_final_assistant_turn():
-    """ChatML auto-detection with FINAL_ASSISTANT_TURN masking method."""
+def test_train_target_final_assistant_turn():
+    """ChatML auto-detection with FINAL_ASSISTANT_TURN train target."""
     tok = _chatml_tokenizer()
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
                 collator_name="text_completions_only_with_padding",
-                masking_method=MaskingMethod.FINAL_ASSISTANT_TURN,
+                train_target=TrainTarget.FINAL_ASSISTANT_TURN,
                 datasets=[DatasetParams(dataset_name="dummy", split="train")],
             )
         ),
@@ -354,14 +354,14 @@ def test_masking_method_final_assistant_turn():
     assert inner.response_template == "<|im_start|>assistant\n"
 
 
-def test_masking_method_llama3():
-    """Llama-3 auto-detection with ASSISTANT_TURN masking method."""
+def test_train_target_llama3():
+    """Llama-3 auto-detection with ALL_ASSISTANT_TURNS train target."""
     tok = _llama3_tokenizer()
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
                 collator_name="text_completions_only_with_padding",
-                masking_method=MaskingMethod.ASSISTANT_TURN,
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
                 datasets=[DatasetParams(dataset_name="dummy", split="train")],
             )
         ),
@@ -379,14 +379,14 @@ def test_masking_method_llama3():
     )
 
 
-def test_masking_method_unknown_tokenizer():
+def test_train_target_unknown_tokenizer():
     """Error when tokenizer vocab does not match any known chat format."""
     tok = _unknown_tokenizer()
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
                 collator_name="text_completions_only_with_padding",
-                masking_method=MaskingMethod.ASSISTANT_TURN,
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
                 datasets=[DatasetParams(dataset_name="dummy", split="train")],
             )
         ),
@@ -400,25 +400,25 @@ def test_masking_method_unknown_tokenizer():
         build_collator_from_config(config, tokenizer=tok)
 
 
-def test_masking_method_and_collator_kwargs_exclusive():
-    """masking_method and collator_kwargs are mutually exclusive."""
+def test_train_target_and_collator_kwargs_exclusive():
+    """train_target and collator_kwargs are mutually exclusive."""
     with pytest.raises(ValueError, match="Cannot specify both"):
         DatasetSplitParams(
             collator_name="text_completions_only_with_padding",
-            masking_method=MaskingMethod.ASSISTANT_TURN,
+            train_target=TrainTarget.ALL_ASSISTANT_TURNS,
             collator_kwargs={"response_template": "<|assistant|>"},
             datasets=[DatasetParams(dataset_name="dummy", split="train")],
         )
 
 
-def test_masking_method_on_wrong_collator():
-    """masking_method is only valid for text_completions_only_with_padding."""
+def test_train_target_on_wrong_collator():
+    """train_target is only valid for text_completions_only_with_padding."""
     tok = _chatml_tokenizer()
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
                 collator_name="text_with_padding",
-                masking_method=MaskingMethod.ASSISTANT_TURN,
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
                 datasets=[DatasetParams(dataset_name="dummy", split="train")],
             )
         ),
@@ -432,8 +432,8 @@ def test_masking_method_on_wrong_collator():
         build_collator_from_config(config, tokenizer=tok)
 
 
-def test_no_masking_method_backward_compat(mock_tokenizer):
-    """collator_kwargs still work when masking_method is not set."""
+def test_no_train_target_backward_compat(mock_tokenizer):
+    """collator_kwargs still work when train_target is not set."""
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
@@ -459,7 +459,7 @@ def test_no_masking_method_backward_compat(mock_tokenizer):
 
 
 def test_bare_collator_name_raises_without_templates(mock_tokenizer):
-    """Bare collator_name without kwargs or masking_method raises an error."""
+    """Bare collator_name without kwargs or train_target raises an error."""
     config = TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
@@ -473,7 +473,7 @@ def test_bare_collator_name_raises_without_templates(mock_tokenizer):
             model_max_length=512,
         ),
     )
-    with pytest.raises(ValueError, match="requires a `response_template`"):
+    with pytest.raises(ValueError, match="response_template"):
         build_collator_from_config(config, tokenizer=mock_tokenizer)
 
 

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -484,23 +484,12 @@ def test_train_target_with_collator_kwargs_override():
 
 def test_train_target_on_wrong_collator():
     """train_target is only valid for text_completions_only_with_padding."""
-    tok = _chatml_tokenizer()
-    config = TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_with_padding",
-                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name="MlpEncoder",
-            tokenizer_name="openai-community/gpt2",
-            model_max_length=512,
-        ),
-    )
     with pytest.raises(ValueError, match="only supported with"):
-        build_collator_from_config(config, tokenizer=tok)
+        DatasetSplitParams(
+            collator_name="text_with_padding",
+            train_target=TrainTarget.ALL_ASSISTANT_TURNS,
+            datasets=[DatasetParams(dataset_name="dummy", split="train")],
+        )
 
 
 def test_no_train_target_backward_compat(mock_tokenizer):

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -275,7 +275,7 @@ def make_span_collator() -> TextCompletionsCollatorWithPadding:
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
-        masking_method="assistant_turn",
+        train_target="all_assistant_turns",
         end_of_turn_template=_EOT_STR,
     )
 
@@ -409,7 +409,7 @@ def test_span_masking_requires_end_of_turn_template():
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
             response_template=_RESP_STR,
-            masking_method="assistant_turn",
+            train_target="all_assistant_turns",
             end_of_turn_template=None,
         )
 

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -63,6 +63,7 @@ def test_success_basic():
         tokenizer=tokenizer,
         instruction_template=instruction_prefix,
         response_template=response_prefix,
+        train_target="_legacy_instruction_response",
     )
     assert callable(collator)
 
@@ -187,6 +188,7 @@ def test_debug_logging(caplog):
         tokenizer=tokenizer,
         instruction_template=instruction_prefix,
         response_template=response_prefix,
+        train_target="_legacy_instruction_response",
         debug=True,
     )
     assert callable(collator)
@@ -464,6 +466,7 @@ def test_span_padding_matching_eot_does_not_false_match():
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
+        train_target="all_assistant_turns",
         end_of_turn_template=str(tokenizer.decode(eot_ids)),
     )
     batch = collator([{"input_ids": seq}])

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -313,27 +313,6 @@ def test_span_single_turn_content_is_unmasked():
     assert labels[n_prefix + len(content) : n_prefix + len(content) + len(eot)] == eot
 
 
-def test_span_single_turn_response_template_tokens_are_masked():
-    resp, eot = get_template_token_ids()
-    seq = flat(resp, [_SENTINELS[0]], eot)
-
-    labels = get_span_labels(make_span_collator(), seq)
-
-    for i in range(len(resp)):
-        assert labels[i] == IGNORE, f"resp template token {i} should be masked"
-
-
-def test_span_single_turn_eot_tokens_are_unmasked():
-    resp, eot = get_template_token_ids()
-    content = [_SENTINELS[0]]
-    seq = flat(resp, content, eot)
-
-    labels = get_span_labels(make_span_collator(), seq)
-
-    eot_start = len(resp) + len(content)
-    assert labels[eot_start : eot_start + len(eot)] == eot
-
-
 # ---------------------------------------------------------------------------
 # Multiple assistant turns
 # ---------------------------------------------------------------------------
@@ -369,40 +348,6 @@ def test_span_content_between_turns_is_masked():
     between_start = len(resp) + len(turn1) + len(eot)
     for i in range(len(between)):
         assert labels[between_start + i] == IGNORE
-
-
-# ---------------------------------------------------------------------------
-# Tool result masking
-# ---------------------------------------------------------------------------
-
-
-def test_span_tool_result_is_masked():
-    resp, eot = get_template_token_ids()
-    tool_call_content = [_SENTINELS[0], _SENTINELS[1]]
-    tool_result = [_SENTINELS[2], _SENTINELS[3]]
-    final_answer = [_SENTINELS[4], _SENTINELS[5]]
-    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
-
-    labels = get_span_labels(make_span_collator(), seq)
-
-    tool_result_start = len(resp) + len(tool_call_content) + len(eot)
-    for i in range(len(tool_result)):
-        assert labels[tool_result_start + i] == IGNORE
-
-
-def test_span_final_answer_after_tool_result_is_unmasked():
-    resp, eot = get_template_token_ids()
-    tool_call_content = [_SENTINELS[0]]
-    tool_result = [_SENTINELS[1]]
-    final_answer = [_SENTINELS[2], _SENTINELS[3]]
-    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
-
-    labels = get_span_labels(make_span_collator(), seq)
-
-    final_start = (
-        len(resp) + len(tool_call_content) + len(eot) + len(tool_result) + len(resp)
-    )
-    assert labels[final_start : final_start + len(final_answer)] == final_answer
 
 
 def test_span_masking_requires_end_of_turn_template():
@@ -526,25 +471,8 @@ def test_span_batch_bad_example_does_not_affect_others():
     assert all(v == IGNORE for v in batch["labels"][1].tolist())
 
 
-def test_span_output_labels_is_torch_tensor():
-    resp, eot = get_template_token_ids()
-    seq = flat(resp, [_SENTINELS[0]], eot)
-    batch = make_span_collator()([{"input_ids": seq}])
-    assert isinstance(batch["labels"], torch.Tensor)
-
-
 def test_span_labels_shape_matches_input_ids():
     resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert batch["labels"].shape == batch["input_ids"].shape
-
-
-def test_span_labels_numpy_values_match_expected():
-    resp, eot = get_template_token_ids()
-    content = [_SENTINELS[0], _SENTINELS[1]]
-    seq = flat(resp, content, eot)
-
-    batch = make_span_collator()([{"input_ids": seq}])
-    expected = [IGNORE] * len(resp) + content + eot
-    assert np.all(batch["labels"].numpy() == np.array([expected], dtype=np.int32))

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -1,10 +1,12 @@
 import functools
+import warnings
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
 
+import oumi.core.constants as constants
 from oumi.builders import build_tokenizer
 from oumi.core.collators.text_completions_collator_with_padding import (
     TextCompletionsCollatorWithPadding,
@@ -12,6 +14,16 @@ from oumi.core.collators.text_completions_collator_with_padding import (
 from oumi.core.configs import ModelParams
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils import logging
+
+IGNORE = constants.LABEL_IGNORE_INDEX
+
+# Template strings for span-masking tests — chosen to be unambiguous in GPT-2's vocab.
+_RESP_STR = " ASSISTANT_RESPONSE_START"
+_EOT_STR = " TURN_ENDS_HERE"
+_TC_STR = " TOOL_CALL_BEGINS"
+
+# Arbitrary token IDs used as "content" that must not appear in any template.
+_SENTINELS = [601, 602, 603, 604, 605, 606, 607, 608]
 
 
 @pytest.fixture
@@ -50,8 +62,8 @@ def test_success_basic():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
     )
     assert callable(collator)
 
@@ -174,8 +186,8 @@ def test_debug_logging(caplog):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=instruction_prefix,
-        response_prefix=response_prefix,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
         debug=True,
     )
     assert callable(collator)
@@ -238,3 +250,348 @@ def test_debug_logging(caplog):
     assert "'input_ids':" in log_text
     assert "'attention_mask':" in log_text
     assert "'labels':" in log_text
+
+
+# ===========================================================================
+# Span-based masking tests (tool-aware collation)
+# ===========================================================================
+
+
+@functools.cache
+def get_template_token_ids() -> tuple[list[int], list[int], list[int]]:
+    """Return (resp_ids, eot_ids, tc_ids) encoded once and cached."""
+    tokenizer, _ = create_test_tokenizer()
+    resp = tokenizer.encode(_RESP_STR, add_special_tokens=False)
+    eot = tokenizer.encode(_EOT_STR, add_special_tokens=False)
+    tc = tokenizer.encode(_TC_STR, add_special_tokens=False)
+    forbidden = set(resp) | set(eot) | set(tc)
+    for sentinel in _SENTINELS:
+        assert sentinel not in forbidden, (
+            f"Sentinel {sentinel} collides with a template token ID. Adjust _SENTINELS."
+        )
+    return resp, eot, tc
+
+
+def make_span_collator(
+    mask_tool_calls: bool = False,
+) -> TextCompletionsCollatorWithPadding:
+    tokenizer, _ = create_test_tokenizer()
+    resp_ids, eot_ids, tc_ids = get_template_token_ids()
+    masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
+    return TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=resp_ids,
+        masking_method=masking_method,
+        end_of_turn_template=eot_ids,
+        tool_call_start_template=tc_ids if mask_tool_calls else None,
+    )
+
+
+def get_span_labels(collator, seq: list[int]) -> list[int]:
+    return collator([{"input_ids": seq}])["labels"][0].tolist()
+
+
+def flat(*parts: list[int]) -> list[int]:
+    result = []
+    for p in parts:
+        result.extend(p)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single assistant turn
+# ---------------------------------------------------------------------------
+
+
+def test_span_single_turn_content_is_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    prefix = [_SENTINELS[0], _SENTINELS[1]]
+    content = [_SENTINELS[2], _SENTINELS[3]]
+    seq = flat(prefix, resp, content, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    n_prefix = len(prefix) + len(resp)
+    assert all(v == IGNORE for v in labels[:n_prefix])
+    assert labels[n_prefix : n_prefix + len(content)] == content
+    # EOT tokens are unmasked (model learns to produce the stop token)
+    assert labels[n_prefix + len(content) : n_prefix + len(content) + len(eot)] == eot
+
+
+def test_span_single_turn_response_template_tokens_are_masked():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0]], eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    for i in range(len(resp)):
+        assert labels[i] == IGNORE, f"resp template token {i} should be masked"
+
+
+def test_span_single_turn_eot_tokens_are_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    content = [_SENTINELS[0]]
+    seq = flat(resp, content, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    eot_start = len(resp) + len(content)
+    assert labels[eot_start : eot_start + len(eot)] == eot
+
+
+# ---------------------------------------------------------------------------
+# Multiple assistant turns
+# ---------------------------------------------------------------------------
+
+
+def test_span_two_turns_both_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    turn1 = [_SENTINELS[0], _SENTINELS[1]]
+    middle = [_SENTINELS[2]]
+    turn2 = [_SENTINELS[3], _SENTINELS[4]]
+    seq = flat(resp, turn1, eot, middle, resp, turn2, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    t1_start = len(resp)
+    t1_end = t1_start + len(turn1)
+    assert labels[t1_start:t1_end] == turn1
+
+    t2_start = t1_end + len(eot) + len(middle) + len(resp)
+    t2_end = t2_start + len(turn2)
+    assert labels[t2_start:t2_end] == turn2
+
+
+def test_span_content_between_turns_is_masked():
+    resp, eot, _ = get_template_token_ids()
+    turn1 = [_SENTINELS[0]]
+    between = [_SENTINELS[1], _SENTINELS[2]]
+    turn2 = [_SENTINELS[3]]
+    seq = flat(resp, turn1, eot, between, resp, turn2, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    between_start = len(resp) + len(turn1) + len(eot)
+    for i in range(len(between)):
+        assert labels[between_start + i] == IGNORE
+
+
+# ---------------------------------------------------------------------------
+# Tool result masking
+# ---------------------------------------------------------------------------
+
+
+def test_span_tool_result_is_masked():
+    resp, eot, _ = get_template_token_ids()
+    tool_call_content = [_SENTINELS[0], _SENTINELS[1]]
+    tool_result = [_SENTINELS[2], _SENTINELS[3]]
+    final_answer = [_SENTINELS[4], _SENTINELS[5]]
+    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    tool_result_start = len(resp) + len(tool_call_content) + len(eot)
+    for i in range(len(tool_result)):
+        assert labels[tool_result_start + i] == IGNORE
+
+
+def test_span_final_answer_after_tool_result_is_unmasked():
+    resp, eot, _ = get_template_token_ids()
+    tool_call_content = [_SENTINELS[0]]
+    tool_result = [_SENTINELS[1]]
+    final_answer = [_SENTINELS[2], _SENTINELS[3]]
+    seq = flat(resp, tool_call_content, eot, tool_result, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    final_start = (
+        len(resp) + len(tool_call_content) + len(eot) + len(tool_result) + len(resp)
+    )
+    assert labels[final_start : final_start + len(final_answer)] == final_answer
+
+
+# ---------------------------------------------------------------------------
+# mask_tool_calls option
+# ---------------------------------------------------------------------------
+
+
+def test_span_tool_call_turn_unmasked_by_default():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    seq = flat(resp, tc_content, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=False), seq)
+
+    content_start = len(resp)
+    assert labels[content_start : content_start + len(tc_content)] == tc_content
+
+
+def test_span_tool_call_turn_masked_when_option_set():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    seq = flat(resp, tc_content, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
+
+    content_start = len(resp)
+    assert all(
+        v == IGNORE for v in labels[content_start : content_start + len(tc_content)]
+    )
+
+
+def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
+    resp, eot, tc = get_template_token_ids()
+    tc_content = flat(tc, [_SENTINELS[0]])
+    final_answer = [_SENTINELS[1], _SENTINELS[2]]
+    seq = flat(resp, tc_content, eot, resp, final_answer, eot)
+
+    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
+
+    final_start = len(resp) + len(tc_content) + len(eot) + len(resp)
+    assert labels[final_start : final_start + len(final_answer)] == final_answer
+
+
+def test_span_mask_tool_calls_requires_template():
+    tokenizer, _ = create_test_tokenizer()
+    resp_ids, eot_ids, _ = get_template_token_ids()
+    with pytest.raises(ValueError, match="tool_call_start_template"):
+        TextCompletionsCollatorWithPadding(
+            tokenizer=tokenizer,
+            response_template=resp_ids,
+            masking_method="assistant_turn_no_tools",
+            end_of_turn_template=eot_ids,
+            tool_call_start_template=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_span_no_response_template_all_masked():
+    seq = [_SENTINELS[0], _SENTINELS[1], _SENTINELS[2]]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        labels = get_span_labels(make_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels)
+    assert any("response template" in str(w.message).lower() for w in caught)
+
+
+def test_span_no_eot_unmasked_to_end_of_sequence():
+    resp, _, _ = get_template_token_ids()
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    seq = flat(resp, content)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert labels[len(resp) :] == content
+
+
+def test_span_empty_content_span():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels)
+
+
+def test_span_padding_matching_eot_does_not_false_match():
+    """When pad_token_id matches the EOT token, padding must not be treated as
+    a real end-of-turn boundary."""
+    tokenizer, pad_token_id = create_test_tokenizer()
+    resp, _, _ = get_template_token_ids()
+
+    # Use pad_token_id itself as the EOT template — worst case scenario.
+    eot_ids = [pad_token_id]
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    # Sequence: [RESP] content (no real EOT), then padding
+    seq = flat(resp, content) + [pad_token_id] * 5
+
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=resp,
+        end_of_turn_template=eot_ids,
+    )
+    batch = collator([{"input_ids": seq}])
+    labels = batch["labels"][0].tolist()
+
+    # Content should be unmasked — the padding should not act as an EOT.
+    content_start = len(resp)
+    assert labels[content_start : content_start + len(content)] == content
+    # Padding should be masked.
+    assert all(v == IGNORE for v in labels[content_start + len(content) :])
+
+
+# ---------------------------------------------------------------------------
+# Batch processing
+# ---------------------------------------------------------------------------
+
+
+def test_span_batch_two_examples_processed_independently():
+    resp, eot, _ = get_template_token_ids()
+    _, pad_token_id = create_test_tokenizer()
+    content_a = [_SENTINELS[0], _SENTINELS[1]]
+    content_b = [_SENTINELS[2]]
+    seq_a = flat(resp, content_a, eot)
+    seq_b = flat(resp, content_b, eot)
+
+    max_len = max(len(seq_a), len(seq_b))
+    pad_a = [pad_token_id] * (max_len - len(seq_a))
+    pad_b = [pad_token_id] * (max_len - len(seq_b))
+
+    collator = make_span_collator()
+    batch = collator([{"input_ids": seq_a + pad_a}, {"input_ids": seq_b + pad_b}])
+    labels_a = batch["labels"][0].tolist()
+    labels_b = batch["labels"][1].tolist()
+
+    assert labels_a[len(resp) : len(resp) + len(content_a)] == content_a
+    assert labels_b[len(resp) : len(resp) + len(content_b)] == content_b
+
+
+def test_span_batch_bad_example_does_not_affect_others():
+    resp, eot, _ = get_template_token_ids()
+    _, pad_token_id = create_test_tokenizer()
+    good_seq = flat(resp, [_SENTINELS[0]], eot)
+    bad_seq = [_SENTINELS[1], _SENTINELS[2]]
+
+    max_len = max(len(good_seq), len(bad_seq))
+    pad_good = [pad_token_id] * (max_len - len(good_seq))
+    pad_bad = [pad_token_id] * (max_len - len(bad_seq))
+
+    collator = make_span_collator()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        batch = collator(
+            [{"input_ids": good_seq + pad_good}, {"input_ids": bad_seq + pad_bad}]
+        )
+
+    assert batch["labels"][0].tolist()[len(resp)] == _SENTINELS[0]
+    assert all(v == IGNORE for v in batch["labels"][1].tolist())
+
+
+def test_span_output_labels_is_torch_tensor():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0]], eot)
+    batch = make_span_collator()([{"input_ids": seq}])
+    assert isinstance(batch["labels"], torch.Tensor)
+
+
+def test_span_labels_shape_matches_input_ids():
+    resp, eot, _ = get_template_token_ids()
+    seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
+    batch = make_span_collator()([{"input_ids": seq}])
+    assert batch["labels"].shape == batch["input_ids"].shape
+
+
+def test_span_labels_numpy_values_match_expected():
+    resp, eot, _ = get_template_token_ids()
+    content = [_SENTINELS[0], _SENTINELS[1]]
+    seq = flat(resp, content, eot)
+
+    batch = make_span_collator()([{"input_ids": seq}])
+    expected = [IGNORE] * len(resp) + content + eot
+    assert np.all(batch["labels"].numpy() == np.array([expected], dtype=np.int32))

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -20,7 +20,6 @@ IGNORE = constants.LABEL_IGNORE_INDEX
 # Template strings for span-masking tests — chosen to be unambiguous in GPT-2's vocab.
 _RESP_STR = " ASSISTANT_RESPONSE_START"
 _EOT_STR = " TURN_ENDS_HERE"
-_TC_STR = " TOOL_CALL_BEGINS"
 
 # Arbitrary token IDs used as "content" that must not appear in any template.
 _SENTINELS = [601, 602, 603, 604, 605, 606, 607, 608]
@@ -258,31 +257,26 @@ def test_debug_logging(caplog):
 
 
 @functools.cache
-def get_template_token_ids() -> tuple[list[int], list[int], list[int]]:
-    """Return (resp_ids, eot_ids, tc_ids) encoded once and cached."""
+def get_template_token_ids() -> tuple[list[int], list[int]]:
+    """Return (resp_ids, eot_ids) encoded once and cached."""
     tokenizer, _ = create_test_tokenizer()
     resp = tokenizer.encode(_RESP_STR, add_special_tokens=False)
     eot = tokenizer.encode(_EOT_STR, add_special_tokens=False)
-    tc = tokenizer.encode(_TC_STR, add_special_tokens=False)
-    forbidden = set(resp) | set(eot) | set(tc)
+    forbidden = set(resp) | set(eot)
     for sentinel in _SENTINELS:
         assert sentinel not in forbidden, (
             f"Sentinel {sentinel} collides with a template token ID. Adjust _SENTINELS."
         )
-    return resp, eot, tc
+    return resp, eot
 
 
-def make_span_collator(
-    mask_tool_calls: bool = False,
-) -> TextCompletionsCollatorWithPadding:
+def make_span_collator() -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
-    masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
-        masking_method=masking_method,
+        masking_method="assistant_turn",
         end_of_turn_template=_EOT_STR,
-        tool_call_start_template=_TC_STR if mask_tool_calls else None,
     )
 
 
@@ -303,7 +297,7 @@ def flat(*parts: list[int]) -> list[int]:
 
 
 def test_span_single_turn_content_is_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     prefix = [_SENTINELS[0], _SENTINELS[1]]
     content = [_SENTINELS[2], _SENTINELS[3]]
     seq = flat(prefix, resp, content, eot)
@@ -318,7 +312,7 @@ def test_span_single_turn_content_is_unmasked():
 
 
 def test_span_single_turn_response_template_tokens_are_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0]], eot)
 
     labels = get_span_labels(make_span_collator(), seq)
@@ -328,7 +322,7 @@ def test_span_single_turn_response_template_tokens_are_masked():
 
 
 def test_span_single_turn_eot_tokens_are_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     content = [_SENTINELS[0]]
     seq = flat(resp, content, eot)
 
@@ -344,7 +338,7 @@ def test_span_single_turn_eot_tokens_are_unmasked():
 
 
 def test_span_two_turns_both_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     turn1 = [_SENTINELS[0], _SENTINELS[1]]
     middle = [_SENTINELS[2]]
     turn2 = [_SENTINELS[3], _SENTINELS[4]]
@@ -362,7 +356,7 @@ def test_span_two_turns_both_unmasked():
 
 
 def test_span_content_between_turns_is_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     turn1 = [_SENTINELS[0]]
     between = [_SENTINELS[1], _SENTINELS[2]]
     turn2 = [_SENTINELS[3]]
@@ -381,7 +375,7 @@ def test_span_content_between_turns_is_masked():
 
 
 def test_span_tool_result_is_masked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     tool_call_content = [_SENTINELS[0], _SENTINELS[1]]
     tool_result = [_SENTINELS[2], _SENTINELS[3]]
     final_answer = [_SENTINELS[4], _SENTINELS[5]]
@@ -395,7 +389,7 @@ def test_span_tool_result_is_masked():
 
 
 def test_span_final_answer_after_tool_result_is_unmasked():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     tool_call_content = [_SENTINELS[0]]
     tool_result = [_SENTINELS[1]]
     final_answer = [_SENTINELS[2], _SENTINELS[3]]
@@ -409,69 +403,15 @@ def test_span_final_answer_after_tool_result_is_unmasked():
     assert labels[final_start : final_start + len(final_answer)] == final_answer
 
 
-# ---------------------------------------------------------------------------
-# mask_tool_calls option
-# ---------------------------------------------------------------------------
-
-
-def test_span_tool_call_turn_unmasked_by_default():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    seq = flat(resp, tc_content, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=False), seq)
-
-    content_start = len(resp)
-    assert labels[content_start : content_start + len(tc_content)] == tc_content
-
-
-def test_span_tool_call_turn_masked_when_option_set():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    seq = flat(resp, tc_content, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
-
-    content_start = len(resp)
-    assert all(
-        v == IGNORE for v in labels[content_start : content_start + len(tc_content)]
-    )
-
-
-def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
-    resp, eot, tc = get_template_token_ids()
-    tc_content = flat(tc, [_SENTINELS[0]])
-    final_answer = [_SENTINELS[1], _SENTINELS[2]]
-    seq = flat(resp, tc_content, eot, resp, final_answer, eot)
-
-    labels = get_span_labels(make_span_collator(mask_tool_calls=True), seq)
-
-    final_start = len(resp) + len(tc_content) + len(eot) + len(resp)
-    assert labels[final_start : final_start + len(final_answer)] == final_answer
-
-
-def test_span_mask_tool_calls_requires_template():
+def test_span_masking_requires_end_of_turn_template():
     tokenizer, _ = create_test_tokenizer()
-    with pytest.raises(ValueError, match="tool_call_start_template"):
+    with pytest.raises(ValueError, match="end_of_turn_template"):
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
             response_template=_RESP_STR,
-            masking_method="assistant_turn_no_tools",
-            end_of_turn_template=_EOT_STR,
-            tool_call_start_template=None,
+            masking_method="assistant_turn",
+            end_of_turn_template=None,
         )
-
-
-def test_span_masking_requires_end_of_turn_template():
-    tokenizer, _ = create_test_tokenizer()
-    for method in ("assistant_turn", "assistant_turn_no_tools"):
-        with pytest.raises(ValueError, match="end_of_turn_template"):
-            TextCompletionsCollatorWithPadding(
-                tokenizer=tokenizer,
-                response_template=_RESP_STR,
-                masking_method=method,
-                end_of_turn_template=None,
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +431,7 @@ def test_span_no_response_template_all_masked():
 
 
 def test_span_no_eot_unmasked_to_end_of_sequence():
-    resp, _, _ = get_template_token_ids()
+    resp, _ = get_template_token_ids()
     content = [_SENTINELS[0], _SENTINELS[1]]
     seq = flat(resp, content)
 
@@ -501,7 +441,7 @@ def test_span_no_eot_unmasked_to_end_of_sequence():
 
 
 def test_span_empty_content_span():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, eot)
 
     labels = get_span_labels(make_span_collator(), seq)
@@ -513,7 +453,7 @@ def test_span_padding_matching_eot_does_not_false_match():
     """When pad_token_id matches the EOT token, padding must not be treated as
     a real end-of-turn boundary."""
     tokenizer, pad_token_id = create_test_tokenizer()
-    resp, _, _ = get_template_token_ids()
+    resp, _ = get_template_token_ids()
 
     # Use pad_token_id itself as the EOT template — worst case scenario.
     eot_ids = [pad_token_id]
@@ -542,7 +482,7 @@ def test_span_padding_matching_eot_does_not_false_match():
 
 
 def test_span_batch_two_examples_processed_independently():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     _, pad_token_id = create_test_tokenizer()
     content_a = [_SENTINELS[0], _SENTINELS[1]]
     content_b = [_SENTINELS[2]]
@@ -563,7 +503,7 @@ def test_span_batch_two_examples_processed_independently():
 
 
 def test_span_batch_bad_example_does_not_affect_others():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     _, pad_token_id = create_test_tokenizer()
     good_seq = flat(resp, [_SENTINELS[0]], eot)
     bad_seq = [_SENTINELS[1], _SENTINELS[2]]
@@ -584,21 +524,21 @@ def test_span_batch_bad_example_does_not_affect_others():
 
 
 def test_span_output_labels_is_torch_tensor():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert isinstance(batch["labels"], torch.Tensor)
 
 
 def test_span_labels_shape_matches_input_ids():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert batch["labels"].shape == batch["input_ids"].shape
 
 
 def test_span_labels_numpy_values_match_expected():
-    resp, eot, _ = get_template_token_ids()
+    resp, eot = get_template_token_ids()
     content = [_SENTINELS[0], _SENTINELS[1]]
     seq = flat(resp, content, eot)
 

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -276,14 +276,13 @@ def make_span_collator(
     mask_tool_calls: bool = False,
 ) -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
-    resp_ids, eot_ids, tc_ids = get_template_token_ids()
     masking_method = "assistant_turn_no_tools" if mask_tool_calls else "assistant_turn"
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_template=resp_ids,
+        response_template=_RESP_STR,
         masking_method=masking_method,
-        end_of_turn_template=eot_ids,
-        tool_call_start_template=tc_ids if mask_tool_calls else None,
+        end_of_turn_template=_EOT_STR,
+        tool_call_start_template=_TC_STR if mask_tool_calls else None,
     )
 
 
@@ -453,13 +452,12 @@ def test_span_non_tool_call_turn_still_unmasked_when_mask_tool_calls_set():
 
 def test_span_mask_tool_calls_requires_template():
     tokenizer, _ = create_test_tokenizer()
-    resp_ids, eot_ids, _ = get_template_token_ids()
     with pytest.raises(ValueError, match="tool_call_start_template"):
         TextCompletionsCollatorWithPadding(
             tokenizer=tokenizer,
-            response_template=resp_ids,
+            response_template=_RESP_STR,
             masking_method="assistant_turn_no_tools",
-            end_of_turn_template=eot_ids,
+            end_of_turn_template=_EOT_STR,
             tool_call_start_template=None,
         )
 
@@ -513,8 +511,8 @@ def test_span_padding_matching_eot_does_not_false_match():
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        response_template=resp,
-        end_of_turn_template=eot_ids,
+        response_template=_RESP_STR,
+        end_of_turn_template=str(tokenizer.decode(eot_ids)),
     )
     batch = collator([{"input_ids": seq}])
     labels = batch["labels"][0].tolist()

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -476,3 +476,62 @@ def test_span_labels_shape_matches_input_ids():
     seq = flat(resp, [_SENTINELS[0], _SENTINELS[1]], eot)
     batch = make_span_collator()([{"input_ids": seq}])
     assert batch["labels"].shape == batch["input_ids"].shape
+
+
+# ---------------------------------------------------------------------------
+# Leading-newline BPE merge regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_leading_newline_bpe_merge_regression():
+    """Stripped response_template matches even when BPE merges trailing \\n.
+
+    BPE tokenizers (e.g. Qwen2.5) merge \\n+\\n into a single \\n\\n
+    token.  A response_template ending with \\n will not be found
+    when the following content also starts with \\n because the
+    merged token differs from the standalone \\n token.  Stripping
+    the trailing \\n from the template avoids this.
+    """
+    from oumi.core.collators.trl_data_collator_for_completion_only_lm import (
+        DataCollatorForCompletionOnlyLM,
+    )
+
+    find = DataCollatorForCompletionOnlyLM._find_pattern
+
+    SPECIAL, ASST, NL, NL_NL, CONTENT = 100, 200, 198, 271, 300
+
+    stripped_pattern = [SPECIAL, ASST]
+    unstripped_pattern = [SPECIAL, ASST, NL]
+
+    # BPE merged template's \n + content's \n into \n\n token
+    merged_seq = [SPECIAL, ASST, NL_NL, CONTENT]
+    assert find(merged_seq, stripped_pattern) != []
+    assert find(merged_seq, unstripped_pattern) == []
+
+    # Normal case (no leading \n): both match
+    normal_seq = [SPECIAL, ASST, NL, CONTENT]
+    assert find(normal_seq, stripped_pattern) != []
+    assert find(normal_seq, unstripped_pattern) != []
+
+
+def test_span_masking_with_leading_newline_content():
+    """Content starting with \\n is correctly unmasked when template is stripped."""
+    tokenizer, _ = create_test_tokenizer()
+    resp_ids = tokenizer.encode(_RESP_STR, add_special_tokens=False)
+    eot_ids = tokenizer.encode(_EOT_STR, add_special_tokens=False)
+    nl_ids = tokenizer.encode("\n\n", add_special_tokens=False)
+    content = [_SENTINELS[0], _SENTINELS[1]]
+
+    seq = flat(resp_ids, nl_ids, content, eot_ids)
+
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=_RESP_STR,
+        train_target="all_assistant_turns",
+        end_of_turn_template=_EOT_STR,
+    )
+    labels = collator([{"input_ids": seq}])["labels"][0].tolist()
+
+    content_start = len(resp_ids)
+    content_region = labels[content_start : content_start + len(nl_ids) + len(content)]
+    assert all(v != IGNORE for v in content_region)

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -462,6 +462,18 @@ def test_span_mask_tool_calls_requires_template():
         )
 
 
+def test_span_masking_requires_end_of_turn_template():
+    tokenizer, _ = create_test_tokenizer()
+    for method in ("assistant_turn", "assistant_turn_no_tools"):
+        with pytest.raises(ValueError, match="end_of_turn_template"):
+            TextCompletionsCollatorWithPadding(
+                tokenizer=tokenizer,
+                response_template=_RESP_STR,
+                masking_method=method,
+                end_of_turn_template=None,
+            )
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/datasets/test_base_sft_dataset.py
+++ b/tests/unit/core/datasets/test_base_sft_dataset.py
@@ -28,6 +28,7 @@ def _get_hf_collator_result(conversation, tokenizer):
         tokenizer=tokenizer,
         instruction_template=_INSTRUCTION_PREFIX,
         response_template=_RESPONSE_PREFIX,
+        train_target="_legacy_instruction_response",
     )
 
     return collator(batch)

--- a/tests/unit/core/datasets/test_base_sft_dataset.py
+++ b/tests/unit/core/datasets/test_base_sft_dataset.py
@@ -26,8 +26,8 @@ def _get_hf_collator_result(conversation, tokenizer):
 
     collator = TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
-        instruction_prefix=_INSTRUCTION_PREFIX,
-        response_prefix=_RESPONSE_PREFIX,
+        instruction_template=_INSTRUCTION_PREFIX,
+        response_template=_RESPONSE_PREFIX,
     )
 
     return collator(batch)


### PR DESCRIPTION
# Description

## Context

Currently, the completions only collator does not consistently mask tool responses (Role.TOOL) correctly. For some chat templates (like Qwen), it accidentally gets it correct, while masking is consistently wrongly applied for llama chat templates. This PR enables the masking to be correctly applied for all chat templates, supporting all four roles (system, user, assistant and tool).

Without `instruction_template`, tool results are masked correctly. But with `instruction_template`, things get weird and some tool results are unmasked. Omitting `instruction_template` causes the collator to find the last `response_template` and masks everything before it (only the final assistant turn trains). With `instruction_template`, the collator searches for `instruction_template` and `response_template` pairs and masks everything in between.


**Case 1: without `instruction_template`**

```
RESPONSE_TEMPLATE = "<|im_start|>assistant\n"

old_no_inst = DataCollatorForCompletionOnlyLM(
    response_template=RESPONSE_TEMPLATE,
    instruction_template=None,
    tokenizer=tokenizer,
)
b = old_no_inst.torch_call([token_ids])
labels_A = b["labels"][0].tolist()
summarise("Case A", labels_A, N)
show_masking(b["input_ids"][0].tolist(), labels_A, tokenizer)
```

<img width="763" height="326" alt="image" src="https://github.com/user-attachments/assets/401a576d-c70e-4c7f-beca-bccd9fd96362" />

Without inst template, collator masks everything before the last resp template. So loss only sees

```
<|im_start|>assistant
The weather in Paris is sunny and 18°C.<|im_end|>
```

**Case 2: with `instruction_template`**

With `instruction_template`, it masks everything between a inst and resp template. Since there isn't an inst template before the tool result, it does not get masked properly. 

```
INSTRUCTION_TEMPLATE = "<|im_start|>user\n"

old_with_inst = DataCollatorForCompletionOnlyLM(
    response_template=RESPONSE_TEMPLATE,
    instruction_template=INSTRUCTION_TEMPLATE,
    tokenizer=tokenizer,
)
b2 = old_with_inst.torch_call([token_ids])
labels_B = b2["labels"][0].tolist()
summarise("Case B", labels_B, N)
show_masking(b2["input_ids"][0].tolist(), labels_B, tokenizer)
```

<img width="751" height="320" alt="image" src="https://github.com/user-attachments/assets/2bef4e3b-880b-44f2-9714-618d593447b8" />


In case 2, the loss sees tool result, which is incorrect.

```
...
<|im_start|>assistant
<tool_call>
{"name": "get_weather", "arguments": {"location": "Paris"}}
</tool_call><|im_end|>
...
<|im_start|>assistant
The weather in Paris is sunny and 18°C.<|im_end|>
```

To confirm my hypothesis of no inst template before the tool result being the cause, I experimented with adding a user turn before the tool call and masking works correctly in that case.

<img width="746" height="359" alt="image" src="https://github.com/user-attachments/assets/1d62e4ab-3999-4ac7-ae3b-02c63b814726" />

## ToolAwareCompletionsCollator
With the new `ToolAwareCompletionsCollator`, tool results are masked properly

Without `instruction_template`
<img width="746" height="325" alt="image" src="https://github.com/user-attachments/assets/6dbbdeef-91ef-484e-8d34-4f924e8de76b" />

With `instruction_template`
<img width="761" height="329" alt="image" src="https://github.com/user-attachments/assets/320597b9-5f6a-4bcd-a842-475615b8304e" />


## Change 1: Extend `DataCollatorForCompletionOnlyLM` with span-based masking
Extend `DataCollatorForCompletionOnlyLM` with span-based masking (detecting assistant turn boundaries via response + end-of-turn tokens) beyond instruction based masking (matching instruction/response string pairs) supported currently. 

## Change 2: `train_target` enum for explicit control of which part of response to train on
- **`assistant_turn`**: Masks everything, then unmasks each assistant response bounded by `response_template` .. `end_of_turn_template` (inclusive of EOT). 
- **`final_assistant_turn`**: Masks all tokens before the last `response_template` occurrence. 

When `train_target` is set, no matter what templates have been provided, `train_target` has final authority on which combination is used. When `train_target` is not set, it is inferred from the templates provided. Eventually, we want users to specify `train_target` instead of relying on combinations of templates to control behavior. However, since we have many configs in production that do not use `train_target` and set templates explicitly, this shall be the interim solution to ensure old configs do not break. Existing configs using `collator_kwargs` with `instruction_template` + `response_template` continue to work via the legacy path (with a deprecation warning). New configs should use `train_target` explicitly. Users can set `train_target` and override the templates manually by setting `collator_kwargs`.

**Before** — users must provide model-specific token strings:
```yaml
collator_name: "text_completions_only_with_padding"
collator_kwargs:
  response_template: "<|im_start|>assistant\n"
  end_of_turn_template: "<|im_end|>"
```

**After** — users express intent, templates auto-resolve from tokenizer:
```yaml
collator_name: "text_completions_only_with_padding"
train_target: "assistant_turn"
```

## Change 3: Auto detection of collator templates
Instead of fragile vocab and collator template matching (requires us to maintain collator templates for all popular models), shift to a more robust approach: apply the chat template to a known test conversation, then finds the assistant boundary strings in the rendered output.

## Migration and deprecation considerations:
1. Configs that **only** specify `collator_name` -> removed support for this with the  removal of the default llama template fallback. This should be ok as no configs in production specify `collator_name` without `collator_kwargs`. Only less than 10 configs in OSS fall in this edgecase and they are being updated in this PR.
2. Enterprise SFT configs -> they should still work with old legacy behavior. Will update them once OSS version is updated in API.

## Open issues for next time
- Move`train_target` into `collator_kwargs` -> I considered putting train_target inside collator_kwargs instead of making it a separate field, but collator_kwargs is an opaque dict. Users wouldn't know train_target exists unless they read the docs. A top-level field makes it more visible. This will eventually be solved when we shift to `CollatorParam`.
- `CollatorParams`: This would mean changing every YAML from:

```
  collator_name: "text_completions_only_with_padding"
  collator_kwargs:
    train_target: "all_assistant_turns"
```
to 

```
  collator:
    name: "text_completions_only_with_padding"
    train_target: "all_assistant_turns"
```

This is much cleaner but its a substantial refactor. In order to manage the scope of this PR, this shall be deferred to a future PR
- Vision specific concerns -> future PR to neaten the vision concerns that are now scattered throughout the LM specific things
- Per-split collator configuration -> `build_collator_from_config` builds a single collator from the training split's settings, which is reused for all splits (train, validation, test). Validation/test split-specific collator settings (e.g. a different `train_target`) are silently ignored. This is pre-existing behavior not introduced by this PR, but worth noting as a known limitation. Fixing it would require refactoring the training loop to build per-split collators.

# Related issues

Fixes https://linear.app/oumi/issue/OPE-1870

# Before submitting

- [ ] This PR only changes documentation.
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

# Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.