### PR TITLE
[Det Env] Phase 1: Planner guided decoding & tool schema

### DIFF
--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -144,7 +144,8 @@ class ToolParams(BaseParams):
     def to_llm_schema(self) -> dict[str, Any]:
         """Export a provider-agnostic schema for LLM tool registration."""
         schema: dict[str, Any] = {
-            "name": self.name,
+            "name": self.id,
+            "display_name": self.name,
             "description": self.description,
             "parameters": self.parameters.to_dict(),
         }

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -104,18 +104,28 @@ class ConversationSynthesizer:
 
         lines = [
             "You have access to the following tools.",
-            "Do not invent tools. Use only the tools listed below.",
-            "When a tool is needed, emit the expected tool-call format exactly.",
+            "When a tool is needed, emit exactly one tool call in this format:",
+            "",
+            "<tool_call>",
+            '{"name": "<tool_name>", "arguments": {...}}',
+            "</tool_call>",
             "",
             "Available tools:",
         ]
         for tool in available_tools:
             schema = tool.to_llm_schema()
-            lines.append(f"- {tool.id}: {schema['description']}")
-            lines.append(
-                f"  Parameters: {json.dumps(schema['parameters'], sort_keys=True)}"
-            )
-        return "\n".join(lines)
+            lines.append("<tool>")
+            lines.append(json.dumps(schema, indent=2))
+            lines.append("</tool>")
+            lines.append("")
+            if tool.output_schema is not None:
+                lines.append(
+                    "  Output schema: "
+                    f"{json.dumps(tool.output_schema.to_dict(), sort_keys=True)}"
+                )
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
 
     def _format_role_persona(
         self,

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -14,6 +14,7 @@
 
 import copy
 import dataclasses
+import json
 import random
 
 from oumi.builders.inference_engines import build_inference_engine
@@ -94,6 +95,46 @@ class ConversationSynthesizer:
                     f"role_instruction_messages. Available roles: "
                     f"{[r.value for r in available_roles]}"
                 )
+
+    def _format_tool_block(self, multiturn_attribute: MultiTurnAttribute) -> str:
+        """Build a tool-usage instruction block for the assistant persona."""
+        available_tools = self._resolve_available_tools(multiturn_attribute)
+        if not available_tools:
+            return ""
+
+        lines = [
+            "You have access to the following tools.",
+            "Do not invent tools. Use only the tools listed below.",
+            "When a tool is needed, emit the expected tool-call format exactly.",
+            "",
+            "Available tools:",
+        ]
+        for tool in available_tools:
+            schema = tool.to_llm_schema()
+            lines.append(f"- {tool.id}: {schema['description']}")
+            lines.append(
+                f"  Parameters: {json.dumps(schema['parameters'], sort_keys=True)}"
+            )
+        return "\n".join(lines)
+
+    def _format_role_persona(
+        self,
+        sample: dict,
+        persona: str,
+        role: Role,
+        multiturn_attribute: MultiTurnAttribute | None = None,
+    ) -> str:
+        """Format a role persona and append assistant tool context when available."""
+        formatted_content = self._formatter.format(
+            sample,
+            persona,
+            missing_values_allowed=False,
+        )
+        if role == Role.ASSISTANT and multiturn_attribute is not None:
+            tool_block = self._format_tool_block(multiturn_attribute)
+            if tool_block:
+                formatted_content = f"{formatted_content}\n\n{tool_block}"
+        return formatted_content
 
     def synthesize(
         self,
@@ -317,21 +358,29 @@ class ConversationSynthesizer:
                 return True
         return False
 
-    def _format_persona(self, sample: dict, persona: str, role: Role) -> Message:
+    def _format_persona(
+        self,
+        sample: dict,
+        persona: str,
+        role: Role,
+        multiturn_attribute: MultiTurnAttribute | None = None,
+    ) -> Message:
         """Format the persona for the sample.
 
         Args:
             sample: The sample dict containing all attributes.
             persona: The persona string to format.
             role: The role for this persona.
+            multiturn_attribute: Optional multiturn config for assistant tool context.
 
         Returns:
             A Message with the formatted persona as a SYSTEM message.
         """
-        formatted_content = self._formatter.format(
+        formatted_content = self._format_role_persona(
             sample,
             persona,
-            missing_values_allowed=False,
+            role,
+            multiturn_attribute=multiturn_attribute,
         )
         return Message(
             role=Role.SYSTEM,
@@ -349,8 +398,11 @@ class ConversationSynthesizer:
         """
         parts = []
         for role, persona in multiturn_attribute.role_instruction_messages.items():
-            formatted = self._formatter.format(
-                sample, persona, missing_values_allowed=False
+            formatted = self._format_role_persona(
+                sample,
+                persona,
+                role,
+                multiturn_attribute=multiturn_attribute,
             )
             parts.append(f"[{role.value.upper()}]\n{formatted}")
 
@@ -525,7 +577,10 @@ class ConversationSynthesizer:
 
                 persona = multiturn_attribute.role_instruction_messages[role]
                 formatted_persona = self._format_persona(
-                    sample_with_turn, persona, role
+                    sample_with_turn,
+                    persona,
+                    role,
+                    multiturn_attribute=multiturn_attribute,
                 )
                 prompt_messages.append(formatted_persona)
                 prompt_messages.extend(histories[i])

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -12,19 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import dataclasses
 import random
 
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.generation_params import GenerationParams
+from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
     MultiTurnAttribute,
 )
 from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.synthesis.attribute_formatter import AttributeFormatter
-from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.conversation import (
+    PLANNER_JSON_SCHEMA,
+    Conversation,
+    Message,
+    Role,
+)
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
 
@@ -223,8 +232,9 @@ class ConversationSynthesizer:
     def _parse_plan(self, plan: str, target_turns: int) -> list[str] | None:
         """Parse a JSON-formatted conversation plan.
 
-        Extracts turn instructions from JSON array. Expects format:
-        [{"turn": 1, "instruction": "..."}, ...]
+        Extracts turn instructions from the planner output. Expects the
+        guided-decoding object form ``{"turns": [{"turn": 1, ...}, ...]}``;
+        also accepts a bare array as a backward-compatible fallback.
 
         Args:
             plan: The full plan text from the planner.
@@ -236,12 +246,17 @@ class ConversationSynthesizer:
         if not plan:
             return None
 
-        turns = extract_json(plan, expected_type=list)
-        if turns is None:
-            single = extract_json(plan, expected_type=dict)
-            if single is not None:
-                turns = [single]
+        wrapped = extract_json(plan, expected_type=dict)
+        if isinstance(wrapped, dict):
+            if isinstance(wrapped.get("turns"), list):
+                turns = wrapped["turns"]
             else:
+                # Backward-compat: planner emitted a single-turn dict.
+                turns = [wrapped]
+        else:
+            # Backward-compat: planner emitted a bare array.
+            turns = extract_json(plan, expected_type=list)
+            if turns is None:
                 return None
 
         result = [""] * target_turns
@@ -361,11 +376,7 @@ class ConversationSynthesizer:
     def _create_planner_prompt(
         self, multiturn_attribute: MultiTurnAttribute, sample: dict
     ) -> Conversation:
-        """Create the planner prompt template with role context and turn order.
-
-        Returns a Conversation with a one-shot example for consistent formatting.
-        The prompt instructs the model to output JSON wrapped in code fences.
-        """
+        """Create the planner prompt template with role context and turn order."""
         role_context = self._build_role_context(sample, multiturn_attribute)
         turn_order = self._default_turn_order
         target_turns = sample["target_turns"]
@@ -374,8 +385,10 @@ class ConversationSynthesizer:
         system_prompt = (
             "You are a conversation planner. Create conversation outlines "
             "that flow logically from start to finish.\n\n"
-            "IMPORTANT: Output your plan as a JSON array wrapped in ```json code "
-            "fences. Each element must have: turn (number) and instruction (string).\n"
+            "IMPORTANT: Output your plan as a raw JSON object with a `turns` "
+            "array. Do not use markdown or code fences. "
+            "Each element of `turns` must have: turn (number) and instruction "
+            "(string).\n"
             "Your instructions MUST be specific to the role context provided. "
             "Each turn's instruction should reflect what that specific role "
             "would do at that point in the conversation."
@@ -393,14 +406,12 @@ class ConversationSynthesizer:
             "Additional instructions: Focus on resolving the order issue "
             "efficiently while maintaining a polite and helpful tone."
         )
-        example_response = """```json
-[
+        example_response = """{"turns": [
   {"turn": 1, "instruction": "Greet support and explain the issue with the order"},
   {"turn": 2, "instruction": "Acknowledge the issue and ask for order details"},
   {"turn": 3, "instruction": "Provide order number and describe the problem further"},
   {"turn": 4, "instruction": "Confirm the issue and offer a resolution"}
-]
-```"""
+]}"""
 
         base_prompt = (
             f"Plan a {target_turns}-turn conversation.\n"
@@ -423,10 +434,7 @@ class ConversationSynthesizer:
             )
             base_prompt += f"\nAdditional instructions: {formatted_planner}\n"
 
-        base_prompt += (
-            "\nOutput ONLY the JSON array wrapped in ```json code fences. "
-            "No other text."
-        )
+        base_prompt += "\nOutput ONLY the JSON object. No markdown. No other text."
 
         return Conversation(
             messages=[
@@ -448,10 +456,33 @@ class ConversationSynthesizer:
         """
         inference_results = self._inference_engine.infer(
             planners,
-            inference_config=self._inference_config,
+            inference_config=self._planner_inference_config(),
         )
 
         return self._extract_response(inference_results)
+
+    def _planner_inference_config(self) -> InferenceConfig:
+        """Create an inference config for planner calls with JSON guided decoding."""
+        base_generation = getattr(self._inference_config, "generation", None)
+        if isinstance(base_generation, GenerationParams):
+            planner_generation = dataclasses.replace(
+                base_generation,
+                guided_decoding=GuidedDecodingParams(json=PLANNER_JSON_SCHEMA),  # noqa: E501
+            )
+        else:
+            planner_generation = GenerationParams(
+                guided_decoding=GuidedDecodingParams(json=PLANNER_JSON_SCHEMA)
+            )
+
+        if isinstance(self._inference_config, InferenceConfig):
+            return dataclasses.replace(
+                self._inference_config,
+                generation=planner_generation,
+            )
+
+        planner_config = copy.copy(self._inference_config)
+        planner_config.generation = planner_generation
+        return planner_config
 
     def _synthesize_all_samples(
         self,
@@ -474,6 +505,7 @@ class ConversationSynthesizer:
         histories: list[list[Message]] = [[] for _ in samples]
         max_turns = max(sample["target_turns"] for sample in samples)
 
+        turn_order = self._default_turn_order
         for turn_idx in range(max_turns):
             current_turn = turn_idx + 1
 
@@ -485,7 +517,6 @@ class ConversationSynthesizer:
                 if turn_idx >= sample["target_turns"]:
                     continue
 
-                turn_order = self._default_turn_order
                 role = turn_order[turn_idx % len(turn_order)]
                 roles_for_turn.append(role)
 

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -618,3 +618,23 @@ class TemplatedMessage(pydantic.BaseModel):
         """Returns the message in oumi format."""
         content = str(self.content)
         return Message(content=content, role=self.role)
+
+
+class PlannedTurn(pydantic.BaseModel):
+    """A single turn in a planned multi-turn conversation."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    turn: int = pydantic.Field(ge=1, description="1-indexed turn number.")
+    instruction: str = pydantic.Field(description="What should happen on this turn.")
+
+
+class PlannerOutput(pydantic.BaseModel):
+    """Top-level planner output: a list of planned turns wrapped in an object."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    turns: list[PlannedTurn]
+
+
+PLANNER_JSON_SCHEMA: dict = PlannerOutput.model_json_schema()

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -56,7 +56,8 @@ def test_tool_params_to_llm_schema():
         ),
     )
     assert tool.to_llm_schema() == {
-        "name": "Search",
+        "name": "search",
+        "display_name": "Search",
         "description": "Search the catalog.",
         "parameters": {
             "type": "object",
@@ -78,7 +79,8 @@ def test_tool_params_to_llm_schema_includes_output_schema():
         ),
     )
     assert tool.to_llm_schema() == {
-        "name": "Search",
+        "name": "search",
+        "display_name": "Search",
         "description": "Search the catalog.",
         "parameters": {"type": "object"},
         "output_schema": {

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -36,6 +36,7 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
+from oumi.environments import ToolParams as Tool
 
 
 @pytest.fixture
@@ -327,6 +328,62 @@ def test_format_persona_replaces_placeholders(
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_format_persona_injects_tools_for_assistant_only(
+    mock_build_inference_engine,
+    mock_inference_config,
+):
+    """Test assistant persona gets tool context without mutating config."""
+    mock_build_inference_engine.return_value = Mock()
+
+    synthesizer = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+    )
+    multiturn_attr = MultiTurnAttribute(
+        id="test_conversation",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are a helpful agent.",
+        },
+    )
+    tool = Tool(
+        id="lookup_order",
+        name="Lookup Order",
+        description="Look up an order by id.",
+        parameters={
+            "type": "object",
+            "properties": {"order_id": {"type": "string"}},
+            "required": ["order_id"],
+        },
+    )
+
+    with patch.object(synthesizer, "_resolve_available_tools", return_value=[tool]):
+        assistant_message = synthesizer._format_persona(
+            {},
+            multiturn_attr.role_instruction_messages[Role.ASSISTANT],
+            Role.ASSISTANT,
+            multiturn_attribute=multiturn_attr,
+        )
+        user_message = synthesizer._format_persona(
+            {},
+            multiturn_attr.role_instruction_messages[Role.USER],
+            Role.USER,
+            multiturn_attribute=multiturn_attr,
+        )
+
+    assert "You have access to the following tools." in assistant_message.content
+    assert "- lookup_order: Look up an order by id." in assistant_message.content
+    assert '"order_id"' in assistant_message.content
+    assert "You have access to the following tools." not in user_message.content
+    assert (
+        multiturn_attr.role_instruction_messages[Role.ASSISTANT]
+        == "You are a helpful agent."
+    )
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_build_role_context_formats_personas(
     mock_build_inference_engine,
     mock_inference_config,
@@ -356,6 +413,42 @@ def test_build_role_context_formats_personas(
     assert "You are a frustrated customer." in result
     assert "[ASSISTANT]" in result
     assert "You are a helpful agent." in result
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_role_context_includes_tools_for_assistant(
+    mock_build_inference_engine,
+    mock_inference_config,
+):
+    """Test planner role context includes assistant tool awareness."""
+    mock_build_inference_engine.return_value = Mock()
+
+    synthesizer = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+    )
+    multiturn_attr = MultiTurnAttribute(
+        id="test_conversation",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a customer.",
+            Role.ASSISTANT: "You are a helpful agent.",
+        },
+    )
+    tool = Tool(
+        id="check_status",
+        name="Check Status",
+        description="Check order status.",
+        parameters={"type": "object", "properties": {}, "required": []},
+    )
+
+    with patch.object(synthesizer, "_resolve_available_tools", return_value=[tool]):
+        result = synthesizer._build_role_context({}, multiturn_attr)
+
+    assert "[ASSISTANT]" in result
+    assert "You have access to the following tools." in result
+    assert "- check_status: Check order status." in result
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -20,6 +20,7 @@ import pytest
 
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.configs.params.remote_params import RemoteParams
 from oumi.core.configs.params.synthesis_params import (
@@ -29,17 +30,23 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttributeValue,
 )
 from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
-from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.conversation import (
+    PLANNER_JSON_SCHEMA,
+    Conversation,
+    Message,
+    Role,
+)
 
 
 @pytest.fixture
 def mock_inference_config():
     """Create a mock inference config."""
-    mock = Mock(spec=InferenceConfig)
-    mock.engine = InferenceEngineType.NATIVE
-    mock.model = Mock(spec=ModelParams)
-    mock.remote_params = Mock(spec=RemoteParams)
-    return mock
+    return InferenceConfig(
+        engine=InferenceEngineType.NATIVE,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
 
 
 @pytest.fixture
@@ -395,9 +402,101 @@ def test_planner_prompt_includes_role_context(
 
     example_response = planner.messages[2].content
     assert isinstance(example_response, str)
-    assert "```json" in example_response
+    assert example_response.startswith('{"turns":')
     assert '"turn": 1' in example_response
     assert '"instruction"' in example_response
+    system_prompt = planner.messages[0].content
+    assert isinstance(system_prompt, str)
+    assert "raw JSON object" in system_prompt
+    assert "```json" not in system_prompt
+    assert "No markdown" in user_message
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_generate_plan_uses_planner_only_guided_decoding(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+    mock_inference_config,
+):
+    """Test planner calls get JSON guided decoding without affecting turn generation."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    planner_result = Conversation(
+        messages=[
+            Message(
+                role=Role.ASSISTANT,
+                content='[{"turn": 1, "instruction": "Ask"}, {"turn": 2, "instruction": "Answer"}]',
+            )
+        ]
+    )
+    turn_result = Conversation(messages=[Message(role=Role.ASSISTANT, content="Turn")])
+    mock_inference_engine.infer.side_effect = [
+        [planner_result],
+        [turn_result],
+        [turn_result],
+    ]
+
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    result = synthesizer.synthesize(
+        [{"customer_type": "friendly", "issue": "product question"}],
+        MultiTurnAttribute(
+            id="test_conversation",
+            min_turns=2,
+            max_turns=2,
+            role_instruction_messages={
+                Role.USER: "You are a {customer_type} customer with issue: {issue}.",
+                Role.ASSISTANT: "You are a helpful support agent.",
+            },
+            conversation_planner="Plan a conversation about {issue}.",
+        ),
+    )
+
+    assert result[0] is not None
+    planner_call = mock_inference_engine.infer.call_args_list[0].kwargs["inference_config"]
+    turn_call = mock_inference_engine.infer.call_args_list[1].kwargs["inference_config"]
+
+    assert planner_call is not mock_inference_config
+    assert planner_call.generation is not mock_inference_config.generation
+    assert planner_call.generation.guided_decoding is not None
+    assert (
+        planner_call.generation.guided_decoding.json == PLANNER_JSON_SCHEMA
+    )
+    assert turn_call is mock_inference_config
+    assert turn_call.generation.guided_decoding is None
+    assert mock_inference_config.generation.guided_decoding is None
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_parse_plan_unwraps_object_form(
+    mock_build_inference_engine,
+    mock_inference_config,
+):
+    """Test that _parse_plan extracts turns from the {"turns": [...]} object form.
+
+    This is the primary shape enforced by ``PLANNER_JSON_SCHEMA`` for guided
+    decoding, so the happy path must be covered directly.
+    """
+    mock_build_inference_engine.return_value = Mock()
+
+    synthesizer = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+    )
+
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "Greet"},'
+        '{"turn": 2, "instruction": "Answer"}'
+        "]}"
+    )
+    result = synthesizer._parse_plan(plan, target_turns=2)
+    assert result == ["Greet", "Answer"]
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -29,6 +29,7 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttribute,
     SampledAttributeValue,
 )
+from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
@@ -348,15 +349,17 @@ def test_format_persona_injects_tools_for_assistant_only(
             Role.ASSISTANT: "You are a helpful agent.",
         },
     )
-    tool = Tool(
-        id="lookup_order",
-        name="Lookup Order",
-        description="Look up an order by id.",
-        parameters={
-            "type": "object",
-            "properties": {"order_id": {"type": "string"}},
-            "required": ["order_id"],
-        },
+    tool = ToolParams.create(
+        {
+            "id": "lookup_order",
+            "name": "Lookup Order",
+            "description": "Look up an order by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"order_id": {"type": "string"}},
+                "required": ["order_id"],
+            },
+        }
     )
 
     with patch.object(synthesizer, "_resolve_available_tools", return_value=[tool]):
@@ -374,7 +377,9 @@ def test_format_persona_injects_tools_for_assistant_only(
         )
 
     assert "You have access to the following tools." in assistant_message.content
-    assert "- lookup_order: Look up an order by id." in assistant_message.content
+    assert '"name": "lookup_order"' in assistant_message.content
+    assert '"display_name": "Lookup Order"' in assistant_message.content
+    assert '"description": "Look up an order by id."' in assistant_message.content
     assert '"order_id"' in assistant_message.content
     assert "You have access to the following tools." not in user_message.content
     assert (
@@ -436,11 +441,13 @@ def test_build_role_context_includes_tools_for_assistant(
             Role.ASSISTANT: "You are a helpful agent.",
         },
     )
-    tool = Tool(
-        id="check_status",
-        name="Check Status",
-        description="Check order status.",
-        parameters={"type": "object", "properties": {}, "required": []},
+    tool = ToolParams.create(
+        {
+            "id": "check_status",
+            "name": "Check Status",
+            "description": "Check order status.",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        }
     )
 
     with patch.object(synthesizer, "_resolve_available_tools", return_value=[tool]):
@@ -448,7 +455,9 @@ def test_build_role_context_includes_tools_for_assistant(
 
     assert "[ASSISTANT]" in result
     assert "You have access to the following tools." in result
-    assert "- check_status: Check order status." in result
+    assert '"name": "check_status"' in result
+    assert '"display_name": "Check Status"' in result
+    assert '"description": "Check order status."' in result
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
@@ -520,7 +529,10 @@ def test_generate_plan_uses_planner_only_guided_decoding(
         messages=[
             Message(
                 role=Role.ASSISTANT,
-                content='[{"turn": 1, "instruction": "Ask"}, {"turn": 2, "instruction": "Answer"}]',
+                content=(
+                    '[{"turn": 1, "instruction": "Ask"}, '
+                    '{"turn": 2, "instruction": "Answer"}]'
+                ),
             )
         ]
     )
@@ -551,7 +563,9 @@ def test_generate_plan_uses_planner_only_guided_decoding(
     )
 
     assert result[0] is not None
-    planner_call = mock_inference_engine.infer.call_args_list[0].kwargs["inference_config"]
+    planner_call = mock_inference_engine.infer.call_args_list[0].kwargs[
+        "inference_config"
+    ]
     turn_call = mock_inference_engine.infer.call_args_list[1].kwargs["inference_config"]
 
     assert planner_call is not mock_inference_config

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -37,7 +37,6 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
-from oumi.environments import ToolParams as Tool
 
 
 @pytest.fixture
@@ -376,12 +375,16 @@ def test_format_persona_injects_tools_for_assistant_only(
             multiturn_attribute=multiturn_attr,
         )
 
-    assert "You have access to the following tools." in assistant_message.content
-    assert '"name": "lookup_order"' in assistant_message.content
-    assert '"display_name": "Lookup Order"' in assistant_message.content
-    assert '"description": "Look up an order by id."' in assistant_message.content
-    assert '"order_id"' in assistant_message.content
-    assert "You have access to the following tools." not in user_message.content
+    assistant_content = assistant_message.content
+    user_content = user_message.content
+    assert isinstance(assistant_content, str)
+    assert isinstance(user_content, str)
+    assert "You have access to the following tools." in assistant_content
+    assert '"name": "lookup_order"' in assistant_content
+    assert '"display_name": "Lookup Order"' in assistant_content
+    assert '"description": "Look up an order by id."' in assistant_content
+    assert '"order_id"' in assistant_content
+    assert "You have access to the following tools." not in user_content
     assert (
         multiturn_attr.role_instruction_messages[Role.ASSISTANT]
         == "You are a helpful agent."
@@ -507,10 +510,10 @@ def test_planner_prompt_includes_role_context(
     assert example_response.startswith('{"turns":')
     assert '"turn": 1' in example_response
     assert '"instruction"' in example_response
-    system_prompt = planner.messages[0].content
-    assert isinstance(system_prompt, str)
-    assert "raw JSON object" in system_prompt
-    assert "```json" not in system_prompt
+    system_content = planner.messages[0].content
+    assert isinstance(system_content, str)
+    assert "raw JSON object" in system_content
+    assert "```json" not in system_content
     assert "No markdown" in user_message
 
 
@@ -571,9 +574,7 @@ def test_generate_plan_uses_planner_only_guided_decoding(
     assert planner_call is not mock_inference_config
     assert planner_call.generation is not mock_inference_config.generation
     assert planner_call.generation.guided_decoding is not None
-    assert (
-        planner_call.generation.guided_decoding.json == PLANNER_JSON_SCHEMA
-    )
+    assert planner_call.generation.guided_decoding.json == PLANNER_JSON_SCHEMA
     assert turn_call is mock_inference_config
     assert turn_call.generation.guided_decoding is None
     assert mock_inference_config.generation.guided_decoding is None


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 1 of 6) - Stage: planner improvements

**What changed**: Add JSON schema guided decoding for planner calls, inject tool context into assistant personas, and refactor `to_llm_schema()` to use tool IDs instead of display names.

**Why**: The planner needs structured JSON output (not markdown-fenced) and assistants need tool awareness in their persona prompts for coherent tool-use conversations.

## PR Chain

1. **Planner guided decoding & tool schema** (this PR)
2. Grounding types & config
3. Grounding in environments
4. Grounding synthesis pipeline
5. Tool use robustness & polish
6. JSON repair & planner refinement

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?