### PR TITLE
[Det Env] Phase 3: Grounding in deterministic environments

### DIFF
--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -16,10 +16,13 @@
 
 from __future__ import annotations
 
+import random
 from abc import ABC, abstractmethod
 from typing import Any
 
 from oumi.core.configs.params.tool_params import ToolParams, ToolResult
+from oumi.environments.deterministic_tool import DeterministicToolOutput
+from oumi.environments.utils import describe_grounding_default
 
 
 class BaseEnvironment(ABC):
@@ -30,3 +33,23 @@ class BaseEnvironment(ABC):
     @abstractmethod
     def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
         """Execute a tool call within this environment."""
+
+    def sample_grounding(
+        self, n: int, *, rng: random.Random
+    ) -> list[DeterministicToolOutput]:
+        """Sample ``n`` grounding facts from this environment.
+
+        Default: returns an empty list. Subclasses that support grounding
+        (currently only ``DeterministicEnvironment``) override this.
+        """
+        return []
+
+    def describe_grounding(self, facts: list[DeterministicToolOutput]) -> str:
+        """Render grounding facts as a bulleted markdown block.
+
+        Default implementation flattens each fact's input and output dicts
+        (output wins on key collisions) into a single bullet line. Suitable
+        for any dict-shaped fact. Subclasses may override for custom
+        rendering.
+        """
+        return describe_grounding_default(facts)

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import random
 from dataclasses import dataclass
 from typing import Any
 
@@ -125,3 +126,18 @@ class DeterministicEnvironment(BaseEnvironment):
             f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
             f"Available tools: {[tool.id for tool in self._params.tools]}"
         )
+
+    def sample_grounding(
+        self, n: int, *, rng: random.Random
+    ) -> list[DeterministicToolOutput]:
+        """Sample grounding facts from the pool of deterministic outputs.
+
+        Pools every ``DeterministicToolOutput`` across every tool owned by
+        this environment, then draws ``min(n, len(pool))`` entries without
+        replacement using the supplied RNG. Silent truncation — the
+        synthesizer is responsible for surfacing a warning when applicable.
+        """
+        pool: list[DeterministicToolOutput] = [
+            entry for tool in self._params.tools for entry in tool.deterministic_outputs
+        ]
+        return rng.sample(pool, min(n, len(pool)))

--- a/tests/unit/environments/test_base_environment.py
+++ b/tests/unit/environments/test_base_environment.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 import dataclasses
+import random
+from typing import Any
 
 import pytest
 
+from oumi.core.configs.params.tool_params import (
+    DeterministicToolOutput,
+    ToolResult,
+)
 from oumi.environments.base_environment import BaseEnvironment
 
 
@@ -34,3 +40,26 @@ def test_subclass_without_step_cannot_instantiate():
 
     with pytest.raises(TypeError, match=r"abstract|instantiate"):
         Incomplete()  # type: ignore[abstract]
+
+
+class _MinimalEnv(BaseEnvironment):
+    """Concrete BaseEnvironment subclass that doesn't override grounding hooks."""
+
+    def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        return ToolResult(output=None)
+
+
+def test_default_sample_grounding_returns_empty():
+    env = _MinimalEnv()
+    assert env.sample_grounding(n=5, rng=random.Random(0)) == []
+
+
+def test_default_describe_grounding_empty_list_returns_empty_string():
+    env = _MinimalEnv()
+    assert env.describe_grounding([]) == ""
+
+
+def test_default_describe_grounding_delegates_to_helper():
+    env = _MinimalEnv()
+    facts = [DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"})]
+    assert env.describe_grounding(facts) == '- id="42", title="Dune"'

--- a/tests/unit/environments/test_base_environment.py
+++ b/tests/unit/environments/test_base_environment.py
@@ -18,11 +18,9 @@ from typing import Any
 
 import pytest
 
-from oumi.core.configs.params.tool_params import (
-    DeterministicToolOutput,
-    ToolResult,
-)
+from oumi.core.configs.params.tool_params import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.deterministic_tool import DeterministicToolOutput
 
 
 def test_base_environment_is_not_a_dataclass():
@@ -46,7 +44,7 @@ class _MinimalEnv(BaseEnvironment):
     """Concrete BaseEnvironment subclass that doesn't override grounding hooks."""
 
     def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        return ToolResult(output=None)
+        return ToolResult(output={})
 
 
 def test_default_sample_grounding_returns_empty():

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -160,7 +160,7 @@ def _det_env_with_n_entries(n: int) -> DeterministicEnvironment:
     return DeterministicEnvironment.from_params(
         _make_params(
             tools=[
-                ToolParams(
+                DeterministicTool(
                     id="lookup",
                     name="Lookup",
                     description="Look up a book.",
@@ -226,7 +226,7 @@ def test_sample_grounding_pools_across_tools():
 
     params = _make_params(
         tools=[
-            ToolParams(
+            DeterministicTool(
                 id="tool_a",
                 name="A",
                 description="Tool A",
@@ -234,7 +234,7 @@ def test_sample_grounding_pools_across_tools():
                     DeterministicToolOutput(input={"k": "a1"}, output={"v": "a1"})
                 ],
             ),
-            ToolParams(
+            DeterministicTool(
                 id="tool_b",
                 name="B",
                 description="Tool B",

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -146,3 +146,107 @@ def test_from_params_coerces_raw_deterministic_outputs():
     assert isinstance(
         env._params.tools[0].deterministic_outputs[0], DeterministicToolOutput
     )
+
+
+# --- DeterministicEnvironment.sample_grounding ---
+
+
+def _det_env_with_n_entries(n: int) -> DeterministicEnvironment:
+    """Build a DeterministicEnvironment with a single tool containing n entries."""
+    outputs = [
+        DeterministicToolOutput(input={"id": str(i)}, output={"title": f"title-{i}"})
+        for i in range(n)
+    ]
+    return DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[
+                ToolParams(
+                    id="lookup",
+                    name="Lookup",
+                    description="Look up a book.",
+                    deterministic_outputs=outputs,
+                )
+            ]
+        )
+    )
+
+
+def test_sample_grounding_returns_n_facts():
+    import random
+
+    env = _det_env_with_n_entries(10)
+    facts = env.sample_grounding(n=3, rng=random.Random(0))
+    assert len(facts) == 3
+    for fact in facts:
+        assert isinstance(fact, DeterministicToolOutput)
+
+
+def test_sample_grounding_no_replacement_within_call():
+    import random
+
+    env = _det_env_with_n_entries(10)
+    facts = env.sample_grounding(n=5, rng=random.Random(0))
+    ids = [fact.input["id"] for fact in facts]
+    assert len(set(ids)) == len(ids)
+
+
+def test_sample_grounding_truncates_when_n_exceeds_pool():
+    import random
+
+    env = _det_env_with_n_entries(3)
+    facts = env.sample_grounding(n=10, rng=random.Random(0))
+    assert len(facts) == 3
+
+
+def test_sample_grounding_seeded_rng_is_reproducible():
+    import random
+
+    env = _det_env_with_n_entries(20)
+    facts_a = env.sample_grounding(n=4, rng=random.Random(42))
+    facts_b = env.sample_grounding(n=4, rng=random.Random(42))
+    ids_a = [fact.input["id"] for fact in facts_a]
+    ids_b = [fact.input["id"] for fact in facts_b]
+    assert ids_a == ids_b
+
+
+def test_sample_grounding_different_seeds_differ():
+    import random
+
+    env = _det_env_with_n_entries(20)
+    facts_a = env.sample_grounding(n=4, rng=random.Random(1))
+    facts_b = env.sample_grounding(n=4, rng=random.Random(999))
+    ids_a = sorted(fact.input["id"] for fact in facts_a)
+    ids_b = sorted(fact.input["id"] for fact in facts_b)
+    # With 20 entries and 4 picks, collision on both sets is vanishingly small.
+    assert ids_a != ids_b
+
+
+def test_sample_grounding_pools_across_tools():
+    import random
+
+    params = _make_params(
+        tools=[
+            ToolParams(
+                id="tool_a",
+                name="A",
+                description="Tool A",
+                deterministic_outputs=[
+                    DeterministicToolOutput(input={"k": "a1"}, output={"v": "a1"})
+                ],
+            ),
+            ToolParams(
+                id="tool_b",
+                name="B",
+                description="Tool B",
+                deterministic_outputs=[
+                    DeterministicToolOutput(input={"k": "b1"}, output={"v": "b1"}),
+                    DeterministicToolOutput(input={"k": "b2"}, output={"v": "b2"}),
+                ],
+            ),
+        ],
+    )
+    env = DeterministicEnvironment.from_params(params)
+    facts = env.sample_grounding(n=3, rng=random.Random(0))
+    assert len(facts) == 3
+    keys = sorted(fact.input["k"] for fact in facts)
+    assert keys == ["a1", "b1", "b2"]


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 3 of 6) - Stage: environment layer integration

**What changed**: Add `sample_grounding()` and `describe_grounding()` methods to `BaseEnvironment`, and override `sample_grounding()` in `DeterministicEnvironment` to pool all tool outputs and sample without replacement using a supplied RNG.

**Why**: Environments own their grounding data — this gives each environment a standard interface for the synthesizer to request grounding facts without knowing the environment's internals.

## PR Chain

1. Planner guided decoding & tool schema
2. Grounding types, config & infrastructure
3. **Grounding in environments** (this PR)
4. Grounding synthesis pipeline
5. Tool use robustness & polish
6. JSON repair & planner refinement

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

----
## Summary by Gitar

- **Configuration updates:**
  - Added `grounding` field to `BaseEnvironment` and updated `create` method to handle `GroundingConfig` deserialization.
- **Testing additions:**
  - Added extensive unit tests in `test_tool_params.py` covering grounding default behaviors and sampling logic.


<sub>This will update automatically on new commits.</sub>