### PR TITLE
feat(analyze): migrate analyze CLI to typed analyzer framework

### DIFF
--- a/configs/examples/analyze/analyze.yaml
+++ b/configs/examples/analyze/analyze.yaml
@@ -8,8 +8,8 @@
 
 # Local file in Oumi format (JSONL with {"messages": [...]})
 dataset_path: data/dataset_examples/oumi_format.jsonl
-# Or, use a HuggingFace dataset
-# dataset_name: argilla/databricks-dolly-15k-curated-en
+# Or, a HuggingFace dataset already in Oumi format ({"messages": [...]} per row):
+# dataset_name: <org>/<repo>
 # split: train
 
 # sample_count: 1000  # Limit samples (null = all)

--- a/configs/examples/analyze/analyze.yaml
+++ b/configs/examples/analyze/analyze.yaml
@@ -23,30 +23,60 @@ analyzers:
     instance_id: Length
     params:
       # Tokenizer name - automatically detects tiktoken vs HuggingFace
-      tokenizer_name: cl100k_base # tiktoken encoding (GPT-4)
+      tokenizer_name: o200k_base # tiktoken encoding (GPT-4o)
+      trust_remote_code: false
       # For HuggingFace tokenizers, use model ID:
       # tokenizer_name: meta-llama/Llama-3.1-8B-Instruct
-  - id: quality
-    instance_id: Quality
   - id: turn_stats
     instance_id: TurnStats
+  - id: quality
+    instance_id: Quality
 
 # Tests validate analysis results against thresholds.
 # Metric paths use "{instance_id}.{field_name}" format.
+# Without max_percentage/min_percentage, a test passes only if zero samples match.
 tests:
-  - id: max_tokens
+  - id: total_tokens
     type: threshold
+    severity: medium
+    title: "Total tokens exceed 8000"
+    description: "Flags conversations whose total token count exceeds 8000."
     metric: Length.total_tokens
     operator: ">"
-    value: 30
-    max_percentage: 5.0
+    value: 8000
+
+  - id: non_alternating_turns
+    type: threshold
     severity: high
-    title: "Token count exceeds 30"
+    title: "Non-alternating user/assistant turns"
+    description: "Flags conversations where user/assistant messages do not alternate."
+    metric: Quality.has_non_alternating_turns
+    operator: "=="
+    value: 1
+
   - id: empty_turns
     type: threshold
+    severity: high
+    title: "Empty turns detected"
+    description: "Flags conversations containing empty or whitespace-only messages."
     metric: Quality.has_empty_turns
     operator: "=="
-    value: true
-    max_percentage: 5.0
+    value: 1
+
+  - id: no_user_message
+    type: threshold
     severity: high
-    title: "Conversations with empty turns"
+    title: "No user message"
+    description: "Flags conversations that contain no user message."
+    metric: Quality.has_no_user_message
+    operator: "=="
+    value: 1
+
+  - id: system_message_not_at_start
+    type: threshold
+    severity: medium
+    title: "System message not at start"
+    description: "Flags conversations where a system message appears after position 0."
+    metric: Quality.has_system_message_not_at_start
+    operator: "=="
+    value: 1

--- a/configs/examples/analyze/analyze.yaml
+++ b/configs/examples/analyze/analyze.yaml
@@ -2,10 +2,11 @@
 # Usage: oumi analyze --config configs/examples/analyze/analyze.yaml
 #
 # Output files:
-#   - message_analysis.csv: Per-message metrics
-#   - conversation_analysis.csv: Per-conversation aggregated metrics
-#   - analysis_summary.json: Statistical summary (mean, std, min, max, median)
-# Local file in Oumi or Alpaca format
+#   - analysis.csv: Per-conversation metrics
+#   - test_results.json: Test pass/fail details
+#   - summary.json: Statistical summary (mean, std, min, max, median)
+
+# Local file in Oumi format (JSONL with {"messages": [...]})
 dataset_path: data/dataset_examples/oumi_format.jsonl
 # Or, use a HuggingFace dataset
 # dataset_name: argilla/databricks-dolly-15k-curated-en
@@ -13,24 +14,39 @@ dataset_path: data/dataset_examples/oumi_format.jsonl
 
 # sample_count: 1000  # Limit samples (null = all)
 
-# Tokenizer for token_count metric (use same tokenizer as your target model)
-# tokenizer_name: openai-community/gpt2
-# tokenizer_kwargs: {}
-
-# For multimodal (vision-language) datasets, specify a processor
-# Presence of processor_name automatically enables multimodal mode
-# processor_name: llava-hf/llava-1.5-7b-hf
-# processor_kwargs: {}
-
-# trust_remote_code: false
-
 output_path: ./analysis_output
 
+# Analyzers to run. Each needs a unique instance_id.
+# Metrics are accessed via paths like "Length.total_tokens".
 analyzers:
   - id: length
+    instance_id: Length
     params:
       # Tokenizer name - automatically detects tiktoken vs HuggingFace
-      tokenizer_name: cl100k_base  # tiktoken encoding (GPT-4)
+      tokenizer_name: cl100k_base # tiktoken encoding (GPT-4)
       # For HuggingFace tokenizers, use model ID:
       # tokenizer_name: meta-llama/Llama-3.1-8B-Instruct
-      # trust_remote_code: false
+  - id: quality
+    instance_id: Quality
+  - id: turn_stats
+    instance_id: TurnStats
+
+# Tests validate analysis results against thresholds.
+# Metric paths use "{instance_id}.{field_name}" format.
+tests:
+  - id: max_tokens
+    type: threshold
+    metric: Length.total_tokens
+    operator: ">"
+    value: 30
+    max_percentage: 5.0
+    severity: high
+    title: "Token count exceeds 30"
+  - id: empty_turns
+    type: threshold
+    metric: Quality.has_empty_turns
+    operator: "=="
+    value: true
+    max_percentage: 5.0
+    severity: high
+    title: "Conversations with empty turns"

--- a/configs/examples/analyze/analyze.yaml
+++ b/configs/examples/analyze/analyze.yaml
@@ -16,24 +16,24 @@ dataset_path: data/dataset_examples/oumi_format.jsonl
 
 output_path: ./analysis_output
 
-# Analyzers to run. Each needs a unique instance_id.
+# Analyzers to run. Each needs a unique `id` (defaults to display_name).
 # Metrics are accessed via paths like "Length.total_tokens".
 analyzers:
-  - id: length
-    instance_id: Length
+  - type: length
+    display_name: Length
     params:
       # Tokenizer name - automatically detects tiktoken vs HuggingFace
       tokenizer_name: o200k_base # tiktoken encoding (GPT-4o)
       trust_remote_code: false
       # For HuggingFace tokenizers, use model ID:
       # tokenizer_name: meta-llama/Llama-3.1-8B-Instruct
-  - id: turn_stats
-    instance_id: TurnStats
-  - id: quality
-    instance_id: Quality
+  - type: turn_stats
+    display_name: TurnStats
+  - type: quality
+    display_name: Quality
 
 # Tests validate analysis results against thresholds.
-# Metric paths use "{instance_id}.{field_name}" format.
+# Metric paths use "{id}.{field_name}" format (id defaults to display_name).
 # Without max_percentage/min_percentage, a test passes only if zero samples match.
 tests:
   - id: total_tokens

--- a/docs/user_guides/analyze/analyze.md
+++ b/docs/user_guides/analyze/analyze.md
@@ -30,8 +30,8 @@ from oumi.cli.analyze import run_typed_analysis
 config = TypedAnalyzeConfig(
     dataset_path="data/dataset_examples/oumi_format.jsonl",
     analyzers=[
-        AnalyzerConfig(id="length", instance_id="Length"),
-        AnalyzerConfig(id="quality", instance_id="Quality"),
+        AnalyzerConfig(type="length", display_name="Length"),
+        AnalyzerConfig(type="quality", display_name="Quality"),
     ],
 )
 
@@ -53,8 +53,8 @@ A minimal YAML configuration:
 dataset_path: data/dataset_examples/oumi_format.jsonl
 
 analyzers:
-  - id: length
-    instance_id: Length
+  - type: length
+    display_name: Length
     params:
       tokenizer_name: cl100k_base
 ```
@@ -160,7 +160,7 @@ from oumi.cli.analyze import run_typed_analysis
 config = TypedAnalyzeConfig.from_yaml("config.yaml")
 output = run_typed_analysis(config)
 
-# Analyzer results keyed by instance_id
+# Analyzer results keyed by id (defaults to display_name)
 for length_result in output["results"]["Length"]:
     print(f"Tokens: {length_result.total_tokens}")
 
@@ -195,12 +195,12 @@ sample_count: 100
 output_path: ./analysis_output
 
 analyzers:
-  - id: length
-    instance_id: Length
+  - type: length
+    display_name: Length
     params:
       tokenizer_name: cl100k_base
-  - id: quality
-    instance_id: Quality
+  - type: quality
+    display_name: Quality
 :::
 :::{code-block} python
 from oumi.analyze import TypedAnalyzeConfig, AnalyzerConfig
@@ -211,8 +211,8 @@ config = TypedAnalyzeConfig(
     split="train",
     sample_count=100,
     analyzers=[
-        AnalyzerConfig(id="length", instance_id="Length"),
-        AnalyzerConfig(id="quality", instance_id="Quality"),
+        AnalyzerConfig(type="length", display_name="Length"),
+        AnalyzerConfig(type="quality", display_name="Quality"),
     ],
 )
 results = run_typed_analysis(config)
@@ -225,10 +225,10 @@ Configure tests to automatically validate your dataset against quality threshold
 
 ```yaml
 analyzers:
-  - id: length
-    instance_id: Length
-  - id: quality
-    instance_id: Quality
+  - type: length
+    display_name: Length
+  - type: quality
+    display_name: Quality
 
 tests:
   - id: max_tokens
@@ -250,7 +250,7 @@ tests:
     title: "Conversations with empty turns"
 ```
 
-Metrics are referenced as `"{instance_id}.{field_name}"` (e.g., `Length.total_tokens`, `Quality.has_empty_turns`).
+Metrics are referenced as `"{id}.{field_name}"` (e.g., `Length.total_tokens`, `Quality.has_empty_turns`). When `id` is omitted it defaults to `display_name`.
 
 See {doc}`analyze_config` for full test configuration options.
 
@@ -288,8 +288,8 @@ Then reference it in YAML the same way as built-ins:
 
 ```yaml
 analyzers:
-  - id: questions
-    instance_id: Questions
+  - type: questions
+    display_name: Questions
 ```
 
 Base classes for different scopes:

--- a/docs/user_guides/analyze/analyze.md
+++ b/docs/user_guides/analyze/analyze.md
@@ -178,15 +178,21 @@ if output["test_summary"]:
 
 Analyze any HuggingFace Hub dataset directly:
 
+Rows must already be in Oumi conversation format
+(each row: `{"messages": [{"role": "...", "content": "..."}]}`). Rows that
+don't parse are skipped with a warning. To analyze instruction-style datasets
+(e.g. `prompt`/`response` fields), pre-convert them to Oumi JSONL first and
+use `dataset_path`.
+
 ::::{tab-set-code}
 :::{code-block} yaml
 
 # hf_analyze.yaml
 
-dataset_name: argilla/databricks-dolly-15k-curated-en
+dataset_name: <org>/<repo>
 split: train
 sample_count: 100
-output_path: ./analysis_output/dolly
+output_path: ./analysis_output
 
 analyzers:
   - id: length
@@ -201,7 +207,7 @@ from oumi.analyze import TypedAnalyzeConfig, AnalyzerConfig
 from oumi.cli.analyze import run_typed_analysis
 
 config = TypedAnalyzeConfig(
-    dataset_name="argilla/databricks-dolly-15k-curated-en",
+    dataset_name="<org>/<repo>",
     split="train",
     sample_count=100,
     analyzers=[

--- a/docs/user_guides/analyze/analyze.md
+++ b/docs/user_guides/analyze/analyze.md
@@ -8,14 +8,14 @@
 analyze_config
 ```
 
-Oumi's dataset analysis framework helps you understand training data before and after fine-tuning. Compute metrics, identify outliers, compare datasets, and create filtered subsets.
+Oumi's dataset analysis framework helps you understand you datasets. Compute metrics, identify quality issues and validate data with configurable tests.
 
 **Key capabilities:**
 
-- **Profile datasets**: Understand text length distributions, token counts, and statistics
-- **Quality control**: Identify outliers, empty samples, or problematic data
-- **Compare datasets**: Analyze multiple datasets with consistent metrics
-- **Filter data**: Create filtered subsets based on analysis results
+- **Profile datasets**: Token counts, length distributions, turn statistics
+- **Quality control**: Turn alternation, empty messages, invalid values
+- **Validate data**: Configurable threshold tests with percentage tolerances
+- **Export results**: CSV, JSON, or Parquet output with statistical summaries
 
 ## Quick Start
 
@@ -24,115 +24,157 @@ Oumi's dataset analysis framework helps you understand training data before and 
 oumi analyze --config configs/examples/analyze/analyze.yaml
 :::
 :::{code-block} python
-from oumi.core.analyze.dataset_analyzer import DatasetAnalyzer
-from oumi.core.configs import AnalyzeConfig, SampleAnalyzerParams
+from oumi.analyze import TypedAnalyzeConfig, AnalyzerConfig
+from oumi.cli.analyze import run_typed_analysis
 
-config = AnalyzeConfig(
+config = TypedAnalyzeConfig(
     dataset_path="data/dataset_examples/oumi_format.jsonl",
-    is_multimodal=False,
-    analyzers=[SampleAnalyzerParams(id="length")],
+    analyzers=[
+        AnalyzerConfig(id="length", instance_id="Length"),
+        AnalyzerConfig(id="quality", instance_id="Quality"),
+    ],
 )
 
-analyzer = DatasetAnalyzer(config)
-analyzer.analyze_dataset()
-print(analyzer.analysis_summary)
+results = run_typed_analysis(config)
 :::
 ::::
 
-Oumi outputs results to `./analysis_output/` including per-message metrics, conversation aggregates, and statistical summaries.
+Results are saved to the output directory (default: current directory) including per-conversation metrics, test results, and statistical summaries. Set it via `--output` on the CLI or `output_path` in the YAML config.
+
+:::{tip}
+You can use `-c` as a shorthand for `--config` in all CLI examples.
+:::
 
 ## Configuration
 
-A minimal configuration for a local file:
+A minimal YAML configuration:
 
 ```yaml
 dataset_path: data/dataset_examples/oumi_format.jsonl
-is_multimodal: false
+
 analyzers:
   - id: length
+    instance_id: Length
+    params:
+      tokenizer_name: cl100k_base
 ```
 
-For complete configuration options including dataset sources, output settings, tokenizer configuration, and validation rules, see {doc}`analyze_config`.
+For complete configuration options including tests, custom metrics, and tokenizer settings, see {doc}`analyze_config`.
 
 ## Available Analyzers
 
-### Length Analyzer
+### Length Analyzer (`length`)
 
-The built-in `length` analyzer computes text length metrics:
+Computes token and message count metrics using a configurable tokenizer.
 
-| Metric | Description |
-|--------|-------------|
-| `char_count` | Number of characters |
-| `word_count` | Number of words (space-separated) |
-| `sentence_count` | Number of sentences (split on `.!?`) |
-| `token_count` | Number of tokens (requires tokenizer) |
+
+| Metric                   | Description                            |
+| ------------------------ | -------------------------------------- |
+| `total_tokens`           | Total tokens across all messages       |
+| `avg_tokens_per_message` | Average tokens per message             |
+| `num_messages`           | Number of messages in the conversation |
+| `user_total_tokens`      | Total tokens in user messages          |
+| `assistant_total_tokens` | Total tokens in assistant messages     |
+| `system_total_tokens`    | Total tokens in system messages        |
+
 
 :::{tip}
-Enable token counting by adding `tokenizer_config` to your configuration. See {doc}`analyze_config` for setup details.
+Configure the tokenizer via `params.tokenizer_name`. Supports tiktoken encodings (e.g., `cl100k_base`) and HuggingFace model IDs (e.g., `meta-llama/Llama-3.1-8B-Instruct`).
 :::
+
+### Quality Analyzer (`quality`)
+
+Fast, non-LLM quality checks for data validation.
+
+
+| Metric                            | Description                                             |
+| --------------------------------- | ------------------------------------------------------- |
+| `has_non_alternating_turns`       | Consecutive same-role messages exist (excluding system) |
+| `has_no_user_message`             | Conversation contains no user message                   |
+| `has_system_message_not_at_start` | System message appears after position 0                 |
+| `has_empty_turns`                 | Any message has empty or whitespace-only content        |
+| `empty_turn_count`                | Number of empty/whitespace-only messages                |
+| `has_invalid_values`              | Contains serialized `NaN`, `null`, `None`, `undefined`  |
+| `invalid_value_patterns`          | List of invalid value patterns found                    |
+
+
+### Turn Stats Analyzer (`turn_stats`)
+
+Conversation structure and turn count metrics.
+
+
+| Metric                | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `num_turns`           | Total number of turns (messages)              |
+| `num_user_turns`      | Number of user turns                          |
+| `num_assistant_turns` | Number of assistant turns                     |
+| `num_tool_turns`      | Number of tool turns                          |
+| `has_system_message`  | Whether the conversation has a system message |
+| `first_turn_role`     | Role of the first message                     |
+| `last_turn_role`      | Role of the last message                      |
+
+
+Use `oumi analyze --list-metrics` to see all available metrics and their descriptions.
 
 ## Working with Results
 
-### Analysis Summary
+### Output Files
 
-Access summary statistics after running analysis:
 
-```python
-summary = analyzer.analysis_summary
+| File                | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `analysis.{format}` | Per-conversation metrics (one row per conversation) |
+| `test_results.json` | Test pass/fail details (if tests configured)        |
+| `summary.json`      | Statistical summary (mean, std, min, max)           |
 
-# Dataset overview
-print(f"Dataset: {summary['dataset_overview']['dataset_name']}")
-print(f"Samples: {summary['dataset_overview']['conversations_analyzed']}")
 
-# Message-level statistics
-for analyzer_name, metrics in summary['message_level_summary'].items():
-    for metric_name, stats in metrics.items():
-        print(f"{metric_name}: mean={stats['mean']}, std={stats['std']}")
-```
+### Exporting
 
-### DataFrames
+::::{tab-set-code}
+:::{code-block} bash
 
-Access raw analysis data as pandas DataFrames:
+# Export to CSV (default)
 
-```python
-message_df = analyzer.message_df        # One row per message
-conversation_df = analyzer.conversation_df  # One row per conversation
-full_df = analyzer.analysis_df          # Merged view
-```
+oumi analyze --config config.yaml
 
-The `conversation_df` includes:
+# Export to JSON
 
-- `conversation_index`: Index of the conversation in the dataset
-- `conversation_id`: Unique identifier for the conversation
-- `num_messages`: Number of messages in the conversation
-- `conversation_text_content`: Full conversation rendered as text (formatted as "ROLE: content" for each message)
+oumi analyze --config config.yaml --format json
 
-### Querying and Filtering
+# Export to Parquet
 
-Filter results using pandas query syntax:
+oumi analyze --config config.yaml --format parquet
+
+# Override output directory
+
+oumi analyze --config config.yaml --output ./my_results
+:::
+::::
+
+### Programmatic Access
 
 ```python
-# Find long messages
-long_messages = analyzer.query("text_content_length_word_count > 10")
+from oumi.analyze import TypedAnalyzeConfig
+from oumi.cli.analyze import run_typed_analysis
 
-# Find short conversations
-short_convos = analyzer.query_conversations("conversation_text_content_length_char_count < 100")
+config = TypedAnalyzeConfig.from_yaml("config.yaml")
+output = run_typed_analysis(config)
 
-# Create filtered dataset
-filtered_dataset = analyzer.filter("text_content_length_word_count < 100")
+# Analyzer results keyed by instance_id
+for length_result in output["results"]["Length"]:
+    print(f"Tokens: {length_result.total_tokens}")
+
+# Pre-built DataFrame (one row per conversation)
+df = output["dataframe"]
+print(df.describe())
+
+# Test summary (if tests were configured)
+if output["test_summary"]:
+    summary = output["test_summary"]
+    print(f"{summary.passed_tests}/{summary.total_tests} passed")
 ```
 
-## Supported Dataset Formats
-
-| Format | Description | Example |
-|--------|-------------|---------|
-| **oumi** | Multi-turn conversations with roles | SFT, instruction-following |
-| **alpaca** | Instruction/input/output format | Stanford Alpaca |
-| **DPO** | Preference pairs (chosen/rejected) | Preference learning |
-| **KTO** | Binary feedback format | Human feedback |
-| **Pretraining** | Raw text | C4, The Pile |
-
-### Analyzing HuggingFace Datasets
+## Analyzing HuggingFace Datasets
 
 Analyze any HuggingFace Hub dataset directly:
 
@@ -145,128 +187,124 @@ dataset_name: argilla/databricks-dolly-15k-curated-en
 split: train
 sample_count: 100
 output_path: ./analysis_output/dolly
-analyzers:
 
-- id: length
+analyzers:
+  - id: length
+    instance_id: Length
+    params:
+      tokenizer_name: cl100k_base
+  - id: quality
+    instance_id: Quality
 :::
 :::{code-block} python
-from oumi.core.analyze.dataset_analyzer import DatasetAnalyzer
-from oumi.core.configs import AnalyzeConfig, SampleAnalyzerParams
+from oumi.analyze import TypedAnalyzeConfig, AnalyzerConfig
+from oumi.cli.analyze import run_typed_analysis
 
-config = AnalyzeConfig(
+config = TypedAnalyzeConfig(
     dataset_name="argilla/databricks-dolly-15k-curated-en",
     split="train",
     sample_count=100,
-    analyzers=[SampleAnalyzerParams(id="length")],
+    analyzers=[
+        AnalyzerConfig(id="length", instance_id="Length"),
+        AnalyzerConfig(id="quality", instance_id="Quality"),
+    ],
 )
-analyzer = DatasetAnalyzer(config)
-analyzer.analyze_dataset()
+results = run_typed_analysis(config)
 :::
 ::::
 
-## Exporting Results
+## Data Validation with Tests
 
-::::{tab-set-code}
-:::{code-block} bash
+Configure tests to automatically validate your dataset against quality thresholds:
 
-# Export to CSV (default)
+```yaml
+analyzers:
+  - id: length
+    instance_id: Length
+  - id: quality
+    instance_id: Quality
 
-oumi analyze --config configs/examples/analyze/analyze.yaml
+tests:
+  - id: max_tokens
+    type: threshold
+    metric: Length.total_tokens
+    operator: ">"
+    value: 10000
+    max_percentage: 5.0
+    severity: high
+    title: "Token count exceeds 10K"
 
-# Export to Parquet
+  - id: no_empty_turns
+    type: threshold
+    metric: Quality.has_empty_turns
+    operator: "=="
+    value: true
+    max_percentage: 5.0
+    severity: high
+    title: "Conversations with empty turns"
+```
 
-oumi analyze --config configs/examples/analyze/analyze.yaml --format parquet
+Metrics are referenced as `"{instance_id}.{field_name}"` (e.g., `Length.total_tokens`, `Quality.has_empty_turns`).
 
-# Override output directory
+See {doc}`analyze_config` for full test configuration options.
 
-oumi analyze --config configs/examples/analyze/analyze.yaml --output ./my_results
-:::
-::::
+## Writing Custom Analyzers
 
-**Output files:**
-
-| File | Description |
-|------|-------------|
-| `message_analysis.{format}` | Per-message metrics |
-| `conversation_analysis.{format}` | Per-conversation aggregated metrics |
-| `analysis_summary.json` | Statistical summary |
-
-## Creating Custom Analyzers
-
-You can create custom analyzers to compute domain-specific metrics for your datasets. Custom analyzers extend the `SampleAnalyzer` base class and are registered using the `@register_sample_analyzer` decorator.
-
-For example, to build a question detector analyzer:
+Create a custom analyzer by subclassing one of the base classes and registering it:
 
 ```python
-import re
-from typing import Optional
-import pandas as pd
-
-from oumi.core.analyze.column_types import ContentType
-from oumi.core.analyze.sample_analyzer import SampleAnalyzer
+from pydantic import BaseModel, Field
+from oumi.analyze.base import ConversationAnalyzer
 from oumi.core.registry import register_sample_analyzer
+from oumi.core.types.conversation import Conversation
+
+
+class QuestionMetrics(BaseModel):
+    num_questions: int = Field(description="Count of '?' in all messages")
+    density: float = Field(description="Questions per message")
 
 
 @register_sample_analyzer("questions")
-class QuestionAnalyzer(SampleAnalyzer):
-    """Counts questions in text fields."""
-
-    def _count_questions(self, text: str) -> int:
-        """Count question marks in text. Replace with your own logic."""
-        return len(re.findall(r"\?", text))
-
-    def analyze_sample(
-        self,
-        df: pd.DataFrame,
-        schema: Optional[dict] = None,
-    ) -> pd.DataFrame:
-        result_df = df.copy()
-
-        # Find text columns using the schema
-        text_columns = [
-            col for col, config in schema.items()
-            if config.get("content_type") == ContentType.TEXT and col in df.columns
-        ]
-
-        for column in text_columns:
-            result_df[f"{column}_question_count"] = (
-                df[column].astype(str).apply(self._count_questions)
-            )
-
-        return result_df
+class QuestionAnalyzer(ConversationAnalyzer[QuestionMetrics]):
+    def analyze(self, conversation: Conversation) -> QuestionMetrics:
+        total = sum(
+            m.content.count("?")
+            for m in conversation.messages
+            if isinstance(m.content, str)
+        )
+        return QuestionMetrics(
+            num_questions=total,
+            density=total / max(len(conversation.messages), 1),
+        )
 ```
 
-Use your analyzer by referencing its registered ID:
+Then reference it in YAML the same way as built-ins:
 
-::::{tab-set-code}
-:::{code-block} yaml
+```yaml
 analyzers:
+  - id: questions
+    instance_id: Questions
+```
 
-- id: questions
-:::
-:::{code-block} python
+Base classes for different scopes:
 
-# Import your analyzer module to trigger registration
-
-import my_analyzers  # noqa: F401
-
-config = AnalyzeConfig(
-    dataset_path="data/my_dataset.jsonl",
-    is_multimodal=False,
-    analyzers=[SampleAnalyzerParams(id="questions")],
-)
-:::
-::::
-
-**Key points:**
-
-- Register with a unique ID via `@register_sample_analyzer("id")`
-- Use `schema` to find text columns (`ContentType.TEXT`)
-- Prefix output columns with the source column name (e.g., `{column}_question_count`)
+| Base Class | Scope | `analyze()` Input |
+|---|---|---|
+| {py:class}`~oumi.analyze.base.MessageAnalyzer` | Per message | `Message` |
+| {py:class}`~oumi.analyze.base.ConversationAnalyzer` | Per conversation | `Conversation` |
+| {py:class}`~oumi.analyze.base.DatasetAnalyzer` | Entire dataset | `list[Conversation]` |
+| {py:class}`~oumi.analyze.base.PreferenceAnalyzer` | Preference pairs | `(Conversation, Conversation)` |
 
 ## API Reference
 
-- {py:class}`~oumi.core.configs.AnalyzeConfig` - Configuration class
-- {py:class}`~oumi.core.analyze.dataset_analyzer.DatasetAnalyzer` - Main analyzer class
-- {py:class}`~oumi.core.analyze.sample_analyzer.SampleAnalyzer` - Base class for analyzers
-- {py:class}`~oumi.core.analyze.length_analyzer.LengthAnalyzer` - Built-in length analyzer
+- {py:class}`~oumi.analyze.config.TypedAnalyzeConfig` - Configuration class
+- {py:class}`~oumi.analyze.config.AnalyzerConfig` - Analyzer configuration
+- {py:class}`~oumi.analyze.pipeline.AnalysisPipeline` - Analysis pipeline
+- {py:class}`~oumi.analyze.base.ConversationAnalyzer` - Base class for conversation-level analyzers
+- {py:class}`~oumi.analyze.base.MessageAnalyzer` - Base class for message-level analyzers
+- {py:class}`~oumi.analyze.base.DatasetAnalyzer` - Base class for dataset-level analyzers
+- {py:class}`~oumi.analyze.analyzers.length.LengthAnalyzer` - Length metrics
+- {py:class}`~oumi.analyze.analyzers.quality.DataQualityAnalyzer` - Quality checks
+- {py:class}`~oumi.analyze.analyzers.turn_stats.TurnStatsAnalyzer` - Turn statistics
+- {py:class}`~oumi.analyze.testing.engine.TestEngine` - Test engine (in-memory)
+- {py:class}`~oumi.analyze.testing.batch_engine.BatchTestEngine` - Incremental test engine

--- a/docs/user_guides/analyze/analyze_config.md
+++ b/docs/user_guides/analyze/analyze_config.md
@@ -15,11 +15,13 @@
 
 Provide either `dataset_name` (HuggingFace Hub) or `dataset_path` (local JSONL file):
 
+Both sources must already be in Oumi conversation format (each row / line: `{"messages": [{"role": "...", "content": "..."}]}`). Rows that fail to parse are skipped with a warning.
+
 ::::{tab-set}
 :::{tab-item} HuggingFace Dataset
 
 ```yaml
-dataset_name: argilla/databricks-dolly-15k-curated-en
+dataset_name: <org>/<repo>
 split: train
 sample_count: 1000
 ```
@@ -30,8 +32,6 @@ sample_count: 1000
 ```yaml
 dataset_path: /path/to/data.jsonl
 ```
-
-Local files must be in JSONL format with Oumi conversation structure (each line: `{"messages": [{"role": "...", "content": "..."}]}`).
 
 :::
 ::::

--- a/docs/user_guides/analyze/analyze_config.md
+++ b/docs/user_guides/analyze/analyze_config.md
@@ -38,30 +38,31 @@ dataset_path: /path/to/data.jsonl
 
 ## Analyzers
 
-Configure analyzers as a list with `id`, `instance_id`, and optional `params`:
+Configure analyzers as a list with `type`, an optional `id`, `display_name`, and `params`:
 
 ```yaml
 analyzers:
-  - id: length
-    instance_id: Length
+  - type: length
+    display_name: Length
     params:
       tokenizer_name: cl100k_base
-  - id: quality
-    instance_id: Quality
-  - id: turn_stats
-    instance_id: TurnStats
+  - type: quality
+    display_name: Quality
+  - type: turn_stats
+    display_name: TurnStats
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `id` | `str` | Yes | — | Analyzer identifier (e.g., `length`, `quality`, `turn_stats`) |
-| `instance_id` | `str` | No | Same as `id` | Label used as result key and metric path prefix |
+| `type` | `str` | Yes | — | Analyzer identifier (e.g., `length`, `quality`, `turn_stats`) |
+| `id` | `str` | No | Same as `display_name` | Stable identifier. Canonical key for results, caches, and test metric paths. |
+| `display_name` | `str` | No | Same as `type` | Human-readable label shown in reports and logs |
 | `params` | `dict` | No | `{}` | Analyzer-specific parameters |
 
-The `instance_id` is used in metric paths for tests (e.g., `Length.total_tokens`) and as the column prefix in output DataFrames.
+Test metric paths use `id`, so they look like `"{id}.{field_name}"`. When `id` is omitted it defaults to `display_name`, so YAMLs that only set `display_name` can still write metric paths like `Length.total_tokens`.
 
 :::{note}
-Each analyzer must have a unique `instance_id`. If omitted, it defaults to the `id` value.
+Each analyzer must have a unique `id`. `display_name` may repeat — two analyzers can share a label as long as their ids differ. The legacy key `instance_id` is accepted as an alias for `display_name` with a deprecation warning.
 :::
 
 ### `length` Analyzer Parameters
@@ -83,7 +84,7 @@ The `turn_stats` analyzer has no configurable parameters. It computes turn count
 
 ## Tests
 
-Tests validate analysis results against configurable thresholds. Metrics are referenced as `"{instance_id}.{field_name}"`.
+Tests validate analysis results against configurable thresholds. Metrics are referenced as `"{id}.{field_name}"` (which equals `"{display_name}.{field_name}"` when `id` is omitted).
 
 ```yaml
 tests:
@@ -159,14 +160,14 @@ sample_count: 1000
 output_path: ./analysis_output
 
 analyzers:
-  - id: length
-    instance_id: Length
+  - type: length
+    display_name: Length
     params:
       tokenizer_name: cl100k_base
-  - id: quality
-    instance_id: Quality
-  - id: turn_stats
-    instance_id: TurnStats
+  - type: quality
+    display_name: Quality
+  - type: turn_stats
+    display_name: TurnStats
 
 tests:
   - id: max_tokens

--- a/docs/user_guides/analyze/analyze_config.md
+++ b/docs/user_guides/analyze/analyze_config.md
@@ -1,145 +1,194 @@
 # Analysis Configuration
 
-{py:class}`~oumi.core.configs.AnalyzeConfig` controls how Oumi OSS analyzes datasets. See {doc}`analyze` for usage examples.
+{py:class}`~oumi.analyze.config.TypedAnalyzeConfig` controls how Oumi analyzes datasets. See {doc}`analyze` for usage examples.
 
 ## Core Settings
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `dataset_name` | `str` | Conditional | `None` | Dataset name (HuggingFace Hub or registered) |
-| `dataset_path` | `str` | Conditional | `None` | Path to local dataset file |
+| `dataset_name` | `str` | Conditional | `None` | HuggingFace dataset name |
+| `dataset_path` | `str` | Conditional | `None` | Path to local JSONL file |
 | `split` | `str` | No | `"train"` | Dataset split to analyze |
 | `subset` | `str` | No | `None` | Dataset subset/config name |
-| `sample_count` | `int` | No | `None` | Max samples to analyze (None = all) |
+| `sample_count` | `int` | No | `None` | Max samples to analyze (`None` = all) |
+| `output_path` | `str` | No | `"."` | Directory for output files |
 
-## Dataset Specification
-
-Provide either a named dataset or local file path:
+Provide either `dataset_name` (HuggingFace Hub) or `dataset_path` (local JSONL file):
 
 ::::{tab-set}
-:::{tab-item} Named Dataset
+:::{tab-item} HuggingFace Dataset
 
 ```yaml
-dataset_name: "argilla/databricks-dolly-15k-curated-en"
+dataset_name: argilla/databricks-dolly-15k-curated-en
 split: train
-subset: null  # Optional
+sample_count: 1000
 ```
 
 :::
 :::{tab-item} Local File
 
 ```yaml
-dataset_path: data/dataset_examples/oumi_format.jsonl
-is_multimodal: false  # Required
+dataset_path: /path/to/data.jsonl
 ```
+
+Local files must be in JSONL format with Oumi conversation structure (each line: `{"messages": [{"role": "...", "content": "..."}]}`).
 
 :::
 ::::
 
-:::{tip}
-You can also pass a pre-loaded dataset directly to `DatasetAnalyzer`:
+## Analyzers
 
-```python
-from oumi.core.analyze.dataset_analyzer import DatasetAnalyzer
-analyzer = DatasetAnalyzer(config, dataset=my_dataset)
+Configure analyzers as a list with `id`, `instance_id`, and optional `params`:
+
+```yaml
+analyzers:
+  - id: length
+    instance_id: Length
+    params:
+      tokenizer_name: cl100k_base
+  - id: quality
+    instance_id: Quality
+  - id: turn_stats
+    instance_id: TurnStats
 ```
 
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | `str` | Yes | — | Analyzer identifier (e.g., `length`, `quality`, `turn_stats`) |
+| `instance_id` | `str` | No | Same as `id` | Label used as result key and metric path prefix |
+| `params` | `dict` | No | `{}` | Analyzer-specific parameters |
+
+The `instance_id` is used in metric paths for tests (e.g., `Length.total_tokens`) and as the column prefix in output DataFrames.
+
+:::{note}
+Each analyzer must have a unique `instance_id`. If omitted, it defaults to the `id` value.
 :::
+
+### `length` Analyzer Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tokenizer_name` | `str` | `cl100k_base` | Tokenizer name (tiktoken encoding or HuggingFace model ID) |
+
+Tiktoken encodings: `cl100k_base` (GPT-4), `p50k_base`, `o200k_base`.
+HuggingFace models: any valid model ID (e.g., `meta-llama/Llama-3.1-8B-Instruct`).
+
+### `quality` Analyzer Parameters
+
+The `quality` analyzer has no configurable parameters. It always checks for non-alternating turns, missing user messages, misplaced system messages, empty messages, and invalid serialized values.
+
+### `turn_stats` Analyzer Parameters
+
+The `turn_stats` analyzer has no configurable parameters. It computes turn counts by role, system message presence, and first/last turn roles.
+
+## Tests
+
+Tests validate analysis results against configurable thresholds. Metrics are referenced as `"{instance_id}.{field_name}"`.
+
+```yaml
+tests:
+  - id: max_tokens
+    type: threshold
+    metric: Length.total_tokens
+    operator: ">"
+    value: 10000
+    max_percentage: 5.0
+    severity: high
+    title: "Token count exceeds limit"
+```
+
+### Common Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | `str` | Yes | — | Unique test identifier |
+| `type` | `str` | Yes | — | Test type (`threshold`) |
+| `metric` | `str` | Yes | — | Metric path (e.g., `Length.total_tokens`) |
+| `severity` | `str` | No | `medium` | Failure severity: `high`, `medium`, or `low` |
+| `title` | `str` | No | `""` | Human-readable title shown in results |
+| `description` | `str` | No | `""` | Description of what the test checks |
+
+### Threshold Tests
+
+Check if a metric exceeds a threshold across the dataset.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `operator` | `str` | Comparison: `<`, `>`, `<=`, `>=`, `==`, `!=` |
+| `value` | `number` | Value to compare against |
+| `max_percentage` | `float` | At most this % of samples can match the condition |
+| `min_percentage` | `float` | At least this % of samples must match the condition |
+
+```yaml
+# At most 5% of conversations can have > 10K tokens
+- id: max_tokens
+  type: threshold
+  metric: Length.total_tokens
+  operator: ">"
+  value: 10000
+  max_percentage: 5.0
+
+# At most 5% of conversations can have non-alternating turns
+- id: non_alternating
+  type: threshold
+  metric: Quality.has_non_alternating_turns
+  operator: "=="
+  value: true
+  max_percentage: 5.0
+```
 
 ## Output Settings
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `output_path` | `str` | `"."` | Directory for output files |
+| `generate_report` | `bool` | `false` | Generate HTML report |
+| `report_title` | `str` | `None` | Custom title for the report |
 
-::::{tab-set-code}
-:::{code-block} yaml
-output_path: "./analysis_results"
-:::
-:::{code-block} bash
-oumi analyze --config config.yaml --output /custom/path
-:::
-::::
-
-## Analyzers
-
-Configure analyzers as a list with `id` and optional `params`:
-
-```yaml
-analyzers:
-  - id: length
-    params:
-      char_count: true
-      word_count: true
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | `str` | Yes | Analyzer identifier (must be registered) |
-| `params` | `dict` | No | Analyzer-specific parameters |
-
-### `length` Analyzer
-
-Computes text length metrics:
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `char_count` | `bool` | `true` | Character count |
-| `word_count` | `bool` | `true` | Word count |
-| `sentence_count` | `bool` | `true` | Sentence count |
-| `token_count` | `bool` | `false` | Token count (requires tokenizer) |
-| `include_special_tokens` | `bool` | `true` | Include special tokens in count |
-
-## Tokenizer Configuration
-
-Required when `token_count: true`:
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `model_name` | `str` | Yes | HuggingFace model/tokenizer name |
-| `tokenizer_kwargs` | `dict` | No | Additional tokenizer arguments |
-| `trust_remote_code` | `bool` | No | Allow remote code execution |
-
-```yaml
-tokenizer_config:
-  model_name: openai-community/gpt2
-  tokenizer_kwargs:
-    use_fast: true
-```
-
-## Multimodal Settings
-
-For vision-language datasets:
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `is_multimodal` | `bool` | `None` | Whether dataset is multimodal |
-| `processor_name` | `str` | `None` | Processor name for VL datasets |
-| `processor_kwargs` | `dict` | `{}` | Processor arguments |
-| `trust_remote_code` | `bool` | `false` | Allow remote code |
-
-```yaml
-dataset_path: "/path/to/vl_data.jsonl"
-is_multimodal: true
-processor_name: "llava-hf/llava-1.5-7b-hf"
-```
-
-:::{note}
-Multimodal datasets require a valid `processor_name`.
-:::
-
-## Example Configuration
-
-Run the example from the Oumi OSS repository root:
+Override the output directory via CLI:
 
 ```bash
-oumi analyze --config configs/examples/analyze/analyze.yaml
+oumi analyze --config config.yaml --output /custom/path --format parquet
 ```
 
-The example config at `configs/examples/analyze/analyze.yaml` demonstrates all available options with detailed comments explaining each setting.
+## Complete Example
+
+```yaml
+dataset_path: /path/to/data.jsonl
+sample_count: 1000
+output_path: ./analysis_output
+
+analyzers:
+  - id: length
+    instance_id: Length
+    params:
+      tokenizer_name: cl100k_base
+  - id: quality
+    instance_id: Quality
+  - id: turn_stats
+    instance_id: TurnStats
+
+tests:
+  - id: max_tokens
+    type: threshold
+    metric: Length.total_tokens
+    operator: ">"
+    value: 10000
+    max_percentage: 5.0
+    severity: high
+    title: "Token count exceeds 10K"
+  - id: empty_turns
+    type: threshold
+    metric: Quality.has_empty_turns
+    operator: "=="
+    value: true
+    max_percentage: 5.0
+    severity: high
+    title: "Conversations with empty turns"
+```
 
 ## See Also
 
 - {doc}`analyze` - Main analysis guide
-- {py:class}`~oumi.core.configs.AnalyzeConfig` - API reference
-- {py:class}`~oumi.core.configs.params.base_params.SampleAnalyzerParams` - Analyzer params
+- {py:class}`~oumi.analyze.config.TypedAnalyzeConfig` - Configuration API reference
+- {py:class}`~oumi.analyze.config.AnalyzerConfig` - Analyzer configuration

--- a/src/oumi/analyze/__init__.py
+++ b/src/oumi/analyze/__init__.py
@@ -93,13 +93,10 @@ def create_analyzer_from_config(
         return None
 
     try:
-        # Prefer from_config() if available for better config handling
-        if hasattr(analyzer_class, "from_config") and callable(
-            getattr(analyzer_class, "from_config")
-        ):
-            return analyzer_class.from_config(params)  # type: ignore[union-attr]
-        else:
-            return analyzer_class(**params)
+        from_config = getattr(analyzer_class, "from_config", None)
+        if callable(from_config):
+            return from_config(params)  # type: ignore[no-any-return]
+        return analyzer_class(**params)
     except Exception as e:
         logger.error(f"Failed to create analyzer {analyzer_id}: {e}")
         return None

--- a/src/oumi/analyze/config.py
+++ b/src/oumi/analyze/config.py
@@ -14,6 +14,7 @@
 
 """Configuration for the typed analyzer framework."""
 
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -27,20 +28,39 @@ from oumi.core.configs.params.test_params import TestParams
 class AnalyzerConfig:
     """Configuration for a single analyzer instance.
 
-    Each analyzer has a type (`id`) and a unique instance name (`instance_id`).
-    Multiple instances of the same type are supported (e.g. two length analyzers
-    with different tokenizers).
+    Three identity-related fields:
+
+    * ``type`` — registry id (e.g. ``"length"``). Picks the analyzer class.
+    * ``id`` — stable identity. Canonical key for results, caches, and test
+      metric paths. Defaults to ``display_name`` when omitted.
+    * ``display_name`` — human-readable label for UI and logs. Defaults to
+      ``type`` when omitted. May repeat across analyzers.
+
+    When callers don't set ``id`` or ``display_name``, all three collapse to
+    ``type`` and today's behavior is preserved. When the API populates ``id``
+    with a generated asset id, ``display_name`` becomes purely cosmetic.
 
     Attributes:
-        id: Analyzer type (registry id, e.g. "length", "difficulty_judge").
-        instance_id: Unique instance name (always required). Used as the results
-            key and in test metric paths.
+        type: Analyzer type (registry id, e.g. "length", "difficulty_judge").
+        id: Stable identifier. Used as the results key and in test metric
+            paths. Defaults to ``display_name`` when omitted.
+        display_name: Human-readable label. Defaults to ``type`` when omitted.
         params: Analyzer-specific parameters.
     """
 
-    id: str
-    instance_id: str
+    type: str = ""
+    id: str = ""
+    display_name: str = ""
     params: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Validate and default the analyzer configuration."""
+        if not self.type:
+            raise ValueError("AnalyzerConfig.type is required.")
+        if not self.display_name:
+            self.display_name = self.type
+        if not self.id:
+            self.id = self.display_name
 
 
 @dataclass
@@ -148,10 +168,10 @@ class TypedAnalyzeConfig:
         output_path: ./analysis_output
 
         analyzers:
-          - id: length
+          - type: length
             params:
               count_tokens: true
-          - id: quality
+          - type: quality
 
         custom_metrics:
           - id: turn_pattern
@@ -163,7 +183,7 @@ class TypedAnalyzeConfig:
         tests:
           - id: max_words
             type: threshold
-            metric: LengthAnalyzer.total_words
+            metric: length.total_words
             operator: ">"
             value: 10000
             max_percentage: 5.0
@@ -229,29 +249,44 @@ class TypedAnalyzeConfig:
 
     @classmethod
     def _parse_analyzers(cls, data: dict[str, Any]) -> list[AnalyzerConfig]:
-        """Parse analyzer configurations, raising on duplicate instance_ids."""
+        """Parse analyzer configurations, raising on duplicate ids.
+
+        Accepts the legacy ``instance_id`` key as an alias for ``display_name``
+        (with a ``DeprecationWarning``) for one release.
+        """
         analyzers = []
         for analyzer_data in data.get("analyzers", []):
-            if isinstance(analyzer_data, dict):
-                # instance_id defaults to id if not provided in YAML
-                if "instance_id" not in analyzer_data:
-                    analyzer_data = {
-                        **analyzer_data,
-                        "instance_id": analyzer_data["id"],
-                    }
-                analyzers.append(AnalyzerConfig(**analyzer_data))
-            elif isinstance(analyzer_data, str):
-                analyzers.append(
-                    AnalyzerConfig(id=analyzer_data, instance_id=analyzer_data)
-                )
+            if isinstance(analyzer_data, str):
+                analyzers.append(AnalyzerConfig(type=analyzer_data))
+                continue
+            if not isinstance(analyzer_data, dict):
+                continue
 
-        # Validate unique instance_ids
-        instance_ids = [a.instance_id for a in analyzers]
-        duplicates = [id for id in set(instance_ids) if instance_ids.count(id) > 1]
+            normalized = dict(analyzer_data)
+            if "instance_id" in normalized:
+                warnings.warn(
+                    "'instance_id' is deprecated; rename to 'display_name'.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                legacy = normalized.pop("instance_id")
+                normalized.setdefault("display_name", legacy)
+            if "type" not in normalized and "id" in normalized:
+                raise ValueError(
+                    "Legacy analyzer entry: 'id' is present without 'type'. "
+                    "The 'id' field now means stable identity, not analyzer "
+                    "type. Rename 'id' to 'type' (and 'instance_id' to "
+                    "'display_name', if present). See "
+                    "docs/user_guides/analyze/analyze_config.md."
+                )
+            analyzers.append(AnalyzerConfig(**normalized))
+
+        ids = [a.id for a in analyzers]
+        duplicates = sorted({i for i in ids if ids.count(i) > 1})
         if duplicates:
             raise ValueError(
-                f"Duplicate analyzer instance_id values: {duplicates}. "
-                "Each analyzer must have a unique instance_id to avoid collisions."
+                f"Duplicate analyzer id values: {duplicates}. "
+                "Each analyzer must have a unique id to avoid collisions."
             )
 
         return analyzers
@@ -313,7 +348,7 @@ class TypedAnalyzeConfig:
 
         Raises:
             ValueError: If config contains custom code but allow_custom_code=False,
-                or if duplicate analyzer instance_ids found.
+                or if duplicate analyzer id values are found.
         """
         analyzers = cls._parse_analyzers(data)
         custom_metrics = cls._parse_custom_metrics(data, allow_custom_code)
@@ -349,7 +384,12 @@ class TypedAnalyzeConfig:
             "sample_count": self.sample_count,
             "output_path": self.output_path,
             "analyzers": [
-                {"id": a.id, "instance_id": a.instance_id, "params": a.params}
+                {
+                    "type": a.type,
+                    "id": a.id,
+                    "display_name": a.display_name,
+                    "params": a.params,
+                }
                 for a in self.analyzers
             ],
             "custom_metrics": [

--- a/src/oumi/analyze/config.py
+++ b/src/oumi/analyze/config.py
@@ -189,7 +189,7 @@ class TypedAnalyzeConfig:
     split: str = "train"
     subset: str | None = None
     sample_count: int | None = None
-    output_path: str = "."
+    output_path: str | None = None
     analyzers: list[AnalyzerConfig] = field(default_factory=list)
     custom_metrics: list[CustomMetricConfig] = field(default_factory=list)
     tests: list[TestParams] = field(default_factory=list)
@@ -327,7 +327,7 @@ class TypedAnalyzeConfig:
             split=data.get("split", "train"),
             subset=data.get("subset"),
             sample_count=data.get("sample_count"),
-            output_path=data.get("output_path", "."),
+            output_path=data.get("output_path"),
             analyzers=analyzers,
             custom_metrics=custom_metrics,
             tests=tests,

--- a/src/oumi/analyze/testing/engine.py
+++ b/src/oumi/analyze/testing/engine.py
@@ -196,7 +196,7 @@ class TestEngine:
         metric: str,
         results: dict[str, list[BaseModel] | BaseModel],
     ) -> list[Any]:
-        """Extract values for a metric path like "instance_id.field_name"."""
+        """Extract values for a metric path like "id.field_name"."""
         parts = metric.split(".")
         if len(parts) < 2:
             return []

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -142,11 +142,11 @@ def run_typed_analysis(
     analyzers = []
     for analyzer_config in config.analyzers:
         analyzer = create_analyzer_from_config(
-            analyzer_config.id,
+            analyzer_config.type,
             analyzer_config.params,
         )
         if analyzer is not None:
-            analyzer.analyzer_id = analyzer_config.instance_id
+            analyzer.analyzer_id = analyzer_config.id
             analyzers.append(analyzer)
 
     if not analyzers:
@@ -308,9 +308,10 @@ def _check_old_config_format(config_path: str) -> None:
             "format.\n\n"
             f"Detected v1 fields: {', '.join(sorted(old_fields_found))}\n\n"
             "The analyze CLI now uses TypedAnalyzeConfig (v2). Key changes:\n"
-            "  - 'analyzers' entries use 'id' and 'instance_id'\n"
-            "  - Metrics are accessed as '{instance_id}.{field}' "
-            "(e.g. 'Length.total_tokens')\n"
+            "  - 'analyzers' entries use 'type' and 'display_name' "
+            "(plus optional 'id')\n"
+            "  - Metrics are accessed as '{id}.{field}' "
+            "(id defaults to display_name, e.g. 'Length.total_tokens')\n"
             "  - 'dataset_source', 'processor_name', 'is_multimodal' "
             "are no longer needed\n\n"
             "See: docs/user_guides/analyze/analyze_config.md for the new format.\n"
@@ -357,7 +358,7 @@ def _run_typed_analysis_cli(
             cli_utils.CONSOLE.print(f"[dim]Config loaded from: {config}[/dim]")
             dataset = typed_config.dataset_name or typed_config.dataset_path
             cli_utils.CONSOLE.print(f"[dim]Dataset: {dataset}[/dim]")
-            analyzer_ids = [a.instance_id for a in typed_config.analyzers]
+            analyzer_ids = [a.id for a in typed_config.analyzers]
             cli_utils.CONSOLE.print(f"[dim]Analyzers: {analyzer_ids}[/dim]")
 
         with cli_utils.CONSOLE.status(

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -494,6 +494,7 @@ def analyze(
     dataset_name: Annotated[
         str | None,
         typer.Option(
+            "--dataset-name",
             "--dataset_name",
             help="Dataset name to analyze (overrides config).",
             rich_help_panel="Data",
@@ -502,6 +503,7 @@ def analyze(
     dataset_path: Annotated[
         str | None,
         typer.Option(
+            "--dataset-path",
             "--dataset_path",
             help="Path to dataset file in JSONL format (overrides config).",
             rich_help_panel="Data",
@@ -510,6 +512,7 @@ def analyze(
     sample_count: Annotated[
         int | None,
         typer.Option(
+            "--sample-count",
             "--sample_count",
             help="Number of samples to analyze (overrides config).",
             rich_help_panel="Data",

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -154,7 +154,7 @@ def run_typed_analysis(
 
     pipeline = AnalysisPipeline(
         analyzers=analyzers,
-        cache_dir=config.output_path if config.output_path != "." else None,
+        cache_dir=config.output_path,
     )
 
     results = pipeline.run(conversations)
@@ -177,7 +177,7 @@ def run_typed_analysis(
 def save_results(
     output_path: str | Path,
     results: dict[str, Any],
-    output_format: str = "parquet",
+    output_format: str = "csv",
 ) -> None:
     """Save analysis results to disk."""
     output_dir = Path(output_path)
@@ -267,7 +267,7 @@ def print_summary(results: dict[str, Any]) -> None:
 def run_from_config_file(
     config_path: str | Path,
     output_path: str | None = None,
-    output_format: str = "parquet",
+    output_format: str = "csv",
 ) -> dict[str, Any]:
     """Run analysis from a YAML configuration file."""
     from oumi.analyze.config import TypedAnalyzeConfig

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -27,13 +27,13 @@ from rich.console import Console
 from rich.table import Table
 
 import oumi.cli.cli_utils as cli_utils
+from oumi.analyze import create_analyzer_from_config
 from oumi.analyze.config import TypedAnalyzeConfig
 from oumi.analyze.discovery import print_analyzer_metrics
 from oumi.analyze.pipeline import AnalysisPipeline
 from oumi.analyze.testing.engine import TestEngine
 from oumi.cli.alias import AliasType, try_get_config_name_for_alias
 from oumi.cli.completions import complete_analyze_config
-from oumi.core.registry import REGISTRY
 from oumi.core.types.conversation import Conversation
 from oumi.utils.io_utils import load_jsonlines
 from oumi.utils.logging import logger
@@ -107,33 +107,6 @@ def load_conversations_from_dataset(
 
     logger.info(f"Loaded {len(conversations)} conversations from {dataset_name}")
     return conversations
-
-
-def get_analyzer_class(name: str) -> Any:
-    """Get an analyzer class by name from the core registry."""
-    return REGISTRY.get_sample_analyzer(name)
-
-
-def create_analyzer_from_config(
-    analyzer_id: str,
-    params: dict[str, Any],
-) -> Any:
-    """Create an analyzer instance from configuration."""
-    analyzer_class = get_analyzer_class(analyzer_id)
-    if analyzer_class is None:
-        logger.warning(f"Unknown analyzer: {analyzer_id}")
-        return None
-
-    try:
-        if hasattr(analyzer_class, "from_config") and callable(
-            getattr(analyzer_class, "from_config")
-        ):
-            return analyzer_class.from_config(params)
-        else:
-            return analyzer_class(**params)
-    except Exception as e:
-        logger.error(f"Failed to create analyzer {analyzer_id}: {e}")
-        return None
 
 
 def run_typed_analysis(

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -12,43 +12,529 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""CLI for the typed analyzer framework."""
+
+from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
-from rich.table import Table
+
+if TYPE_CHECKING:
+    from oumi.analyze.config import TypedAnalyzeConfig
+    from oumi.core.types.conversation import Conversation
 
 import oumi.cli.cli_utils as cli_utils
 from oumi.cli.alias import AliasType, try_get_config_name_for_alias
 from oumi.cli.completions import complete_analyze_config
 from oumi.utils.logging import logger
 
-# Valid output formats for analysis results
 _VALID_OUTPUT_FORMATS = ("csv", "json", "parquet")
 
 _list_configs_callback = cli_utils.create_list_configs_callback(
     AliasType.ANALYZE, "Available Analysis Configs", "analyze"
 )
 
-if TYPE_CHECKING:
-    import pandas as pd
+_OLD_CONFIG_FIELDS = {
+    "dataset_source",
+    "dataset_format",
+    "processor_name",
+    "processor_kwargs",
+    "is_multimodal",
+    "trust_remote_code",
+}
 
-    from oumi.core.analyze.dataset_analyzer import DatasetAnalyzer
+
+def load_conversations_from_path(
+    path: str | Path,
+    sample_count: int | None = None,
+) -> list[Conversation]:
+    """Load conversations from a JSONL file."""
+    from oumi.core.types.conversation import Conversation  # noqa: F811
+    from oumi.utils.io_utils import load_jsonlines
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+
+    data = load_jsonlines(str(path))
+    conversations: list[Conversation] = []
+
+    for i, item in enumerate(data):
+        if sample_count is not None and i >= sample_count:
+            break
+
+        try:
+            conv = Conversation.from_dict(item)
+            conversations.append(conv)
+        except Exception as e:
+            logger.warning(f"Failed to parse conversation at index {i}: {e}")
+
+    return conversations
+
+
+def load_conversations_from_dataset(
+    dataset_name: str,
+    split: str = "train",
+    subset: str | None = None,
+    sample_count: int | None = None,
+) -> list[Conversation]:
+    """Load conversations from a HuggingFace dataset."""
+    from datasets import load_dataset
+
+    logger.info(f"Loading dataset: {dataset_name} (split={split}, subset={subset})")
+
+    dataset = load_dataset(dataset_name, subset, split=split)
+    conversations: list[Conversation] = []
+    total = len(dataset)
+    limit = sample_count if sample_count else total
+
+    for i in range(min(limit, total)):
+        try:
+            item = dataset[i]
+            conv = _item_to_conversation(item, i)
+            if conv is not None:
+                conversations.append(conv)
+        except Exception as e:
+            logger.warning(f"Failed to convert item at index {i}: {e}")
+
+    logger.info(f"Loaded {len(conversations)} conversations from {dataset_name}")
+    return conversations
+
+
+def _item_to_conversation(item: Any, index: int) -> Any:
+    """Convert a dataset item to a Conversation, or None if conversion fails."""
+    from oumi.core.types.conversation import Conversation, Message, Role
+
+    if isinstance(item, Conversation):
+        return item
+
+    if isinstance(item, dict):
+        if "messages" in item:
+            try:
+                return Conversation.from_dict(item)
+            except Exception:
+                pass
+
+        if "conversation" in item:
+            conv_data = item["conversation"]
+            if isinstance(conv_data, list):
+                messages = []
+                for msg in conv_data:
+                    if isinstance(msg, dict):
+                        role_str = msg.get("role", msg.get("from", "user"))
+                        content = msg.get(
+                            "content", msg.get("text", msg.get("value", ""))
+                        )
+                        try:
+                            role = Role(role_str.lower())
+                        except ValueError:
+                            role = (
+                                Role.USER
+                                if role_str.lower() in ("human", "user")
+                                else Role.ASSISTANT
+                            )
+                        messages.append(Message(role=role, content=content))
+                return Conversation(messages=messages, metadata={"source_index": index})
+
+        prompt = None
+        response = None
+        context = None
+
+        for key in [
+            "prompt",
+            "instruction",
+            "original-instruction",
+            "question",
+            "input",
+        ]:
+            if key in item and item[key]:
+                prompt = item[key]
+                break
+
+        for key in [
+            "response",
+            "output",
+            "completion",
+            "original-response",
+            "answer",
+            "target",
+        ]:
+            if key in item and item[key]:
+                response = item[key]
+                break
+
+        for key in ["context", "original-context", "input_context"]:
+            if key in item and item[key]:
+                context = item[key]
+                break
+
+        if prompt:
+            if context:
+                full_prompt = f"{context}\n\n{prompt}"
+            else:
+                full_prompt = str(prompt)
+
+            messages = [
+                Message(role=Role.USER, content=full_prompt),
+            ]
+            if response:
+                messages.append(Message(role=Role.ASSISTANT, content=str(response)))
+            return Conversation(messages=messages, metadata={"source_index": index})
+
+        try:
+            return Conversation.from_dict(item)
+        except Exception:
+            pass
+
+    logger.debug(f"Could not convert item at index {index} to Conversation")
+    return None
+
+
+def get_analyzer_class(name: str) -> Any:
+    """Get an analyzer class by name from the core registry."""
+    from oumi.core.registry import REGISTRY
+
+    return REGISTRY.get_sample_analyzer(name)
+
+
+def create_analyzer_from_config(
+    analyzer_id: str,
+    params: dict[str, Any],
+) -> Any:
+    """Create an analyzer instance from configuration."""
+    analyzer_class = get_analyzer_class(analyzer_id)
+    if analyzer_class is None:
+        logger.warning(f"Unknown analyzer: {analyzer_id}")
+        return None
+
+    try:
+        if hasattr(analyzer_class, "from_config") and callable(
+            getattr(analyzer_class, "from_config")
+        ):
+            return analyzer_class.from_config(params)
+        else:
+            return analyzer_class(**params)
+    except Exception as e:
+        logger.error(f"Failed to create analyzer {analyzer_id}: {e}")
+        return None
+
+
+def run_typed_analysis(
+    config: TypedAnalyzeConfig,  # noqa: F821
+    conversations: list | None = None,
+) -> dict[str, Any]:
+    """Run the typed analysis pipeline."""
+    from oumi.analyze.pipeline import AnalysisPipeline
+    from oumi.analyze.testing.engine import TestEngine
+
+    if conversations is None:
+        if config.dataset_path:
+            conversations = load_conversations_from_path(
+                config.dataset_path,
+                config.sample_count,
+            )
+        elif config.dataset_name:
+            conversations = load_conversations_from_dataset(
+                config.dataset_name,
+                config.split,
+                config.subset,
+                config.sample_count,
+            )
+        else:
+            raise ValueError(
+                "Either conversations, dataset_path, or dataset_name must be provided"
+            )
+
+    logger.info(f"Loaded {len(conversations)} conversations for analysis")
+
+    analyzers = []
+    for analyzer_config in config.analyzers:
+        analyzer = create_analyzer_from_config(
+            analyzer_config.id,
+            analyzer_config.params,
+        )
+        if analyzer is not None:
+            analyzer.analyzer_id = analyzer_config.instance_id
+            analyzers.append(analyzer)
+
+    if not analyzers:
+        raise ValueError("No valid analyzers configured")
+
+    pipeline = AnalysisPipeline(
+        analyzers=analyzers,
+        cache_dir=config.output_path if config.output_path != "." else None,
+    )
+
+    results = pipeline.run(conversations)
+
+    test_summary = None
+    if config.tests:
+        test_engine = TestEngine(config.tests)
+        test_summary = test_engine.run(results)
+
+    df = pipeline.to_dataframe()
+
+    return {
+        "results": results,
+        "test_summary": test_summary,
+        "dataframe": df,
+        "conversations": conversations,
+    }
+
+
+def save_results(
+    output_path: str | Path,
+    results: dict[str, Any],
+    output_format: str = "parquet",
+) -> None:
+    """Save analysis results to disk."""
+    output_dir = Path(output_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    df = results["dataframe"]
+    if output_format == "csv":
+        df.to_csv(output_dir / "analysis.csv", index=False)
+    elif output_format == "json":
+        df.to_json(output_dir / "analysis.json", orient="records", indent=2)
+    elif output_format == "parquet":
+        df.to_parquet(output_dir / "analysis.parquet", index=False)
+
+    logger.info(f"Saved analysis DataFrame to {output_dir}/analysis.{output_format}")
+
+    test_summary = results.get("test_summary")
+    if test_summary:
+        with open(output_dir / "test_results.json", "w") as f:
+            json.dump(test_summary.to_dict(), f, indent=2, default=str)
+        logger.info(f"Saved test results to {output_dir}/test_results.json")
+
+    summary: dict[str, Any] = {
+        "total_conversations": len(results["conversations"]),
+        "analyzers_run": list(results["results"].keys()),
+    }
+    if test_summary:
+        summary["tests"] = {
+            "total": test_summary.total_tests,
+            "passed": test_summary.passed_tests,
+            "failed": test_summary.failed_tests,
+            "pass_rate": test_summary.pass_rate,
+        }
+
+    with open(output_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+    logger.info(f"Saved analysis summary to {output_dir}/summary.json")
+
+
+def print_summary(results: dict[str, Any]) -> None:
+    """Print a summary of analysis results to console."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+
+    console.print("\n[bold cyan]Analysis Summary[/bold cyan]\n")
+    console.print(f"Conversations analyzed: {len(results['conversations'])}")
+    console.print(f"Analyzers run: {', '.join(results['results'].keys())}")
+
+    test_summary = results.get("test_summary")
+    if test_summary:
+        console.print("\n[bold]Test Results:[/bold]")
+        console.print(
+            f"  Passed: {test_summary.passed_tests}/{test_summary.total_tests} "
+            f"({test_summary.pass_rate}%)"
+        )
+        if test_summary.high_severity_failures > 0:
+            console.print(
+                "  [red]High severity failures: "
+                f"{test_summary.high_severity_failures}[/red]"
+            )
+
+        failed = test_summary.get_failed_results()
+        if failed:
+            console.print("\n[bold red]Failed Tests:[/bold red]")
+            table = Table(show_header=True)
+            table.add_column("Test ID")
+            table.add_column("Severity")
+            table.add_column("Affected")
+            table.add_column("Title")
+
+            for result in failed[:10]:  # Show first 10
+                table.add_row(
+                    result.test_id,
+                    result.severity.value,
+                    f"{result.affected_percentage}%",
+                    result.title,
+                )
+            console.print(table)
+
+    df = results["dataframe"]
+    console.print(
+        f"\n[bold]DataFrame Shape:[/bold] {df.shape[0]} rows x {df.shape[1]} columns"
+    )
+
+    metric_cols = [c for c in df.columns if "__" in c][:5]
+    if metric_cols:
+        console.print("\n[bold]Sample Metrics:[/bold]")
+        for col in metric_cols:
+            values = df[col].dropna()
+            if len(values) > 0:
+                # Skip list-type columns (e.g., message_token_counts)
+                if values.apply(lambda x: isinstance(x, list)).any():
+                    continue
+                if values.dtype in ["int64", "float64"]:
+                    console.print(
+                        f"  {col}: mean={values.mean():.2f}, "
+                        f"min={values.min()}, max={values.max()}"
+                    )
+                else:
+                    try:
+                        console.print(
+                            f"  {col}: {values.value_counts().head(3).to_dict()}"
+                        )
+                    except TypeError:
+                        continue
+
+
+def run_from_config_file(
+    config_path: str | Path,
+    output_path: str | None = None,
+    output_format: str = "parquet",
+) -> dict[str, Any]:
+    """Run analysis from a YAML configuration file."""
+    from oumi.analyze.config import TypedAnalyzeConfig
+
+    config = TypedAnalyzeConfig.from_yaml(config_path)
+    if output_path:
+        config.output_path = output_path
+
+    results = run_typed_analysis(config)
+    if config.output_path:
+        save_results(config.output_path, results, output_format)
+
+    return results
+
+
+def list_metrics(analyzer_name: str | None = None) -> None:
+    """List available metrics for analyzers."""
+    from oumi.analyze.discovery import print_analyzer_metrics
+
+    print_analyzer_metrics(analyzer_name)
+
+
+def _check_old_config_format(config_path: str) -> None:
+    """Check if a config file uses the old AnalyzeConfig (v1) format and exit if so."""
+    import yaml
+
+    try:
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+    except Exception:
+        return  # Let the normal loader handle errors
+
+    if not isinstance(data, dict):
+        return
+
+    old_fields_found = _OLD_CONFIG_FIELDS & set(data.keys())
+    if old_fields_found:
+        cli_utils.CONSOLE.print(
+            "[red]Error:[/red] This config file uses the old AnalyzeConfig (v1) "
+            "format.\n\n"
+            f"Detected v1 fields: {', '.join(sorted(old_fields_found))}\n\n"
+            "The analyze CLI now uses TypedAnalyzeConfig (v2). Key changes:\n"
+            "  - 'analyzers' entries use 'id' and 'instance_id'\n"
+            "  - Metrics are accessed as '{instance_id}.{field}' "
+            "(e.g. 'Length.total_tokens')\n"
+            "  - 'dataset_source', 'processor_name', 'is_multimodal' "
+            "are no longer needed\n\n"
+            "See: docs/user_guides/analyze/analyze_config.md for the new format.\n"
+            "Example: configs/examples/analyze/analyze.yaml"
+        )
+        raise typer.Exit(code=1)
+
+
+def _run_typed_analysis_cli(
+    config: str,
+    output: str | None,
+    output_format: str,
+    list_metrics_flag: bool,
+    verbose: bool,
+    dataset_name: str | None = None,
+    dataset_path: str | None = None,
+    sample_count: int | None = None,
+) -> None:
+    """Run analysis using the typed analyzer system."""
+    from oumi.analyze.config import TypedAnalyzeConfig
+
+    try:
+        if list_metrics_flag:
+            cli_utils.CONSOLE.print("\n[bold cyan]Available Metrics[/bold cyan]\n")
+            list_metrics()
+            return
+
+        _check_old_config_format(config)
+        with cli_utils.CONSOLE.status(
+            "[green]Loading configuration...[/green]", spinner="dots"
+        ):
+            typed_config = TypedAnalyzeConfig.from_yaml(config)
+
+        if output:
+            typed_config.output_path = output
+        if dataset_name is not None:
+            typed_config.dataset_name = dataset_name
+        if dataset_path is not None:
+            typed_config.dataset_path = dataset_path
+        if sample_count is not None:
+            typed_config.sample_count = sample_count
+
+        if verbose:
+            cli_utils.CONSOLE.print(f"[dim]Config loaded from: {config}[/dim]")
+            dataset = typed_config.dataset_name or typed_config.dataset_path
+            cli_utils.CONSOLE.print(f"[dim]Dataset: {dataset}[/dim]")
+            analyzer_ids = [a.instance_id for a in typed_config.analyzers]
+            cli_utils.CONSOLE.print(f"[dim]Analyzers: {analyzer_ids}[/dim]")
+
+        with cli_utils.CONSOLE.status(
+            "[green]Running analysis...[/green]", spinner="dots"
+        ):
+            results = run_typed_analysis(typed_config)
+
+        print_summary(results)
+
+        if typed_config.output_path:
+            save_results(typed_config.output_path, results, output_format)
+            cli_utils.CONSOLE.print(
+                f"\n[green]Results saved to:[/green] {typed_config.output_path}"
+            )
+
+    except FileNotFoundError as e:
+        logger.error(f"Configuration file not found: {e}")
+        cli_utils.CONSOLE.print(f"[red]Error:[/red] Configuration file not found: {e}")
+        raise typer.Exit(code=1)
+
+    except ValueError as e:
+        logger.error(f"Invalid configuration: {e}")
+        cli_utils.CONSOLE.print(f"[red]Error:[/red] Invalid configuration: {e}")
+        raise typer.Exit(code=1)
+
+    except Exception as e:
+        logger.error(f"Analysis failed: {e}", exc_info=True)
+        cli_utils.CONSOLE.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
 
 
 def analyze(
     ctx: typer.Context,
-    # Main options
     config: Annotated[
-        str,
+        str | None,
         typer.Option(
             *cli_utils.CONFIG_FLAGS,
             help="Path or config name for analysis.",
             rich_help_panel="Options",
             autocompletion=complete_analyze_config,
         ),
-    ],
+    ] = None,
     list_configs: Annotated[
         bool,
         typer.Option(
@@ -56,6 +542,14 @@ def analyze(
             help="List all available analysis configs.",
             callback=_list_configs_callback,
             is_eager=True,
+            rich_help_panel="Options",
+        ),
+    ] = False,
+    list_metrics_flag: Annotated[
+        bool,
+        typer.Option(
+            "--list-metrics",
+            help="List all available metrics for test configurations.",
             rich_help_panel="Options",
         ),
     ] = False,
@@ -81,12 +575,11 @@ def analyze(
             rich_help_panel="Options",
         ),
     ] = False,
-    # Data overrides
     dataset_name: Annotated[
         str | None,
         typer.Option(
             "--dataset_name",
-            help="Dataset name to analyze.",
+            help="Dataset name to analyze (overrides config).",
             rich_help_panel="Data",
         ),
     ] = None,
@@ -94,7 +587,7 @@ def analyze(
         str | None,
         typer.Option(
             "--dataset_path",
-            help="Path to custom dataset file (JSON or JSONL).",
+            help="Path to dataset file in JSONL format (overrides config).",
             rich_help_panel="Data",
         ),
     ] = None,
@@ -102,17 +595,16 @@ def analyze(
         int | None,
         typer.Option(
             "--sample_count",
-            help="Number of examples to sample from the dataset.",
+            help="Number of samples to analyze (overrides config).",
             rich_help_panel="Data",
         ),
     ] = None,
-    # Output options
     output: Annotated[
         str | None,
         typer.Option(
             "--output",
             "-o",
-            help="Output directory for analysis results.",
+            help="Output directory for analysis results (overrides config).",
             rich_help_panel="Output",
         ),
     ] = None,
@@ -126,23 +618,34 @@ def analyze(
         ),
     ] = "csv",
 ):
-    """Analyze a dataset to compute metrics and statistics.
+    """Analyze a dataset to compute metrics and statistics."""
+    if ctx.invoked_subcommand is not None:
+        return
 
-    Args:
-        ctx: The Typer context object.
-        config: Path to the configuration file for analysis.
-        list_configs: List all available analysis configs.
-        level: The logging level for the specified command.
-        verbose: Enable verbose logging with additional debug information.
-        dataset_name: Dataset name to analyze.
-        dataset_path: Path to custom dataset file.
-        sample_count: Number of examples to sample.
-        output: Output directory for results.
-        output_format: Output format (csv, json, parquet).
-    """
-    from oumi.core.analyze.dataset_analyzer import DatasetAnalyzer
+    if list_metrics_flag:
+        _run_typed_analysis_cli(
+            config=config or "",
+            output=output,
+            output_format="csv",
+            list_metrics_flag=True,
+            verbose=verbose,
+        )
+        return
 
-    # Validate output format early before any expensive operations
+    if config is not None:
+        config = str(
+            cli_utils.resolve_and_fetch_config(
+                try_get_config_name_for_alias(config, AliasType.ANALYZE),
+            )
+        )
+
+    if config is None:
+        cli_utils.CONSOLE.print(
+            "[red]Error:[/red] Missing option '--config' / '-c'.\n"
+            "Run 'oumi analyze --help' for usage."
+        )
+        raise typer.Exit(code=1)
+
     output_format = output_format.lower()
     if output_format not in _VALID_OUTPUT_FORMATS:
         cli_utils.CONSOLE.print(
@@ -151,256 +654,13 @@ def analyze(
         )
         raise typer.Exit(code=1)
 
-    try:
-        # Auto-collect overrides from dot-notation options
-        option_overrides = cli_utils.collect_config_overrides(ctx)
-        # Parse any additional extra args from command line
-        extra_args = cli_utils.parse_extra_cli_args(ctx)
-        # Combine: explicit options take precedence (added last)
-        all_overrides = extra_args + option_overrides
-
-        config = str(
-            cli_utils.resolve_and_fetch_config(
-                try_get_config_name_for_alias(config, AliasType.ANALYZE),
-            )
-        )
-
-        with cli_utils.CONSOLE.status(
-            "[green]Loading configuration...[/green]", spinner="dots"
-        ):
-            # Delayed imports
-            from oumi.core.configs import AnalyzeConfig
-
-        # Load configuration
-        parsed_config: AnalyzeConfig = AnalyzeConfig.from_yaml_and_arg_list(
-            config, all_overrides, logger=logger
-        )
-
-        # Apply non-dot-notation overrides
-        if dataset_name is not None:
-            parsed_config.dataset_name = dataset_name
-        if dataset_path is not None:
-            parsed_config.dataset_path = dataset_path
-        if sample_count is not None:
-            parsed_config.sample_count = sample_count
-        if output is not None:
-            parsed_config.output_path = output
-
-        # Validate configuration
-        parsed_config.finalize_and_validate()
-
-        if verbose:
-            parsed_config.print_config(logger)
-
-        # Create analyzer
-        with cli_utils.CONSOLE.status(
-            "[green]Loading dataset...[/green]", spinner="dots"
-        ):
-            analyzer = DatasetAnalyzer(parsed_config)
-
-        # Run analysis
-        with cli_utils.CONSOLE.status(
-            "[green]Running analysis...[/green]", spinner="dots"
-        ):
-            analyzer.analyze_dataset()
-
-        # Display summary
-        _display_analysis_summary(analyzer)
-
-        # Export results
-        if parsed_config.output_path:
-            _export_results(analyzer, parsed_config.output_path, output_format)
-
-    except FileNotFoundError as e:
-        logger.error(f"Configuration file not found: {e}")
-        cli_utils.CONSOLE.print(f"[red]Error:[/red] Configuration file not found: {e}")
-        raise typer.Exit(code=1)
-
-    except ValueError as e:
-        logger.error(f"Invalid configuration: {e}")
-        cli_utils.CONSOLE.print(f"[red]Error:[/red] Invalid configuration: {e}")
-        raise typer.Exit(code=1)
-
-    except RuntimeError as e:
-        logger.error(f"Analysis failed: {e}")
-        cli_utils.CONSOLE.print(f"[red]Error:[/red] Analysis failed: {e}")
-        raise typer.Exit(code=1)
-
-    except Exception as e:
-        logger.error(f"Unexpected error during analysis: {e}", exc_info=True)
-        cli_utils.CONSOLE.print(f"[red]Unexpected error:[/red] {e}")
-        raise typer.Exit(code=1)
-
-
-def _display_analysis_summary(analyzer: "DatasetAnalyzer") -> None:
-    """Display analysis summary in formatted tables to the console."""
-    summary = analyzer.analysis_summary
-
-    # Dataset overview table
-    overview = summary.get("dataset_overview", {})
-    if overview:
-        table = Table(
-            title="Dataset Overview",
-            title_style="bold magenta",
-            show_lines=True,
-        )
-        table.add_column("Metric", style="cyan")
-        table.add_column("Value", style="green")
-
-        table.add_row("Dataset Name", str(overview.get("dataset_name", "N/A")))
-        table.add_row(
-            "Total Conversations", str(overview.get("total_conversations", "N/A"))
-        )
-        table.add_row(
-            "Conversations Analyzed", str(overview.get("conversations_analyzed", "N/A"))
-        )
-        table.add_row(
-            "Coverage",
-            f"{overview.get('dataset_coverage_percentage', 0):.1f}%",
-        )
-        table.add_row("Total Messages", str(overview.get("total_messages", "N/A")))
-        table.add_row(
-            "Analyzers Used",
-            ", ".join(overview.get("analyzers_used", [])) or "None",
-        )
-        cli_utils.CONSOLE.print(table)
-
-    # Message-level summary
-    msg_summary = summary.get("message_level_summary", {})
-    if msg_summary:
-        table = Table(
-            title="Message-Level Metrics",
-            title_style="bold blue",
-            show_lines=True,
-        )
-        table.add_column("Metric", style="cyan")
-        table.add_column("Mean", style="green")
-        table.add_column("Std", style="yellow")
-        table.add_column("Min", style="dim")
-        table.add_column("Max", style="dim")
-        table.add_column("Median", style="dim")
-
-        for metric_name, stats in msg_summary.items():
-            if isinstance(stats, dict):
-                table.add_row(
-                    metric_name,
-                    f"{stats.get('mean', 'N/A'):.2f}"
-                    if isinstance(stats.get("mean"), int | float)
-                    else "N/A",
-                    f"{stats.get('std', 'N/A'):.2f}"
-                    if isinstance(stats.get("std"), int | float)
-                    else "N/A",
-                    str(stats.get("min", "N/A")),
-                    str(stats.get("max", "N/A")),
-                    f"{stats.get('median', 'N/A'):.2f}"
-                    if isinstance(stats.get("median"), int | float)
-                    else "N/A",
-                )
-        cli_utils.CONSOLE.print(table)
-
-    # Conversation-level summary
-    conv_summary = summary.get("conversation_level_summary", {})
-    if conv_summary:
-        table = Table(
-            title="Conversation-Level Metrics",
-            title_style="bold green",
-            show_lines=True,
-        )
-        table.add_column("Metric", style="cyan")
-        table.add_column("Mean", style="green")
-        table.add_column("Std", style="yellow")
-        table.add_column("Min", style="dim")
-        table.add_column("Max", style="dim")
-        table.add_column("Median", style="dim")
-
-        for metric_name, stats in conv_summary.items():
-            if isinstance(stats, dict):
-                table.add_row(
-                    metric_name,
-                    f"{stats.get('mean', 'N/A'):.2f}"
-                    if isinstance(stats.get("mean"), int | float)
-                    else "N/A",
-                    f"{stats.get('std', 'N/A'):.2f}"
-                    if isinstance(stats.get("std"), int | float)
-                    else "N/A",
-                    str(stats.get("min", "N/A")),
-                    str(stats.get("max", "N/A")),
-                    f"{stats.get('median', 'N/A'):.2f}"
-                    if isinstance(stats.get("median"), int | float)
-                    else "N/A",
-                )
-        cli_utils.CONSOLE.print(table)
-
-    # Conversation turns summary
-    turns_summary = summary.get("conversation_turns", {})
-    if turns_summary and isinstance(turns_summary, dict) and turns_summary.get("count"):
-        table = Table(
-            title="Conversation Turns",
-            title_style="bold yellow",
-            show_lines=True,
-        )
-        table.add_column("Statistic", style="cyan")
-        table.add_column("Value", style="green")
-
-        table.add_row("Count", str(turns_summary.get("count", "N/A")))
-        table.add_row(
-            "Mean",
-            f"{turns_summary.get('mean', 0):.2f}"
-            if isinstance(turns_summary.get("mean"), int | float)
-            else "N/A",
-        )
-        table.add_row(
-            "Std",
-            f"{turns_summary.get('std', 0):.2f}"
-            if isinstance(turns_summary.get("std"), int | float)
-            else "N/A",
-        )
-        table.add_row("Min", str(turns_summary.get("min", "N/A")))
-        table.add_row("Max", str(turns_summary.get("max", "N/A")))
-        table.add_row(
-            "Median",
-            f"{turns_summary.get('median', 0):.2f}"
-            if isinstance(turns_summary.get("median"), int | float)
-            else "N/A",
-        )
-        cli_utils.CONSOLE.print(table)
-
-
-def _export_results(
-    analyzer: "DatasetAnalyzer",
-    output_path: str,
-    output_format: str,
-) -> None:
-    """Export analysis results to files."""
-    output_dir = Path(output_path)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Export message-level results
-    if analyzer.message_df is not None and not analyzer.message_df.empty:
-        msg_path = output_dir / f"message_analysis.{output_format}"
-        _save_dataframe(analyzer.message_df, msg_path, output_format)
-        cli_utils.CONSOLE.print(f"[green]Saved message analysis to:[/green] {msg_path}")
-
-    # Export conversation-level results
-    if analyzer.conversation_df is not None and not analyzer.conversation_df.empty:
-        conv_path = output_dir / f"conversation_analysis.{output_format}"
-        _save_dataframe(analyzer.conversation_df, conv_path, output_format)
-        cli_utils.CONSOLE.print(
-            f"[green]Saved conversation analysis to:[/green] {conv_path}"
-        )
-
-    # Export summary as JSON
-    summary_path = output_dir / "analysis_summary.json"
-    with open(summary_path, "w") as f:
-        json.dump(analyzer.analysis_summary, f, indent=2, default=str)
-    cli_utils.CONSOLE.print(f"[green]Saved analysis summary to:[/green] {summary_path}")
-
-
-def _save_dataframe(df: "pd.DataFrame", path: Path, output_format: str) -> None:
-    """Save a DataFrame to the specified format."""
-    if output_format == "csv":
-        df.to_csv(path, index=False)
-    elif output_format == "json":
-        df.to_json(path, orient="records", indent=2)
-    elif output_format == "parquet":
-        df.to_parquet(path, index=False)
+    _run_typed_analysis_cli(
+        config=config,
+        output=output,
+        output_format=output_format,
+        list_metrics_flag=False,
+        verbose=verbose,
+        dataset_name=dataset_name,
+        dataset_path=dataset_path,
+        sample_count=sample_count,
+    )

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -97,7 +97,7 @@ def load_conversations_from_dataset(
     dataset = load_dataset(dataset_name, subset, split=split)
     conversations: list[Conversation] = []
     total = len(dataset)
-    limit = sample_count if sample_count else total
+    limit = sample_count if sample_count is not None else total
 
     for i in range(min(limit, total)):
         item = dataset[i]

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -81,8 +81,15 @@ def load_conversations_from_dataset(
     subset: str | None = None,
     sample_count: int | None = None,
 ) -> list[Conversation]:
-    """Load conversations from a HuggingFace dataset."""
+    """Load conversations from a HuggingFace dataset in Oumi format.
+
+    Each item must be parseable by ``Conversation.from_dict`` — i.e., already
+    have the Oumi ``{"messages": [...]}`` shape. Items that don't parse are
+    skipped with a warning.
+    """
     from datasets import load_dataset
+
+    from oumi.core.types.conversation import Conversation  # noqa: F811
 
     logger.info(f"Loading dataset: {dataset_name} (split={split}, subset={subset})")
 
@@ -92,105 +99,14 @@ def load_conversations_from_dataset(
     limit = sample_count if sample_count else total
 
     for i in range(min(limit, total)):
+        item = dataset[i]
         try:
-            item = dataset[i]
-            conv = _item_to_conversation(item, i)
-            if conv is not None:
-                conversations.append(conv)
+            conversations.append(Conversation.from_dict(item))
         except Exception as e:
-            logger.warning(f"Failed to convert item at index {i}: {e}")
+            logger.warning(f"Failed to parse conversation at index {i}: {e}")
 
     logger.info(f"Loaded {len(conversations)} conversations from {dataset_name}")
     return conversations
-
-
-def _item_to_conversation(item: Any, index: int) -> Any:
-    """Convert a dataset item to a Conversation, or None if conversion fails."""
-    from oumi.core.types.conversation import Conversation, Message, Role
-
-    if isinstance(item, Conversation):
-        return item
-
-    if isinstance(item, dict):
-        if "messages" in item:
-            try:
-                return Conversation.from_dict(item)
-            except Exception:
-                pass
-
-        if "conversation" in item:
-            conv_data = item["conversation"]
-            if isinstance(conv_data, list):
-                messages = []
-                for msg in conv_data:
-                    if isinstance(msg, dict):
-                        role_str = msg.get("role", msg.get("from", "user"))
-                        content = msg.get(
-                            "content", msg.get("text", msg.get("value", ""))
-                        )
-                        try:
-                            role = Role(role_str.lower())
-                        except ValueError:
-                            role = (
-                                Role.USER
-                                if role_str.lower() in ("human", "user")
-                                else Role.ASSISTANT
-                            )
-                        messages.append(Message(role=role, content=content))
-                return Conversation(messages=messages, metadata={"source_index": index})
-
-        prompt = None
-        response = None
-        context = None
-
-        for key in [
-            "prompt",
-            "instruction",
-            "original-instruction",
-            "question",
-            "input",
-        ]:
-            if key in item and item[key]:
-                prompt = item[key]
-                break
-
-        for key in [
-            "response",
-            "output",
-            "completion",
-            "original-response",
-            "answer",
-            "target",
-        ]:
-            if key in item and item[key]:
-                response = item[key]
-                break
-
-        for key in ["context", "original-context", "input_context"]:
-            if key in item and item[key]:
-                context = item[key]
-                break
-
-        if prompt:
-            if context:
-                full_prompt = f"{context}\n\n{prompt}"
-            else:
-                full_prompt = str(prompt)
-
-            messages = [
-                Message(role=Role.USER, content=full_prompt),
-            ]
-            if response:
-                messages.append(Message(role=Role.ASSISTANT, content=str(response)))
-            return Conversation(messages=messages, metadata={"source_index": index})
-
-        try:
-            return Conversation.from_dict(item)
-        except Exception:
-            pass
-
-    logger.debug(f"Could not convert item at index {index} to Conversation")
-    return None
 
 
 def get_analyzer_class(name: str) -> Any:

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -255,28 +255,6 @@ def print_summary(results: dict[str, Any]) -> None:
         f"\n[bold]DataFrame Shape:[/bold] {df.shape[0]} rows x {df.shape[1]} columns"
     )
 
-    metric_cols = [c for c in df.columns if "__" in c][:5]
-    if metric_cols:
-        console.print("\n[bold]Sample Metrics:[/bold]")
-        for col in metric_cols:
-            values = df[col].dropna()
-            if len(values) > 0:
-                # Skip list-type columns (e.g., message_token_counts)
-                if values.apply(lambda x: isinstance(x, list)).any():
-                    continue
-                if values.dtype in ["int64", "float64"]:
-                    console.print(
-                        f"  {col}: mean={values.mean():.2f}, "
-                        f"min={values.min()}, max={values.max()}"
-                    )
-                else:
-                    try:
-                        console.print(
-                            f"  {col}: {values.value_counts().head(3).to_dict()}"
-                        )
-                    except TypeError:
-                        continue
-
 
 def run_from_config_file(
     config_path: str | Path,

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -18,25 +18,20 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 import yaml
-from datasets import load_dataset
-from rich.console import Console
-from rich.table import Table
 
 import oumi.cli.cli_utils as cli_utils
-from oumi.analyze import create_analyzer_from_config
-from oumi.analyze.config import TypedAnalyzeConfig
-from oumi.analyze.discovery import print_analyzer_metrics
-from oumi.analyze.pipeline import AnalysisPipeline
-from oumi.analyze.testing.engine import TestEngine
 from oumi.cli.alias import AliasType, try_get_config_name_for_alias
 from oumi.cli.completions import complete_analyze_config
-from oumi.core.types.conversation import Conversation
 from oumi.utils.io_utils import load_jsonlines
 from oumi.utils.logging import logger
+
+if TYPE_CHECKING:
+    from oumi.analyze.config import TypedAnalyzeConfig
+    from oumi.core.types.conversation import Conversation
 
 _VALID_OUTPUT_FORMATS = ("csv", "json", "parquet")
 
@@ -59,6 +54,8 @@ def load_conversations_from_path(
     sample_count: int | None = None,
 ) -> list[Conversation]:
     """Load conversations from a JSONL file."""
+    from oumi.core.types.conversation import Conversation
+
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Dataset file not found: {path}")
@@ -91,6 +88,10 @@ def load_conversations_from_dataset(
     have the Oumi ``{"messages": [...]}`` shape. Items that don't parse are
     skipped with a warning.
     """
+    from datasets import load_dataset
+
+    from oumi.core.types.conversation import Conversation
+
     logger.info(f"Loading dataset: {dataset_name} (split={split}, subset={subset})")
 
     dataset = load_dataset(dataset_name, subset, split=split)
@@ -114,6 +115,10 @@ def run_typed_analysis(
     conversations: list | None = None,
 ) -> dict[str, Any]:
     """Run the typed analysis pipeline."""
+    from oumi.analyze import create_analyzer_from_config
+    from oumi.analyze.pipeline import AnalysisPipeline
+    from oumi.analyze.testing.engine import TestEngine
+
     if conversations is None:
         if config.dataset_path:
             conversations = load_conversations_from_path(
@@ -213,6 +218,9 @@ def save_results(
 
 def print_summary(results: dict[str, Any]) -> None:
     """Print a summary of analysis results to console."""
+    from rich.console import Console
+    from rich.table import Table
+
     console = Console()
 
     console.print("\n[bold cyan]Analysis Summary[/bold cyan]\n")
@@ -262,6 +270,8 @@ def run_from_config_file(
     output_format: str = "parquet",
 ) -> dict[str, Any]:
     """Run analysis from a YAML configuration file."""
+    from oumi.analyze.config import TypedAnalyzeConfig
+
     config = TypedAnalyzeConfig.from_yaml(config_path)
     if output_path:
         config.output_path = output_path
@@ -275,6 +285,8 @@ def run_from_config_file(
 
 def list_metrics(analyzer_name: str | None = None) -> None:
     """List available metrics for analyzers."""
+    from oumi.analyze.discovery import print_analyzer_metrics
+
     print_analyzer_metrics(analyzer_name)
 
 
@@ -318,6 +330,8 @@ def _run_typed_analysis_cli(
     sample_count: int | None = None,
 ) -> None:
     """Run analysis using the typed analyzer system."""
+    from oumi.analyze.config import TypedAnalyzeConfig
+
     try:
         if list_metrics_flag:
             cli_utils.CONSOLE.print("\n[bold cyan]Available Metrics[/bold cyan]\n")

--- a/src/oumi/cli/analyze.py
+++ b/src/oumi/cli/analyze.py
@@ -18,17 +18,24 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import Annotated, Any
 
 import typer
-
-if TYPE_CHECKING:
-    from oumi.analyze.config import TypedAnalyzeConfig
-    from oumi.core.types.conversation import Conversation
+import yaml
+from datasets import load_dataset
+from rich.console import Console
+from rich.table import Table
 
 import oumi.cli.cli_utils as cli_utils
+from oumi.analyze.config import TypedAnalyzeConfig
+from oumi.analyze.discovery import print_analyzer_metrics
+from oumi.analyze.pipeline import AnalysisPipeline
+from oumi.analyze.testing.engine import TestEngine
 from oumi.cli.alias import AliasType, try_get_config_name_for_alias
 from oumi.cli.completions import complete_analyze_config
+from oumi.core.registry import REGISTRY
+from oumi.core.types.conversation import Conversation
+from oumi.utils.io_utils import load_jsonlines
 from oumi.utils.logging import logger
 
 _VALID_OUTPUT_FORMATS = ("csv", "json", "parquet")
@@ -52,9 +59,6 @@ def load_conversations_from_path(
     sample_count: int | None = None,
 ) -> list[Conversation]:
     """Load conversations from a JSONL file."""
-    from oumi.core.types.conversation import Conversation  # noqa: F811
-    from oumi.utils.io_utils import load_jsonlines
-
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Dataset file not found: {path}")
@@ -87,10 +91,6 @@ def load_conversations_from_dataset(
     have the Oumi ``{"messages": [...]}`` shape. Items that don't parse are
     skipped with a warning.
     """
-    from datasets import load_dataset
-
-    from oumi.core.types.conversation import Conversation  # noqa: F811
-
     logger.info(f"Loading dataset: {dataset_name} (split={split}, subset={subset})")
 
     dataset = load_dataset(dataset_name, subset, split=split)
@@ -111,8 +111,6 @@ def load_conversations_from_dataset(
 
 def get_analyzer_class(name: str) -> Any:
     """Get an analyzer class by name from the core registry."""
-    from oumi.core.registry import REGISTRY
-
     return REGISTRY.get_sample_analyzer(name)
 
 
@@ -139,13 +137,10 @@ def create_analyzer_from_config(
 
 
 def run_typed_analysis(
-    config: TypedAnalyzeConfig,  # noqa: F821
+    config: TypedAnalyzeConfig,
     conversations: list | None = None,
 ) -> dict[str, Any]:
     """Run the typed analysis pipeline."""
-    from oumi.analyze.pipeline import AnalysisPipeline
-    from oumi.analyze.testing.engine import TestEngine
-
     if conversations is None:
         if config.dataset_path:
             conversations = load_conversations_from_path(
@@ -245,9 +240,6 @@ def save_results(
 
 def print_summary(results: dict[str, Any]) -> None:
     """Print a summary of analysis results to console."""
-    from rich.console import Console
-    from rich.table import Table
-
     console = Console()
 
     console.print("\n[bold cyan]Analysis Summary[/bold cyan]\n")
@@ -319,8 +311,6 @@ def run_from_config_file(
     output_format: str = "parquet",
 ) -> dict[str, Any]:
     """Run analysis from a YAML configuration file."""
-    from oumi.analyze.config import TypedAnalyzeConfig
-
     config = TypedAnalyzeConfig.from_yaml(config_path)
     if output_path:
         config.output_path = output_path
@@ -334,15 +324,11 @@ def run_from_config_file(
 
 def list_metrics(analyzer_name: str | None = None) -> None:
     """List available metrics for analyzers."""
-    from oumi.analyze.discovery import print_analyzer_metrics
-
     print_analyzer_metrics(analyzer_name)
 
 
 def _check_old_config_format(config_path: str) -> None:
     """Check if a config file uses the old AnalyzeConfig (v1) format and exit if so."""
-    import yaml
-
     try:
         with open(config_path) as f:
             data = yaml.safe_load(f)
@@ -381,8 +367,6 @@ def _run_typed_analysis_cli(
     sample_count: int | None = None,
 ) -> None:
     """Run analysis using the typed analyzer system."""
-    from oumi.analyze.config import TypedAnalyzeConfig
-
     try:
         if list_metrics_flag:
             cli_utils.CONSOLE.print("\n[bold cyan]Available Metrics[/bold cyan]\n")

--- a/src/oumi/cli/main.py
+++ b/src/oumi/cli/main.py
@@ -165,13 +165,21 @@ def get_app() -> typer.Typer:
     )(quantize)
 
     # Data
-    app.command(
+    analyze_app = typer.Typer(
+        pretty_exceptions_enable=False, context_settings=_HELP_OPTION_NAMES
+    )
+    analyze_app.callback(
+        invoke_without_command=True,
         context_settings=CONTEXT_ALLOW_EXTRA_ARGS,
+    )(analyze)
+    app.add_typer(
+        analyze_app,
+        name="analyze",
         help=get_command_help(
             "Compute statistics and metrics for a dataset.", AliasType.ANALYZE
         ),
         rich_help_panel="Data",
-    )(analyze)
+    )
     app.command(
         context_settings=CONTEXT_ALLOW_EXTRA_ARGS,
         help=get_command_help(

--- a/tests/unit/analyze/test_config.py
+++ b/tests/unit/analyze/test_config.py
@@ -23,16 +23,33 @@ from oumi.analyze.config import AnalyzerConfig, TypedAnalyzeConfig
 # -----------------------------------------------------------------------------
 
 
-def test_analyzer_config_requires_instance_id():
-    """Test that instance_id is required."""
-    config = AnalyzerConfig(id="length", instance_id="length")
-    assert config.instance_id == "length"
+def test_analyzer_config_defaults_display_name_to_type():
+    """display_name falls back to type when omitted."""
+    config = AnalyzerConfig(type="length")
+    assert config.type == "length"
+    assert config.display_name == "length"
+    assert config.id == "length"
 
 
-def test_analyzer_config_preserves_explicit_instance_id():
-    """Test that explicit instance_id is preserved."""
-    config = AnalyzerConfig(id="length", instance_id="length_custom")
-    assert config.instance_id == "length_custom"
+def test_analyzer_config_defaults_id_to_display_name():
+    """id falls back to display_name when omitted."""
+    config = AnalyzerConfig(type="length", display_name="My Length")
+    assert config.display_name == "My Length"
+    assert config.id == "My Length"
+
+
+def test_analyzer_config_preserves_explicit_id_and_display_name():
+    """Explicit id and display_name both survive __post_init__."""
+    config = AnalyzerConfig(type="length", id="asset-123", display_name="My Length")
+    assert config.type == "length"
+    assert config.id == "asset-123"
+    assert config.display_name == "My Length"
+
+
+def test_analyzer_config_requires_type():
+    """type must be provided."""
+    with pytest.raises(ValueError, match="type is required"):
+        AnalyzerConfig()
 
 
 # -----------------------------------------------------------------------------
@@ -41,11 +58,11 @@ def test_analyzer_config_preserves_explicit_instance_id():
 
 
 def test_from_dict_parses_analyzers():
-    """Test parsing analyzers from dict."""
+    """Parse analyzers using new field names."""
     data = {
         "analyzers": [
-            {"id": "length"},
-            {"id": "quality", "instance_id": "quality_check"},
+            {"type": "length"},
+            {"type": "quality", "display_name": "quality_check"},
             "turn_stats",  # String shorthand
         ]
     }
@@ -53,57 +70,120 @@ def test_from_dict_parses_analyzers():
     config = TypedAnalyzeConfig.from_dict(data)
 
     assert len(config.analyzers) == 3
+    assert config.analyzers[0].type == "length"
+    assert config.analyzers[0].display_name == "length"
     assert config.analyzers[0].id == "length"
-    assert config.analyzers[0].instance_id == "length"
-    assert config.analyzers[1].id == "quality"
-    assert config.analyzers[1].instance_id == "quality_check"
-    assert config.analyzers[2].id == "turn_stats"
+    assert config.analyzers[1].type == "quality"
+    assert config.analyzers[1].display_name == "quality_check"
+    assert config.analyzers[1].id == "quality_check"
+    assert config.analyzers[2].type == "turn_stats"
 
 
-def test_from_dict_raises_on_duplicate_instance_ids():
-    """Test that duplicate instance_id values raise an error."""
+def test_from_dict_accepts_explicit_id():
+    """An explicit id in YAML becomes the canonical identity."""
     data = {
         "analyzers": [
-            {"id": "length"},
-            {"id": "quality", "instance_id": "length"},  # Duplicate!
+            {"type": "length", "id": "asset-1", "display_name": "Length A"},
+            {"type": "length", "id": "asset-2", "display_name": "Length B"},
         ]
     }
 
-    with pytest.raises(ValueError, match="Duplicate analyzer instance_id"):
-        TypedAnalyzeConfig.from_dict(data)
+    config = TypedAnalyzeConfig.from_dict(data)
+
+    assert [a.id for a in config.analyzers] == ["asset-1", "asset-2"]
+    assert [a.display_name for a in config.analyzers] == ["Length A", "Length B"]
 
 
-def test_from_dict_raises_on_duplicate_default_instance_ids():
-    """Test that duplicate default instance_ids (from same id) raise an error."""
+def test_from_dict_allows_duplicate_display_names_when_ids_differ():
+    """Two analyzers may share a display_name as long as ids differ."""
     data = {
         "analyzers": [
-            {"id": "length"},
-            {"id": "length"},  # Same id -> same default instance_id
-        ]
-    }
-
-    with pytest.raises(ValueError, match="Duplicate analyzer instance_id"):
-        TypedAnalyzeConfig.from_dict(data)
-
-
-def test_from_dict_allows_same_type_with_different_instance_ids():
-    """Test that same analyzer type with different instance_ids is allowed."""
-    data = {
-        "analyzers": [
-            {"id": "length", "instance_id": "length_1"},
-            {"id": "length", "instance_id": "length_2"},
+            {"type": "length", "id": "asset-1", "display_name": "Length"},
+            {"type": "length", "id": "asset-2", "display_name": "Length"},
         ]
     }
 
     config = TypedAnalyzeConfig.from_dict(data)
 
     assert len(config.analyzers) == 2
-    assert config.analyzers[0].instance_id == "length_1"
-    assert config.analyzers[1].instance_id == "length_2"
+    assert config.analyzers[0].display_name == "Length"
+    assert config.analyzers[1].display_name == "Length"
+
+
+def test_from_dict_raises_on_duplicate_ids():
+    """Duplicate id values raise."""
+    data = {
+        "analyzers": [
+            {"type": "length", "id": "dup"},
+            {"type": "quality", "id": "dup"},
+        ]
+    }
+
+    with pytest.raises(ValueError, match="Duplicate analyzer id"):
+        TypedAnalyzeConfig.from_dict(data)
+
+
+def test_from_dict_raises_on_duplicate_defaulted_ids():
+    """Duplicate default ids (same type, no id/display_name) raise."""
+    data = {
+        "analyzers": [
+            {"type": "length"},
+            {"type": "length"},
+        ]
+    }
+
+    with pytest.raises(ValueError, match="Duplicate analyzer id"):
+        TypedAnalyzeConfig.from_dict(data)
+
+
+def test_from_dict_accepts_legacy_instance_id_with_deprecation():
+    """Legacy instance_id key still maps to display_name (with a warning)."""
+    data = {
+        "analyzers": [
+            {"type": "length", "instance_id": "length_custom"},
+        ]
+    }
+
+    with pytest.warns(DeprecationWarning, match="instance_id"):
+        config = TypedAnalyzeConfig.from_dict(data)
+
+    assert config.analyzers[0].display_name == "length_custom"
+    assert config.analyzers[0].id == "length_custom"
+
+
+def test_from_dict_handles_both_instance_id_and_display_name():
+    """When both legacy and new keys are present, display_name wins."""
+    data = {
+        "analyzers": [
+            {
+                "type": "length",
+                "instance_id": "legacy_name",
+                "display_name": "new_name",
+            },
+        ]
+    }
+
+    with pytest.warns(DeprecationWarning, match="instance_id"):
+        config = TypedAnalyzeConfig.from_dict(data)
+
+    assert config.analyzers[0].display_name == "new_name"
+
+
+def test_from_dict_rejects_legacy_id_as_type():
+    """Pre-#2376 YAMLs that used `id` in place of `type` now fail loudly.
+
+    `id` has new semantics (stable identity), so a YAML entry with only
+    `id` and no `type` triggers a targeted migration error pointing the
+    user at the rename.
+    """
+    data = {"analyzers": [{"id": "length"}]}
+
+    with pytest.raises(ValueError, match="Legacy analyzer entry"):
+        TypedAnalyzeConfig.from_dict(data)
 
 
 def test_from_dict_empty_analyzers():
-    """Test that empty analyzers list is valid."""
+    """Empty analyzers list is valid."""
     data = {"analyzers": []}
 
     config = TypedAnalyzeConfig.from_dict(data)
@@ -112,12 +192,32 @@ def test_from_dict_empty_analyzers():
 
 
 # -----------------------------------------------------------------------------
+# Tests: TypedAnalyzeConfig.to_dict
+# -----------------------------------------------------------------------------
+
+
+def test_to_dict_includes_id_field():
+    """to_dict round-trips type, id, and display_name."""
+    config = TypedAnalyzeConfig(
+        analyzers=[
+            AnalyzerConfig(type="length", id="asset-1", display_name="Length"),
+        ],
+    )
+
+    out = config.to_dict()
+
+    assert out["analyzers"][0]["type"] == "length"
+    assert out["analyzers"][0]["id"] == "asset-1"
+    assert out["analyzers"][0]["display_name"] == "Length"
+
+
+# -----------------------------------------------------------------------------
 # Tests: Custom Code Security
 # -----------------------------------------------------------------------------
 
 
 def test_from_dict_rejects_custom_code_by_default():
-    """Test that custom metrics with code are rejected by default."""
+    """Custom metrics with code are rejected by default."""
     data = {
         "custom_metrics": [
             {
@@ -132,7 +232,7 @@ def test_from_dict_rejects_custom_code_by_default():
 
 
 def test_from_dict_allows_custom_code_when_opted_in():
-    """Test that custom metrics with code work when allow_custom_code=True."""
+    """Custom metrics with code work when allow_custom_code=True."""
     data = {
         "custom_metrics": [
             {
@@ -149,7 +249,7 @@ def test_from_dict_allows_custom_code_when_opted_in():
 
 
 def test_from_dict_allows_empty_function():
-    """Test that custom metrics without function code are allowed."""
+    """Custom metrics without function code are allowed."""
     data = {
         "custom_metrics": [
             {

--- a/tests/unit/analyze/test_testing_engine.py
+++ b/tests/unit/analyze/test_testing_engine.py
@@ -470,7 +470,7 @@ def test_multi_instance_metrics_resolve_correctly():
 
     from pydantic import BaseModel
 
-    # Two length analyzers with different instance_ids
+    # Two length analyzers with different ids
     results: dict[str, list[BaseModel] | BaseModel] = {
         "length_tiktoken": cast(
             list[BaseModel],

--- a/tests/unit/cli/test_cli_analyze.py
+++ b/tests/unit/cli/test_cli_analyze.py
@@ -12,240 +12,174 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+import json
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
 
-import pytest
 import typer
+import yaml
 from typer.testing import CliRunner
 
-import oumi.cli.alias
 from oumi.cli.analyze import analyze
 from oumi.cli.cli_utils import CONTEXT_ALLOW_EXTRA_ARGS
-from oumi.core.configs import AnalyzeConfig, SampleAnalyzerParams
-from oumi.utils.logging import logger
 
 runner = CliRunner()
 
 
-@pytest.fixture
-def mock_fetch():
-    with patch("oumi.cli.cli_utils.resolve_and_fetch_config") as m_fetch:
-        yield m_fetch
-
-
-@pytest.fixture
-def mock_alias():
-    with patch("oumi.cli.analyze.try_get_config_name_for_alias") as try_alias:
-        yield try_alias
-
-
-def _create_analyze_config() -> AnalyzeConfig:
-    """Create a minimal valid AnalyzeConfig for testing."""
-    return AnalyzeConfig(
-        dataset_name="oumi-ai/oumi-synthetic-document-claims",
-        split="train",
-        sample_count=10,
-        analyzers=[
-            SampleAnalyzerParams(
-                id="length",
-                params={"char_count": True, "word_count": True},
-            )
+def _create_typed_config_yaml(
+    dataset_path: str,
+    output_path: str = "",
+) -> dict:
+    """Create a minimal typed analyzer config dict."""
+    return {
+        "dataset_path": dataset_path,
+        "output_path": output_path,
+        "analyzers": [
+            {"id": "length", "instance_id": "Length"},
         ],
-        output_path="",  # Empty to skip export in tests
-    )
+    }
 
 
-@pytest.fixture
-def app():
-    fake_app = typer.Typer()
-    fake_app.command(context_settings=CONTEXT_ALLOW_EXTRA_ARGS)(analyze)
-    yield fake_app
-
-
-@pytest.fixture
-def mock_dataset_analyzer():
-    # DatasetAnalyzer is imported inside the analyze function, so we need to patch
-    # it in the module where it's looked up
-    with patch(
-        "oumi.core.analyze.dataset_analyzer.DatasetAnalyzer", autospec=True
-    ) as m_analyzer_class:
-        # Create a mock analyzer instance
-        mock_instance = MagicMock()
-        mock_instance.analysis_summary = {
-            "dataset_overview": {
-                "dataset_name": "test_dataset",
-                "total_conversations": 100,
-                "conversations_analyzed": 10,
-                "dataset_coverage_percentage": 10.0,
-                "total_messages": 50,
-                "analyzers_used": ["length"],
-            },
-            "message_level_summary": {},
-            "conversation_level_summary": {},
-            "conversation_turns": {},
-        }
-        mock_instance.message_df = None
-        mock_instance.conversation_df = None
-        m_analyzer_class.return_value = mock_instance
-        yield m_analyzer_class
-
-
-def test_analyze_runs(app, mock_dataset_analyzer):
-    """Test that analyze command runs successfully with a valid config."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
-
-        runner.invoke(app, ["--config", yaml_path])
-
-        # Check the command completed (may exit with 0 or show output)
-        mock_dataset_analyzer.assert_called_once()
-        mock_dataset_analyzer.return_value.analyze_dataset.assert_called_once()
-
-
-def test_analyze_calls_alias(app, mock_dataset_analyzer, mock_alias):
-    """Test that analyze command resolves aliases correctly."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        mock_alias.return_value = yaml_path
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
-
-        _ = runner.invoke(app, ["--config", "an_alias"])
-
-        mock_alias.assert_has_calls(
-            [
-                call("an_alias", oumi.cli.alias.AliasType.ANALYZE),
+def _create_test_dataset(path: str) -> None:
+    """Create a minimal JSONL dataset file."""
+    conversations = [
+        {
+            "messages": [
+                {"role": "user", "content": "Hello, how are you?"},
+                {"role": "assistant", "content": "I'm doing well, thanks!"},
             ]
-        )
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "What is Python?"},
+                {
+                    "role": "assistant",
+                    "content": "Python is a programming language.",
+                },
+            ]
+        },
+    ]
+    with open(path, "w") as f:
+        for conv in conversations:
+            f.write(json.dumps(conv) + "\n")
 
 
-def test_analyze_with_output_override(app, mock_dataset_analyzer):
-    """Test that output path can be overridden via CLI."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        output_dir = str(Path(output_temp_dir) / "custom_output")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
-
-        # Mock message_df and conversation_df to test export
-        mock_dataset_analyzer.return_value.message_df = MagicMock()
-        mock_dataset_analyzer.return_value.message_df.empty = False
-        mock_dataset_analyzer.return_value.conversation_df = MagicMock()
-        mock_dataset_analyzer.return_value.conversation_df.empty = False
-
-        runner.invoke(app, ["--config", yaml_path, "--output", output_dir])
-
-        # The analyzer should have been called
-        mock_dataset_analyzer.assert_called_once()
+def _get_app() -> typer.Typer:
+    """Create a test Typer app with the analyze command."""
+    app = typer.Typer()
+    app.command(context_settings=CONTEXT_ALLOW_EXTRA_ARGS)(analyze)
+    return app
 
 
-def test_analyze_with_format_override(app, mock_dataset_analyzer):
-    """Test that output format can be overridden via CLI."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
+def test_analyze_runs_with_typed_config():
+    """Test that analyze command runs successfully with a typed config."""
+    app = _get_app()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dataset_path = str(Path(tmpdir) / "data.jsonl")
+        output_path = str(Path(tmpdir) / "output")
+        config_path = str(Path(tmpdir) / "config.yaml")
 
-        runner.invoke(app, ["--config", yaml_path, "--format", "json"])
+        _create_test_dataset(dataset_path)
+        config = _create_typed_config_yaml(dataset_path, output_path)
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
 
-        mock_dataset_analyzer.assert_called_once()
+        result = runner.invoke(app, ["--config", config_path])
+
+        assert result.exit_code == 0
+        # Output should contain analysis summary
+        assert "Analysis Summary" in result.stdout
+        assert "Conversations analyzed: 2" in result.stdout
+        # Output files should be created
+        assert Path(output_path).exists()
 
 
-def test_analyze_invalid_format(app):
+def test_analyze_invalid_format():
     """Test that invalid format raises an error early."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
+    app = _get_app()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = str(Path(tmpdir) / "config.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump({"analyzers": [{"id": "length"}]}, f)
 
         result = runner.invoke(
-            app, ["--config", yaml_path, "--format", "invalid_format"]
+            app, ["--config", config_path, "--format", "invalid_format"]
         )
 
         assert result.exit_code == 1
         assert "Invalid output format" in result.stdout
 
 
-def test_analyze_logging_levels(app, mock_dataset_analyzer):
-    """Test that logging levels can be configured via CLI."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
+def test_analyze_missing_config():
+    """Test that missing config shows an error."""
+    app = _get_app()
+    result = runner.invoke(app, [])
 
-        _ = runner.invoke(app, ["--config", yaml_path, "--log-level", "DEBUG"])
-        assert logger.level == logging.DEBUG
-
-        _ = runner.invoke(app, ["--config", yaml_path, "-log", "WARNING"])
-        assert logger.level == logging.WARNING
+    assert result.exit_code == 1
+    assert "Missing option" in result.stdout
 
 
-def test_analyze_with_cli_overrides(app, mock_dataset_analyzer):
-    """Test that config values can be overridden via CLI arguments."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
+def test_analyze_list_metrics():
+    """Test that --list-metrics flag works without a config."""
+    app = _get_app()
+    result = runner.invoke(app, ["--list-metrics"])
 
-        runner.invoke(
-            app,
-            [
-                "--config",
-                yaml_path,
-                "--sample_count",
-                "5",
-            ],
-        )
-
-        mock_dataset_analyzer.assert_called_once()
+    assert result.exit_code == 0
+    assert "Available Metrics" in result.stdout
+    assert "LengthAnalyzer" in result.stdout
 
 
-def test_analyze_with_oumi_prefix(app, mock_dataset_analyzer, mock_fetch):
-    """Test that oumi:// prefix config paths are resolved correctly."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        output_dir = Path(output_temp_dir)
-        yaml_path = "oumi://configs/examples/analyze/analyze.yaml"
-        expected_path = output_dir / "configs/examples/analyze/analyze.yaml"
+def test_analyze_output_format_csv():
+    """Test CSV output format."""
+    app = _get_app()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dataset_path = str(Path(tmpdir) / "data.jsonl")
+        output_path = str(Path(tmpdir) / "output")
+        config_path = str(Path(tmpdir) / "config.yaml")
 
-        config = _create_analyze_config()
-        expected_path.parent.mkdir(parents=True, exist_ok=True)
-        config.to_yaml(expected_path)
-        mock_fetch.return_value = expected_path
+        _create_test_dataset(dataset_path)
+        config = _create_typed_config_yaml(dataset_path, output_path)
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
 
-        with patch.dict("os.environ", {"OUMI_DIR": str(output_dir)}):
-            runner.invoke(app, ["--config", yaml_path])
+        result = runner.invoke(app, ["--config", config_path, "--format", "csv"])
 
-        mock_fetch.assert_called_once_with(yaml_path)
-
-
-def test_analyze_verbose_flag(app, mock_dataset_analyzer):
-    """Test that verbose flag enables additional debug output."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
-
-        runner.invoke(app, ["--config", yaml_path, "--verbose"])
-
-        mock_dataset_analyzer.assert_called_once()
+        assert result.exit_code == 0
+        assert (Path(output_path) / "analysis.csv").exists()
 
 
-def test_analyze_format_case_insensitive(app, mock_dataset_analyzer):
+def test_analyze_output_format_json():
+    """Test JSON output format."""
+    app = _get_app()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dataset_path = str(Path(tmpdir) / "data.jsonl")
+        output_path = str(Path(tmpdir) / "output")
+        config_path = str(Path(tmpdir) / "config.yaml")
+
+        _create_test_dataset(dataset_path)
+        config = _create_typed_config_yaml(dataset_path, output_path)
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+
+        result = runner.invoke(app, ["--config", config_path, "--format", "json"])
+
+        assert result.exit_code == 0
+        assert (Path(output_path) / "analysis.json").exists()
+
+
+def test_analyze_format_case_insensitive():
     """Test that output format is case-insensitive."""
-    with tempfile.TemporaryDirectory() as output_temp_dir:
-        yaml_path = str(Path(output_temp_dir) / "analyze.yaml")
-        config = _create_analyze_config()
-        config.to_yaml(yaml_path)
+    app = _get_app()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dataset_path = str(Path(tmpdir) / "data.jsonl")
+        output_path = str(Path(tmpdir) / "output")
+        config_path = str(Path(tmpdir) / "config.yaml")
 
-        # Test uppercase format
-        runner.invoke(app, ["--config", yaml_path, "--format", "CSV"])
-        mock_dataset_analyzer.assert_called()
+        _create_test_dataset(dataset_path)
+        config = _create_typed_config_yaml(dataset_path, output_path)
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
 
-        # Test mixed case format
-        runner.invoke(app, ["--config", yaml_path, "--format", "Json"])
-        mock_dataset_analyzer.assert_called()
+        result = runner.invoke(app, ["--config", config_path, "--format", "CSV"])
+
+        assert result.exit_code == 0

--- a/tests/unit/cli/test_cli_analyze.py
+++ b/tests/unit/cli/test_cli_analyze.py
@@ -35,7 +35,7 @@ def _create_typed_config_yaml(
         "dataset_path": dataset_path,
         "output_path": output_path,
         "analyzers": [
-            {"id": "length", "instance_id": "Length"},
+            {"type": "length", "display_name": "Length"},
         ],
     }
 
@@ -100,7 +100,7 @@ def test_analyze_invalid_format():
     with tempfile.TemporaryDirectory() as tmpdir:
         config_path = str(Path(tmpdir) / "config.yaml")
         with open(config_path, "w") as f:
-            yaml.dump({"analyzers": [{"id": "length"}]}, f)
+            yaml.dump({"analyzers": [{"type": "length"}]}, f)
 
         result = runner.invoke(
             app, ["--config", config_path, "--format", "invalid_format"]

--- a/tests/unit/core/configs/test_parse_configs.py
+++ b/tests/unit/core/configs/test_parse_configs.py
@@ -51,6 +51,7 @@ def _get_all_config_paths(exclude_yaml_suffixes: set[str] | None) -> list[str]:
         exclude_yaml_suffixes={
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
+            "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
         }
     ),
 )
@@ -86,6 +87,7 @@ def test_parse_configs(config_path: str):
         exclude_yaml_suffixes={
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
+            "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
         }
     ),
 )


### PR DESCRIPTION
# Description

Migrates `oumi analyze` from the legacy `DatasetAnalyzer` onto the typed framework (`TypedAnalyzeConfig` + `AnalysisPipeline` + `TestEngine`) that already lives in `src/oumi/analyze/`. First PR of a 4-PR split of #2370.

**What changed**

- Rewrite `src/oumi/cli/analyze.py` on top of the typed framework. Delegates analyzer construction to `oumi.analyze.create_analyzer_from_config` instead of keeping its own duplicate.
- Restore CLI flags: `--config`, `--list`, `--list-metrics`, `--log-level`, `--output`, `--format`, `--verbose`, plus `--dataset-path` / `--dataset-name` / `--sample-count` (snake_case forms accepted as aliases).
- Emit a friendly migration error when a user passes a legacy v1 `AnalyzeConfig` YAML (detected via `dataset_source`, `processor_name`, `is_multimodal`, etc.).
- Wrap analyze as a nested Typer app in `src/oumi/cli/main.py` so subcommands and help panels render.
- Replace `configs/examples/analyze/analyze.yaml` with the three-analyzer, five-test default recipe used by the API's auto-analysis flow.
- Rewrite `docs/user_guides/analyze/{analyze,analyze_config}.md` to match the new shape; exclude the v2 example from the legacy-config sweep in `tests/unit/core/configs/test_parse_configs.py`.

**Out of scope (follow-up PRs)**

- `type`/`display_name` rename in `AnalyzerConfig` → #2376
- `testing/engine.py` refactor + index / MRO fixes → #2377
- `analyze/{base,pipeline,discovery,utils}` cleanup → #2378

**Verification**

- `pytest tests/unit/cli/test_cli_analyze.py` — 7/7 pass.
- `pytest tests/unit/core/configs/test_parse_configs.py` — 984/984 pass.
- Smoke test: `oumi analyze --config configs/examples/analyze/analyze.yaml --dataset-path <local.jsonl>` runs end-to-end and writes `analysis.csv`, `test_results.json`, `summary.json`.

Usage example:
<img width="1744" height="1055" alt="analyze_cli_usage" src="https://github.com/user-attachments/assets/adfe8e9d-1604-4fa5-8263-5f466b578277" />


Using the old config (errors):
<img width="1747" height="742" alt="analyze_cli_old_config" src="https://github.com/user-attachments/assets/b94a14ad-d5a8-4ae9-9f70-e142de6652a0" />


## Related issues

Linear Issue: OPE-1868
Fixes OPE-1868

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of \`oumi-ai/oumi-staff\` is required.