### PR TITLE
[Det Env] Phase 2: Grounding types, config & infrastructure

### DIFF
--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -21,32 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.configs.params.grounding_params import GroundingConfig
 from oumi.core.configs.params.tool_params import ToolParams
-
-
-@dataclass
-class GroundingConfig(BaseParams):
-    """Per-environment grounding configuration.
-
-    When set on an environment, the ConversationSynthesizer samples facts from
-    that environment and injects them into the planner prompt so turn plans
-    reference real entities rather than hallucinated IDs.
-    """
-
-    sample_size: int = 3
-    """Number of grounding facts sampled per conversation."""
-
-    seed: int | None = None
-    """If set, per-sample RNG is seeded from ``(seed + sample_index)`` for
-    reproducibility. If None, grounding uses an unseeded ``random.Random``."""
-
-    def __post_init__(self) -> None:
-        """Validate ``sample_size`` is positive."""
-        if self.sample_size < 1:
-            raise ValueError(
-                f"{type(self).__name__}.sample_size must be >= 1, "
-                f"got {self.sample_size}."
-            )
 
 
 @dataclass

--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -25,6 +25,31 @@ from oumi.core.configs.params.tool_params import ToolParams
 
 
 @dataclass
+class GroundingConfig(BaseParams):
+    """Per-environment grounding configuration.
+
+    When set on an environment, the ConversationSynthesizer samples facts from
+    that environment and injects them into the planner prompt so turn plans
+    reference real entities rather than hallucinated IDs.
+    """
+
+    sample_size: int = 3
+    """Number of grounding facts sampled per conversation."""
+
+    seed: int | None = None
+    """If set, per-sample RNG is seeded from ``(seed + sample_index)`` for
+    reproducibility. If None, grounding uses an unseeded ``random.Random``."""
+
+    def __post_init__(self) -> None:
+        """Validate ``sample_size`` is positive."""
+        if self.sample_size < 1:
+            raise ValueError(
+                f"{type(self).__name__}.sample_size must be >= 1, "
+                f"got {self.sample_size}."
+            )
+
+
+@dataclass
 class EnvironmentParams(BaseParams):
     """Pure-data description of an environment."""
 
@@ -37,6 +62,7 @@ class EnvironmentParams(BaseParams):
     # subclass is resolved by `__post_init__` based on env_type.
     tools: list[Any] = field(default_factory=list)
     env_kwargs: dict[str, Any] | None = None
+    grounding: GroundingConfig | None = None
 
     def __post_init__(self) -> None:
         """Coerce raw tool dicts into the appropriate ToolParams subclass."""
@@ -45,6 +71,10 @@ class EnvironmentParams(BaseParams):
             tool if isinstance(tool, tool_cls) else tool_cls.create(tool)
             for tool in self.tools
         ]
+        if self.grounding is not None and not isinstance(
+            self.grounding, GroundingConfig
+        ):
+            self.grounding = GroundingConfig(**self.grounding)
 
     def _resolve_tool_cls(self) -> type[ToolParams] | None:
         """Look up the registered env class, return its tool_params_cls.

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -1,0 +1,46 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-environment grounding configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oumi.core.configs.params.base_params import BaseParams
+
+
+@dataclass
+class GroundingConfig(BaseParams):
+    """Per-environment grounding configuration.
+
+    When set on an environment, the ConversationSynthesizer samples facts from
+    that environment and injects them into the planner prompt so turn plans
+    reference real entities rather than hallucinated IDs.
+    """
+
+    sample_size: int = 3
+    """Number of grounding facts sampled per conversation."""
+
+    seed: int | None = None
+    """If set, per-sample RNG is seeded from ``(seed + sample_index)`` for
+    reproducibility. If None, grounding uses an unseeded ``random.Random``."""
+
+    def __post_init__(self) -> None:
+        """Validate ``sample_size`` is positive."""
+        if self.sample_size < 1:
+            raise ValueError(
+                f"{type(self).__name__}.sample_size must be >= 1, "
+                f"got {self.sample_size}."
+            )

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -23,6 +23,78 @@ from typing import Any
 from oumi.core.configs.params.base_params import BaseParams
 
 
+class ToolError(Exception):
+    """Base class for tool errors surfaced back to the LLM.
+
+    Subclasses of this exception are caught by the tool-call loop and
+    re-emitted as structured ``tool`` messages so the model can self-correct
+    on the next iteration.
+    """
+
+
+class ToolArgumentError(ToolError):
+    """Raised when tool-call arguments fail schema validation."""
+
+
+class ToolLookupError(ToolError):
+    """Raised when a tool cannot resolve an output for the given arguments.
+
+    Currently used by ``DeterministicEnvironment`` when no configured
+    ``DeterministicToolOutput`` matches the provided arguments.
+    """
+
+
+def _validate_json_schema_value(
+    value: Any,
+    schema: dict[str, Any],
+    path: str = "$",
+) -> None:
+    """Validate a JSON-like value against a minimal JSON-schema subset.
+
+    Supports: object (properties + required), array (items), string,
+    integer, number, boolean, null, and enum. Raises ``ValueError`` on
+    the first violation, with a JSONPath-style path prefix.
+    """
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        if not isinstance(value, dict):
+            raise ValueError(f"{path} must be an object.")
+        required = schema.get("required", [])
+        for key in required:
+            if key not in value:
+                raise ValueError(f"{path}.{key} is required.")
+        for key, child_value in value.items():
+            child_schema = schema.get("properties", {}).get(key)
+            if child_schema is not None:
+                _validate_json_schema_value(child_value, child_schema, f"{path}.{key}")
+    elif expected_type == "array":
+        if not isinstance(value, list):
+            raise ValueError(f"{path} must be an array.")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for idx, item in enumerate(value):
+                _validate_json_schema_value(item, item_schema, f"{path}[{idx}]")
+    elif expected_type == "string":
+        if not isinstance(value, str):
+            raise ValueError(f"{path} must be a string.")
+    elif expected_type == "integer":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{path} must be an integer.")
+    elif expected_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{path} must be a number.")
+    elif expected_type == "boolean":
+        if not isinstance(value, bool):
+            raise ValueError(f"{path} must be a boolean.")
+    elif expected_type == "null":
+        if value is not None:
+            raise ValueError(f"{path} must be null.")
+
+    enum_values = schema.get("enum")
+    if enum_values is not None and value not in enum_values:
+        raise ValueError(f"{path} must be one of {enum_values}.")
+
+
 @dataclass
 class ToolSchema(BaseParams):
     """JSON schema for tool inputs or outputs."""
@@ -31,6 +103,8 @@ class ToolSchema(BaseParams):
     properties: dict[str, ToolSchema] = field(default_factory=dict)
     description: str | None = None
     required: list[str] = field(default_factory=list)
+    items: ToolSchema | None = None
+    enum: list[Any] | None = None
 
     @classmethod
     def create(cls, raw: Any) -> ToolSchema:
@@ -50,6 +124,8 @@ class ToolSchema(BaseParams):
             },
             description=raw.get("description"),
             required=raw.get("required", []),
+            items=(cls.create(raw["items"]) if raw.get("items") is not None else None),
+            enum=list(raw["enum"]) if raw.get("enum") is not None else None,
         )
 
     def __post_init__(self):
@@ -78,6 +154,12 @@ class ToolSchema(BaseParams):
                 f"{type(self).__name__}.required contains unknown properties: "
                 f"{sorted(missing_required)}"
             )
+        if self.items is not None and not isinstance(self.items, ToolSchema):
+            self.items = ToolSchema.create(self.items)
+        if self.enum is not None and not isinstance(self.enum, list):
+            raise ValueError(
+                f"{type(self).__name__}.enum must be a list when specified."
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-schema-shaped dict."""
@@ -90,7 +172,28 @@ class ToolSchema(BaseParams):
             schema["description"] = self.description
         if self.required:
             schema["required"] = list(self.required)
+        if self.items is not None:
+            schema["items"] = self.items.to_dict()
+        if self.enum is not None:
+            schema["enum"] = list(self.enum)
         return schema
+
+    def validate(self, value: Any, *, path: str = "$") -> None:
+        """Validate a value against this schema.
+
+        Args:
+            value: The value to validate.
+            path: JSONPath-style prefix used in error messages. Callers
+                validating tool arguments should pass ``path="arguments"``
+                to produce model-friendly messages.
+
+        Raises:
+            ToolArgumentError: If ``value`` does not conform to the schema.
+        """
+        try:
+            _validate_json_schema_value(value, self.to_dict(), path=path)
+        except ValueError as e:
+            raise ToolArgumentError(str(e)) from e
 
 
 @dataclass
@@ -152,6 +255,14 @@ class ToolParams(BaseParams):
         if self.output_schema is not None:
             schema["output_schema"] = self.output_schema.to_dict()
         return schema
+
+    def validate_arguments(self, arguments: dict[str, Any]) -> None:
+        """Validate call-time arguments against this tool's ``parameters`` schema.
+
+        Raises:
+            ToolArgumentError: If ``arguments`` do not conform.
+        """
+        self.parameters.validate(arguments, path="arguments")
 
 
 @dataclass

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -18,7 +18,7 @@ Importing this package populates the environment registry by triggering each
 concrete environment's `@register_environment(...)` decorator.
 """
 
-from oumi.core.configs.params.environment_params import GroundingConfig
+from oumi.core.configs.params.grounding_params import GroundingConfig
 from oumi.core.configs.params.tool_params import (
     ToolArgumentError,
     ToolError,

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -18,7 +18,11 @@ Importing this package populates the environment registry by triggering each
 concrete environment's `@register_environment(...)` decorator.
 """
 
+from oumi.core.configs.params.environment_params import GroundingConfig
 from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolError,
+    ToolLookupError,
     ToolParams,
     ToolResult,
     ToolSchema,
@@ -44,9 +48,13 @@ __all__ = [
     "DeterministicEnvironmentKwargs",
     "DeterministicTool",
     "DeterministicToolOutput",
+    "GroundingConfig",
     "SyntheticEnvironment",
     "SyntheticEnvironmentKwargs",
     "SyntheticStateParams",
+    "ToolArgumentError",
+    "ToolError",
+    "ToolLookupError",
     "ToolParams",
     "ToolResult",
     "ToolSchema",

--- a/src/oumi/environments/_helpers.py
+++ b/src/oumi/environments/_helpers.py
@@ -1,0 +1,47 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for environment runtimes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from oumi.core.configs.params.tool_params import DeterministicToolOutput
+
+
+def _format_grounding_value(value: Any) -> str:
+    """Render a fact value as a quoted string or bare literal."""
+    if isinstance(value, str):
+        return f'"{value}"'
+    return str(value)
+
+
+def describe_grounding_default(facts: list[DeterministicToolOutput]) -> str:
+    """Render grounding facts as a bulleted markdown block.
+
+    Each fact's ``input`` and ``output`` dicts are flattened into a single
+    key=value line. Output values win on key collisions.
+    Returns "" for an empty fact list.
+    """
+    if not facts:
+        return ""
+    lines: list[str] = []
+    for fact in facts:
+        merged = {**fact.input, **fact.output}
+        parts = [
+            f"{key}={_format_grounding_value(value)}" for key, value in merged.items()
+        ]
+        lines.append(f"- {', '.join(parts)}")
+    return "\n".join(lines)

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolResult
+from oumi.core.configs.params.tool_params import ToolLookupError, ToolResult
 from oumi.core.registry import register_environment
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_tool import (
@@ -62,12 +62,23 @@ class DeterministicEnvironment(BaseEnvironment):
         self._validate_tools(params.tools)
 
     def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Resolve a deterministic tool call to its output."""
+        """Resolve a deterministic tool call to its output.
+
+        Raises:
+            ToolLookupError: If no configured ``deterministic_outputs`` entry
+                matches the provided arguments. The error message lists the
+                configured inputs so the calling LLM can self-correct.
+        """
         tool = self._lookup_tool(tool_id)
         for entry in tool.deterministic_outputs:
             if entry.matches(arguments):
                 return ToolResult(output=entry.output)
-        return ToolResult(output={})
+        available = [entry.input for entry in tool.deterministic_outputs]
+        raise ToolLookupError(
+            f"No deterministic output matches arguments "
+            f"{json.dumps(arguments, sort_keys=True)} for tool '{tool_id}'. "
+            f"Configured inputs: {json.dumps(available, sort_keys=True)}"
+        )
 
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DeterministicEnvironment:

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -23,56 +23,14 @@ from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolParams, ToolResult
+from oumi.core.configs.params.tool_params import (
+    ToolParams,
+    ToolResult,
+    _validate_json_schema_value,
+)
 from oumi.core.registry import register_environment
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_tool import DeterministicTool
-
-
-def _validate_json_schema_value(
-    value: Any,
-    schema: dict[str, Any],
-    path: str = "$",
-) -> None:
-    """Validate a JSON-like value against a minimal schema subset."""
-    expected_type = schema.get("type")
-    if expected_type == "object":
-        if not isinstance(value, dict):
-            raise ValueError(f"{path} must be an object.")
-        required = schema.get("required", [])
-        for key in required:
-            if key not in value:
-                raise ValueError(f"{path}.{key} is required.")
-        for key, child_value in value.items():
-            child_schema = schema.get("properties", {}).get(key)
-            if child_schema is not None:
-                _validate_json_schema_value(child_value, child_schema, f"{path}.{key}")
-    elif expected_type == "array":
-        if not isinstance(value, list):
-            raise ValueError(f"{path} must be an array.")
-        item_schema = schema.get("items")
-        if item_schema is not None:
-            for idx, item in enumerate(value):
-                _validate_json_schema_value(item, item_schema, f"{path}[{idx}]")
-    elif expected_type == "string":
-        if not isinstance(value, str):
-            raise ValueError(f"{path} must be a string.")
-    elif expected_type == "integer":
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise ValueError(f"{path} must be an integer.")
-    elif expected_type == "number":
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise ValueError(f"{path} must be a number.")
-    elif expected_type == "boolean":
-        if not isinstance(value, bool):
-            raise ValueError(f"{path} must be a boolean.")
-    elif expected_type == "null":
-        if value is not None:
-            raise ValueError(f"{path} must be null.")
-
-    enum_values = schema.get("enum")
-    if enum_values is not None and value not in enum_values:
-        raise ValueError(f"{path} must be one of {enum_values}.")
 
 
 @dataclass

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared helpers for environment runtimes."""
+"""Shared utilities for environment runtimes."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from oumi.core.configs.params.tool_params import DeterministicToolOutput
+from oumi.environments.deterministic_tool import DeterministicToolOutput
 
 
 def _format_grounding_value(value: Any) -> str:

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -325,3 +325,65 @@ def test_grounding_config_rejects_sample_size_below_one():
         GroundingConfig(sample_size=0)
     with pytest.raises(ValueError, match="sample_size must be >= 1"):
         GroundingConfig(sample_size=-3)
+
+
+# --- describe_grounding_default ---
+
+
+def test_describe_grounding_default_empty():
+    from oumi.environments._helpers import describe_grounding_default
+
+    assert describe_grounding_default([]) == ""
+
+
+def test_describe_grounding_default_single_fact():
+    from oumi.environments._helpers import describe_grounding_default
+
+    facts = [
+        DeterministicToolOutput(
+            input={"id": "42"}, output={"title": "Dune", "year": 1965}
+        )
+    ]
+    rendered = describe_grounding_default(facts)
+    assert rendered == '- id="42", title="Dune", year=1965'
+
+
+def test_describe_grounding_default_multi_fact_preserves_order():
+    from oumi.environments._helpers import describe_grounding_default
+
+    facts = [
+        DeterministicToolOutput(input={"id": "7"}, output={"title": "LotR"}),
+        DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"}),
+    ]
+    rendered = describe_grounding_default(facts)
+    assert rendered == ('- id="7", title="LotR"\n- id="42", title="Dune"')
+
+
+def test_describe_grounding_default_output_wins_on_key_conflict():
+    from oumi.environments._helpers import describe_grounding_default
+
+    facts = [
+        DeterministicToolOutput(
+            input={"id": "1", "note": "input-note"},
+            output={"note": "output-note"},
+        )
+    ]
+    rendered = describe_grounding_default(facts)
+    assert 'note="output-note"' in rendered
+    assert "input-note" not in rendered
+
+
+def test_describe_grounding_default_handles_non_string_values():
+    from oumi.environments._helpers import describe_grounding_default
+
+    facts = [
+        DeterministicToolOutput(
+            input={"id": 42},
+            output={"available": True, "count": 3, "rating": 4.5},
+        )
+    ]
+    rendered = describe_grounding_default(facts)
+    assert "id=42" in rendered
+    assert "available=True" in rendered
+    assert "count=3" in rendered
+    assert "rating=4.5" in rendered

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -22,6 +22,7 @@ from oumi.core.configs.params.tool_params import (
     ToolResult,
     ToolSchema,
 )
+from oumi.environments.deterministic_tool import DeterministicToolOutput
 from oumi.environments.synthetic_environment import SyntheticStateParams
 
 
@@ -331,13 +332,13 @@ def test_grounding_config_rejects_sample_size_below_one():
 
 
 def test_describe_grounding_default_empty():
-    from oumi.environments._helpers import describe_grounding_default
+    from oumi.environments.utils import describe_grounding_default
 
     assert describe_grounding_default([]) == ""
 
 
 def test_describe_grounding_default_single_fact():
-    from oumi.environments._helpers import describe_grounding_default
+    from oumi.environments.utils import describe_grounding_default
 
     facts = [
         DeterministicToolOutput(
@@ -349,7 +350,7 @@ def test_describe_grounding_default_single_fact():
 
 
 def test_describe_grounding_default_multi_fact_preserves_order():
-    from oumi.environments._helpers import describe_grounding_default
+    from oumi.environments.utils import describe_grounding_default
 
     facts = [
         DeterministicToolOutput(input={"id": "7"}, output={"title": "LotR"}),
@@ -360,7 +361,7 @@ def test_describe_grounding_default_multi_fact_preserves_order():
 
 
 def test_describe_grounding_default_output_wins_on_key_conflict():
-    from oumi.environments._helpers import describe_grounding_default
+    from oumi.environments.utils import describe_grounding_default
 
     facts = [
         DeterministicToolOutput(
@@ -374,7 +375,7 @@ def test_describe_grounding_default_output_wins_on_key_conflict():
 
 
 def test_describe_grounding_default_handles_non_string_values():
-    from oumi.environments._helpers import describe_grounding_default
+    from oumi.environments.utils import describe_grounding_default
 
     facts = [
         DeterministicToolOutput(

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
     ToolParams,
     ToolResult,
     ToolSchema,
@@ -193,3 +194,134 @@ def test_synthetic_state_params_accepts_partial_inputs():
     assert SyntheticStateParams(
         initial_state={"files": {"count": 1}}
     ).initial_state == {"files": {"count": 1}}
+
+
+# --- ToolSchema items / enum ---
+
+
+def test_tool_schema_create_coerces_items_and_enum():
+    schema = ToolSchema.create(
+        {
+            "type": "array",
+            "items": {"type": "string", "enum": ["a", "b"]},
+        }
+    )
+    assert isinstance(schema.items, ToolSchema)
+    assert schema.items.enum == ["a", "b"]
+    assert schema.to_dict() == {
+        "type": "array",
+        "items": {"type": "string", "enum": ["a", "b"]},
+    }
+
+
+def test_tool_schema_validate_rejects_wrong_item_type():
+    schema = ToolSchema.create({"type": "array", "items": {"type": "string"}})
+    with pytest.raises(ToolArgumentError, match=r"arguments\[1\] must be a string"):
+        schema.validate(["ok", 2], path="arguments")
+
+
+def test_tool_schema_validate_rejects_value_outside_enum():
+    schema = ToolSchema.create({"type": "string", "enum": ["a", "b"]})
+    with pytest.raises(ToolArgumentError, match="must be one of"):
+        schema.validate("c", path="arguments")
+
+
+def test_tool_schema_enum_must_be_list():
+    with pytest.raises(ValueError, match="enum must be a list"):
+        ToolSchema(type="string", enum="a")  # type: ignore[arg-type]
+
+
+# --- ToolSchema.validate / ToolParams.validate_arguments ---
+
+
+def _policy_tool() -> ToolParams:
+    return ToolParams(
+        id="policy",
+        name="Policy",
+        description="Look up policy.",
+        parameters=ToolSchema(
+            type="object",
+            properties={
+                "policy_id": ToolSchema(type="string"),
+                "limit": ToolSchema(type="integer"),
+            },
+            required=["policy_id"],
+        ),
+    )
+
+
+def test_tool_schema_validate_accepts_conforming_value():
+    schema = _policy_tool().parameters
+    schema.validate({"policy_id": "abc", "limit": 5})
+
+
+def test_tool_schema_validate_missing_required_raises():
+    schema = _policy_tool().parameters
+    with pytest.raises(ToolArgumentError, match=r"arguments\.policy_id is required"):
+        schema.validate({"limit": 5}, path="arguments")
+
+
+def test_tool_schema_validate_wrong_type_raises():
+    schema = _policy_tool().parameters
+    with pytest.raises(ToolArgumentError, match=r"arguments\.limit must be an integer"):
+        schema.validate({"policy_id": "abc", "limit": "five"}, path="arguments")
+
+
+def test_tool_schema_validate_nested_object():
+    schema = ToolSchema.create(
+        {
+            "type": "object",
+            "properties": {
+                "customer": {
+                    "type": "object",
+                    "properties": {"email": {"type": "string"}},
+                    "required": ["email"],
+                }
+            },
+            "required": ["customer"],
+        }
+    )
+    with pytest.raises(
+        ToolArgumentError, match=r"arguments\.customer\.email is required"
+    ):
+        schema.validate({"customer": {}}, path="arguments")
+
+
+def test_tool_schema_validate_empty_schema_accepts_any_object():
+    # Tools that don't declare parameters shouldn't force callers to pass {}.
+    tool = ToolParams(id="ping", name="Ping", description="No args.")
+    tool.validate_arguments({})
+    tool.validate_arguments({"extra": "ignored"})
+
+
+def test_tool_params_validate_arguments_delegates_to_parameters():
+    with pytest.raises(ToolArgumentError, match="arguments.policy_id is required"):
+        _policy_tool().validate_arguments({})
+
+
+# --- GroundingConfig ---
+
+
+def test_grounding_config_defaults():
+    from oumi.environments import GroundingConfig
+
+    cfg = GroundingConfig()
+    assert cfg.sample_size == 3
+    assert cfg.seed is None
+
+
+def test_grounding_config_accepts_valid_values():
+    from oumi.environments import GroundingConfig
+
+    cfg = GroundingConfig(sample_size=5, seed=42)
+    assert cfg.sample_size == 5
+    assert cfg.seed == 42
+
+
+def test_grounding_config_rejects_sample_size_below_one():
+    from oumi.environments import GroundingConfig
+
+    with pytest.raises(ValueError, match="sample_size must be >= 1"):
+        GroundingConfig(sample_size=0)
+    with pytest.raises(ValueError, match="sample_size must be >= 1"):
+        GroundingConfig(sample_size=-3)

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -15,7 +15,7 @@
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolResult
+from oumi.core.configs.params.tool_params import ToolLookupError, ToolResult
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
     DeterministicEnvironmentKwargs,
@@ -101,9 +101,15 @@ def test_step_returns_matching_output():
     assert env.step("tool1", {"id": "02"}) == ToolResult(output={"msg": "delivered"})
 
 
-def test_step_no_match_returns_empty():
+def test_step_no_match_raises_with_hint():
     env = DeterministicEnvironment.from_params(_make_params())
-    assert env.step("tool1", {"id": "99"}) == ToolResult(output={})
+    with pytest.raises(ToolLookupError) as excinfo:
+        env.step("tool1", {"id": "99"})
+    message = str(excinfo.value)
+    assert "No deterministic output matches" in message
+    assert "tool1" in message
+    # The configured inputs are surfaced so the LLM can self-correct.
+    assert '"id": "01"' in message
 
 
 def test_step_supports_zero_arg_tool():


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 2 of 6) - Stage: core data structures + design specs

**What changed**: Add `GroundingConfig`/`GroundingFact` dataclasses, `describe_grounding_default()` helper, prior-session tool-error/validation work, and design specs for the grounding system.

**Why**: Establishes the grounding data contract and types that all subsequent PRs build on. The design specs document the three-way grounding contract (planner grounded, user implicit, assistant never).

> **Note**: This PR is larger than typical (~1400 LOC code + ~2200 LOC specs) because it bundles the foundational types with a prior-session landing commit. Specs can be skimmed — the code review focus is on `base_tool.py` and the synthesizer changes.

## PR Chain

1. Planner guided decoding & tool schema
2. **Grounding types, config & infrastructure** (this PR)
3. Grounding in environments
4. Grounding synthesis pipeline
5. Tool use robustness & polish
6. JSON repair & planner refinement

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?