### PR TITLE
[Det Env] Phase 4: Wire grounding into synthesis pipeline

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -496,7 +496,7 @@ class ConversationSynthesizer:
         grounding_facts = sample.get("grounding_facts") or []
         if grounding_facts:
             from oumi.builders.environments import build_environment
-            from oumi.environments._helpers import describe_grounding_default
+            from oumi.environments.utils import describe_grounding_default
 
             # Pick the first grounded env's describer. In v1 every env uses
             # the default describer; future envs with custom describers

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -20,6 +20,7 @@ import random
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.inference_engine_type import InferenceEngineType
 from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
@@ -35,6 +36,8 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
+from oumi.environments import DeterministicToolOutput
+from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
 
@@ -699,3 +702,59 @@ class ConversationSynthesizer:
         if seed is None:
             return random.Random()
         return random.Random(seed + sample_index)
+
+    def _attach_grounding_facts(
+        self,
+        samples: list[dict],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> None:
+        """Attach per-sample grounding facts drawn from grounded envs in scope.
+
+        Writes ``sample["grounding_facts"]`` as a flat list concatenated
+        across all envs in scope that declare a ``GroundingConfig``. No-op
+        when ``environment_config`` is absent or no env in scope declares
+        grounding. Emits one ``logger.warning`` per env when truncation
+        occurs (sample_size > pool_size).
+        """
+        if self._environment_config is None:
+            return
+
+        from oumi.builders.environments import build_environment
+
+        scoped_env_ids = (
+            set(multiturn_attribute.available_environments)
+            if multiturn_attribute.available_environments
+            else {env.id for env in self._environment_config.environments}
+        )
+        grounding_env_pairs: list[tuple[EnvironmentParams, BaseEnvironment]] = [
+            (env_params, build_environment(env_params))
+            for env_params in self._environment_config.environments
+            if env_params.id in scoped_env_ids and env_params.grounding is not None
+        ]
+        if not grounding_env_pairs:
+            return
+
+        warned_envs: set[str] = set()
+        for sample_index, sample in enumerate(samples):
+            facts: list[DeterministicToolOutput] = []
+            for env_params, env_runtime in grounding_env_pairs:
+                grounding = env_params.grounding
+                assert grounding is not None  # filtered above
+                rng = self._make_grounding_rng(grounding.seed, sample_index)
+                sampled = env_runtime.sample_grounding(
+                    n=grounding.sample_size, rng=rng
+                )
+                if (
+                    len(sampled) < grounding.sample_size
+                    and env_params.id not in warned_envs
+                ):
+                    logger.warning(
+                        "Grounding sample_size=%d exceeds pool size for "
+                        "environment '%s'; truncating to %d facts.",
+                        grounding.sample_size,
+                        env_params.id,
+                        len(sampled),
+                    )
+                    warned_envs.add(env_params.id)
+                facts.extend(sampled)
+            sample["grounding_facts"] = facts

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -184,6 +184,7 @@ class ConversationSynthesizer:
                 [tool.id for tool in available_tools],
             )
 
+        self._attach_grounding_facts(samples, multiturn_attributes)
         samples = self._plan_samples(samples, multiturn_attributes)
         conversations = self._synthesize_all_samples(samples, multiturn_attributes)
 
@@ -490,6 +491,37 @@ class ConversationSynthesizer:
 
         if role_context:
             base_prompt += f"\nRole context:\n{role_context}\n"
+
+        grounding_facts = sample.get("grounding_facts") or []
+        if grounding_facts:
+            from oumi.builders.environments import build_environment
+            from oumi.environments._helpers import describe_grounding_default
+
+            # Pick the first grounded env's describer. In v1 every env uses
+            # the default describer; future envs with custom describers
+            # should be revisited here.
+            describer_env_params = next(
+                (
+                    env_params
+                    for env_params in (
+                        self._environment_config.environments
+                        if self._environment_config
+                        else []
+                    )
+                    if env_params.grounding is not None
+                ),
+                None,
+            )
+            if describer_env_params is not None:
+                describer_env = build_environment(describer_env_params)
+                block = describer_env.describe_grounding(grounding_facts)
+            else:
+                block = describe_grounding_default(grounding_facts)
+            base_prompt += (
+                "\nGround this plan in these specific entities:\n"
+                f"{block}\n"
+                "Your turn plans must only reference these entities.\n"
+            )
 
         if multiturn_attribute.conversation_planner:
             formatted_planner = self._formatter.format(

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -685,3 +685,17 @@ class ConversationSynthesizer:
             system_message,
         )
         return Message(role=Role.SYSTEM, content=formatted_content.strip())
+
+    def _make_grounding_rng(
+        self, seed: int | None, sample_index: int
+    ) -> random.Random:
+        """Build the RNG used for sampling grounding facts for one sample.
+
+        Unseeded (``seed=None``) uses the default ``random.Random()`` with
+        entropy from the OS, matching the non-reproducible behavior used by
+        ``DatasetPlanner`` for sampled attributes. Seeded mode makes each
+        sample's facts deterministic from ``(seed + sample_index)``.
+        """
+        if seed is None:
+            return random.Random()
+        return random.Random(seed + sample_index)

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -20,8 +20,8 @@ import random
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
-from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.synthesis_params import (
@@ -184,6 +184,7 @@ class ConversationSynthesizer:
                 [tool.id for tool in available_tools],
             )
 
+        self._warn_on_grounding_placeholder(multiturn_attributes)
         self._attach_grounding_facts(samples, multiturn_attributes)
         samples = self._plan_samples(samples, multiturn_attributes)
         conversations = self._synthesize_all_samples(samples, multiturn_attributes)
@@ -721,9 +722,7 @@ class ConversationSynthesizer:
         )
         return Message(role=Role.SYSTEM, content=formatted_content.strip())
 
-    def _make_grounding_rng(
-        self, seed: int | None, sample_index: int
-    ) -> random.Random:
+    def _make_grounding_rng(self, seed: int | None, sample_index: int) -> random.Random:
         """Build the RNG used for sampling grounding facts for one sample.
 
         Unseeded (``seed=None``) uses the default ``random.Random()`` with
@@ -734,6 +733,32 @@ class ConversationSynthesizer:
         if seed is None:
             return random.Random()
         return random.Random(seed + sample_index)
+
+    def _warn_on_grounding_placeholder(
+        self, multiturn_attribute: MultiTurnAttribute
+    ) -> None:
+        """Warn if ``{grounding_facts}`` appears in user/assistant personas.
+
+        Grounding facts are planner-only — placing the placeholder in a
+        user or assistant persona template defeats its purpose and may
+        leak env state to roles that should not see it.
+        """
+        for role, persona in multiturn_attribute.role_instruction_messages.items():
+            if not isinstance(persona, str):
+                continue
+            if "{grounding_facts}" in persona and role in (
+                Role.USER,
+                Role.ASSISTANT,
+            ):
+                logger.warning(
+                    "MultiTurnAttribute '%s' references {grounding_facts} in "
+                    "the %s persona template. grounding is planner-only; "
+                    "placing {grounding_facts} in user/assistant templates "
+                    "defeats its purpose and may leak env state to roles "
+                    "that should not see it.",
+                    multiturn_attribute.id,
+                    role.value,
+                )
 
     def _attach_grounding_facts(
         self,
@@ -773,9 +798,7 @@ class ConversationSynthesizer:
                 grounding = env_params.grounding
                 assert grounding is not None  # filtered above
                 rng = self._make_grounding_rng(grounding.seed, sample_index)
-                sampled = env_runtime.sample_grounding(
-                    n=grounding.sample_size, rng=rng
-                )
+                sampled = env_runtime.sample_grounding(n=grounding.sample_size, rng=rng)
                 if (
                     len(sampled) < grounding.sample_size
                     and env_params.id not in warned_envs

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1116,3 +1116,262 @@ def test_make_grounding_rng_seeded_varies_across_sample_indices(
     rng_0 = synth._make_grounding_rng(seed=42, sample_index=0)
     rng_1 = synth._make_grounding_rng(seed=42, sample_index=1)
     assert [rng_0.random() for _ in range(5)] != [rng_1.random() for _ in range(5)]
+
+
+# --- _attach_grounding_facts ---
+
+
+def _grounded_env_params(
+    env_id: str = "env1",
+    tool_id: str = "lookup",
+    n_entries: int = 10,
+    sample_size: int = 3,
+    seed: int | None = None,
+):
+    from oumi.core.configs.params.environment_params import (
+        EnvironmentParams,
+        GroundingConfig,
+    )
+    from oumi.core.configs.params.tool_params import (
+        DeterministicToolOutput,
+        ToolParams,
+    )
+
+    outputs = [
+        DeterministicToolOutput(
+            input={"id": str(i)},
+            output={"title": f"title-{i}"},
+        )
+        for i in range(n_entries)
+    ]
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"env {env_id}",
+        env_type="deterministic",
+        grounding=GroundingConfig(sample_size=sample_size, seed=seed),
+        tools=[
+            ToolParams(
+                id=tool_id,
+                name=tool_id,
+                description="Look up an id.",
+                deterministic_outputs=outputs,
+            )
+        ],
+    )
+
+
+def _grounded_env_config(**env_kwargs):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    return EnvironmentConfig(environments=[_grounded_env_params(**env_kwargs)])
+
+
+def _ungrounded_env_config():
+    from oumi.core.configs.environment_config import EnvironmentConfig
+    from oumi.core.configs.params.environment_params import EnvironmentParams
+    from oumi.core.configs.params.tool_params import (
+        DeterministicToolOutput,
+        ToolParams,
+    )
+
+    return EnvironmentConfig(
+        environments=[
+            EnvironmentParams(
+                id="env1",
+                name="env1",
+                description="ungrounded env",
+                env_type="deterministic",
+                tools=[
+                    ToolParams(
+                        id="lookup",
+                        name="lookup",
+                        description="Look up an id.",
+                        deterministic_outputs=[
+                            DeterministicToolOutput(
+                                input={"id": "1"}, output={"title": "t"}
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+
+
+def _grounding_attr(available_envs=None, available_tools=None):
+    return MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "u",
+            Role.ASSISTANT: "a",
+        },
+        available_environments=available_envs,
+        available_tools=available_tools,
+    )
+
+
+def test_attach_grounding_facts_noop_without_env_config(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    samples = [{"a": 1}, {"b": 2}]
+
+    synth._attach_grounding_facts(samples, _grounding_attr())
+
+    assert "grounding_facts" not in samples[0]
+    assert "grounding_facts" not in samples[1]
+
+
+def test_attach_grounding_facts_noop_when_no_env_has_grounding(
+    mock_inference_config,
+):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    samples = [{}, {}]
+
+    synth._attach_grounding_facts(
+        samples, _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    )
+
+    assert "grounding_facts" not in samples[0]
+    assert "grounding_facts" not in samples[1]
+
+
+def test_attach_grounding_facts_populates_samples(mock_inference_config):
+    from oumi.core.configs.params.tool_params import DeterministicToolOutput
+
+    env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    samples = [{}, {}, {}]
+
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+    )
+
+    for sample in samples:
+        assert "grounding_facts" in sample
+        assert len(sample["grounding_facts"]) == 3
+        for fact in sample["grounding_facts"]:
+            assert isinstance(fact, DeterministicToolOutput)
+
+
+def test_attach_grounding_facts_seeded_is_reproducible(mock_inference_config):
+    synth_a = _make_synthesizer(
+        mock_inference_config,
+        environment_config=_grounded_env_config(n_entries=20, sample_size=4, seed=7),
+    )
+    synth_b = _make_synthesizer(
+        mock_inference_config,
+        environment_config=_grounded_env_config(n_entries=20, sample_size=4, seed=7),
+    )
+    samples_a = [{}, {}, {}]
+    samples_b = [{}, {}, {}]
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+
+    synth_a._attach_grounding_facts(samples_a, attr)
+    synth_b._attach_grounding_facts(samples_b, attr)
+
+    for a, b in zip(samples_a, samples_b):
+        assert [f.input["id"] for f in a["grounding_facts"]] == [
+            f.input["id"] for f in b["grounding_facts"]
+        ]
+
+
+def test_attach_grounding_facts_seeded_different_samples_differ(
+    mock_inference_config,
+):
+    env_config = _grounded_env_config(n_entries=50, sample_size=3, seed=7)
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    samples = [{}, {}]
+
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+    )
+
+    ids_0 = sorted(f.input["id"] for f in samples[0]["grounding_facts"])
+    ids_1 = sorted(f.input["id"] for f in samples[1]["grounding_facts"])
+    assert ids_0 != ids_1
+
+
+def test_attach_grounding_facts_respects_available_environments_scoping(
+    mock_inference_config,
+):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    env_a = _grounded_env_params(
+        env_id="env_a", tool_id="tool_a", n_entries=5, sample_size=2, seed=1
+    )
+    env_b = _grounded_env_params(
+        env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=2, seed=2
+    )
+    env_config = EnvironmentConfig(environments=[env_a, env_b])
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    samples = [{}]
+
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env_a"], available_tools=["tool_a"]),
+    )
+
+    # Only env_a contributes facts (sample_size=2).
+    assert len(samples[0]["grounding_facts"]) == 2
+
+
+def test_attach_grounding_facts_concatenates_across_multiple_envs(
+    mock_inference_config,
+):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    env_a = _grounded_env_params(
+        env_id="env_a", tool_id="tool_a", n_entries=5, sample_size=2, seed=1
+    )
+    env_b = _grounded_env_params(
+        env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=3, seed=2
+    )
+    env_config = EnvironmentConfig(environments=[env_a, env_b])
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    samples = [{}]
+
+    # available_environments=None -> all envs in config are in scope
+    synth._attach_grounding_facts(
+        samples, _grounding_attr(available_tools=["tool_a", "tool_b"])
+    )
+
+    assert len(samples[0]["grounding_facts"]) == 5  # 2 + 3
+
+
+def test_attach_grounding_facts_truncation_emits_logger_warning(
+    mock_inference_config, caplog
+):
+    import logging
+
+    env_config = _grounded_env_config(n_entries=2, sample_size=5, seed=1)
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    samples = [{}, {}]
+
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._attach_grounding_facts(
+            samples,
+            _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+        )
+
+    truncation_records = [
+        rec for rec in caplog.records if "sample_size" in rec.getMessage()
+    ]
+    # Exactly one warning per env per synthesize invocation, even with 2 samples.
+    assert len(truncation_records) == 1
+    assert "env1" in truncation_records[0].getMessage()

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1375,3 +1375,158 @@ def test_attach_grounding_facts_truncation_emits_logger_warning(
     # Exactly one warning per env per synthesize invocation, even with 2 samples.
     assert len(truncation_records) == 1
     assert "env1" in truncation_records[0].getMessage()
+
+
+# --- Planner prompt grounding injection ---
+
+
+def test_create_planner_prompt_injects_grounding_block_when_facts_present(
+    mock_inference_config,
+):
+    from oumi.core.configs.params.tool_params import DeterministicToolOutput
+
+    env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=1)
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config
+    )
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+        "grounding_facts": [
+            DeterministicToolOutput(
+                input={"id": "42"}, output={"title": "Dune"}
+            ),
+            DeterministicToolOutput(
+                input={"id": "7"}, output={"title": "LotR"}
+            ),
+        ],
+    }
+
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan in these specific entities" in planner_user_msg
+    assert '- id="42", title="Dune"' in planner_user_msg
+    assert '- id="7", title="LotR"' in planner_user_msg
+    assert (
+        "Your turn plans must only reference these entities" in planner_user_msg
+    )
+
+
+def test_create_planner_prompt_no_grounding_block_when_facts_absent(
+    mock_inference_config,
+):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    attr = _grounding_attr(
+        available_envs=["env1"], available_tools=["lookup"]
+    )
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+    }
+
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan" not in planner_user_msg
+
+
+def test_create_planner_prompt_empty_grounding_facts_omits_block(
+    mock_inference_config,
+):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    attr = _grounding_attr(
+        available_envs=["env1"], available_tools=["lookup"]
+    )
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+        "grounding_facts": [],
+    }
+
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan" not in planner_user_msg
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_invokes_attach_grounding_facts(
+    mock_build_inference_engine, mock_inference_config
+):
+    """End-to-end: synthesize() calls _attach_grounding_facts before planning."""
+    plan_json = (
+        '```json\n'
+        '[{"turn": 1, "instruction": "a"}, {"turn": 2, "instruction": "b"}]\n'
+        '```'
+    )
+
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    call_count = {"n": 0}
+
+    def infer_side_effect(conversations, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Planner call.
+            return [
+                Conversation(
+                    messages=[Message(role=Role.ASSISTANT, content=plan_json)]
+                )
+                for _ in conversations
+            ]
+        # Subsequent calls are turn generations.
+        return [
+            Conversation(
+                messages=[Message(role=Role.ASSISTANT, content="response")]
+            )
+            for _ in conversations
+        ]
+
+    mock_inference_engine.infer.side_effect = infer_side_effect
+
+    env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=5)
+    synth = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+        environment_config=env_config,
+    )
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+
+    samples = [{}]
+    result = synth.synthesize(samples, attr)
+
+    # The sample dict passed in should have grounding_facts attached.
+    assert "grounding_facts" in samples[0]
+    assert len(samples[0]["grounding_facts"]) == 2
+    # Basic regression: result shape is preserved.
+    assert len(result) == 1

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1073,3 +1073,46 @@ def test_synthesize_filters_all_conversations_returns_empty(
         result = synthesizer.synthesize(samples, multiturn_attr)
 
     assert result == [None, None]
+
+
+# --- _make_grounding_rng ---
+
+
+def _make_synthesizer(mock_inference_config, environment_config=None):
+    """Build a synthesizer with the inference engine builder patched out.
+
+    Returns the synthesizer; callers can ignore the patch since the engine
+    isn't exercised by the methods these tests target.
+    """
+    with patch(
+        "oumi.core.synthesis.conversation_synthesizer.build_inference_engine"
+    ):
+        return ConversationSynthesizer(
+            GeneralSynthesisParams(),
+            mock_inference_config,
+            environment_config=environment_config,
+        )
+
+
+def test_make_grounding_rng_unseeded_returns_fresh_random(mock_inference_config):
+    import random as _random
+
+    synth = _make_synthesizer(mock_inference_config)
+    rng = synth._make_grounding_rng(seed=None, sample_index=0)
+    assert isinstance(rng, _random.Random)
+
+
+def test_make_grounding_rng_seeded_is_reproducible(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    rng_a = synth._make_grounding_rng(seed=42, sample_index=3)
+    rng_b = synth._make_grounding_rng(seed=42, sample_index=3)
+    assert [rng_a.random() for _ in range(5)] == [rng_b.random() for _ in range(5)]
+
+
+def test_make_grounding_rng_seeded_varies_across_sample_indices(
+    mock_inference_config,
+):
+    synth = _make_synthesizer(mock_inference_config)
+    rng_0 = synth._make_grounding_rng(seed=42, sample_index=0)
+    rng_1 = synth._make_grounding_rng(seed=42, sample_index=1)
+    assert [rng_0.random() for _ in range(5)] != [rng_1.random() for _ in range(5)]

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1126,13 +1126,11 @@ def _grounded_env_params(
     sample_size: int = 3,
     seed: int | None = None,
 ):
-    from oumi.core.configs.params.environment_params import (
-        EnvironmentParams,
-        GroundingConfig,
-    )
-    from oumi.core.configs.params.tool_params import (
+    from oumi.core.configs.params.environment_params import EnvironmentParams
+    from oumi.core.configs.params.grounding_params import GroundingConfig
+    from oumi.environments.deterministic_tool import (
+        DeterministicTool,
         DeterministicToolOutput,
-        ToolParams,
     )
 
     outputs = [
@@ -1149,7 +1147,7 @@ def _grounded_env_params(
         env_type="deterministic",
         grounding=GroundingConfig(sample_size=sample_size, seed=seed),
         tools=[
-            ToolParams(
+            DeterministicTool(
                 id=tool_id,
                 name=tool_id,
                 description="Look up an id.",
@@ -1168,9 +1166,9 @@ def _grounded_env_config(**env_kwargs):
 def _ungrounded_env_config():
     from oumi.core.configs.environment_config import EnvironmentConfig
     from oumi.core.configs.params.environment_params import EnvironmentParams
-    from oumi.core.configs.params.tool_params import (
+    from oumi.environments.deterministic_tool import (
+        DeterministicTool,
         DeterministicToolOutput,
-        ToolParams,
     )
 
     return EnvironmentConfig(
@@ -1181,7 +1179,7 @@ def _ungrounded_env_config():
                 description="ungrounded env",
                 env_type="deterministic",
                 tools=[
-                    ToolParams(
+                    DeterministicTool(
                         id="lookup",
                         name="lookup",
                         description="Look up an id.",
@@ -1241,7 +1239,7 @@ def test_attach_grounding_facts_noop_when_no_env_has_grounding(
 
 
 def test_attach_grounding_facts_populates_samples(mock_inference_config):
-    from oumi.core.configs.params.tool_params import DeterministicToolOutput
+    from oumi.environments.deterministic_tool import DeterministicToolOutput
 
     env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
@@ -1374,7 +1372,7 @@ def test_attach_grounding_facts_truncation_emits_logger_warning(
 def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     mock_inference_config,
 ):
-    from oumi.core.configs.params.tool_params import DeterministicToolOutput
+    from oumi.environments.deterministic_tool import DeterministicToolOutput
 
     env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=1)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1084,9 +1084,7 @@ def _make_synthesizer(mock_inference_config, environment_config=None):
     Returns the synthesizer; callers can ignore the patch since the engine
     isn't exercised by the methods these tests target.
     """
-    with patch(
-        "oumi.core.synthesis.conversation_synthesizer.build_inference_engine"
-    ):
+    with patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine"):
         return ConversationSynthesizer(
             GeneralSynthesisParams(),
             mock_inference_config,
@@ -1199,7 +1197,10 @@ def _ungrounded_env_config():
     )
 
 
-def _grounding_attr(available_envs=None, available_tools=None):
+def _grounding_attr(
+    available_envs: list[str] | None = None,
+    available_tools: list[str] | None = None,
+):
     return MultiTurnAttribute(
         id="t",
         min_turns=2,
@@ -1208,8 +1209,8 @@ def _grounding_attr(available_envs=None, available_tools=None):
             Role.USER: "u",
             Role.ASSISTANT: "a",
         },
-        available_environments=available_envs,
-        available_tools=available_tools,
+        available_environments=available_envs or [],
+        available_tools=available_tools or [],
     )
 
 
@@ -1243,9 +1244,7 @@ def test_attach_grounding_facts_populates_samples(mock_inference_config):
     from oumi.core.configs.params.tool_params import DeterministicToolOutput
 
     env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}, {}]
 
     synth._attach_grounding_facts(
@@ -1286,9 +1285,7 @@ def test_attach_grounding_facts_seeded_different_samples_differ(
     mock_inference_config,
 ):
     env_config = _grounded_env_config(n_entries=50, sample_size=3, seed=7)
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
 
     synth._attach_grounding_facts(
@@ -1313,9 +1310,7 @@ def test_attach_grounding_facts_respects_available_environments_scoping(
         env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=2, seed=2
     )
     env_config = EnvironmentConfig(environments=[env_a, env_b])
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}]
 
     synth._attach_grounding_facts(
@@ -1339,9 +1334,7 @@ def test_attach_grounding_facts_concatenates_across_multiple_envs(
         env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=3, seed=2
     )
     env_config = EnvironmentConfig(environments=[env_a, env_b])
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}]
 
     # available_environments=None -> all envs in config are in scope
@@ -1358,9 +1351,7 @@ def test_attach_grounding_facts_truncation_emits_logger_warning(
     import logging
 
     env_config = _grounded_env_config(n_entries=2, sample_size=5, seed=1)
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
 
     with caplog.at_level(logging.WARNING, logger="oumi"):
@@ -1386,9 +1377,7 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     from oumi.core.configs.params.tool_params import DeterministicToolOutput
 
     env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=1)
-    synth = _make_synthesizer(
-        mock_inference_config, environment_config=env_config
-    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     attr = MultiTurnAttribute(
         id="t",
         min_turns=2,
@@ -1405,12 +1394,8 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
         "conversation_plan": "",
         "parsed_turn_plans": [""] * 2,
         "grounding_facts": [
-            DeterministicToolOutput(
-                input={"id": "42"}, output={"title": "Dune"}
-            ),
-            DeterministicToolOutput(
-                input={"id": "7"}, output={"title": "LotR"}
-            ),
+            DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"}),
+            DeterministicToolOutput(input={"id": "7"}, output={"title": "LotR"}),
         ],
     }
 
@@ -1420,9 +1405,7 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     assert "Ground this plan in these specific entities" in planner_user_msg
     assert '- id="42", title="Dune"' in planner_user_msg
     assert '- id="7", title="LotR"' in planner_user_msg
-    assert (
-        "Your turn plans must only reference these entities" in planner_user_msg
-    )
+    assert "Your turn plans must only reference these entities" in planner_user_msg
 
 
 def test_create_planner_prompt_no_grounding_block_when_facts_absent(
@@ -1431,9 +1414,7 @@ def test_create_planner_prompt_no_grounding_block_when_facts_absent(
     synth = _make_synthesizer(
         mock_inference_config, environment_config=_ungrounded_env_config()
     )
-    attr = _grounding_attr(
-        available_envs=["env1"], available_tools=["lookup"]
-    )
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
     sample = {
         "target_turns": 2,
         "conversation_plan": "",
@@ -1452,9 +1433,7 @@ def test_create_planner_prompt_empty_grounding_facts_omits_block(
     synth = _make_synthesizer(
         mock_inference_config, environment_config=_ungrounded_env_config()
     )
-    attr = _grounding_attr(
-        available_envs=["env1"], available_tools=["lookup"]
-    )
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
     sample = {
         "target_turns": 2,
         "conversation_plan": "",
@@ -1474,9 +1453,9 @@ def test_synthesize_invokes_attach_grounding_facts(
 ):
     """End-to-end: synthesize() calls _attach_grounding_facts before planning."""
     plan_json = (
-        '```json\n'
+        "```json\n"
         '[{"turn": 1, "instruction": "a"}, {"turn": 2, "instruction": "b"}]\n'
-        '```'
+        "```"
     )
 
     mock_inference_engine = Mock()
@@ -1489,16 +1468,12 @@ def test_synthesize_invokes_attach_grounding_facts(
         if call_count["n"] == 1:
             # Planner call.
             return [
-                Conversation(
-                    messages=[Message(role=Role.ASSISTANT, content=plan_json)]
-                )
+                Conversation(messages=[Message(role=Role.ASSISTANT, content=plan_json)])
                 for _ in conversations
             ]
         # Subsequent calls are turn generations.
         return [
-            Conversation(
-                messages=[Message(role=Role.ASSISTANT, content="response")]
-            )
+            Conversation(messages=[Message(role=Role.ASSISTANT, content="response")])
             for _ in conversations
         ]
 
@@ -1530,3 +1505,79 @@ def test_synthesize_invokes_attach_grounding_facts(
     assert len(samples[0]["grounding_facts"]) == 2
     # Basic regression: result shape is preserved.
     assert len(result) == 1
+
+
+# --- {grounding_facts} placeholder misuse warning ---
+
+
+def test_warn_on_grounding_placeholder_warns_in_user_persona(
+    mock_inference_config, caplog
+):
+    import logging
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user interested in {grounding_facts}.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+
+    warnings = [rec for rec in caplog.records if "grounding_facts" in rec.getMessage()]
+    assert len(warnings) >= 1
+    assert "user" in warnings[0].getMessage().lower()
+
+
+def test_warn_on_grounding_placeholder_warns_in_assistant_persona(
+    mock_inference_config, caplog
+):
+    import logging
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You know these entities: {grounding_facts}.",
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+
+    warnings = [rec for rec in caplog.records if "grounding_facts" in rec.getMessage()]
+    assert len(warnings) >= 1
+    assert "assistant" in warnings[0].getMessage().lower()
+
+
+def test_warn_on_grounding_placeholder_no_warning_when_placeholder_absent(
+    mock_inference_config, caplog
+):
+    import logging
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+
+    grounding_warnings = [
+        rec for rec in caplog.records if "grounding_facts" in rec.getMessage()
+    ]
+    assert grounding_warnings == []


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 4 of 6) - Stage: synthesis integration

**What changed**: Add `_make_grounding_rng()` and `_attach_grounding_facts()` to the synthesizer, wire grounding fact sampling and injection into `synthesize()` and the planner prompt, and add validation that `{grounding_facts}` only appears in the planner template.

**Why**: This is the integration layer that connects grounding types (Phase 2) and environment sampling (Phase 3) to the actual synthesis loop, so the planner receives per-sample grounding facts in its prompt.

## PR Chain

1. Planner guided decoding & tool schema
2. Grounding types, config & infrastructure
3. Grounding in environments
4. **Wire grounding into synthesis pipeline** (this PR)
5. Tool use robustness & polish
6. JSON repair & planner refinement

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?