### PR TITLE
feat(deploy): surface Fireworks GatewayStatus on Endpoint

### DIFF
--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -103,6 +103,8 @@ class Endpoint:
     created_at: datetime | None = None
     display_name: str | None = None
     inference_model_name: str | None = None  # Model name to use for inference calls
+    status_code: str | None = None  # Provider status code, e.g. "RESOURCE_EXHAUSTED"
+    status_message: str | None = None  # Raw provider status message (operator-only)
 
 
 # Async callback for upload/deploy progress updates.

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -281,6 +281,10 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         if not endpoint_url:
             endpoint_url = "https://api.fireworks.ai/inference/v1/chat/completions"
 
+        status = deployment.status
+        status_code = status.code.value if status and status.code else None
+        status_message = status.message if status else None
+
         return Endpoint(
             endpoint_id=endpoint_id,
             provider=DeploymentProvider.FIREWORKS,
@@ -292,6 +296,8 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             created_at=deployment.create_time,
             display_name=deployment.display_name,
             inference_model_name=name or None,
+            status_code=status_code,
+            status_message=status_message,
         )
 
     @staticmethod

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -32,8 +32,10 @@ from oumi.deploy.base_client import (
 from oumi.deploy.fireworks_api import (
     FW_STATE_TO_ENDPOINT,
     GatewayAcceleratorType,
+    GatewayCode,
     GatewayDeployment,
     GatewayDeploymentState,
+    GatewayStatus,
 )
 from oumi.deploy.fireworks_client import (
     FIREWORKS_ACCELERATORS,
@@ -193,6 +195,33 @@ class TestFireworksDeploymentClient:
         assert endpoint.autoscaling.max_replicas == 3
         assert endpoint.display_name == "My Deployment"
         assert endpoint.provider == DeploymentProvider.FIREWORKS
+        assert endpoint.status_code is None
+        assert endpoint.status_message is None
+
+    def test_parse_deployment_passes_through_status(self):
+        """Status code and message are surfaced on the Endpoint dataclass.
+
+        Fireworks reports scheduling failures (e.g. no A100s available) via
+        ``GatewayDeployment.status`` while the state remains ``CREATING``.
+        Callers polling the endpoint need that signal to fail fast instead of
+        waiting out the full poll budget.
+        """
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        deployment = GatewayDeployment(
+            name="accounts/test-account/deployments/deploy-123",
+            baseModel="accounts/test-account/models/model-456",
+            state=GatewayDeploymentState.CREATING,
+            status=GatewayStatus(
+                code=GatewayCode.RESOURCE_EXHAUSTED,
+                message="No A100 capacity in us-central1",
+            ),
+        )
+
+        endpoint = client._parse_deployment(deployment)
+
+        assert endpoint.status_code == "RESOURCE_EXHAUSTED"
+        assert endpoint.status_message == "No A100 capacity in us-central1"
 
     @pytest.mark.asyncio
     async def test_create_endpoint_payload(self):


### PR DESCRIPTION
# Description

Fireworks reports scheduling failures (e.g. \"no A100 capacity\") via `GatewayDeployment.status` with `code=RESOURCE_EXHAUSTED` while the deployment state stays in `CREATING`. Callers currently have no visibility into that signal and must wait out their full poll budget before timing out.

This change adds optional `status_code` / `status_message` fields to the `Endpoint` dataclass and populates them from `deployment.status` in the Fireworks client's `_parse_deployment`. Consumers (e.g. the api worker's poll activity) can now inspect these fields and fail fast with an actionable error instead of polling until timeout.

Parasail endpoints keep the new fields at their `None` defaults — no parasail-side change is required.

## Related issues

Fixes (Linear issue, ex. LOU-123)

Towards LOU-1560

## Before submitting

- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
- [x] Did you run relevant e2e/integration tests? (manually verified end-to-end from oumi-ai/api — Fireworks endpoint stuck in STARTING with RESOURCE_EXHAUSTED status code now surfaces via Endpoint.status_code)