### PR TITLE
fix(analyze): preserve sample indices and fix threshold truthiness

### DIFF
--- a/src/oumi/analyze/testing/batch_engine.py
+++ b/src/oumi/analyze/testing/batch_engine.py
@@ -289,7 +289,11 @@ class BatchTestEngine:
             affected_count=len(affected_ids),
             total_count=acc.total_count,
             affected_percentage=round(affected_pct, 2),
-            threshold=test.max_percentage or test.min_percentage,
+            threshold=(
+                test.max_percentage
+                if test.max_percentage is not None
+                else test.min_percentage
+            ),
             actual_value=None,
             sample_indices=[],  # Not meaningful for batch mode
             all_affected_indices=[],  # Not meaningful for batch mode

--- a/src/oumi/analyze/testing/engine.py
+++ b/src/oumi/analyze/testing/engine.py
@@ -113,7 +113,11 @@ class TestEngine:
             affected_count=len(affected_indices),
             total_count=total_count,
             affected_percentage=round(affected_pct, 2),
-            threshold=test.max_percentage or test.min_percentage,
+            threshold=(
+                test.max_percentage
+                if test.max_percentage is not None
+                else test.min_percentage
+            ),
             actual_value=actual_value,
             sample_indices=affected_indices[:MAX_SAMPLE_INDICES],
             all_affected_indices=affected_indices,
@@ -179,15 +183,15 @@ class TestEngine:
         if not test.metric:
             return self._create_error_result(test, "Test requires 'metric' field")
 
-        values = self._extract_metric_values(test.metric, results)
+        indexed_values = self._extract_metric_values(test.metric, results)
 
-        if not values:
+        if not indexed_values:
             return self._create_error_result(
                 test, f"Metric '{test.metric}' not found in results"
             )
 
         if test.type == TestType.THRESHOLD:
-            return self._run_threshold_test(test, values)
+            return self._run_threshold_test(test, indexed_values)
         else:
             return self._create_error_result(test, f"Unknown test type: {test.type}")
 
@@ -195,8 +199,14 @@ class TestEngine:
         self,
         metric: str,
         results: dict[str, list[BaseModel] | BaseModel],
-    ) -> list[Any]:
-        """Extract values for a metric path like "id.field_name"."""
+    ) -> list[tuple[int, Any]]:
+        """Extract ``(original_index, value)`` pairs for a metric path like "id.field_name".
+
+        Preserving the original sample index ensures that ``sample_indices``
+        and ``all_affected_indices`` in the resulting ``TestResult`` map back
+        to actual conversation positions, even if some samples are missing
+        the metric (and therefore filtered out).
+        """
         parts = metric.split(".")
         if len(parts) < 2:
             return []
@@ -211,15 +221,15 @@ class TestEngine:
 
         if isinstance(analyzer_results, BaseModel):
             value = self._get_nested_value(analyzer_results, field_path)
-            return [value] if value is not None else []
+            return [(0, value)] if value is not None else []
 
-        values = []
-        for result in analyzer_results:
+        indexed_values: list[tuple[int, Any]] = []
+        for i, result in enumerate(analyzer_results):
             value = self._get_nested_value(result, field_path)
             if value is not None:
-                values.append(value)
+                indexed_values.append((i, value))
 
-        return values
+        return indexed_values
 
     def _get_nested_value(self, obj: Any, field_path: list[str]) -> Any:
         """Get a nested field value from a Pydantic model or dict."""
@@ -259,7 +269,7 @@ class TestEngine:
     def _run_threshold_test(
         self,
         test: TestParams,
-        values: list[Any],
+        indexed_values: list[tuple[int, Any]],
     ) -> TestResult:
         """Run a threshold test against metric values."""
         if test.operator is None or test.value is None:
@@ -276,25 +286,25 @@ class TestEngine:
         matching_reasons: dict[int, str] = {}
         non_matching_reasons: dict[int, str] = {}
 
-        for i, value in enumerate(values):
+        for orig_idx, value in indexed_values:
             try:
                 if op_func(value, test.value):
-                    matching_indices.append(i)
-                    matching_reasons[i] = (
+                    matching_indices.append(orig_idx)
+                    matching_reasons[orig_idx] = (
                         f"Flagged: {test.metric} {test.operator} {test.value}"
                         f" (value={value})"
                     )
                 else:
-                    non_matching_indices.append(i)
-                    non_matching_reasons[i] = (
+                    non_matching_indices.append(orig_idx)
+                    non_matching_reasons[orig_idx] = (
                         f"Not flagged: {test.metric} {test.operator} {test.value}"
                         f" (value={value})"
                     )
             except (TypeError, ValueError):
-                non_matching_indices.append(i)
-                non_matching_reasons[i] = f"Cannot evaluate: {value}"
+                non_matching_indices.append(orig_idx)
+                non_matching_reasons[orig_idx] = f"Cannot evaluate: {value}"
 
-        total_count = len(values)
+        total_count = len(indexed_values)
         matching_count = len(matching_indices)
         if total_count > 0:
             matching_pct = 100.0 * matching_count / total_count
@@ -330,13 +340,15 @@ class TestEngine:
             affected_pct = matching_pct
             failure_reasons = matching_reasons
 
+        raw_values = [v for _, v in indexed_values]
+
         return self._build_test_result(
             test=test,
             passed=passed,
             total_count=total_count,
             affected_indices=affected_indices,
             affected_pct=affected_pct,
-            actual_value=self._get_actual_value(values),
+            actual_value=self._get_actual_value(raw_values),
             details={
                 "operator": test.operator,
                 "value": test.value,

--- a/src/oumi/analyze/testing/engine.py
+++ b/src/oumi/analyze/testing/engine.py
@@ -200,12 +200,24 @@ class TestEngine:
         metric: str,
         results: dict[str, list[BaseModel] | BaseModel],
     ) -> list[tuple[int, Any]]:
-        """Extract ``(original_index, value)`` pairs for a metric path like "id.field_name".
+        """Extract ``(original_index, value)`` pairs for a metric path.
 
-        Preserving the original sample index ensures that ``sample_indices``
-        and ``all_affected_indices`` in the resulting ``TestResult`` map back
-        to actual conversation positions, even if some samples are missing
-        the metric (and therefore filtered out).
+        The metric path is "id.field_name" (e.g., "length.total_tokens").
+
+        A sample can be "missing" a metric for several reasons:
+          - The analyzer's result model declares the field as optional and
+            leaves it ``None`` for that sample (e.g., couldn't compute on an
+            empty conversation, or a conditional code path that doesn't
+            produce the field).
+          - The metric lives in a ``CustomMetricResult.values`` dict whose
+            keys vary per sample (custom metric functions are user-written
+            and may emit different keys).
+          - A nested dict path has a missing intermediate key.
+
+        Such samples are filtered out, but we keep their original index so
+        ``sample_indices`` and ``all_affected_indices`` on the resulting
+        ``TestResult`` still point at real dataset positions instead of
+        offsets into the filtered list.
         """
         parts = metric.split(".")
         if len(parts) < 2:

--- a/tests/unit/analyze/test_testing_engine.py
+++ b/tests/unit/analyze/test_testing_engine.py
@@ -509,3 +509,55 @@ def test_multi_instance_metrics_resolve_correctly():
 
     assert summary.total_tests == 2
     assert summary.passed_tests == 2
+
+
+class _PartialMetrics(BaseModel):
+    """Metrics with an optional value for index-tracking tests."""
+
+    value: int | None = None
+
+
+def test_sample_indices_map_to_original_positions_when_values_are_missing():
+    """When some samples lack the metric, sample_indices must point to the
+    original conversation positions, not filtered-list positions."""
+    results: dict[str, list[BaseModel] | BaseModel] = {
+        "m": [
+            _PartialMetrics(value=1),
+            _PartialMetrics(value=None),  # index 1 is skipped during extraction
+            _PartialMetrics(value=999),  # the flagged one; must be reported as 2
+            _PartialMetrics(value=2),
+        ]
+    }
+    tests = [
+        TestParams(
+            id="flag_high",
+            type=TestType.THRESHOLD,
+            metric="m.value",
+            operator=">",
+            value=100,
+        )
+    ]
+    summary = TestEngine(tests).run(results)
+
+    result = summary.results[0]
+    assert result.passed is False
+    assert result.sample_indices == [2]
+    assert result.all_affected_indices == [2]
+
+
+def test_threshold_with_max_percentage_zero_sets_threshold_field():
+    """A max_percentage of 0 must surface as threshold=0.0, not fall through
+    to min_percentage (fixes the ``a or b`` truthiness bug)."""
+    results: dict[str, list[BaseModel] | BaseModel] = {"m": [_PartialMetrics(value=1)]}
+    tests = [
+        TestParams(
+            id="zero_pct",
+            type=TestType.THRESHOLD,
+            metric="m.value",
+            operator=">",
+            value=100,
+            max_percentage=0.0,
+        )
+    ]
+    summary = TestEngine(tests).run(results)
+    assert summary.results[0].threshold == 0.0

--- a/tests/unit/analyze/test_testing_engine.py
+++ b/tests/unit/analyze/test_testing_engine.py
@@ -518,14 +518,26 @@ class _PartialMetrics(BaseModel):
 
 
 def test_sample_indices_map_to_original_positions_when_values_are_missing():
-    """When some samples lack the metric, sample_indices must point to the
-    original conversation positions, not filtered-list positions."""
+    """Regression test: when some samples lack the metric, ``sample_indices``
+    must point to the original conversation positions, not offsets into the
+    filtered list.
+
+    Previous code built ``values: list[Any]`` by enumerating analyzer
+    results and dropping ``None``s, then re-numbered the survivors 0..N-1.
+    With the dataset below, the flagged sample is at dataset index ``2``,
+    but the old code reported it as ``1`` (its position after filtering).
+    Downstream "drop these rows" tooling that consumed ``all_affected_indices``
+    therefore deleted the wrong rows.
+
+    The fix changes extraction to return ``(original_index, value)`` pairs,
+    so the index reported in the result still maps to the dataset.
+    """
     results: dict[str, list[BaseModel] | BaseModel] = {
         "m": [
-            _PartialMetrics(value=1),
-            _PartialMetrics(value=None),  # index 1 is skipped during extraction
-            _PartialMetrics(value=999),  # the flagged one; must be reported as 2
-            _PartialMetrics(value=2),
+            _PartialMetrics(value=1),  # dataset idx 0 — not flagged
+            _PartialMetrics(value=None),  # dataset idx 1 — filtered out
+            _PartialMetrics(value=999),  # dataset idx 2 — the flagged sample
+            _PartialMetrics(value=2),  # dataset idx 3 — not flagged
         ]
     }
     tests = [
@@ -545,19 +557,69 @@ def test_sample_indices_map_to_original_positions_when_values_are_missing():
     assert result.all_affected_indices == [2]
 
 
-def test_threshold_with_max_percentage_zero_sets_threshold_field():
-    """A max_percentage of 0 must surface as threshold=0.0, not fall through
-    to min_percentage (fixes the ``a or b`` truthiness bug)."""
+def test_zero_tolerance_threshold_is_reported_as_zero_not_none():
+    """Regression test: ``max_percentage=0.0`` must surface as
+    ``threshold=0.0`` on the TestResult.
+
+    Previous code built the result with::
+
+        threshold=test.max_percentage or test.min_percentage
+
+    Because ``0.0`` is falsy in Python, ``0.0 or None`` evaluated to
+    ``None`` — so a "zero tolerance" policy (e.g., ``max_percentage=0.0``
+    on a "no PII allowed" rule) was reported with ``threshold=None``,
+    making the rendered CLI/JSON output gaslight reviewers about which
+    threshold actually fired. The pass/fail decision was still correct
+    (it uses ``is not None`` checks), but the reported threshold was wrong.
+
+    This test pins the reporting fix.
+    """
+    # A single sample that flags the rule (value=1 > 0), driving the
+    # test to FAIL with matching_pct=100% > max_percentage=0.0%.
     results: dict[str, list[BaseModel] | BaseModel] = {"m": [_PartialMetrics(value=1)]}
     tests = [
         TestParams(
-            id="zero_pct",
+            id="no_pii_allowed",  # mimics a real "zero tolerance" rule
             type=TestType.THRESHOLD,
             metric="m.value",
             operator=">",
-            value=100,
-            max_percentage=0.0,
+            value=0,
+            max_percentage=0.0,  # the value the old `a or b` swallowed
         )
     ]
     summary = TestEngine(tests).run(results)
-    assert summary.results[0].threshold == 0.0
+
+    result = summary.results[0]
+    assert result.passed is False, "1/1 samples flagged > 0% allowed → must fail"
+    assert result.threshold == 0.0, (
+        "threshold must reflect the user-configured 0.0, not fall through to "
+        "min_percentage via Python's truthy `or` semantics"
+    )
+
+
+def test_zero_tolerance_threshold_picks_max_when_both_are_set():
+    """Regression test for the "both set" variant of the truthiness bug.
+
+    With ``max_percentage=0.0`` and ``min_percentage=50.0``, the old
+    ``test.max_percentage or test.min_percentage`` evaluated to ``50.0``
+    — confidently misattributing the threshold to the min rule when the
+    max rule is the one that fired. The fix's explicit ``is not None``
+    check picks ``max_percentage`` whenever it was set, regardless of value.
+    """
+    results: dict[str, list[BaseModel] | BaseModel] = {"m": [_PartialMetrics(value=1)]}
+    tests = [
+        TestParams(
+            id="zero_max_with_min",
+            type=TestType.THRESHOLD,
+            metric="m.value",
+            operator=">",
+            value=0,
+            max_percentage=0.0,
+            min_percentage=50.0,
+        )
+    ]
+    summary = TestEngine(tests).run(results)
+
+    assert summary.results[0].threshold == 0.0, (
+        "max_percentage=0.0 was explicitly set; it must win over min_percentage"
+    )


### PR DESCRIPTION
# Description

Part of the **analyze v2** split of #2370 (Phase 3 of 4). Standalone fixes — not dependent on PRs #2375 / #2376.

Two related fixes to the analyze test engine.

## 1. Preserve original sample indices

`TestEngine._extract_metric_values` now returns `(original_index, value)` pairs so that `sample_indices` and `all_affected_indices` on the resulting `TestResult` point to real conversation positions in the dataset.

**Why a sample can be "missing" a metric** (i.e., why `_get_nested_value` returns `None`):

- The analyzer's result model declares the field as optional and leaves it `None` for that sample (e.g., couldn't compute on an empty conversation, or a conditional code path that doesn't produce the field).
- The metric lives in a `CustomMetricResult.values` dict whose keys vary per sample (custom metric functions are user-written and may emit different keys per input).
- A nested dict path has a missing intermediate key.

**The bug.** Previously, the code enumerated `analyzer_results` and dropped Nones, then re-numbered the survivors `0..N-1`. With 100 samples where #5 and #42 lacked the metric, indices `5..98` in the result list pointed to dataset samples `6..99`. Any downstream "drop these flagged rows" tooling consuming `all_affected_indices` deleted the wrong rows.

## 2. Fix threshold truthiness bug

The result-builder used:

```python
threshold=test.max_percentage or test.min_percentage,
```

`or` returns the first truthy operand, and **`0.0` is falsy in Python**. So a "zero tolerance" rule like:

```yaml
- id: no_pii_allowed
  type: threshold
  metric: pii.count
  operator: ">"
  value: 0
  max_percentage: 0.0   # fail if ANY sample has pii.count > 0
```

…produced `0.0 or None` → `None` on the `TestResult.threshold` field. The CLI table, `--output-json`, and any downstream tool reading the result then displayed `threshold: —` instead of `0.0`, hiding the user's actual policy.

The "both set" variant is sneakier: with `max_percentage=0.0` and `min_percentage=50.0`, `0.0 or 50.0` → `50.0` — confidently misattributing the threshold to the min rule when the max rule fired.

The pass/fail decision itself wasn't broken (that path uses explicit `is not None` checks). What was broken was the *reported* threshold. Replaced with explicit `is not None` in both the in-memory `TestEngine` and the incremental `BatchTestEngine`:

```python
threshold=(
    test.max_percentage
    if test.max_percentage is not None
    else test.min_percentage
),
```

## Tests

`tests/unit/analyze/test_testing_engine.py` adds three regression tests with docstrings that quote the buggy code so the intent survives future rewrites:

- `test_sample_indices_map_to_original_positions_when_values_are_missing`
- `test_zero_tolerance_threshold_is_reported_as_zero_not_none`
- `test_zero_tolerance_threshold_picks_max_when_both_are_set`

## Related issues

Linear Issue: [OPE-1868](https://linear.app/oumi-team/issue/OPE-1868)
Towards OPE-1868

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

🤖 Generated with [Claude Code](https://claude.com/claude-code)