### PR TITLE
[Det Env] Phase 5: Tool use robustness & grounding polish

### DIFF
--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -1,0 +1,342 @@
+# Library Assistant — Tool-Use Conversation Synthesis
+#
+# Generates grounded multi-turn conversations between a library patron and a
+# library-assistant chatbot that looks up book circulation status via a
+# DeterministicEnvironment tool.
+#
+# Grounding is enabled on the environment: a small random subset of real
+# catalog entries is surfaced to the planner each conversation so turn plans
+# reference book IDs/titles that actually exist. The user persona enacts
+# those plans; the assistant persona is un-grounded and must call the
+# `lookup_book_status` tool to learn any circulation details.
+#
+# Requirements:
+#   - Set ANTHROPIC_API_KEY in the environment
+#     (example: `export ANTHROPIC_API_KEY=your_api_key`)
+#   - Or change the inference_config to use a different provider/engine.
+#
+# Usage:
+#   oumi synth -c configs/examples/synthesis/library_tool_use_synth.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/synth.html
+#   - Grounding spec: docs/superpowers/specs/2026-04-17-deterministic-env-grounding-design.md
+#   - Config class: oumi.core.configs.SynthesisConfig
+#   - Environment config: oumi.core.configs.EnvironmentConfig
+
+strategy: GENERAL
+num_samples: 10
+output_path: library_tool_use_dataset.jsonl
+
+environment_config:
+  environments:
+    - id: library_catalog
+      type: deterministic
+      name: Library Catalog
+      description: Circulation lookup for the city library.
+      grounding:
+        sample_size: 3
+        seed: 42
+      tools:
+        - id: lookup_book_status
+          name: Lookup Book Status
+          description: >-
+            Look up a book's circulation status by book_id. Returns the
+            title, author, current borrower, borrow date, and due date.
+          parameters:
+            type: object
+            properties:
+              book_id:
+                type: string
+                description: The library's book identifier (e.g. "B001").
+            required:
+              - book_id
+          output_schema:
+            type: object
+            properties:
+              title:
+                type: string
+              author:
+                type: string
+              borrower_name:
+                type: string
+              borrow_date:
+                type: string
+              return_date:
+                type: string
+              status:
+                type: string
+          deterministic_outputs:
+            - input: { book_id: "B001" }
+              output:
+                title: "The Great Gatsby"
+                author: "F. Scott Fitzgerald"
+                borrower_name: "Sarah Chen"
+                borrow_date: "2026-03-15"
+                return_date: "2026-04-15"
+                status: "overdue"
+            - input: { book_id: "B002" }
+              output:
+                title: "To Kill a Mockingbird"
+                author: "Harper Lee"
+                borrower_name: "Marcus Johnson"
+                borrow_date: "2026-04-01"
+                return_date: "2026-05-01"
+                status: "borrowed"
+            - input: { book_id: "B003" }
+              output:
+                title: "1984"
+                author: "George Orwell"
+                borrower_name: "Aisha Patel"
+                borrow_date: "2026-04-10"
+                return_date: "2026-05-10"
+                status: "borrowed"
+            - input: { book_id: "B004" }
+              output:
+                title: "Pride and Prejudice"
+                author: "Jane Austen"
+                borrower_name: "David Kim"
+                borrow_date: "2026-03-20"
+                return_date: "2026-04-20"
+                status: "borrowed"
+            - input: { book_id: "B005" }
+              output:
+                title: "Dune"
+                author: "Frank Herbert"
+                borrower_name: "Elena Rodriguez"
+                borrow_date: "2026-04-05"
+                return_date: "2026-05-05"
+                status: "borrowed"
+            - input: { book_id: "B006" }
+              output:
+                title: "The Catcher in the Rye"
+                author: "J.D. Salinger"
+                borrower_name: "James Wright"
+                borrow_date: "2026-02-28"
+                return_date: "2026-03-28"
+                status: "overdue"
+            - input: { book_id: "B007" }
+              output:
+                title: "Brave New World"
+                author: "Aldous Huxley"
+                borrower_name: "Priya Sharma"
+                borrow_date: "2026-04-12"
+                return_date: "2026-05-12"
+                status: "borrowed"
+            - input: { book_id: "B008" }
+              output:
+                title: "The Hobbit"
+                author: "J.R.R. Tolkien"
+                borrower_name: "Liam O'Connor"
+                borrow_date: "2026-04-14"
+                return_date: "2026-05-14"
+                status: "borrowed"
+            - input: { book_id: "B009" }
+              output:
+                title: "Fahrenheit 451"
+                author: "Ray Bradbury"
+                borrower_name: "Nina Volkov"
+                borrow_date: "2026-03-25"
+                return_date: "2026-04-25"
+                status: "borrowed"
+            - input: { book_id: "B010" }
+              output:
+                title: "One Hundred Years of Solitude"
+                author: "Gabriel García Márquez"
+                borrower_name: "Takeshi Yamamoto"
+                borrow_date: "2026-04-08"
+                return_date: "2026-05-08"
+                status: "borrowed"
+            - input: { book_id: "B011" }
+              output:
+                title: "The Name of the Wind"
+                author: "Patrick Rothfuss"
+                borrower_name: "Zoe Anderson"
+                borrow_date: "2026-04-02"
+                return_date: "2026-05-02"
+                status: "borrowed"
+            - input: { book_id: "B012" }
+              output:
+                title: "Project Hail Mary"
+                author: "Andy Weir"
+                borrower_name: "Omar Hassan"
+                borrow_date: "2026-03-30"
+                return_date: "2026-04-30"
+                status: "borrowed"
+            - input: { book_id: "B013" }
+              output:
+                title: "Klara and the Sun"
+                author: "Kazuo Ishiguro"
+                borrower_name: "Mira Gupta"
+                borrow_date: "2026-04-13"
+                return_date: "2026-05-13"
+                status: "borrowed"
+            - input: { book_id: "B014" }
+              output:
+                title: "The Midnight Library"
+                author: "Matt Haig"
+                borrower_name: "Chen Wei"
+                borrow_date: "2026-03-18"
+                return_date: "2026-04-18"
+                status: "overdue"
+            - input: { book_id: "B015" }
+              output:
+                title: "Circe"
+                author: "Madeline Miller"
+                borrower_name: "Ana Silva"
+                borrow_date: "2026-04-06"
+                return_date: "2026-05-06"
+                status: "borrowed"
+
+strategy_params:
+  sampled_attributes:
+    # Patron type drives tone + what they typically ask about
+    - id: patron_type
+      name: Patron Type
+      description: The type of library patron interacting with the assistant
+      possible_values:
+        - id: student
+          name: Student
+          description: A university student, often in a hurry, focused on due dates
+          sample_rate: 0.35
+        - id: professor
+          name: Professor
+          description: A faculty researcher, precise and expects efficient service
+          sample_rate: 0.2
+        - id: casual_reader
+          name: Casual Reader
+          description: A local resident browsing casually, friendly and chatty
+          sample_rate: 0.3
+        - id: parent
+          name: Parent
+          description: A parent borrowing on behalf of their child, sometimes uncertain
+          sample_rate: 0.15
+
+    # What the patron wants to accomplish this conversation
+    - id: query_intent
+      name: Query Intent
+      description: The reason the patron is contacting the library assistant
+      possible_values:
+        - id: due_date_check
+          name: Due Date Check
+          description: Wants to know when a specific book is due back
+          sample_rate: 0.35
+        - id: borrower_identification
+          name: Borrower Identification
+          description: Wants to find out who currently has a particular book
+          sample_rate: 0.2
+        - id: overdue_concern
+          name: Overdue Concern
+          description: Worried a book they borrowed is overdue, wants status
+          sample_rate: 0.25
+        - id: multi_book_inquiry
+          name: Multi-Book Inquiry
+          description: Asks about the status of more than one book in the same chat
+          sample_rate: 0.2
+
+    # Conversational style
+    - id: patron_demeanor
+      name: Patron Demeanor
+      description: The emotional tone the patron brings to the conversation
+      possible_values:
+        - id: polite
+          name: Polite
+          description: Courteous, patient, uses please/thank you
+          sample_rate: 0.45
+        - id: hurried
+          name: Hurried
+          description: Short messages, wants a quick answer
+          sample_rate: 0.25
+        - id: confused
+          name: Confused
+          description: Not sure what book IDs are or how to phrase the question
+          sample_rate: 0.15
+        - id: friendly
+          name: Friendly
+          description: Warm and conversational, likes small talk
+          sample_rate: 0.15
+
+  # Per-sample first name for realism
+  generated_attributes:
+    - id: patron_name
+      instruction_messages:
+        - role: SYSTEM
+          content: |
+            Generate a realistic first name only. Output just the name, nothing else.
+        - role: USER
+          content: |
+            Generate a common first name.
+
+  # The multi-turn conversation definition
+  multiturn_attributes:
+    - id: "library_conversation"
+      min_turns: 3
+      max_turns: 8
+      available_environments:
+        - library_catalog
+      available_tools:
+        - lookup_book_status
+      max_tool_calls_per_turn: 4
+
+      role_instruction_messages:
+        USER: |
+          You are {patron_name}, a {patron_type.name} visiting the city library's
+          online assistant.
+
+          Your background: {patron_type.description}
+          Your mood today: {patron_demeanor.name} — {patron_demeanor.description}
+          What you want: {query_intent.description}
+
+          Guidelines:
+          - Follow the plan's direction for this turn, but respond naturally.
+          - Stay in character. Do not break the fourth wall.
+          - You do NOT have access to the library database — only the assistant does.
+            When you want to know about a book, ask the assistant; do not claim to
+            know its status yourself.
+          - Keep messages conversational and to 1-3 sentences.
+
+          If this is your first message, open the conversation with a greeting and
+          your question.
+
+          Output only your message, nothing else.
+
+        ASSISTANT: |
+          You are LibBot, the city library's circulation assistant. You help
+          patrons look up book status using the tools provided to you.
+
+          Rules:
+          - When a patron asks about a specific book, call the `lookup_book_status`
+            tool with the relevant book_id to retrieve current circulation data.
+          - If the patron mentions a title without an ID, politely ask for the
+            book_id before calling the tool. The ID format is `B` followed by
+            three digits (e.g. B001).
+          - After you get the tool result, summarize it in friendly, natural
+            language. Include title, borrower, borrow date, due date, and status.
+          - If the tool returns an error (e.g. unknown book_id), apologize,
+            mention the ID was not found, and ask the patron to double-check.
+          - Never fabricate circulation details. Only state facts that came from
+            the tool.
+          - Keep responses under 3 sentences unless summarizing multiple books.
+
+          Follow the plan's direction for this turn. Output only your response.
+
+      output_system_prompt: |
+        You are LibBot, the city library's circulation assistant. You help
+        patrons look up book status using the lookup_book_status tool.
+        Always call the tool for circulation queries; never fabricate data.
+
+  passthrough_attributes:
+    - library_conversation
+    - library_conversation_plan
+
+inference_config:
+  model:
+    model_name: claude-sonnet-4-20250514
+  engine: ANTHROPIC
+  generation:
+    max_new_tokens: 4096
+    temperature: 0.7
+    top_p: 0.9
+  remote_params:
+    num_workers: 10
+    politeness_policy: 60

--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -39,7 +39,7 @@ output_path: library_tool_use_dataset.jsonl
 environment_config:
   environments:
     - id: library_catalog
-      type: deterministic
+      env_type: deterministic
       name: Library Catalog
       description: Circulation lookup for the city library.
       grounding:

--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -1,14 +1,22 @@
 # Library Assistant — Tool-Use Conversation Synthesis
 #
 # Generates grounded multi-turn conversations between a library patron and a
-# library-assistant chatbot that looks up book circulation status via a
-# DeterministicEnvironment tool.
+# library-assistant chatbot. The assistant has two DeterministicEnvironment
+# tools:
+#   1. `list_book_catalog`  — returns the full {book_id, title, author}
+#      catalog. Used to resolve a patron-spoken title into a book_id.
+#   2. `lookup_book_status` — returns circulation details for a book_id.
+#
+# Patrons in this synthesis only ever refer to books by TITLE (the way a real
+# patron would speak), never by internal IDs. The assistant must call
+# `list_book_catalog` first when a title is given, then chain into
+# `lookup_book_status` with the resolved id.
 #
 # Grounding is enabled on the environment: a small random subset of real
 # catalog entries is surfaced to the planner each conversation so turn plans
-# reference book IDs/titles that actually exist. The user persona enacts
-# those plans; the assistant persona is un-grounded and must call the
-# `lookup_book_status` tool to learn any circulation details.
+# reference titles that actually exist. The user persona enacts those plans;
+# the assistant persona is un-grounded and must use the tools to learn any
+# circulation details.
 #
 # Requirements:
 #   - Set ANTHROPIC_API_KEY in the environment
@@ -38,6 +46,102 @@ environment_config:
         sample_size: 3
         seed: 42
       tools:
+        - id: list_book_catalog
+          name: List Book Catalog
+          description: >-
+            Returns the library's full catalog as a list of
+            {book_id, title, author} entries. Call this first whenever a
+            patron names a book by TITLE so you can resolve the title to a
+            book_id before calling lookup_book_status.
+          parameters:
+            type: object
+            properties: {}
+          output_schema:
+            type: object
+            properties:
+              books:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    book_id:
+                      type: string
+                    title:
+                      type: string
+                    author:
+                      type: string
+          deterministic_outputs:
+            - input: {}
+              output:
+                books:
+                  - {
+                      book_id: "B001",
+                      title: "The Great Gatsby",
+                      author: "F. Scott Fitzgerald",
+                    }
+                  - {
+                      book_id: "B002",
+                      title: "To Kill a Mockingbird",
+                      author: "Harper Lee",
+                    }
+                  - { book_id: "B003", title: "1984", author: "George Orwell" }
+                  - {
+                      book_id: "B004",
+                      title: "Pride and Prejudice",
+                      author: "Jane Austen",
+                    }
+                  - { book_id: "B005", title: "Dune", author: "Frank Herbert" }
+                  - {
+                      book_id: "B006",
+                      title: "The Catcher in the Rye",
+                      author: "J.D. Salinger",
+                    }
+                  - {
+                      book_id: "B007",
+                      title: "Brave New World",
+                      author: "Aldous Huxley",
+                    }
+                  - {
+                      book_id: "B008",
+                      title: "The Hobbit",
+                      author: "J.R.R. Tolkien",
+                    }
+                  - {
+                      book_id: "B009",
+                      title: "Fahrenheit 451",
+                      author: "Ray Bradbury",
+                    }
+                  - {
+                      book_id: "B010",
+                      title: "One Hundred Years of Solitude",
+                      author: "Gabriel García Márquez",
+                    }
+                  - {
+                      book_id: "B011",
+                      title: "The Name of the Wind",
+                      author: "Patrick Rothfuss",
+                    }
+                  - {
+                      book_id: "B012",
+                      title: "Project Hail Mary",
+                      author: "Andy Weir",
+                    }
+                  - {
+                      book_id: "B013",
+                      title: "Klara and the Sun",
+                      author: "Kazuo Ishiguro",
+                    }
+                  - {
+                      book_id: "B014",
+                      title: "The Midnight Library",
+                      author: "Matt Haig",
+                    }
+                  - {
+                      book_id: "B015",
+                      title: "Circe",
+                      author: "Madeline Miller",
+                    }
+
         - id: lookup_book_status
           name: Lookup Book Status
           description: >-
@@ -135,10 +239,10 @@ environment_config:
               output:
                 title: "Fahrenheit 451"
                 author: "Ray Bradbury"
-                borrower_name: "Nina Volkov"
-                borrow_date: "2026-03-25"
-                return_date: "2026-04-25"
-                status: "borrowed"
+                borrower_name: ""
+                borrow_date: ""
+                return_date: ""
+                status: "available"
             - input: { book_id: "B010" }
               output:
                 title: "One Hundred Years of Solitude"
@@ -175,18 +279,18 @@ environment_config:
               output:
                 title: "The Midnight Library"
                 author: "Matt Haig"
-                borrower_name: "Chen Wei"
-                borrow_date: "2026-03-18"
-                return_date: "2026-04-18"
-                status: "overdue"
+                borrower_name: ""
+                borrow_date: ""
+                return_date: ""
+                status: "available"
             - input: { book_id: "B015" }
               output:
                 title: "Circe"
                 author: "Madeline Miller"
-                borrower_name: "Ana Silva"
-                borrow_date: "2026-04-06"
-                return_date: "2026-05-06"
-                status: "borrowed"
+                borrower_name: ""
+                borrow_date: ""
+                return_date: ""
+                status: "available"
 
 strategy_params:
   sampled_attributes:
@@ -197,44 +301,79 @@ strategy_params:
       possible_values:
         - id: student
           name: Student
-          description: A university student, often in a hurry, focused on due dates
-          sample_rate: 0.35
+          description: A university student juggling deadlines, focused on due dates and renewals
+          sample_rate: 0.18
         - id: professor
           name: Professor
-          description: A faculty researcher, precise and expects efficient service
-          sample_rate: 0.2
+          description: A faculty researcher, precise and expects efficient service; can be condescending
+          sample_rate: 0.12
         - id: casual_reader
           name: Casual Reader
           description: A local resident browsing casually, friendly and chatty
-          sample_rate: 0.3
+          sample_rate: 0.15
         - id: parent
           name: Parent
           description: A parent borrowing on behalf of their child, sometimes uncertain
-          sample_rate: 0.15
+          sample_rate: 0.10
+        - id: new_patron
+          name: New Patron
+          description: First-time visitor, unfamiliar with how the library or its catalog works
+          sample_rate: 0.10
+        - id: frequent_borrower
+          name: Frequent Borrower
+          description: Power user who reads constantly and tracks several titles at once; can be impatient
+          sample_rate: 0.10
+        - id: elderly_patron
+          name: Elderly Patron
+          description: Long-time member who prefers titles to codes and likes a bit of small talk
+          sample_rate: 0.10
+        - id: book_club_member
+          name: Book Club Member
+          description: Coordinating reading lists for a group; asks about several titles at once
+          sample_rate: 0.07
+        - id: teen
+          name: Teen
+          description: A high-school student looking for novels for class; informal, sometimes terse
+          sample_rate: 0.05
+        - id: disgruntled_member
+          name: Disgruntled Member
+          description: Frustrated with past library experiences (lost holds, fees, slow service)
+          sample_rate: 0.03
 
     # What the patron wants to accomplish this conversation
     - id: query_intent
       name: Query Intent
       description: The reason the patron is contacting the library assistant
       possible_values:
+        - id: availability_check
+          name: Availability Check
+          description: Wants to know if a specific titled book is currently on the shelf to borrow
         - id: due_date_check
           name: Due Date Check
-          description: Wants to know when a specific book is due back
-          sample_rate: 0.35
+          description: Wants to know when a specific titled book is due back
         - id: borrower_identification
           name: Borrower Identification
-          description: Wants to find out who currently has a particular book
-          sample_rate: 0.2
+          description: Wants to find out who currently has a particular titled book
         - id: overdue_concern
           name: Overdue Concern
-          description: Worried a book they borrowed is overdue, wants status
-          sample_rate: 0.25
+          description: Worried a book they borrowed is overdue and wants the current status
         - id: multi_book_inquiry
           name: Multi-Book Inquiry
-          description: Asks about the status of more than one book in the same chat
-          sample_rate: 0.2
+          description: Asks about the status of two or more titles in the same chat
+        - id: title_recall
+          name: Title Recall
+          description: Half-remembers a title (partial name, fuzzy author) and needs help identifying it
+        - id: catalog_browse
+          name: Catalog Browse
+          description: Wants to see what's in the catalog before deciding what to borrow
+        - id: complaint
+          name: Service Complaint
+          description: Vents about fees, holds, or wait times while still trying to get information about a book
+        - id: recommendation_followup
+          name: Recommendation Follow-up
+          description: Heard about a book from a friend or review and wants to check it on the spot
 
-    # Conversational style
+    # Conversational style — drives tone, length, vocabulary, and patience
     - id: patron_demeanor
       name: Patron Demeanor
       description: The emotional tone the patron brings to the conversation
@@ -242,19 +381,42 @@ strategy_params:
         - id: polite
           name: Polite
           description: Courteous, patient, uses please/thank you
-          sample_rate: 0.45
         - id: hurried
           name: Hurried
-          description: Short messages, wants a quick answer
-          sample_rate: 0.25
+          description: Short, clipped messages; wants the answer in one shot
         - id: confused
           name: Confused
-          description: Not sure what book IDs are or how to phrase the question
-          sample_rate: 0.15
+          description: Unsure of titles or how to phrase the question; meanders a bit
         - id: friendly
           name: Friendly
-          description: Warm and conversational, likes small talk
-          sample_rate: 0.15
+          description: Warm and conversational; small talk and tangents are normal
+        - id: rude
+          name: Rude
+          description: Curt and dismissive; skips greetings, no please/thank you, treats the bot as a search box
+        - id: angry
+          name: Angry
+          description: Openly frustrated, may use ALL CAPS, exclamation points, complain before asking
+        - id: frustrated
+          name: Frustrated
+          description: Annoyed at having to ask at all; sighs, mutters, but still wants help
+        - id: sarcastic
+          name: Sarcastic
+          description: Dry, cynical humor; pokes fun at the bot or the library
+        - id: anxious
+          name: Anxious
+          description: Worried, asks the same question multiple ways, seeks reassurance
+        - id: distracted
+          name: Distracted
+          description: Multitasking; messages have typos, half sentences, sudden topic switches
+        - id: demanding
+          name: Demanding
+          description: Entitled, expects immediate and complete service; pushes back on partial answers
+        - id: apologetic
+          name: Apologetic
+          description: Over-apologizes for taking up time, even for normal questions
+        - id: chatty
+          name: Chatty
+          description: Talks at length about life details before getting to the actual question
 
   # Per-sample first name for realism
   generated_attributes:
@@ -270,13 +432,14 @@ strategy_params:
   # The multi-turn conversation definition
   multiturn_attributes:
     - id: "library_conversation"
-      min_turns: 3
-      max_turns: 8
+      min_turns: 2
+      max_turns: 6
       available_environments:
         - library_catalog
       available_tools:
+        - list_book_catalog
         - lookup_book_status
-      max_tool_calls_per_turn: 4
+      max_tool_calls_per_turn: 6
 
       role_instruction_messages:
         USER: |
@@ -288,42 +451,83 @@ strategy_params:
           What you want: {query_intent.description}
 
           Guidelines:
-          - Follow the plan's direction for this turn, but respond naturally.
-          - Stay in character. Do not break the fourth wall.
-          - You do NOT have access to the library database — only the assistant does.
-            When you want to know about a book, ask the assistant; do not claim to
-            know its status yourself.
-          - Keep messages conversational and to 1-3 sentences.
+          - Follow the plan's direction for this turn, but respond naturally and
+            in character. Let your mood shape word choice, message length, and
+            patience level — a rude patron does not say "please"; an angry one may
+            vent before getting to the point; a chatty one rambles; a hurried one
+            is curt; a confused one second-guesses themselves.
+          - You ONLY know books by their TITLE (and sometimes a vague author),
+            the way a normal person does. You do NOT know the library's internal
+            book IDs (the "B001" / "B042" codes). Always refer to books by title.
+            If the assistant asks for a book ID, tell them you don't know it and
+            give the title again.
+          - You do NOT have access to the library database — only the assistant
+            does. Don't claim to know the borrower, due date, or status of a book
+            until the assistant has told you.
+          - Keep messages conversational. Length should match your mood: hurried
+            and rude patrons stay terse; friendly, chatty, anxious, or confused
+            patrons can run longer; angry or frustrated ones may complain mid-message.
+          - Vary openings: not every conversation starts with "Hi there!" — some
+            patrons skip greetings entirely, others launch straight into a complaint,
+            others say only "hey".
+          - Do not break character or reference the simulation, the planner, or
+            the fact that you are an AI.
 
-          If this is your first message, open the conversation with a greeting and
-          your question.
+          If this is your first message, open the conversation in whatever way
+          fits your mood, then state what you want.
 
           Output only your message, nothing else.
 
         ASSISTANT: |
-          You are LibBot, the city library's circulation assistant. You help
-          patrons look up book status using the tools provided to you.
+          You are LibBot, the city library's circulation assistant. You have
+          two tools available:
+
+          1. `list_book_catalog` — returns the full catalog as a list of
+             {{book_id, title, author}} entries. Use this whenever the patron
+             names a book by TITLE so you can resolve it to a book_id.
+          2. `lookup_book_status` — returns circulation details (borrower,
+             borrow date, due date, status) for a given book_id.
+
+          Standard flow:
+          - Patron names one or more titles → call `list_book_catalog` once →
+            find the matching book_id(s) → call `lookup_book_status` for each
+            relevant id → summarize the result(s) in natural language.
+          - Patron supplies a book_id directly (rare) → skip the catalog and
+            call `lookup_book_status` immediately.
+          - If a title is partial or ambiguous, surface the closest catalog
+            match(es) and ask the patron to confirm before looking up status.
+          - If the title is not in the catalog at all, say so clearly and
+            offer to look for something similar.
+          - For catalog-browse intent, you may share the title list from
+            `list_book_catalog` without immediately calling `lookup_book_status`.
 
           Rules:
-          - When a patron asks about a specific book, call the `lookup_book_status`
-            tool with the relevant book_id to retrieve current circulation data.
-          - If the patron mentions a title without an ID, politely ask for the
-            book_id before calling the tool. The ID format is `B` followed by
-            three digits (e.g. B001).
-          - After you get the tool result, summarize it in friendly, natural
-            language. Include title, borrower, borrow date, due date, and status.
-          - If the tool returns an error (e.g. unknown book_id), apologize,
-            mention the ID was not found, and ask the patron to double-check.
-          - Never fabricate circulation details. Only state facts that came from
-            the tool.
-          - Keep responses under 3 sentences unless summarizing multiple books.
+          - ALWAYS use the tools for any circulation or catalog information.
+            Never fabricate titles, authors, borrowers, dates, or statuses.
+          - Do NOT invent procedural information you cannot verify (online
+            renewal flows, PIN reset steps, fee amounts, hold queue length,
+            etc.). If asked, acknowledge you don't have that capability and
+            suggest contacting the circulation desk.
+          - Stay calm, professional, and helpful no matter how rude, angry,
+            sarcastic, or demanding the patron is. Acknowledge frustration
+            briefly when appropriate, but do not grovel and do not match
+            their tone.
+          - Don't volunteer the borrower's name unless the patron specifically
+            asked who has the book.
+          - Keep responses tight (under 3 sentences) unless summarizing
+            multiple books, in which case use a short list.
 
           Follow the plan's direction for this turn. Output only your response.
 
       output_system_prompt: |
         You are LibBot, the city library's circulation assistant. You help
-        patrons look up book status using the lookup_book_status tool.
-        Always call the tool for circulation queries; never fabricate data.
+        patrons find books and check circulation status using two tools:
+          - `list_book_catalog`  — returns {{book_id, title, author}} for the
+            full catalog. Use this to resolve a patron-spoken title to a
+            book_id.
+          - `lookup_book_status` — returns circulation details for a book_id.
+        Always call the tools for catalog or circulation information; never
+        fabricate data. Stay professional with rude or angry patrons.
 
   passthrough_attributes:
     - library_conversation
@@ -338,5 +542,5 @@ inference_config:
     temperature: 0.7
     top_p: 0.9
   remote_params:
-    num_workers: 10
+    num_workers: 50
     politeness_policy: 60

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Per-environment grounding configuration."""
+"""Per-environment grounding configuration and fact types."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 
@@ -44,3 +45,18 @@ class GroundingConfig(BaseParams):
                 f"{type(self).__name__}.sample_size must be >= 1, "
                 f"got {self.sample_size}."
             )
+
+
+@dataclass
+class GroundingFact(BaseParams):
+    """Env-agnostic representation of a single grounding fact.
+
+    A fact is a flat key-value dict that environments produce during sampling
+    and the synthesizer renders into planner prompts. Environments convert
+    their native state (DeterministicToolOutput entries, synthetic state
+    snippets, DB rows, etc.) into GroundingFact instances. The data dict
+    is expected to be JSON-serializable scalars and is rendered verbatim
+    by ``describe_grounding_default``.
+    """
+
+    data: dict[str, Any] = field(default_factory=dict)

--- a/src/oumi/core/configs/synthesis_config.py
+++ b/src/oumi/core/configs/synthesis_config.py
@@ -105,7 +105,15 @@ class SynthesisConfig(BaseConfig):
             )
 
         if self.environment_config is not None:
-            return self.environment_config
+            if isinstance(self.environment_config, EnvironmentConfig):
+                return self.environment_config
+            if isinstance(self.environment_config, dict):
+                return EnvironmentConfig(**self.environment_config)
+            raise ValueError(
+                "SynthesisConfig.environment_config must be an "
+                "EnvironmentConfig instance or a dict; got "
+                f"{type(self.environment_config).__name__}."
+            )
 
         if self.environment_config_path is not None:
             if self.environment_config_path == "":

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -16,7 +16,6 @@ import copy
 import dataclasses
 import json
 import random
-import re
 
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
@@ -43,37 +42,20 @@ from oumi.core.types.conversation import (
 )
 from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.utils import (
+    TOOL_CALL_RE,
+    close_dangling_tool_call,
+    strip_tool_call_blocks,
+    truncate_after_last_tool_call,
+)
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
-
-_TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 
 _FORCED_FINALIZE_NUDGE = (
     "You have reached the tool-call limit. Do NOT emit any more "
     "<tool_call> blocks. Based on the information gathered so far, "
     "provide your final response to the user now."
 )
-
-
-def _strip_tool_call_blocks(text: str) -> str:
-    return _TOOL_CALL_RE.sub("", text)
-
-
-def _close_dangling_tool_call(text: str) -> str:
-    """Re-append ``</tool_call>`` when stop-sequence inference stripped it."""
-    opens = text.count("<tool_call>")
-    closes = text.count("</tool_call>")
-    if opens > closes:
-        return text + "</tool_call>"
-    return text
-
-
-def _truncate_after_last_tool_call(text: str) -> str:
-    """Return the text prefix up to and including the LAST ``</tool_call>``."""
-    last_close = text.rfind("</tool_call>")
-    if last_close == -1:
-        return text
-    return text[: last_close + len("</tool_call>")]
 
 
 def _tool_result_message(content: str) -> Message:
@@ -845,8 +827,8 @@ class ConversationSynthesizer:
                 )
             )
             for i, text in zip(active, texts):
-                text = _close_dangling_tool_call(text)
-                text = _truncate_after_last_tool_call(text)
+                text = close_dangling_tool_call(text)
+                text = truncate_after_last_tool_call(text)
                 turn_messages[i].append(Message(role=Role.ASSISTANT, content=text))
                 if self._is_final_response(text):
                     done[i] = True
@@ -876,7 +858,7 @@ class ConversationSynthesizer:
                 )
             )
             for i, text in zip(stragglers, texts):
-                final = _strip_tool_call_blocks(text).strip()
+                final = strip_tool_call_blocks(text).strip()
                 turn_messages[i].append(Message(role=Role.ASSISTANT, content=final))
 
         return [turn_messages[i] for i in sample_indices]
@@ -895,14 +877,14 @@ class ConversationSynthesizer:
         )
 
     def _is_final_response(self, text: str) -> bool:
-        return _TOOL_CALL_RE.search(text) is None
+        return TOOL_CALL_RE.search(text) is None
 
     def _execute_tool_calls(
         self, response_text: str, tool_dispatch: dict[str, BaseEnvironment]
     ) -> list[Message]:
         return [
             self._run_single_tool_call(match.group(1).strip(), tool_dispatch)
-            for match in _TOOL_CALL_RE.finditer(response_text)
+            for match in TOOL_CALL_RE.finditer(response_text)
         ]
 
     def _run_single_tool_call(

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -67,7 +67,6 @@ def _tool_error_msg(error: str) -> Message:
     return _tool_result_message(json.dumps({"error": error}))
 
 
-
 class ConversationSynthesizer:
     """Synthesizes a conversation.
 

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -16,6 +16,7 @@ import copy
 import dataclasses
 import json
 import random
+import re
 
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
@@ -28,7 +29,11 @@ from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
     MultiTurnAttribute,
 )
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolError,
+    ToolParams,
+)
 from oumi.core.synthesis.attribute_formatter import AttributeFormatter
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
@@ -40,6 +45,23 @@ from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
+
+_TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+
+_FORCED_FINALIZE_NUDGE = (
+    "You have reached the tool-call limit. Do NOT emit any more "
+    "<tool_call> blocks. Based on the information gathered so far, "
+    "provide your final response to the user now."
+)
+
+
+def _strip_tool_call_blocks(text: str) -> str:
+    return _TOOL_CALL_RE.sub("", text)
+
+
+def _tool_error_msg(error: str) -> Message:
+    return Message(role=Role.TOOL, content=json.dumps({"error": error}))
+
 
 
 class ConversationSynthesizer:
@@ -99,6 +121,29 @@ class ConversationSynthesizer:
                     f"{[r.value for r in available_roles]}"
                 )
 
+    def _validate_tool_configuration(
+        self, multiturn_attribute: MultiTurnAttribute
+    ) -> None:
+        """Validate that tool/environment declarations have a backing config.
+
+        Args:
+            multiturn_attribute: The multi-turn attribute to validate.
+
+        Raises:
+            ValueError: If ``available_tools`` or ``available_environments`` is
+                declared but no ``environment_config`` was provided to the
+                synthesizer.
+        """
+        declares_tools = bool(multiturn_attribute.available_tools) or bool(
+            multiturn_attribute.available_environments
+        )
+        if declares_tools and self._environment_config is None:
+            raise ValueError(
+                f"MultiTurnAttribute '{multiturn_attribute.id}' declares "
+                f"available_tools/available_environments but no "
+                f"environment_config was provided to ConversationSynthesizer."
+            )
+
     def _format_tool_block(self, multiturn_attribute: MultiTurnAttribute) -> str:
         """Build a tool-usage instruction block for the assistant persona."""
         available_tools = self._resolve_available_tools(multiturn_attribute)
@@ -107,7 +152,7 @@ class ConversationSynthesizer:
 
         lines = [
             "You have access to the following tools.",
-            "When a tool is needed, emit exactly one tool call in this format:",
+            "When tools are needed, emit one or more tool calls, each in this format:",
             "",
             "<tool_call>",
             '{"name": "<tool_name>", "arguments": {...}}',
@@ -171,6 +216,7 @@ class ConversationSynthesizer:
             return []
 
         self._validate_roles(multiturn_attributes)
+        self._validate_tool_configuration(multiturn_attributes)
 
         logger.info(
             f"Synthesizing {len(samples)} conversations for "
@@ -601,78 +647,67 @@ class ConversationSynthesizer:
             return []
 
         histories: list[list[Message]] = [[] for _ in samples]
+        user_histories: list[list[Message]] = [[] for _ in samples]
+        tool_dispatch = self._build_tool_dispatch(multiturn_attribute)
+        tool_use = bool(tool_dispatch)
         max_turns = max(sample["target_turns"] for sample in samples)
 
         turn_order = self._default_turn_order
         for turn_idx in range(max_turns):
             current_turn = turn_idx + 1
+            role = turn_order[turn_idx % len(turn_order)]
 
-            prompts: list[Conversation] = []
-            sample_indices: list[int] = []
-            roles_for_turn: list[Role] = []
-
-            for i, sample in enumerate(samples):
-                if turn_idx >= sample["target_turns"]:
-                    continue
-
-                role = turn_order[turn_idx % len(turn_order)]
-                roles_for_turn.append(role)
-
-                prompt_messages: list[Message] = []
-                sample_with_turn = {**sample, "current_turn": current_turn}
-
-                persona = multiturn_attribute.role_instruction_messages[role]
-                formatted_persona = self._format_persona(
-                    sample_with_turn,
-                    persona,
-                    role,
-                    multiturn_attribute=multiturn_attribute,
-                )
-                prompt_messages.append(formatted_persona)
-                prompt_messages.extend(histories[i])
-
-                target_turns = sample["target_turns"]
-                parsed_turn_plans = sample.get("parsed_turn_plans", [])
-
-                turn_instruction = ""
-                if turn_idx < len(parsed_turn_plans):
-                    turn_instruction = parsed_turn_plans[turn_idx]
-
-                turn_info = (
-                    f"You are generating turn {current_turn} of {target_turns} "
-                    f"as the {role.value.upper()}.\n\n"
-                )
-                if turn_instruction:
-                    turn_info += f"For this turn: {turn_instruction}\n\n"
-                turn_info += (
-                    "Generate ONLY your response for this turn. Stay in character."
-                )
-                prompt_messages.append(Message(role=Role.USER, content=turn_info))
-
-                prompts.append(Conversation(messages=prompt_messages))
-                sample_indices.append(i)
-
-            if not prompts:
+            sample_indices = [
+                i
+                for i, sample in enumerate(samples)
+                if turn_idx < sample["target_turns"]
+            ]
+            if not sample_indices:
                 break
 
-            inference_results = self._inference_engine.infer(
-                prompts,
-                inference_config=self._inference_config,
+            if role == Role.ASSISTANT and tool_use:
+                per_sample_msgs = self._run_assistant_turn(
+                    samples=samples,
+                    sample_indices=sample_indices,
+                    histories=histories,
+                    current_turn=current_turn,
+                    multiturn_attribute=multiturn_attribute,
+                    tool_dispatch=tool_dispatch,
+                )
+                for i, msgs in zip(sample_indices, per_sample_msgs):
+                    histories[i].extend(msgs)
+                    user_histories[i].append(msgs[-1])
+                continue
+
+            history_source = (
+                user_histories if (role == Role.USER and tool_use) else histories
             )
-
-            generated_texts = self._extract_response(inference_results)
-
+            prompts = [
+                self._build_turn_prompt(
+                    samples[i],
+                    role,
+                    history_source[i],
+                    current_turn,
+                    multiturn_attribute,
+                )
+                for i in sample_indices
+            ]
+            generated_texts = self._extract_response(
+                self._inference_engine.infer(
+                    prompts,
+                    inference_config=self._inference_config,
+                )
+            )
             if len(generated_texts) != len(prompts):
                 raise RuntimeError(
                     f"Inference engine returned {len(generated_texts)} results "
                     f"but {len(prompts)} prompts were submitted. "
                     f"This may indicate an inference engine error."
                 )
-
-            for idx, generated_text, role in zip(
-                sample_indices, generated_texts, roles_for_turn
-            ):
-                histories[idx].append(Message(role=role, content=generated_text))
+            for i, text in zip(sample_indices, generated_texts):
+                msg = Message(role=role, content=text)
+                histories[i].append(msg)
+                user_histories[i].append(msg)
 
         conversations: list[Conversation] = []
         for sample, history in zip(samples, histories):
@@ -686,6 +721,218 @@ class ConversationSynthesizer:
             conversations.append(Conversation(messages=output_messages))
 
         return conversations
+
+    def _build_turn_prompt(
+        self,
+        sample: dict,
+        role: Role,
+        history: list[Message],
+        current_turn: int,
+        multiturn_attribute: MultiTurnAttribute,
+        trailing: list[Message] | None = None,
+    ) -> Conversation:
+        """Build the inference prompt for one sample at one turn."""
+        target_turns = sample["target_turns"]
+        parsed_turn_plans = sample.get("parsed_turn_plans", [])
+        turn_idx = current_turn - 1
+        turn_instruction = (
+            parsed_turn_plans[turn_idx] if turn_idx < len(parsed_turn_plans) else ""
+        )
+
+        persona_msg = self._format_persona(
+            {**sample, "current_turn": current_turn},
+            multiturn_attribute.role_instruction_messages[role],
+            role,
+            multiturn_attribute=multiturn_attribute,
+        )
+
+        turn_info = (
+            f"You are generating turn {current_turn} of {target_turns} "
+            f"as the {role.value.upper()}.\n\n"
+        )
+        if turn_instruction:
+            turn_info += f"For this turn: {turn_instruction}\n\n"
+        turn_info += "Generate ONLY your response for this turn. Stay in character."
+
+        messages = [persona_msg, *history, Message(role=Role.USER, content=turn_info)]
+        if trailing:
+            messages.extend(trailing)
+        return Conversation(messages=messages)
+
+    def _run_assistant_turn(
+        self,
+        samples: list[dict],
+        sample_indices: list[int],
+        histories: list[list[Message]],
+        current_turn: int,
+        multiturn_attribute: MultiTurnAttribute,
+        tool_dispatch: dict[str, BaseEnvironment],
+    ) -> list[list[Message]]:
+        """Run the inner tool-call loop for the assistant role at one turn."""
+        cap = multiturn_attribute.max_tool_calls_per_turn
+        turn_messages: dict[int, list[Message]] = {i: [] for i in sample_indices}
+        done: dict[int, bool] = {i: False for i in sample_indices}
+        tool_count: dict[int, int] = {i: 0 for i in sample_indices}
+
+        while True:
+            active = [i for i in sample_indices if not done[i] and tool_count[i] < cap]
+            if not active:
+                break
+
+            prompts = [
+                self._build_turn_prompt(
+                    samples[i],
+                    Role.ASSISTANT,
+                    histories[i] + turn_messages[i],
+                    current_turn,
+                    multiturn_attribute,
+                )
+                for i in active
+            ]
+            texts = self._extract_response(
+                self._inference_engine.infer(
+                    prompts,
+                    inference_config=self._inference_config,
+                )
+            )
+            for i, text in zip(active, texts):
+                turn_messages[i].append(Message(role=Role.ASSISTANT, content=text))
+                if self._is_final_response(text):
+                    done[i] = True
+                    continue
+                tool_messages = self._execute_tool_calls(text, tool_dispatch)
+                turn_messages[i].extend(tool_messages)
+                tool_count[i] += len(tool_messages)
+
+        stragglers = [i for i in sample_indices if not done[i]]
+        if stragglers:
+            nudge = Message(role=Role.USER, content=_FORCED_FINALIZE_NUDGE)
+            prompts = [
+                self._build_turn_prompt(
+                    samples[i],
+                    Role.ASSISTANT,
+                    histories[i] + turn_messages[i],
+                    current_turn,
+                    multiturn_attribute,
+                    trailing=[nudge],
+                )
+                for i in stragglers
+            ]
+            texts = self._extract_response(
+                self._inference_engine.infer(
+                    prompts,
+                    inference_config=self._inference_config,
+                )
+            )
+            for i, text in zip(stragglers, texts):
+                final = _strip_tool_call_blocks(text).strip()
+                turn_messages[i].append(Message(role=Role.ASSISTANT, content=final))
+
+        return [turn_messages[i] for i in sample_indices]
+
+    def _is_final_response(self, text: str) -> bool:
+        return _TOOL_CALL_RE.search(text) is None
+
+    def _execute_tool_calls(
+        self, response_text: str, tool_dispatch: dict[str, BaseEnvironment]
+    ) -> list[Message]:
+        return [
+            self._run_single_tool_call(match.group(1).strip(), tool_dispatch)
+            for match in _TOOL_CALL_RE.finditer(response_text)
+        ]
+
+    def _run_single_tool_call(
+        self, body: str, tool_dispatch: dict[str, BaseEnvironment]
+    ) -> Message:
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as e:
+            return _tool_error_msg(f"Malformed tool_call JSON: {e}")
+        if not isinstance(parsed, dict):
+            return _tool_error_msg("tool_call body must be a JSON object")
+
+        name = parsed.get("name")
+        arguments = parsed.get("arguments", {})
+
+        if not isinstance(name, str) or not name:
+            return _tool_error_msg("tool_call missing 'name'")
+        if not isinstance(arguments, dict):
+            return _tool_error_msg("tool_call 'arguments' must be an object")
+
+        assert self._environment_config is not None
+
+        tool = self._environment_config.get_tool(name)
+        if tool is None:
+            return _tool_error_msg(f"Unknown tool '{name}'")
+
+        try:
+            tool.validate_arguments(arguments)
+        except ToolArgumentError as e:
+            return _tool_error_msg(f"Invalid arguments for tool '{name}': {e}")
+
+        environment = tool_dispatch.get(name)
+        if environment is None:
+            return _tool_error_msg(f"Unknown tool '{name}'")
+
+        try:
+            result = environment.step(name, arguments)
+        except ToolError as e:
+            return _tool_error_msg(str(e))
+        except Exception as e:  # noqa: BLE001
+            return _tool_error_msg(f"Tool '{name}' raised: {e}")
+
+        output = result.output
+
+        if output is None:
+            content = ""
+        elif isinstance(output, str):
+            content = output
+        else:
+            content = json.dumps(output)
+        return Message(role=Role.TOOL, content=content)
+
+    def _build_tool_dispatch(
+        self, multiturn_attribute: MultiTurnAttribute
+    ) -> dict[str, BaseEnvironment]:
+        """Build a tool_id -> runtime BaseEnvironment map for tool dispatch.
+
+        Honors ``available_environments`` / ``available_tools`` filters. Builds
+        each scoped environment's runtime instance once and indexes by tool
+        id so the tool-call loop can route ``step()`` without rebuilding.
+        Returns an empty dict when no environment_config is configured or when
+        no tools are in scope.
+        """
+        if self._environment_config is None:
+            return {}
+
+        from oumi.builders.environments import build_environment
+
+        scoped_env_ids = (
+            set(multiturn_attribute.available_environments)
+            if multiturn_attribute.available_environments
+            else {env.id for env in self._environment_config.environments}
+        )
+        scoped_tool_ids = (
+            set(multiturn_attribute.available_tools)
+            if multiturn_attribute.available_tools
+            else None
+        )
+
+        dispatch: dict[str, BaseEnvironment] = {}
+        for env_params in self._environment_config.environments:
+            if env_params.id not in scoped_env_ids:
+                continue
+            tools_in_scope = [
+                tool
+                for tool in env_params.tools
+                if scoped_tool_ids is None or tool.id in scoped_tool_ids
+            ]
+            if not tools_in_scope:
+                continue
+            runtime_env = build_environment(env_params)
+            for tool in tools_in_scope:
+                dispatch[tool.id] = runtime_env
+        return dispatch
 
     def _select_target_turns(
         self, multiturn_attribute: MultiTurnAttribute, turn_order: list[Role]

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -36,7 +36,7 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
-from oumi.environments import DeterministicToolOutput
+from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
@@ -793,7 +793,7 @@ class ConversationSynthesizer:
 
         warned_envs: set[str] = set()
         for sample_index, sample in enumerate(samples):
-            facts: list[DeterministicToolOutput] = []
+            facts: list[GroundingFact] = []
             for env_params, env_runtime in grounding_env_pairs:
                 grounding = env_params.grounding
                 assert grounding is not None  # filtered above

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -59,8 +59,30 @@ def _strip_tool_call_blocks(text: str) -> str:
     return _TOOL_CALL_RE.sub("", text)
 
 
+def _close_dangling_tool_call(text: str) -> str:
+    """Re-append ``</tool_call>`` when stop-sequence inference stripped it."""
+    opens = text.count("<tool_call>")
+    closes = text.count("</tool_call>")
+    if opens > closes:
+        return text + "</tool_call>"
+    return text
+
+
+def _truncate_after_last_tool_call(text: str) -> str:
+    """Return the text prefix up to and including the LAST ``</tool_call>``."""
+    last_close = text.rfind("</tool_call>")
+    if last_close == -1:
+        return text
+    return text[: last_close + len("</tool_call>")]
+
+
+def _tool_result_message(content: str) -> Message:
+    """Wrap a tool output as a user-role message with a <tool_result> marker."""
+    return Message(role=Role.USER, content=f"<tool_result>{content}</tool_result>")
+
+
 def _tool_error_msg(error: str) -> Message:
-    return Message(role=Role.TOOL, content=json.dumps({"error": error}))
+    return _tool_result_message(json.dumps({"error": error}))
 
 
 
@@ -152,11 +174,26 @@ class ConversationSynthesizer:
 
         lines = [
             "You have access to the following tools.",
-            "When tools are needed, emit one or more tool calls, each in this format:",
+            "",
+            "When you need information from a tool, emit EXACTLY ONE tool call",
+            "in this format and then STOP — do not write any text after the",
+            "closing </tool_call> tag:",
             "",
             "<tool_call>",
             '{"name": "<tool_name>", "arguments": {...}}',
             "</tool_call>",
+            "",
+            "Strict rules:",
+            "- Emit only the tool call. Do NOT include prose, explanation, or",
+            "  a fabricated answer after </tool_call>. The tool result will be",
+            "  delivered in the next turn — only then should you respond.",
+            "- Never invent fields like titles, names, IDs, or dates. State",
+            "  only facts that came back from a tool.",
+            "- If more than one tool call is needed, issue them one at a time",
+            "  across successive turns, waiting for each result before deciding",
+            "  the next call.",
+            "- When you have all the information you need, reply with a plain",
+            "  natural-language message (no <tool_call> block).",
             "",
             "Available tools:",
         ]
@@ -516,15 +553,23 @@ class ConversationSynthesizer:
             "You are a customer who has an issue with a recent order.\n\n"
             "[ASSISTANT]\n"
             "You are a helpful support agent who resolves customer issues.\n\n"
+            "Ground this plan in these specific entities:\n"
+            '- order_id="ORD-4421", item="laptop stand", status="delayed"\n\n'
             "Additional instructions: Focus on resolving the order issue "
             "efficiently while maintaining a polite and helpful tone."
         )
-        example_response = """{"turns": [
-  {"turn": 1, "instruction": "Greet support and explain the issue with the order"},
-  {"turn": 2, "instruction": "Acknowledge the issue and ask for order details"},
-  {"turn": 3, "instruction": "Provide order number and describe the problem further"},
-  {"turn": 4, "instruction": "Confirm the issue and offer a resolution"}
-]}"""
+        example_response = (
+            '{"turns": [\n'
+            '  {"turn": 1, "instruction": "Greet support and explain that '
+            'order ORD-4421 has not arrived"},\n'
+            '  {"turn": 2, "instruction": "Acknowledge the issue and ask '
+            'for details on order ORD-4421"},\n'
+            '  {"turn": 3, "instruction": "Describe that the laptop stand '
+            'from order ORD-4421 is late"},\n'
+            '  {"turn": 4, "instruction": "Confirm the delay on order '
+            'ORD-4421 and offer a resolution"}\n'
+            "]}"
+        )
 
         base_prompt = (
             f"Plan a {target_turns}-turn conversation.\n"
@@ -567,7 +612,11 @@ class ConversationSynthesizer:
             base_prompt += (
                 "\nGround this plan in these specific entities:\n"
                 f"{block}\n"
-                "Your turn plans must only reference these entities.\n"
+                "Every turn instruction that references one of these entities "
+                "MUST spell out the concrete identifier verbatim (e.g. write "
+                "'book B007', not 'the book'). The user persona cannot see "
+                "this list — only text you write into each instruction "
+                "reaches them.\n"
             )
 
         if multiturn_attribute.conversation_planner:
@@ -792,10 +841,12 @@ class ConversationSynthesizer:
             texts = self._extract_response(
                 self._inference_engine.infer(
                     prompts,
-                    inference_config=self._inference_config,
+                    inference_config=self._assistant_inference_config(),
                 )
             )
             for i, text in zip(active, texts):
+                text = _close_dangling_tool_call(text)
+                text = _truncate_after_last_tool_call(text)
                 turn_messages[i].append(Message(role=Role.ASSISTANT, content=text))
                 if self._is_final_response(text):
                     done[i] = True
@@ -829,6 +880,19 @@ class ConversationSynthesizer:
                 turn_messages[i].append(Message(role=Role.ASSISTANT, content=final))
 
         return [turn_messages[i] for i in sample_indices]
+
+    def _assistant_inference_config(self) -> InferenceConfig:
+        """Build the inference config used for assistant turns in the tool loop."""
+        existing_stops = list(self._inference_config.generation.stop_strings or [])
+        if "</tool_call>" not in existing_stops:
+            existing_stops = [*existing_stops, "</tool_call>"]
+        return dataclasses.replace(
+            self._inference_config,
+            generation=dataclasses.replace(
+                self._inference_config.generation,
+                stop_strings=existing_stops,
+            ),
+        )
 
     def _is_final_response(self, text: str) -> bool:
         return _TOOL_CALL_RE.search(text) is None
@@ -889,7 +953,7 @@ class ConversationSynthesizer:
             content = output
         else:
             content = json.dumps(output)
-        return Message(role=Role.TOOL, content=content)
+        return _tool_result_message(content)
 
     def _build_tool_dispatch(
         self, multiturn_attribute: MultiTurnAttribute

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -18,7 +18,10 @@ Importing this package populates the environment registry by triggering each
 concrete environment's `@register_environment(...)` decorator.
 """
 
-from oumi.core.configs.params.grounding_params import GroundingConfig
+from oumi.core.configs.params.grounding_params import (
+    GroundingConfig,
+    GroundingFact,
+)
 from oumi.core.configs.params.tool_params import (
     ToolArgumentError,
     ToolError,
@@ -49,6 +52,7 @@ __all__ = [
     "DeterministicTool",
     "DeterministicToolOutput",
     "GroundingConfig",
+    "GroundingFact",
     "SyntheticEnvironment",
     "SyntheticEnvironmentKwargs",
     "SyntheticStateParams",

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -20,8 +20,8 @@ import random
 from abc import ABC, abstractmethod
 from typing import Any
 
+from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolParams, ToolResult
-from oumi.environments.deterministic_tool import DeterministicToolOutput
 from oumi.environments.utils import describe_grounding_default
 
 
@@ -34,9 +34,7 @@ class BaseEnvironment(ABC):
     def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
         """Execute a tool call within this environment."""
 
-    def sample_grounding(
-        self, n: int, *, rng: random.Random
-    ) -> list[DeterministicToolOutput]:
+    def sample_grounding(self, n: int, *, rng: random.Random) -> list[GroundingFact]:
         """Sample ``n`` grounding facts from this environment.
 
         Default: returns an empty list. Subclasses that support grounding
@@ -44,12 +42,10 @@ class BaseEnvironment(ABC):
         """
         return []
 
-    def describe_grounding(self, facts: list[DeterministicToolOutput]) -> str:
+    def describe_grounding(self, facts: list[GroundingFact]) -> str:
         """Render grounding facts as a bulleted markdown block.
 
-        Default implementation flattens each fact's input and output dicts
-        (output wins on key collisions) into a single bullet line. Suitable
-        for any dict-shaped fact. Subclasses may override for custom
-        rendering.
+        Default implementation renders each fact's ``data`` dict as a
+        single bullet line. Subclasses may override for custom rendering.
         """
         return describe_grounding_default(facts)

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolLookupError, ToolResult
 from oumi.core.registry import register_environment
 from oumi.environments.base_environment import BaseEnvironment
@@ -127,17 +128,20 @@ class DeterministicEnvironment(BaseEnvironment):
             f"Available tools: {[tool.id for tool in self._params.tools]}"
         )
 
-    def sample_grounding(
-        self, n: int, *, rng: random.Random
-    ) -> list[DeterministicToolOutput]:
+    def sample_grounding(self, n: int, *, rng: random.Random) -> list[GroundingFact]:
         """Sample grounding facts from the pool of deterministic outputs.
 
         Pools every ``DeterministicToolOutput`` across every tool owned by
-        this environment, then draws ``min(n, len(pool))`` entries without
-        replacement using the supplied RNG. Silent truncation — the
-        synthesizer is responsible for surfacing a warning when applicable.
+        this environment, draws ``min(n, len(pool))`` entries without
+        replacement using the supplied RNG, and converts each entry into a
+        ``GroundingFact`` by flattening its ``input`` and ``output`` dicts
+        (output wins on key collisions). Silent truncation — the synthesizer
+        is responsible for surfacing a warning when applicable.
         """
         pool: list[DeterministicToolOutput] = [
             entry for tool in self._params.tools for entry in tool.deterministic_outputs
         ]
-        return rng.sample(pool, min(n, len(pool)))
+        sampled = rng.sample(pool, min(n, len(pool)))
+        return [
+            GroundingFact(data={**entry.input, **entry.output}) for entry in sampled
+        ]

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -16,9 +16,34 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from oumi.core.configs.params.grounding_params import GroundingFact
+
+TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+
+
+def strip_tool_call_blocks(text: str) -> str:
+    """Remove every ``<tool_call>...</tool_call>`` block from ``text``."""
+    return TOOL_CALL_RE.sub("", text)
+
+
+def close_dangling_tool_call(text: str) -> str:
+    """Re-append ``</tool_call>`` when stop-sequence inference stripped it."""
+    opens = text.count("<tool_call>")
+    closes = text.count("</tool_call>")
+    if opens > closes:
+        return text + "</tool_call>"
+    return text
+
+
+def truncate_after_last_tool_call(text: str) -> str:
+    """Return the text prefix up to and including the LAST ``</tool_call>``."""
+    last_close = text.rfind("</tool_call>")
+    if last_close == -1:
+        return text
+    return text[: last_close + len("</tool_call>")]
 
 
 def _format_grounding_value(value: Any) -> str:

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from oumi.environments.deterministic_tool import DeterministicToolOutput
+from oumi.core.configs.params.grounding_params import GroundingFact
 
 
 def _format_grounding_value(value: Any) -> str:
@@ -28,20 +28,19 @@ def _format_grounding_value(value: Any) -> str:
     return str(value)
 
 
-def describe_grounding_default(facts: list[DeterministicToolOutput]) -> str:
+def describe_grounding_default(facts: list[GroundingFact]) -> str:
     """Render grounding facts as a bulleted markdown block.
 
-    Each fact's ``input`` and ``output`` dicts are flattened into a single
-    key=value line. Output values win on key collisions.
-    Returns "" for an empty fact list.
+    Each fact's ``data`` dict is rendered as a single ``key=value,
+    key=value`` line. Returns "" for an empty fact list.
     """
     if not facts:
         return ""
     lines: list[str] = []
     for fact in facts:
-        merged = {**fact.input, **fact.output}
         parts = [
-            f"{key}={_format_grounding_value(value)}" for key, value in merged.items()
+            f"{key}={_format_grounding_value(value)}"
+            for key, value in fact.data.items()
         ]
         lines.append(f"- {', '.join(parts)}")
     return "\n".join(lines)

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -22,7 +22,6 @@ from oumi.core.configs.params.tool_params import (
     ToolResult,
     ToolSchema,
 )
-from oumi.environments.deterministic_tool import DeterministicToolOutput
 from oumi.environments.synthetic_environment import SyntheticStateParams
 
 

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -338,50 +338,32 @@ def test_describe_grounding_default_empty():
 
 
 def test_describe_grounding_default_single_fact():
+    from oumi.core.configs.params.grounding_params import GroundingFact
     from oumi.environments.utils import describe_grounding_default
 
-    facts = [
-        DeterministicToolOutput(
-            input={"id": "42"}, output={"title": "Dune", "year": 1965}
-        )
-    ]
+    facts = [GroundingFact(data={"id": "42", "title": "Dune", "year": 1965})]
     rendered = describe_grounding_default(facts)
     assert rendered == '- id="42", title="Dune", year=1965'
 
 
 def test_describe_grounding_default_multi_fact_preserves_order():
+    from oumi.core.configs.params.grounding_params import GroundingFact
     from oumi.environments.utils import describe_grounding_default
 
     facts = [
-        DeterministicToolOutput(input={"id": "7"}, output={"title": "LotR"}),
-        DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"}),
+        GroundingFact(data={"id": "7", "title": "LotR"}),
+        GroundingFact(data={"id": "42", "title": "Dune"}),
     ]
     rendered = describe_grounding_default(facts)
     assert rendered == ('- id="7", title="LotR"\n- id="42", title="Dune"')
 
 
-def test_describe_grounding_default_output_wins_on_key_conflict():
-    from oumi.environments.utils import describe_grounding_default
-
-    facts = [
-        DeterministicToolOutput(
-            input={"id": "1", "note": "input-note"},
-            output={"note": "output-note"},
-        )
-    ]
-    rendered = describe_grounding_default(facts)
-    assert 'note="output-note"' in rendered
-    assert "input-note" not in rendered
-
-
 def test_describe_grounding_default_handles_non_string_values():
+    from oumi.core.configs.params.grounding_params import GroundingFact
     from oumi.environments.utils import describe_grounding_default
 
     facts = [
-        DeterministicToolOutput(
-            input={"id": 42},
-            output={"available": True, "count": 3, "rating": 4.5},
-        )
+        GroundingFact(data={"id": 42, "available": True, "count": 3, "rating": 4.5})
     ]
     rendered = describe_grounding_default(facts)
     assert "id=42" in rendered

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2288,9 +2288,11 @@ def test_run_assistant_turn_cap_hit_strips_residual_tool_calls(mock_inference_co
     )
     final = msgs[0][-1]
     assert final.role == Role.ASSISTANT
-    assert "<tool_call>" not in final.content
-    assert "leftover prose" in final.content
-    assert "tail" in final.content
+    final_content = final.content
+    assert isinstance(final_content, str)
+    assert "<tool_call>" not in final_content
+    assert "leftover prose" in final_content
+    assert "tail" in final_content
 
 
 def test_run_assistant_turn_cap_hit_only_tool_calls_yields_empty_final(

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -14,12 +14,15 @@
 
 """Tests for ConversationSynthesizer."""
 
+import json
 from unittest.mock import Mock, patch
 
 import pytest
 
+from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.configs.params.remote_params import RemoteParams
@@ -29,7 +32,11 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttribute,
     SampledAttributeValue,
 )
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.tool_params import (
+    DeterministicToolOutput,
+    ToolParams,
+    ToolSchema,
+)
 from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
@@ -1581,3 +1588,712 @@ def test_warn_on_grounding_placeholder_no_warning_when_placeholder_absent(
         rec for rec in caplog.records if "grounding_facts" in rec.getMessage()
     ]
     assert grounding_warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Tool-call loop tests
+# ---------------------------------------------------------------------------
+
+
+def _tool_env_params(*, tool_id: str = "lookup") -> EnvironmentParams:
+    """Build an EnvironmentParams wrapping a deterministic tool."""
+    return EnvironmentParams(
+        id="env1",
+        name="Env",
+        description="Test env",
+        env_type="deterministic",
+        tools=[
+            ToolParams(
+                id=tool_id,
+                name="Lookup",
+                description="Look up an id.",
+                deterministic_outputs=[
+                    DeterministicToolOutput(
+                        input={"id": "01"}, output={"status": "ok"}
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def _tool_env_config(*, tool_id: str = "lookup") -> EnvironmentConfig:
+    """Build an EnvironmentConfig wrapping a deterministic environment."""
+    return EnvironmentConfig(environments=[_tool_env_params(tool_id=tool_id)])
+
+
+def _typed_tool_env_config() -> EnvironmentConfig:
+    """Env with a typed parameter schema so we can exercise validation."""
+    env = EnvironmentParams(
+        id="env1",
+        name="Env",
+        description="Test env",
+        env_type="deterministic",
+        tools=[
+            ToolParams(
+                id="lookup",
+                name="Lookup",
+                description="Look up a policy.",
+                parameters=ToolSchema(
+                    type="object",
+                    properties={
+                        "policy_id": ToolSchema(type="string"),
+                        "limit": ToolSchema(type="integer"),
+                    },
+                    required=["policy_id"],
+                ),
+                deterministic_outputs=[
+                    DeterministicToolOutput(
+                        input={"policy_id": "p1", "limit": 5},
+                        output={"policy": "ok"},
+                    ),
+                ],
+            )
+        ],
+    )
+    return EnvironmentConfig(environments=[env])
+
+
+def _scripted_inference_engine(responses_per_call: list[list[str]]) -> Mock:
+    """Inference engine mock returning one batched response set per call."""
+    engine = Mock()
+    iterator = iter(responses_per_call)
+
+    def infer_side_effect(conversations, **kwargs):
+        batch = next(iterator)
+        assert len(batch) == len(conversations), (
+            f"scripted batch size {len(batch)} != prompt count {len(conversations)}"
+        )
+        return [
+            Conversation(messages=[Message(role=Role.ASSISTANT, content=text)])
+            for text in batch
+        ]
+
+    engine.infer.side_effect = infer_side_effect
+    return engine
+
+
+def _make_synthesizer(
+    mock_inference_config,
+    *,
+    environment_config: EnvironmentConfig | None = None,
+    inference_engine: Mock | None = None,
+) -> ConversationSynthesizer:
+    with patch(
+        "oumi.core.synthesis.conversation_synthesizer.build_inference_engine"
+    ) as mock_build:
+        mock_build.return_value = inference_engine or Mock()
+        return ConversationSynthesizer(
+            GeneralSynthesisParams(),
+            mock_inference_config,
+            environment_config=environment_config,
+        )
+
+
+def _tool_multiturn_attr(tool_id: str = "lookup", cap: int = 50) -> MultiTurnAttribute:
+    return MultiTurnAttribute(
+        id="tool_conv",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=[tool_id],
+        max_tool_calls_per_turn=cap,
+    )
+
+
+# --- _execute_tool_calls ---
+
+
+def test_execute_tool_calls_happy_path(mock_inference_config):
+    env_config = _tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    response = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+
+    messages = synth._execute_tool_calls(response, dispatch)
+
+    assert len(messages) == 1
+    assert messages[0].role == Role.TOOL
+    assert json.loads(messages[0].content) == {"status": "ok"}
+
+
+def test_execute_tool_calls_multiple_blocks_in_order(mock_inference_config):
+    env_config = _tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    response = (
+        '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+        "some prose between"
+        '<tool_call>{"name": "lookup", "arguments": {"id": "99"}}</tool_call>'
+    )
+
+    messages = synth._execute_tool_calls(response, dispatch)
+
+    assert len(messages) == 2
+    assert json.loads(messages[0].content) == {"status": "ok"}
+    err = json.loads(messages[1].content)["error"]
+    assert "No deterministic output matches" in err
+    assert '"id": "01"' in err  # configured input is surfaced for self-correction
+
+
+def test_execute_tool_calls_passes_through_string_output(mock_inference_config):
+    from oumi.core.configs.params.tool_params import ToolResult
+
+    env_config = _tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    dispatch["lookup"].step = Mock(return_value=ToolResult(output="hello"))
+
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>',
+        dispatch,
+    )
+    assert messages[0].content == "hello"
+
+
+def test_execute_tool_calls_malformed_json(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls("<tool_call>not json</tool_call>", dispatch)
+    assert len(messages) == 1
+    assert "Malformed" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_non_object_body(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls("<tool_call>[1, 2]</tool_call>", dispatch)
+    assert "must be a JSON object" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_missing_name(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"arguments": {}}</tool_call>', dispatch
+    )
+    assert "missing 'name'" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_non_dict_arguments(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", "arguments": "oops"}</tool_call>', dispatch
+    )
+    assert "must be an object" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_unknown_tool(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "nope", "arguments": {}}</tool_call>', dispatch
+    )
+    assert "Unknown tool 'nope'" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_missing_required_argument(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_typed_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", "arguments": {"limit": 5}}</tool_call>', dispatch
+    )
+    err = json.loads(messages[0].content)["error"]
+    assert "Invalid arguments for tool 'lookup'" in err
+    assert "arguments.policy_id is required" in err
+
+
+def test_execute_tool_calls_wrong_argument_type(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_typed_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", '
+        '"arguments": {"policy_id": "p1", "limit": "five"}}</tool_call>',
+        dispatch,
+    )
+    err = json.loads(messages[0].content)["error"]
+    assert "Invalid arguments for tool 'lookup'" in err
+    assert "arguments.limit must be an integer" in err
+
+
+def test_execute_tool_calls_validation_runs_before_env_step(mock_inference_config):
+    """Argument validation should short-circuit before hitting env.step()."""
+    env_config = _typed_tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    dispatch["lookup"].step = Mock(
+        side_effect=AssertionError("step() must not be called")
+    )
+
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", "arguments": {}}</tool_call>', dispatch
+    )
+
+    assert dispatch["lookup"].step.call_count == 0
+    assert "Invalid arguments" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_valid_arguments_hit_env_step(mock_inference_config):
+    """Schema-valid arguments that miss the deterministic table still surface
+    a structured ToolLookupError — not a silent null output.
+    """
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_typed_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", '
+        '"arguments": {"policy_id": "unknown", "limit": 5}}</tool_call>',
+        dispatch,
+    )
+    err = json.loads(messages[0].content)["error"]
+    assert "No deterministic output matches" in err
+    assert '"policy_id": "p1"' in err  # existing configured input is surfaced
+
+
+def test_execute_tool_calls_env_raises(mock_inference_config):
+    env_config = _tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    dispatch["lookup"].step = Mock(side_effect=RuntimeError("boom"))
+    messages = synth._execute_tool_calls(
+        '<tool_call>{"name": "lookup", "arguments": {}}</tool_call>', dispatch
+    )
+    assert "Tool 'lookup' raised" in json.loads(messages[0].content)["error"]
+    assert "boom" in json.loads(messages[0].content)["error"]
+
+
+def test_execute_tool_calls_no_block_returns_empty(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    assert synth._execute_tool_calls("just plain prose", dispatch) == []
+
+
+def test_is_final_response_detects_tool_call(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    assert synth._is_final_response("answer to user") is True
+    assert (
+        synth._is_final_response(
+            'chatty <tool_call>{"name": "lookup", "arguments": {}}</tool_call>'
+        )
+        is False
+    )
+
+
+# --- _run_assistant_turn ---
+
+
+def test_run_assistant_turn_lockstep_final_response(mock_inference_config):
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine([["final answer A", "final answer B"]])
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    samples = [
+        {"target_turns": 2, "parsed_turn_plans": ["", ""]},
+        {"target_turns": 2, "parsed_turn_plans": ["", ""]},
+    ]
+    msgs = synth._run_assistant_turn(
+        samples=samples,
+        sample_indices=[0, 1],
+        histories=[[], []],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 1
+    assert len(msgs) == 2
+    assert len(msgs[0]) == 1
+    assert msgs[0][0].role == Role.ASSISTANT
+    assert msgs[0][0].content == "final answer A"
+    assert msgs[1][0].content == "final answer B"
+
+
+def test_run_assistant_turn_asymmetric_batches(mock_inference_config):
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            [  # iteration 1: sample 0 finalizes, sample 1 calls tool
+                "done!",
+                '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>',
+            ],
+            [  # iteration 2: only sample 1 re-enters the batch
+                "final for sample 1",
+            ],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    msgs = synth._run_assistant_turn(
+        samples=[
+            {"target_turns": 2, "parsed_turn_plans": ["", ""]},
+            {"target_turns": 2, "parsed_turn_plans": ["", ""]},
+        ],
+        sample_indices=[0, 1],
+        histories=[[], []],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 2
+    assert len(msgs[0]) == 1
+    assert msgs[0][0].content == "done!"
+    assert [m.role for m in msgs[1]] == [Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
+    assert json.loads(msgs[1][1].content) == {"status": "ok"}
+    assert msgs[1][2].content == "final for sample 1"
+
+
+def test_run_assistant_turn_multiple_tool_calls_one_response(mock_inference_config):
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            [
+                '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+                '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+            ],
+            ["all done"],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+    roles = [m.role for m in msgs[0]]
+    assert roles == [Role.ASSISTANT, Role.TOOL, Role.TOOL, Role.ASSISTANT]
+    assert msgs[0][-1].content == "all done"
+
+
+def test_run_assistant_turn_cap_hit_forces_finalize(mock_inference_config):
+    env_config = _tool_env_config()
+    tool_call = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+    engine = _scripted_inference_engine(
+        [
+            [tool_call],
+            ["forced final answer"],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    attr = _tool_multiturn_attr(cap=1)
+    dispatch = synth._build_tool_dispatch(attr)
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=attr,
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 2
+    second_call_conv = engine.infer.call_args_list[1].args[0][0]
+    assert "tool-call limit" in second_call_conv.messages[-1].content
+    assert [m.role for m in msgs[0]] == [Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
+    assert msgs[0][-1].content == "forced final answer"
+
+
+def test_run_assistant_turn_cap_hit_strips_residual_tool_calls(mock_inference_config):
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'],
+            [
+                "leftover prose "
+                '<tool_call>{"name": "lookup", "arguments": {}}</tool_call>'
+                " tail"
+            ],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    attr = _tool_multiturn_attr(cap=1)
+    dispatch = synth._build_tool_dispatch(attr)
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=attr,
+        tool_dispatch=dispatch,
+    )
+    final = msgs[0][-1]
+    assert final.role == Role.ASSISTANT
+    assert "<tool_call>" not in final.content
+    assert "leftover prose" in final.content
+    assert "tail" in final.content
+
+
+def test_run_assistant_turn_cap_hit_only_tool_calls_yields_empty_final(
+    mock_inference_config,
+):
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'],
+            ['<tool_call>{"name": "lookup", "arguments": {}}</tool_call>'],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    attr = _tool_multiturn_attr(cap=1)
+    dispatch = synth._build_tool_dispatch(attr)
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=attr,
+        tool_dispatch=dispatch,
+    )
+    assert msgs[0][-1].content == ""
+
+
+def test_run_assistant_turn_self_corrects_after_tool_error(mock_inference_config):
+    """Model receives a structured tool error and recovers on next iteration."""
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "99"}}</tool_call>'],
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'],
+            ["The lookup succeeded: status ok."],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 3
+    sample_msgs = msgs[0]
+    roles = [m.role for m in sample_msgs]
+    assert roles == [
+        Role.ASSISTANT,
+        Role.TOOL,
+        Role.ASSISTANT,
+        Role.TOOL,
+        Role.ASSISTANT,
+    ]
+
+    first_tool_payload = json.loads(sample_msgs[1].content)
+    assert "error" in first_tool_payload
+    assert "No deterministic output matches" in first_tool_payload["error"]
+
+    assert json.loads(sample_msgs[3].content) == {"status": "ok"}
+    assert sample_msgs[-1].content == "The lookup succeeded: status ok."
+
+
+def test_run_assistant_turn_self_corrects_after_invalid_arguments(
+    mock_inference_config,
+):
+    """Schema-level validation error is surfaced, then model corrects."""
+    env_config = _typed_tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {}}</tool_call>'],
+            [
+                '<tool_call>{"name": "lookup", '
+                '"arguments": {"policy_id": "p1", "limit": 5}}</tool_call>'
+            ],
+            ["Policy looks good."],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 3
+    sample_msgs = msgs[0]
+    roles = [m.role for m in sample_msgs]
+    assert roles == [
+        Role.ASSISTANT,
+        Role.TOOL,
+        Role.ASSISTANT,
+        Role.TOOL,
+        Role.ASSISTANT,
+    ]
+
+    first_tool_payload = json.loads(sample_msgs[1].content)
+    assert "error" in first_tool_payload
+    assert "Invalid arguments for tool 'lookup'" in first_tool_payload["error"]
+    assert "arguments.policy_id is required" in first_tool_payload["error"]
+
+    assert json.loads(sample_msgs[3].content) == {"policy": "ok"}
+    assert sample_msgs[-1].content == "Policy looks good."
+
+
+# --- end-to-end synthesize with tools ---
+
+
+def test_synthesize_end_to_end_with_tool_use(mock_inference_config):
+    env_config = _tool_env_config()
+    plan_json = (
+        '[{"turn": 1, "instruction": "ask"}, {"turn": 2, "instruction": "answer"}]'
+    )
+    engine = _scripted_inference_engine(
+        [
+            [plan_json],
+            ["What is the status of order 01?"],
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'],
+            ["The order is ok."],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+
+    attr = MultiTurnAttribute(
+        id="tool_conv",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+
+    records = synth.synthesize([{}], attr)
+
+    assert len(records) == 1
+    assert records[0] is not None
+    conv = records[0]["tool_conv"]
+    assert isinstance(conv, dict)
+    roles = [m["role"] for m in conv["messages"]]
+    assert roles == [Role.USER, Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
+    assert conv["messages"][-1]["content"] == "The order is ok."
+
+
+def test_synthesize_drops_sample_when_cap_hit_produces_empty_final(
+    mock_inference_config,
+):
+    env_config = _tool_env_config()
+    plan_json = (
+        '[{"turn": 1, "instruction": "ask"}, {"turn": 2, "instruction": "answer"}]'
+    )
+    tool_call = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+    engine = _scripted_inference_engine(
+        [
+            [plan_json],
+            ["ask"],
+            [tool_call],
+            [tool_call],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    attr = MultiTurnAttribute(
+        id="tool_conv",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+        max_tool_calls_per_turn=1,
+    )
+
+    records = synth.synthesize([{}], attr)
+    assert records == [None]
+
+
+def test_synthesize_raises_when_tools_declared_without_env_config(
+    mock_inference_config,
+):
+    """available_tools without environment_config must fail loudly."""
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="tool_conv",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_tools=["lookup"],
+    )
+
+    with pytest.raises(ValueError, match="available_tools"):
+        synth.synthesize([{}], attr)
+
+
+def test_synthesize_raises_when_environments_declared_without_env_config(
+    mock_inference_config,
+):
+    """available_environments without environment_config must fail loudly."""
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="tool_conv",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+    )
+
+    with pytest.raises(ValueError, match="environment_config"):
+        synth.synthesize([{}], attr)

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2548,3 +2548,95 @@ def test_synthesize_raises_when_environments_declared_without_env_config(
 
     with pytest.raises(ValueError, match="environment_config"):
         synth.synthesize([{}], attr)
+
+
+# --- Regression + integration: planner prompt byte-equivalence when ungrounded ---
+
+
+def test_create_planner_prompt_byte_identical_when_no_grounding(
+    mock_inference_config,
+):
+    """Regression: when no env in scope has grounding, planner prompt is
+    unchanged from the pre-grounding baseline.
+    """
+    env_config = _tool_env_config()
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    attr = _tool_multiturn_attr()
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+    }
+
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+
+    # Real-text grounding markers must be absent. The strict-rules version of
+    # the example_request still mentions "Ground this plan" once as part of
+    # the few-shot demo, but the runtime base prompt must not include the
+    # grounded section.
+    assert "spell out the concrete identifier verbatim" not in planner_user_msg
+    assert "user persona cannot see this list" not in planner_user_msg
+    assert "{grounding_facts}" not in planner_user_msg
+
+
+def test_end_to_end_grounded_conversation_uses_sampled_entity_ids(
+    mock_inference_config,
+):
+    """Full synthesize() flow: grounded planner prompt drives the plan
+    through a scripted inference engine, confirming the facts make it all
+    the way into the planner call.
+    """
+    env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=13)
+
+    captured_planner_prompts: list[str] = []
+
+    def infer_side_effect(conversations, **kwargs):
+        results = []
+        for conv in conversations:
+            last = conv.messages[-1].content
+            is_planner = isinstance(last, str) and "Plan" in last
+            if is_planner:
+                captured_planner_prompts.append(last)
+                content = (
+                    '[{"turn": 1, "instruction": "a"}, {"turn": 2, "instruction": "b"}]'
+                )
+            else:
+                content = "turn content"
+            results.append(
+                Conversation(messages=[Message(role=Role.ASSISTANT, content=content)])
+            )
+        return results
+
+    engine = Mock()
+    engine.infer.side_effect = infer_side_effect
+
+    synth = _make_synthesizer(
+        mock_inference_config,
+        environment_config=env_config,
+        inference_engine=engine,
+    )
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+    samples = [{}]
+    synth.synthesize(samples, attr)
+
+    assert captured_planner_prompts, "planner prompt was never captured"
+    planner_prompt = captured_planner_prompts[0]
+    assert "Ground this plan in these specific entities" in planner_prompt
+    configured_ids = {str(i) for i in range(10)}
+    facts = samples[0]["grounding_facts"]
+    for fact in facts:
+        fact_id = fact.data["id"]
+        assert fact_id in configured_ids
+        assert f'id="{fact_id}"' in planner_prompt

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -46,6 +46,24 @@ from oumi.core.types.conversation import (
 )
 
 
+def _unwrap_tool_result(content: str) -> str:
+    """Strip the ``<tool_result>...</tool_result>`` wrapper from a tool-result
+    message so assertions can inspect the inner JSON/text payload.
+
+    The synthesizer emits tool results as ``Role.USER`` messages wrapped in
+    ``<tool_result>`` markers (keeps the conversation portable across provider
+    APIs that disallow a ``tool`` role). Tests use this helper to peek at the
+    underlying content.
+    """
+    prefix = "<tool_result>"
+    suffix = "</tool_result>"
+    assert isinstance(content, str)
+    assert content.startswith(prefix) and content.endswith(suffix), (
+        f"Expected <tool_result>-wrapped content, got: {content!r}"
+    )
+    return content[len(prefix) : -len(suffix)]
+
+
 @pytest.fixture
 def mock_inference_config():
     """Create a mock inference config."""
@@ -1412,7 +1430,8 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     assert "Ground this plan in these specific entities" in planner_user_msg
     assert '- id="42", title="Dune"' in planner_user_msg
     assert '- id="7", title="LotR"' in planner_user_msg
-    assert "Your turn plans must only reference these entities" in planner_user_msg
+    assert "spell out the concrete identifier verbatim" in planner_user_msg
+    assert "user persona cannot see this list" in planner_user_msg
 
 
 def test_create_planner_prompt_no_grounding_block_when_facts_absent(
@@ -1717,8 +1736,8 @@ def test_execute_tool_calls_happy_path(mock_inference_config):
     messages = synth._execute_tool_calls(response, dispatch)
 
     assert len(messages) == 1
-    assert messages[0].role == Role.TOOL
-    assert json.loads(messages[0].content) == {"status": "ok"}
+    assert messages[0].role == Role.USER
+    assert json.loads(_unwrap_tool_result(messages[0].content)) == {"status": "ok"}
 
 
 def test_execute_tool_calls_multiple_blocks_in_order(mock_inference_config):
@@ -1734,8 +1753,8 @@ def test_execute_tool_calls_multiple_blocks_in_order(mock_inference_config):
     messages = synth._execute_tool_calls(response, dispatch)
 
     assert len(messages) == 2
-    assert json.loads(messages[0].content) == {"status": "ok"}
-    err = json.loads(messages[1].content)["error"]
+    assert json.loads(_unwrap_tool_result(messages[0].content)) == {"status": "ok"}
+    err = json.loads(_unwrap_tool_result(messages[1].content))["error"]
     assert "No deterministic output matches" in err
     assert '"id": "01"' in err  # configured input is surfaced for self-correction
 
@@ -1752,7 +1771,7 @@ def test_execute_tool_calls_passes_through_string_output(mock_inference_config):
         '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>',
         dispatch,
     )
-    assert messages[0].content == "hello"
+    assert _unwrap_tool_result(messages[0].content) == "hello"
 
 
 def test_execute_tool_calls_malformed_json(mock_inference_config):
@@ -1762,7 +1781,7 @@ def test_execute_tool_calls_malformed_json(mock_inference_config):
     dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
     messages = synth._execute_tool_calls("<tool_call>not json</tool_call>", dispatch)
     assert len(messages) == 1
-    assert "Malformed" in json.loads(messages[0].content)["error"]
+    assert "Malformed" in json.loads(_unwrap_tool_result(messages[0].content))["error"]
 
 
 def test_execute_tool_calls_non_object_body(mock_inference_config):
@@ -1771,7 +1790,10 @@ def test_execute_tool_calls_non_object_body(mock_inference_config):
     )
     dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
     messages = synth._execute_tool_calls("<tool_call>[1, 2]</tool_call>", dispatch)
-    assert "must be a JSON object" in json.loads(messages[0].content)["error"]
+    assert (
+        "must be a JSON object"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
 
 
 def test_execute_tool_calls_missing_name(mock_inference_config):
@@ -1782,7 +1804,10 @@ def test_execute_tool_calls_missing_name(mock_inference_config):
     messages = synth._execute_tool_calls(
         '<tool_call>{"arguments": {}}</tool_call>', dispatch
     )
-    assert "missing 'name'" in json.loads(messages[0].content)["error"]
+    assert (
+        "missing 'name'"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
 
 
 def test_execute_tool_calls_non_dict_arguments(mock_inference_config):
@@ -1793,7 +1818,10 @@ def test_execute_tool_calls_non_dict_arguments(mock_inference_config):
     messages = synth._execute_tool_calls(
         '<tool_call>{"name": "lookup", "arguments": "oops"}</tool_call>', dispatch
     )
-    assert "must be an object" in json.loads(messages[0].content)["error"]
+    assert (
+        "must be an object"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
 
 
 def test_execute_tool_calls_unknown_tool(mock_inference_config):
@@ -1804,7 +1832,10 @@ def test_execute_tool_calls_unknown_tool(mock_inference_config):
     messages = synth._execute_tool_calls(
         '<tool_call>{"name": "nope", "arguments": {}}</tool_call>', dispatch
     )
-    assert "Unknown tool 'nope'" in json.loads(messages[0].content)["error"]
+    assert (
+        "Unknown tool 'nope'"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
 
 
 def test_execute_tool_calls_missing_required_argument(mock_inference_config):
@@ -1815,7 +1846,7 @@ def test_execute_tool_calls_missing_required_argument(mock_inference_config):
     messages = synth._execute_tool_calls(
         '<tool_call>{"name": "lookup", "arguments": {"limit": 5}}</tool_call>', dispatch
     )
-    err = json.loads(messages[0].content)["error"]
+    err = json.loads(_unwrap_tool_result(messages[0].content))["error"]
     assert "Invalid arguments for tool 'lookup'" in err
     assert "arguments.policy_id is required" in err
 
@@ -1830,7 +1861,7 @@ def test_execute_tool_calls_wrong_argument_type(mock_inference_config):
         '"arguments": {"policy_id": "p1", "limit": "five"}}</tool_call>',
         dispatch,
     )
-    err = json.loads(messages[0].content)["error"]
+    err = json.loads(_unwrap_tool_result(messages[0].content))["error"]
     assert "Invalid arguments for tool 'lookup'" in err
     assert "arguments.limit must be an integer" in err
 
@@ -1849,7 +1880,10 @@ def test_execute_tool_calls_validation_runs_before_env_step(mock_inference_confi
     )
 
     assert dispatch["lookup"].step.call_count == 0
-    assert "Invalid arguments" in json.loads(messages[0].content)["error"]
+    assert (
+        "Invalid arguments"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
 
 
 def test_execute_tool_calls_valid_arguments_hit_env_step(mock_inference_config):
@@ -1865,7 +1899,7 @@ def test_execute_tool_calls_valid_arguments_hit_env_step(mock_inference_config):
         '"arguments": {"policy_id": "unknown", "limit": 5}}</tool_call>',
         dispatch,
     )
-    err = json.loads(messages[0].content)["error"]
+    err = json.loads(_unwrap_tool_result(messages[0].content))["error"]
     assert "No deterministic output matches" in err
     assert '"policy_id": "p1"' in err  # existing configured input is surfaced
 
@@ -1878,8 +1912,11 @@ def test_execute_tool_calls_env_raises(mock_inference_config):
     messages = synth._execute_tool_calls(
         '<tool_call>{"name": "lookup", "arguments": {}}</tool_call>', dispatch
     )
-    assert "Tool 'lookup' raised" in json.loads(messages[0].content)["error"]
-    assert "boom" in json.loads(messages[0].content)["error"]
+    assert (
+        "Tool 'lookup' raised"
+        in json.loads(_unwrap_tool_result(messages[0].content))["error"]
+    )
+    assert "boom" in json.loads(_unwrap_tool_result(messages[0].content))["error"]
 
 
 def test_execute_tool_calls_no_block_returns_empty(mock_inference_config):
@@ -1903,7 +1940,221 @@ def test_is_final_response_detects_tool_call(mock_inference_config):
     )
 
 
+# --- Pre-result hallucination hardening ---
+
+
+def test_truncate_after_last_tool_call_strips_trailing_prose():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _truncate_after_last_tool_call,
+    )
+
+    text = (
+        '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>\n\n'
+        "I found it! The book is 'Dune' by Frank Herbert. Due back 2024-01-15."
+    )
+    cleaned = _truncate_after_last_tool_call(text)
+    assert cleaned.endswith("</tool_call>")
+    assert "Dune" not in cleaned
+    assert "2024" not in cleaned
+
+
+def test_truncate_after_last_tool_call_preserves_leading_prose():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _truncate_after_last_tool_call,
+    )
+
+    text = (
+        "Let me check that for you.\n"
+        '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+    )
+    cleaned = _truncate_after_last_tool_call(text)
+    assert cleaned == text
+
+
+def test_truncate_after_last_tool_call_keeps_plain_response():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _truncate_after_last_tool_call,
+    )
+
+    text = "Here is a normal final response with no tool call."
+    assert _truncate_after_last_tool_call(text) == text
+
+
+def test_truncate_after_last_tool_call_keeps_multiple_calls():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _truncate_after_last_tool_call,
+    )
+
+    text = (
+        '<tool_call>{"name": "a", "arguments": {}}</tool_call>'
+        '<tool_call>{"name": "b", "arguments": {}}</tool_call>'
+        "Trailing hallucinated answer."
+    )
+    cleaned = _truncate_after_last_tool_call(text)
+    assert cleaned.endswith("</tool_call>")
+    assert "hallucinated" not in cleaned
+    assert cleaned.count("<tool_call>") == 2
+
+
+def test_close_dangling_tool_call_appends_missing_close_tag():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _close_dangling_tool_call,
+    )
+
+    truncated = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}'
+    closed = _close_dangling_tool_call(truncated)
+    assert closed.endswith("</tool_call>")
+    assert closed.count("<tool_call>") == closed.count("</tool_call>")
+
+
+def test_close_dangling_tool_call_noop_when_balanced():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _close_dangling_tool_call,
+    )
+
+    text = '<tool_call>{"name": "x", "arguments": {}}</tool_call>'
+    assert _close_dangling_tool_call(text) == text
+
+
+def test_close_dangling_tool_call_noop_when_no_tool_call():
+    from oumi.core.synthesis.conversation_synthesizer import (
+        _close_dangling_tool_call,
+    )
+
+    text = "Plain response, no tool tags here."
+    assert _close_dangling_tool_call(text) == text
+
+
+def test_assistant_inference_config_adds_stop_sequence(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    cfg = synth._assistant_inference_config()
+    assert "</tool_call>" in (cfg.generation.stop_strings or [])
+    base_stops = list(mock_inference_config.generation.stop_strings or [])
+    assert "</tool_call>" not in base_stops
+
+
+def test_assistant_inference_config_preserves_existing_stops(
+    mock_inference_config,
+):
+    mock_inference_config.generation.stop_strings = ["<|end|>", "STOP"]
+    synth = _make_synthesizer(mock_inference_config)
+    cfg = synth._assistant_inference_config()
+    stops = cfg.generation.stop_strings
+    assert "<|end|>" in stops
+    assert "STOP" in stops
+    assert "</tool_call>" in stops
+
+
 # --- _run_assistant_turn ---
+
+
+def test_run_assistant_turn_strips_prose_after_tool_call_in_response(
+    mock_inference_config,
+):
+    """Real models often emit <tool_call> AND a fabricated follow-up answer
+    in the same message. Trailing prose must be stripped before storing the
+    assistant message, otherwise the conversation contains contradictory
+    data that poisons training.
+    """
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            [
+                '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}'
+                "</tool_call>\n\n"
+                "I found it! The book is 'Dune' by Frank Herbert. Due 2024-01-15."
+            ],
+            ["The real status is ok."],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config,
+        environment_config=env_config,
+        inference_engine=engine,
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assistant_msg = msgs[0][0]
+    assert assistant_msg.role == Role.ASSISTANT
+    assert "Dune" not in assistant_msg.content
+    assert "2024" not in assistant_msg.content
+    assert assistant_msg.content.rstrip().endswith("</tool_call>")
+    assert msgs[0][-1].content == "The real status is ok."
+
+
+def test_run_assistant_turn_rehydrates_stop_sequence_stripped_close_tag(
+    mock_inference_config,
+):
+    """When a provider strips the matched stop_sequence (Anthropic drops
+    </tool_call>), the pipeline must re-append it so downstream parsing
+    round-trips.
+    """
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}'],
+            ["done"],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config,
+        environment_config=env_config,
+        inference_engine=engine,
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assistant_msg = msgs[0][0]
+    assert assistant_msg.content.endswith("</tool_call>")
+    assert msgs[0][1].role == Role.USER
+    tool_payload = json.loads(_unwrap_tool_result(msgs[0][1].content))
+    assert tool_payload == {"status": "ok"}
+
+
+def test_run_assistant_turn_uses_assistant_inference_config(
+    mock_inference_config,
+):
+    """Assistant turns must run through ``_assistant_inference_config()``
+    (which adds </tool_call> to stop_strings) — not the base config.
+    """
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine([["final answer"]])
+    synth = _make_synthesizer(
+        mock_inference_config,
+        environment_config=env_config,
+        inference_engine=engine,
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+
+    synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", ""]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    call_kwargs = engine.infer.call_args_list[0].kwargs
+    cfg = call_kwargs["inference_config"]
+    assert "</tool_call>" in (cfg.generation.stop_strings or [])
 
 
 def test_run_assistant_turn_lockstep_final_response(mock_inference_config):
@@ -1967,8 +2218,8 @@ def test_run_assistant_turn_asymmetric_batches(mock_inference_config):
     assert engine.infer.call_count == 2
     assert len(msgs[0]) == 1
     assert msgs[0][0].content == "done!"
-    assert [m.role for m in msgs[1]] == [Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
-    assert json.loads(msgs[1][1].content) == {"status": "ok"}
+    assert [m.role for m in msgs[1]] == [Role.ASSISTANT, Role.USER, Role.ASSISTANT]
+    assert json.loads(_unwrap_tool_result(msgs[1][1].content)) == {"status": "ok"}
     assert msgs[1][2].content == "final for sample 1"
 
 
@@ -1996,7 +2247,7 @@ def test_run_assistant_turn_multiple_tool_calls_one_response(mock_inference_conf
         tool_dispatch=dispatch,
     )
     roles = [m.role for m in msgs[0]]
-    assert roles == [Role.ASSISTANT, Role.TOOL, Role.TOOL, Role.ASSISTANT]
+    assert roles == [Role.ASSISTANT, Role.USER, Role.USER, Role.ASSISTANT]
     assert msgs[0][-1].content == "all done"
 
 
@@ -2026,7 +2277,7 @@ def test_run_assistant_turn_cap_hit_forces_finalize(mock_inference_config):
     assert engine.infer.call_count == 2
     second_call_conv = engine.infer.call_args_list[1].args[0][0]
     assert "tool-call limit" in second_call_conv.messages[-1].content
-    assert [m.role for m in msgs[0]] == [Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
+    assert [m.role for m in msgs[0]] == [Role.ASSISTANT, Role.USER, Role.ASSISTANT]
     assert msgs[0][-1].content == "forced final answer"
 
 
@@ -2117,17 +2368,17 @@ def test_run_assistant_turn_self_corrects_after_tool_error(mock_inference_config
     roles = [m.role for m in sample_msgs]
     assert roles == [
         Role.ASSISTANT,
-        Role.TOOL,
+        Role.USER,
         Role.ASSISTANT,
-        Role.TOOL,
+        Role.USER,
         Role.ASSISTANT,
     ]
 
-    first_tool_payload = json.loads(sample_msgs[1].content)
+    first_tool_payload = json.loads(_unwrap_tool_result(sample_msgs[1].content))
     assert "error" in first_tool_payload
     assert "No deterministic output matches" in first_tool_payload["error"]
 
-    assert json.loads(sample_msgs[3].content) == {"status": "ok"}
+    assert json.loads(_unwrap_tool_result(sample_msgs[3].content)) == {"status": "ok"}
     assert sample_msgs[-1].content == "The lookup succeeded: status ok."
 
 
@@ -2165,18 +2416,18 @@ def test_run_assistant_turn_self_corrects_after_invalid_arguments(
     roles = [m.role for m in sample_msgs]
     assert roles == [
         Role.ASSISTANT,
-        Role.TOOL,
+        Role.USER,
         Role.ASSISTANT,
-        Role.TOOL,
+        Role.USER,
         Role.ASSISTANT,
     ]
 
-    first_tool_payload = json.loads(sample_msgs[1].content)
+    first_tool_payload = json.loads(_unwrap_tool_result(sample_msgs[1].content))
     assert "error" in first_tool_payload
     assert "Invalid arguments for tool 'lookup'" in first_tool_payload["error"]
     assert "arguments.policy_id is required" in first_tool_payload["error"]
 
-    assert json.loads(sample_msgs[3].content) == {"policy": "ok"}
+    assert json.loads(_unwrap_tool_result(sample_msgs[3].content)) == {"policy": "ok"}
     assert sample_msgs[-1].content == "Policy looks good."
 
 
@@ -2219,7 +2470,7 @@ def test_synthesize_end_to_end_with_tool_use(mock_inference_config):
     conv = records[0]["tool_conv"]
     assert isinstance(conv, dict)
     roles = [m["role"] for m in conv["messages"]]
-    assert roles == [Role.USER, Role.ASSISTANT, Role.TOOL, Role.ASSISTANT]
+    assert roles == [Role.USER, Role.ASSISTANT, Role.USER, Role.ASSISTANT]
     assert conv["messages"][-1]["content"] == "The order is ok."
 
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -33,7 +33,6 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttributeValue,
 )
 from oumi.core.configs.params.tool_params import (
-    DeterministicToolOutput,
     ToolParams,
     ToolSchema,
 )
@@ -43,6 +42,10 @@ from oumi.core.types.conversation import (
     Conversation,
     Message,
     Role,
+)
+from oumi.environments.deterministic_tool import (
+    DeterministicTool,
+    DeterministicToolOutput,
 )
 
 
@@ -1610,7 +1613,7 @@ def _tool_env_params(*, tool_id: str = "lookup") -> EnvironmentParams:
         description="Test env",
         env_type="deterministic",
         tools=[
-            ToolParams(
+            DeterministicTool(
                 id=tool_id,
                 name="Lookup",
                 description="Look up an id.",
@@ -1637,7 +1640,7 @@ def _typed_tool_env_config() -> EnvironmentConfig:
         description="Test env",
         env_type="deterministic",
         tools=[
-            ToolParams(
+            DeterministicTool(
                 id="lookup",
                 name="Lookup",
                 description="Look up a policy.",

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1239,7 +1239,7 @@ def test_attach_grounding_facts_noop_when_no_env_has_grounding(
 
 
 def test_attach_grounding_facts_populates_samples(mock_inference_config):
-    from oumi.environments.deterministic_tool import DeterministicToolOutput
+    from oumi.core.configs.params.grounding_params import GroundingFact
 
     env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
@@ -1254,7 +1254,9 @@ def test_attach_grounding_facts_populates_samples(mock_inference_config):
         assert "grounding_facts" in sample
         assert len(sample["grounding_facts"]) == 3
         for fact in sample["grounding_facts"]:
-            assert isinstance(fact, DeterministicToolOutput)
+            assert isinstance(fact, GroundingFact)
+            assert "id" in fact.data
+            assert "title" in fact.data
 
 
 def test_attach_grounding_facts_seeded_is_reproducible(mock_inference_config):
@@ -1274,8 +1276,8 @@ def test_attach_grounding_facts_seeded_is_reproducible(mock_inference_config):
     synth_b._attach_grounding_facts(samples_b, attr)
 
     for a, b in zip(samples_a, samples_b):
-        assert [f.input["id"] for f in a["grounding_facts"]] == [
-            f.input["id"] for f in b["grounding_facts"]
+        assert [f.data["id"] for f in a["grounding_facts"]] == [
+            f.data["id"] for f in b["grounding_facts"]
         ]
 
 
@@ -1291,8 +1293,8 @@ def test_attach_grounding_facts_seeded_different_samples_differ(
         _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
     )
 
-    ids_0 = sorted(f.input["id"] for f in samples[0]["grounding_facts"])
-    ids_1 = sorted(f.input["id"] for f in samples[1]["grounding_facts"])
+    ids_0 = sorted(f.data["id"] for f in samples[0]["grounding_facts"])
+    ids_1 = sorted(f.data["id"] for f in samples[1]["grounding_facts"])
     assert ids_0 != ids_1
 
 
@@ -1372,7 +1374,7 @@ def test_attach_grounding_facts_truncation_emits_logger_warning(
 def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     mock_inference_config,
 ):
-    from oumi.environments.deterministic_tool import DeterministicToolOutput
+    from oumi.core.configs.params.grounding_params import GroundingFact
 
     env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=1)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
@@ -1392,8 +1394,8 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
         "conversation_plan": "",
         "parsed_turn_plans": [""] * 2,
         "grounding_facts": [
-            DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"}),
-            DeterministicToolOutput(input={"id": "7"}, output={"title": "LotR"}),
+            GroundingFact(data={"id": "42", "title": "Dune"}),
+            GroundingFact(data={"id": "7", "title": "LotR"}),
         ],
     }
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -46,18 +46,20 @@ from oumi.core.types.conversation import (
 )
 
 
-def _unwrap_tool_result(content: str) -> str:
+def _unwrap_tool_result(content: object) -> str:
     """Strip the ``<tool_result>...</tool_result>`` wrapper from a tool-result
     message so assertions can inspect the inner JSON/text payload.
 
     The synthesizer emits tool results as ``Role.USER`` messages wrapped in
     ``<tool_result>`` markers (keeps the conversation portable across provider
     APIs that disallow a ``tool`` role). Tests use this helper to peek at the
-    underlying content.
+    underlying content. ``content`` is typed as ``object`` so callers can
+    pass ``Message.content`` (a ``str | list[ContentItem]``) without first
+    narrowing the type; the runtime assertion makes str-ness explicit.
     """
     prefix = "<tool_result>"
     suffix = "</tool_result>"
-    assert isinstance(content, str)
+    assert isinstance(content, str), f"expected str content, got {type(content)}"
     assert content.startswith(prefix) and content.endswith(suffix), (
         f"Expected <tool_result>-wrapped content, got: {content!r}"
     )
@@ -1103,20 +1105,6 @@ def test_synthesize_filters_all_conversations_returns_empty(
 # --- _make_grounding_rng ---
 
 
-def _make_synthesizer(mock_inference_config, environment_config=None):
-    """Build a synthesizer with the inference engine builder patched out.
-
-    Returns the synthesizer; callers can ignore the patch since the engine
-    isn't exercised by the methods these tests target.
-    """
-    with patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine"):
-        return ConversationSynthesizer(
-            GeneralSynthesisParams(),
-            mock_inference_config,
-            environment_config=environment_config,
-        )
-
-
 def test_make_grounding_rng_unseeded_returns_fresh_random(mock_inference_config):
     import random as _random
 
@@ -2040,6 +2028,7 @@ def test_assistant_inference_config_preserves_existing_stops(
     synth = _make_synthesizer(mock_inference_config)
     cfg = synth._assistant_inference_config()
     stops = cfg.generation.stop_strings
+    assert stops is not None
     assert "<|end|>" in stops
     assert "STOP" in stops
     assert "</tool_call>" in stops
@@ -2085,6 +2074,7 @@ def test_run_assistant_turn_strips_prose_after_tool_call_in_response(
 
     assistant_msg = msgs[0][0]
     assert assistant_msg.role == Role.ASSISTANT
+    assert isinstance(assistant_msg.content, str)
     assert "Dune" not in assistant_msg.content
     assert "2024" not in assistant_msg.content
     assert assistant_msg.content.rstrip().endswith("</tool_call>")
@@ -2122,6 +2112,7 @@ def test_run_assistant_turn_rehydrates_stop_sequence_stripped_close_tag(
     )
 
     assistant_msg = msgs[0][0]
+    assert isinstance(assistant_msg.content, str)
     assert assistant_msg.content.endswith("</tool_call>")
     assert msgs[0][1].role == Role.USER
     tool_payload = json.loads(_unwrap_tool_result(msgs[0][1].content))

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1934,86 +1934,72 @@ def test_is_final_response_detects_tool_call(mock_inference_config):
 # --- Pre-result hallucination hardening ---
 
 
-def test_truncate_after_last_tool_call_strips_trailing_prose():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _truncate_after_last_tool_call,
-    )
+def testtruncate_after_last_tool_call_strips_trailing_prose():
+    from oumi.environments.utils import truncate_after_last_tool_call
 
     text = (
         '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>\n\n'
         "I found it! The book is 'Dune' by Frank Herbert. Due back 2024-01-15."
     )
-    cleaned = _truncate_after_last_tool_call(text)
+    cleaned = truncate_after_last_tool_call(text)
     assert cleaned.endswith("</tool_call>")
     assert "Dune" not in cleaned
     assert "2024" not in cleaned
 
 
-def test_truncate_after_last_tool_call_preserves_leading_prose():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _truncate_after_last_tool_call,
-    )
+def testtruncate_after_last_tool_call_preserves_leading_prose():
+    from oumi.environments.utils import truncate_after_last_tool_call
 
     text = (
         "Let me check that for you.\n"
         '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
     )
-    cleaned = _truncate_after_last_tool_call(text)
+    cleaned = truncate_after_last_tool_call(text)
     assert cleaned == text
 
 
-def test_truncate_after_last_tool_call_keeps_plain_response():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _truncate_after_last_tool_call,
-    )
+def testtruncate_after_last_tool_call_keeps_plain_response():
+    from oumi.environments.utils import truncate_after_last_tool_call
 
     text = "Here is a normal final response with no tool call."
-    assert _truncate_after_last_tool_call(text) == text
+    assert truncate_after_last_tool_call(text) == text
 
 
-def test_truncate_after_last_tool_call_keeps_multiple_calls():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _truncate_after_last_tool_call,
-    )
+def testtruncate_after_last_tool_call_keeps_multiple_calls():
+    from oumi.environments.utils import truncate_after_last_tool_call
 
     text = (
         '<tool_call>{"name": "a", "arguments": {}}</tool_call>'
         '<tool_call>{"name": "b", "arguments": {}}</tool_call>'
         "Trailing hallucinated answer."
     )
-    cleaned = _truncate_after_last_tool_call(text)
+    cleaned = truncate_after_last_tool_call(text)
     assert cleaned.endswith("</tool_call>")
     assert "hallucinated" not in cleaned
     assert cleaned.count("<tool_call>") == 2
 
 
-def test_close_dangling_tool_call_appends_missing_close_tag():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _close_dangling_tool_call,
-    )
+def testclose_dangling_tool_call_appends_missing_close_tag():
+    from oumi.environments.utils import close_dangling_tool_call
 
     truncated = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}'
-    closed = _close_dangling_tool_call(truncated)
+    closed = close_dangling_tool_call(truncated)
     assert closed.endswith("</tool_call>")
     assert closed.count("<tool_call>") == closed.count("</tool_call>")
 
 
-def test_close_dangling_tool_call_noop_when_balanced():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _close_dangling_tool_call,
-    )
+def testclose_dangling_tool_call_noop_when_balanced():
+    from oumi.environments.utils import close_dangling_tool_call
 
     text = '<tool_call>{"name": "x", "arguments": {}}</tool_call>'
-    assert _close_dangling_tool_call(text) == text
+    assert close_dangling_tool_call(text) == text
 
 
-def test_close_dangling_tool_call_noop_when_no_tool_call():
-    from oumi.core.synthesis.conversation_synthesizer import (
-        _close_dangling_tool_call,
-    )
+def testclose_dangling_tool_call_noop_when_no_tool_call():
+    from oumi.environments.utils import close_dangling_tool_call
 
     text = "Plain response, no tool tags here."
-    assert _close_dangling_tool_call(text) == text
+    assert close_dangling_tool_call(text) == text
 
 
 def test_assistant_inference_config_adds_stop_sequence(mock_inference_config):

--- a/tests/unit/environments/test_base_environment.py
+++ b/tests/unit/environments/test_base_environment.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pytest
 
+from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_tool import DeterministicToolOutput
@@ -59,5 +60,5 @@ def test_default_describe_grounding_empty_list_returns_empty_string():
 
 def test_default_describe_grounding_delegates_to_helper():
     env = _MinimalEnv()
-    facts = [DeterministicToolOutput(input={"id": "42"}, output={"title": "Dune"})]
+    facts = [GroundingFact(data={"id": "42", "title": "Dune"})]
     assert env.describe_grounding(facts) == '- id="42", title="Dune"'

--- a/tests/unit/environments/test_base_environment.py
+++ b/tests/unit/environments/test_base_environment.py
@@ -21,7 +21,6 @@ import pytest
 from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
-from oumi.environments.deterministic_tool import DeterministicToolOutput
 
 
 def test_base_environment_is_not_a_dataclass():

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -15,6 +15,7 @@
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolLookupError, ToolResult
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
@@ -178,7 +179,39 @@ def test_sample_grounding_returns_n_facts():
     facts = env.sample_grounding(n=3, rng=random.Random(0))
     assert len(facts) == 3
     for fact in facts:
-        assert isinstance(fact, DeterministicToolOutput)
+        assert isinstance(fact, GroundingFact)
+        assert "id" in fact.data
+        assert "title" in fact.data
+
+
+def test_sample_grounding_merges_input_and_output_into_data():
+    import random
+
+    # Override-on-conflict: output values win over input values for matching keys.
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[
+                ToolParams(
+                    id="lookup",
+                    name="Lookup",
+                    description="Look up.",
+                    deterministic_outputs=[
+                        DeterministicToolOutput(
+                            input={"id": "1", "note": "input-note"},
+                            output={"note": "output-note", "title": "Dune"},
+                        ),
+                    ],
+                )
+            ]
+        )
+    )
+    facts = env.sample_grounding(n=1, rng=random.Random(0))
+    assert len(facts) == 1
+    assert facts[0].data == {
+        "id": "1",
+        "note": "output-note",  # output wins on key collision
+        "title": "Dune",
+    }
 
 
 def test_sample_grounding_no_replacement_within_call():
@@ -186,7 +219,7 @@ def test_sample_grounding_no_replacement_within_call():
 
     env = _det_env_with_n_entries(10)
     facts = env.sample_grounding(n=5, rng=random.Random(0))
-    ids = [fact.input["id"] for fact in facts]
+    ids = [fact.data["id"] for fact in facts]
     assert len(set(ids)) == len(ids)
 
 
@@ -204,8 +237,8 @@ def test_sample_grounding_seeded_rng_is_reproducible():
     env = _det_env_with_n_entries(20)
     facts_a = env.sample_grounding(n=4, rng=random.Random(42))
     facts_b = env.sample_grounding(n=4, rng=random.Random(42))
-    ids_a = [fact.input["id"] for fact in facts_a]
-    ids_b = [fact.input["id"] for fact in facts_b]
+    ids_a = [fact.data["id"] for fact in facts_a]
+    ids_b = [fact.data["id"] for fact in facts_b]
     assert ids_a == ids_b
 
 
@@ -215,8 +248,8 @@ def test_sample_grounding_different_seeds_differ():
     env = _det_env_with_n_entries(20)
     facts_a = env.sample_grounding(n=4, rng=random.Random(1))
     facts_b = env.sample_grounding(n=4, rng=random.Random(999))
-    ids_a = sorted(fact.input["id"] for fact in facts_a)
-    ids_b = sorted(fact.input["id"] for fact in facts_b)
+    ids_a = sorted(fact.data["id"] for fact in facts_a)
+    ids_b = sorted(fact.data["id"] for fact in facts_b)
     # With 20 entries and 4 picks, collision on both sets is vanishingly small.
     assert ids_a != ids_b
 
@@ -248,5 +281,5 @@ def test_sample_grounding_pools_across_tools():
     env = DeterministicEnvironment.from_params(params)
     facts = env.sample_grounding(n=3, rng=random.Random(0))
     assert len(facts) == 3
-    keys = sorted(fact.input["k"] for fact in facts)
+    keys = sorted(fact.data["k"] for fact in facts)
     assert keys == ["a1", "b1", "b2"]

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -191,7 +191,7 @@ def test_sample_grounding_merges_input_and_output_into_data():
     env = DeterministicEnvironment.from_params(
         _make_params(
             tools=[
-                ToolParams(
+                DeterministicTool(
                     id="lookup",
                     name="Lookup",
                     description="Look up.",


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 5 of 6) - Stage: tool result handling + polish

**What changed**: Add `<tool_result>` wrapping with USER role, `</tool_call>` stop sequences to prevent hallucination, dangling tag closure, library tool-use config example, decouple `GroundingFact` from `DeterministicToolOutput`, and clean up tests and design specs.

**Why**: Tool results need consistent wrapping for portable API usage, and the planner needs stop sequences to prevent it from hallucinating past a tool call. The grounding decoupling makes the fact type env-agnostic as designed.

> **Note**: The diff shows large deletions because the design spec docs (added in Phase 2) are removed here — they served their purpose during development.

## PR Chain

1. Planner guided decoding & tool schema
2. Grounding types, config & infrastructure
3. Grounding in environments
4. Wire grounding into synthesis pipeline
5. **Tool use robustness & grounding polish** (this PR)
6. JSON repair & planner refinement

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?