### PR TITLE
[Det Env] Phase 6: JSON brace repair & planner refinement

### DIFF
--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -1,16 +1,25 @@
-# Library Assistant — Tool-Use Conversation Synthesis
+# Library Assistant — Agentic Tool-Use Conversation Synthesis
 #
 # Generates grounded multi-turn conversations between a library patron and a
-# library-assistant chatbot. The assistant has two DeterministicEnvironment
-# tools:
+# library-assistant chatbot. The assistant has four DeterministicEnvironment
+# tools and must pick the right one based on patron intent:
 #   1. `list_book_catalog`  — returns the full {book_id, title, author}
 #      catalog. Used to resolve a patron-spoken title into a book_id.
 #   2. `lookup_book_status` — returns circulation details for a book_id.
+#   3. `checkout_book`      — borrows an available book for the patron.
+#      Fails if the book is already borrowed or overdue.
+#   4. `checkin_book`       — returns a borrowed (or overdue) book. Fails
+#      if the book is not currently checked out.
 #
-# Patrons in this synthesis only ever refer to books by TITLE (the way a real
-# patron would speak), never by internal IDs. The assistant must call
-# `list_book_catalog` first when a title is given, then chain into
-# `lookup_book_status` with the resolved id.
+# This makes the dataset *agentic* rather than a single-shot Q&A: the
+# assistant must reason about state before acting (look up before checkout,
+# respond to tool errors with alternatives, chain lookup→checkout or
+# catalog→lookup→checkout flows).
+#
+# Patrons only ever refer to books by TITLE (the way a real patron would
+# speak), never by internal IDs. The assistant calls `list_book_catalog` to
+# resolve titles, then chains into `lookup_book_status` / `checkout_book` /
+# `checkin_book` as appropriate.
 #
 # Grounding is enabled on the environment: a small random subset of real
 # catalog entries is surfaced to the planner each conversation so turn plans
@@ -19,8 +28,8 @@
 # circulation details.
 #
 # Requirements:
-#   - Set ANTHROPIC_API_KEY in the environment
-#     (example: `export ANTHROPIC_API_KEY=your_api_key`)
+#   - Set OPENAI_API_KEY in the environment
+#     (example: `export OPENAI_API_KEY=your_api_key`)
 #   - Or change the inference_config to use a different provider/engine.
 #
 # Usage:
@@ -33,7 +42,7 @@
 #   - Environment config: oumi.core.configs.EnvironmentConfig
 
 strategy: GENERAL
-num_samples: 10
+num_samples: 50
 output_path: library_tool_use_dataset.jsonl
 
 environment_config:
@@ -199,10 +208,10 @@ environment_config:
               output:
                 title: "Pride and Prejudice"
                 author: "Jane Austen"
-                borrower_name: "David Kim"
-                borrow_date: "2026-03-20"
-                return_date: "2026-04-20"
-                status: "borrowed"
+                borrower_name: ""
+                borrow_date: ""
+                return_date: ""
+                status: "available"
             - input: { book_id: "B005" }
               output:
                 title: "Dune"
@@ -271,10 +280,10 @@ environment_config:
               output:
                 title: "Klara and the Sun"
                 author: "Kazuo Ishiguro"
-                borrower_name: "Mira Gupta"
-                borrow_date: "2026-04-13"
-                return_date: "2026-05-13"
-                status: "borrowed"
+                borrower_name: ""
+                borrow_date: ""
+                return_date: ""
+                status: "available"
             - input: { book_id: "B014" }
               output:
                 title: "The Midnight Library"
@@ -291,6 +300,150 @@ environment_config:
                 borrow_date: ""
                 return_date: ""
                 status: "available"
+
+        # ----- Action tools: mutate circulation state -------------------
+        # The deterministic environment is stateless, so outcomes are
+        # pre-declared: available books checkout successfully, already-
+        # borrowed books error with a current-borrower message. Checkin
+        # is the mirror: borrowed/overdue books return successfully,
+        # available books error (nothing to return).
+        - id: checkout_book
+          name: Checkout Book
+          description: >-
+            Check a book out to the current patron. Succeeds only if the
+            book is available. Returns an error with the current borrower
+            if the book is already checked out or overdue.
+          parameters:
+            type: object
+            properties:
+              book_id:
+                type: string
+                description: The library's book identifier (e.g. "B004").
+            required:
+              - book_id
+          output_schema:
+            type: object
+            properties:
+              status:
+                type: string
+              book_id:
+                type: string
+              due_date:
+                type: string
+              error:
+                type: string
+              current_borrower:
+                type: string
+          deterministic_outputs:
+            # --- Available books → success ---
+            - input: { book_id: "B004" }
+              output:
+                status: "checked_out"
+                book_id: "B004"
+                due_date: "2026-05-20"
+            - input: { book_id: "B009" }
+              output:
+                status: "checked_out"
+                book_id: "B009"
+                due_date: "2026-05-20"
+            - input: { book_id: "B013" }
+              output:
+                status: "checked_out"
+                book_id: "B013"
+                due_date: "2026-05-20"
+            - input: { book_id: "B014" }
+              output:
+                status: "checked_out"
+                book_id: "B014"
+                due_date: "2026-05-20"
+            - input: { book_id: "B015" }
+              output:
+                status: "checked_out"
+                book_id: "B015"
+                due_date: "2026-05-20"
+            # --- Already-borrowed books → error ---
+            - input: { book_id: "B001" }
+              output:
+                status: "error"
+                error: "already_borrowed"
+                current_borrower: "Sarah Chen"
+            - input: { book_id: "B003" }
+              output:
+                status: "error"
+                error: "already_borrowed"
+                current_borrower: "Aisha Patel"
+            - input: { book_id: "B008" }
+              output:
+                status: "error"
+                error: "already_borrowed"
+                current_borrower: "Liam O'Connor"
+
+        - id: checkin_book
+          name: Checkin Book
+          description: >-
+            Return a borrowed or overdue book to the library. Succeeds for
+            books currently checked out. Returns an error if the book is
+            already on the shelf.
+          parameters:
+            type: object
+            properties:
+              book_id:
+                type: string
+                description: The library's book identifier (e.g. "B001").
+            required:
+              - book_id
+          output_schema:
+            type: object
+            properties:
+              status:
+                type: string
+              book_id:
+                type: string
+              late_days:
+                type: integer
+              error:
+                type: string
+          deterministic_outputs:
+            # --- Currently-borrowed books → success ---
+            - input: { book_id: "B002" }
+              output:
+                status: "returned"
+                book_id: "B002"
+                late_days: 0
+            - input: { book_id: "B005" }
+              output:
+                status: "returned"
+                book_id: "B005"
+                late_days: 0
+            - input: { book_id: "B011" }
+              output:
+                status: "returned"
+                book_id: "B011"
+                late_days: 0
+            # --- Overdue books → success (with late days flagged) ---
+            - input: { book_id: "B001" }
+              output:
+                status: "returned"
+                book_id: "B001"
+                late_days: 5
+            - input: { book_id: "B006" }
+              output:
+                status: "returned"
+                book_id: "B006"
+                late_days: 23
+            # --- Already-available books → error ---
+            - input: { book_id: "B004" }
+              output:
+                status: "error"
+                error: "not_checked_out"
+            - input: { book_id: "B009" }
+              output:
+                status: "error"
+                error: "not_checked_out"
+            - input: { book_id: "B015" }
+              output:
+                status: "error"
+                error: "not_checked_out"
 
 strategy_params:
   sampled_attributes:
@@ -372,6 +525,18 @@ strategy_params:
         - id: recommendation_followup
           name: Recommendation Follow-up
           description: Heard about a book from a friend or review and wants to check it on the spot
+        - id: borrow_book
+          name: Borrow Book
+          description: Wants to actually check out a specific titled book, not just see its status
+        - id: return_book
+          name: Return Book
+          description: Wants to return a book they currently have checked out
+        - id: borrow_fallback
+          name: Borrow with Fallback
+          description: Wants to borrow a specific title, but is open to alternatives if it's unavailable
+        - id: return_and_borrow
+          name: Return and Borrow
+          description: Wants to return one book and immediately check out another in the same visit
 
     # Conversational style — drives tone, length, vocabulary, and patience
     - id: patron_demeanor
@@ -439,6 +604,8 @@ strategy_params:
       available_tools:
         - list_book_catalog
         - lookup_book_status
+        - checkout_book
+        - checkin_book
       max_tool_calls_per_turn: 6
 
       role_instruction_messages:
@@ -480,30 +647,44 @@ strategy_params:
 
         ASSISTANT: |
           You are LibBot, the city library's circulation assistant. You have
-          two tools available:
+          four tools available:
 
           1. `list_book_catalog` — returns the full catalog as a list of
              {{book_id, title, author}} entries. Use this whenever the patron
              names a book by TITLE so you can resolve it to a book_id.
           2. `lookup_book_status` — returns circulation details (borrower,
              borrow date, due date, status) for a given book_id.
+          3. `checkout_book` — borrows an available book on behalf of the
+             patron. Fails with `{{"status": "error", "error":
+             "already_borrowed"}}` if the book is already out.
+          4. `checkin_book` — returns a borrowed or overdue book to the
+             library. Fails with `{{"status": "error", "error":
+             "not_checked_out"}}` if the book is already on the shelf.
 
-          Standard flow:
-          - Patron names one or more titles → call `list_book_catalog` once →
-            find the matching book_id(s) → call `lookup_book_status` for each
-            relevant id → summarize the result(s) in natural language.
-          - Patron supplies a book_id directly (rare) → skip the catalog and
-            call `lookup_book_status` immediately.
-          - If a title is partial or ambiguous, surface the closest catalog
-            match(es) and ask the patron to confirm before looking up status.
-          - If the title is not in the catalog at all, say so clearly and
-            offer to look for something similar.
-          - For catalog-browse intent, you may share the title list from
-            `list_book_catalog` without immediately calling `lookup_book_status`.
+          Standard flows:
+          - Status inquiry (availability / due date / borrower / overdue):
+            resolve title → `list_book_catalog` → `lookup_book_status` →
+            summarize.
+          - Borrow request: resolve title → `lookup_book_status` → if
+            `status == "available"`, call `checkout_book` and confirm the
+            due date; if borrowed/overdue, report the current due date and
+            offer alternatives instead of attempting checkout.
+          - Return request: resolve title → call `checkin_book`. If it
+            errors with `not_checked_out`, clarify with the patron. If the
+            book was overdue, acknowledge the late return without lecturing.
+          - Catalog-browse intent: share the title list from
+            `list_book_catalog` without chaining further.
+          - Patron supplies a book_id directly (rare): skip the catalog.
 
           Rules:
-          - ALWAYS use the tools for any circulation or catalog information.
-            Never fabricate titles, authors, borrowers, dates, or statuses.
+          - ALWAYS use the tools for any circulation, catalog, checkout, or
+            return action. Never fabricate titles, authors, borrowers, dates,
+            statuses, or confirmation numbers.
+          - NEVER call `checkout_book` without first confirming availability
+            via `lookup_book_status` — calling checkout on a borrowed book is
+            a wasted action and embarrasses the agent.
+          - When a tool returns an error, acknowledge it naturally (don't
+            paste the raw error) and offer the patron a concrete next step.
           - Do NOT invent procedural information you cannot verify (online
             renewal flows, PIN reset steps, fee amounts, hold queue length,
             etc.). If asked, acknowledge you don't have that capability and
@@ -521,13 +702,16 @@ strategy_params:
 
       output_system_prompt: |
         You are LibBot, the city library's circulation assistant. You help
-        patrons find books and check circulation status using two tools:
+        patrons find, borrow, and return books using four tools:
           - `list_book_catalog`  — returns {{book_id, title, author}} for the
             full catalog. Use this to resolve a patron-spoken title to a
             book_id.
           - `lookup_book_status` — returns circulation details for a book_id.
-        Always call the tools for catalog or circulation information; never
-        fabricate data. Stay professional with rude or angry patrons.
+          - `checkout_book`      — borrows an available book for the patron.
+          - `checkin_book`       — returns a borrowed or overdue book.
+        Always call the tools for catalog, circulation, or checkout/return
+        actions; never fabricate data. Confirm availability before checkout.
+        Stay professional with rude or angry patrons.
 
   passthrough_attributes:
     - library_conversation
@@ -535,8 +719,8 @@ strategy_params:
 
 inference_config:
   model:
-    model_name: claude-sonnet-4-20250514
-  engine: ANTHROPIC
+    model_name: gpt-4o
+  engine: OPENAI
   generation:
     max_new_tokens: 4096
     temperature: 0.7

--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -608,6 +608,37 @@ strategy_params:
         - checkin_book
       max_tool_calls_per_turn: 6
 
+      conversation_planner: |
+        The patron's query intent is "{query_intent.name}":
+        {query_intent.description}
+
+        Plan turn instructions according to the intent:
+
+        - If the intent is "Borrow Book", "Borrow with Fallback", or
+          "Return and Borrow": the FINAL assistant turn MUST instruct the
+          assistant to "call `checkout_book` with the resolved book_id"
+          (and report the due date). Never end on "offer to check it out"
+          or "ask if the patron wants to borrow" — the patron already
+          asked, that IS consent. Reserve at least one assistant turn for
+          `lookup_book_status` and the SAME or a later assistant turn for
+          `checkout_book`. If turns are tight, chain status and checkout
+          in the same assistant turn.
+        - If the intent is "Return Book" or "Return and Borrow": the
+          assistant turn handling the return MUST instruct "call
+          `checkin_book` with the resolved book_id". Do not end on
+          "offer to return" — call the tool.
+        - For any other intent (Availability Check, Due Date Check,
+          Borrower Identification, Overdue Concern, Multi-Book Inquiry,
+          Title Recall, Catalog Browse, Service Complaint,
+          Recommendation Follow-up): the assistant should use
+          `list_book_catalog` and/or `lookup_book_status` only — do NOT
+          plan a `checkout_book` / `checkin_book` call unless the patron
+          explicitly asks to borrow or return.
+
+        Use action verbs in instructions ("call `checkout_book`...",
+        "call `checkin_book`...") rather than soft offers ("offer to
+        check out", "ask if they want to borrow").
+
       role_instruction_messages:
         USER: |
           You are {patron_name}, a {patron_type.name} visiting the city library's
@@ -666,12 +697,17 @@ strategy_params:
             resolve title → `list_book_catalog` → `lookup_book_status` →
             summarize.
           - Borrow request: resolve title → `lookup_book_status` → if
-            `status == "available"`, call `checkout_book` and confirm the
-            due date; if borrowed/overdue, report the current due date and
-            offer alternatives instead of attempting checkout.
-          - Return request: resolve title → call `checkin_book`. If it
-            errors with `not_checked_out`, clarify with the patron. If the
-            book was overdue, acknowledge the late return without lecturing.
+            `status == "available"`, IMMEDIATELY call `checkout_book` in
+            the SAME assistant turn and report the due date. Do NOT ask
+            the patron "would you like me to check it out?" — they already
+            asked to borrow it, that IS consent. If borrowed/overdue,
+            report the current due date and offer alternatives instead of
+            attempting checkout.
+          - Return request: resolve title → call `checkin_book` in the
+            same turn (do not ask permission to return — the patron asked
+            you to). If it errors with `not_checked_out`, clarify with the
+            patron. If the book was overdue, acknowledge the late return
+            without lecturing.
           - Catalog-browse intent: share the title list from
             `list_book_catalog` without chaining further.
           - Patron supplies a book_id directly (rare): skip the catalog.
@@ -683,6 +719,11 @@ strategy_params:
           - NEVER call `checkout_book` without first confirming availability
             via `lookup_book_status` — calling checkout on a borrowed book is
             a wasted action and embarrasses the agent.
+          - For borrow/return intents, the conversation is NOT complete until
+            you have actually called `checkout_book` or `checkin_book`. A
+            response that only OFFERS to check out (e.g. "would you like me
+            to borrow it?") is a failure — the patron's original request
+            already authorized the action.
           - When a tool returns an error, acknowledge it naturally (don't
             paste the raw error) and offer the patron a concrete next step.
           - Do NOT invent procedural information you cannot verify (online
@@ -710,8 +751,13 @@ strategy_params:
           - `checkout_book`      — borrows an available book for the patron.
           - `checkin_book`       — returns a borrowed or overdue book.
         Always call the tools for catalog, circulation, or checkout/return
-        actions; never fabricate data. Confirm availability before checkout.
-        Stay professional with rude or angry patrons.
+        actions; never fabricate data. Verify availability with
+        `lookup_book_status` before calling `checkout_book` — but if a
+        patron has already asked to borrow a title, treat that as consent
+        and call `checkout_book` immediately once availability is confirmed.
+        Do not ask the patron "would you like me to check it out?" after
+        they've already requested the borrow. Stay professional with rude
+        or angry patrons.
 
   passthrough_attributes:
     - library_conversation

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -58,6 +58,13 @@ _FORCED_FINALIZE_NUDGE = (
     "provide your final response to the user now."
 )
 
+_TOOL_LOOP_CONTINUATION = (
+    "Based on the tool results above, decide your next step: call another "
+    "tool ONLY if you need NEW information you do not already have, or "
+    "respond to the user with a final text answer. Do NOT repeat a tool "
+    "call you have already made with the same arguments."
+)
+
 
 def _tool_result_message(content: str) -> Message:
     """Wrap a tool output as a user-role message with a <tool_result> marker."""
@@ -776,6 +783,7 @@ class ConversationSynthesizer:
         current_turn: int,
         multiturn_attribute: MultiTurnAttribute,
         trailing: list[Message] | None = None,
+        is_tool_continuation: bool = False,
     ) -> Conversation:
         """Build the inference prompt for one sample at one turn."""
         target_turns = sample["target_turns"]
@@ -792,13 +800,16 @@ class ConversationSynthesizer:
             multiturn_attribute=multiturn_attribute,
         )
 
-        turn_info = (
-            f"You are generating turn {current_turn} of {target_turns} "
-            f"as the {role.value.upper()}.\n\n"
-        )
-        if turn_instruction:
-            turn_info += f"For this turn: {turn_instruction}\n\n"
-        turn_info += "Generate ONLY your response for this turn. Stay in character."
+        if is_tool_continuation:
+            turn_info = _TOOL_LOOP_CONTINUATION
+        else:
+            turn_info = (
+                f"You are generating turn {current_turn} of {target_turns} "
+                f"as the {role.value.upper()}.\n\n"
+            )
+            if turn_instruction:
+                turn_info += f"For this turn: {turn_instruction}\n\n"
+            turn_info += "Generate ONLY your response for this turn. Stay in character."
 
         messages = [persona_msg, *history, Message(role=Role.USER, content=turn_info)]
         if trailing:
@@ -832,6 +843,7 @@ class ConversationSynthesizer:
                     histories[i] + turn_messages[i],
                     current_turn,
                     multiturn_attribute,
+                    is_tool_continuation=tool_count[i] > 0,
                 )
                 for i in active
             ]

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -534,7 +534,9 @@ class ConversationSynthesizer:
             "[USER]\n"
             "You are a customer who has an issue with a recent order.\n\n"
             "[ASSISTANT]\n"
-            "You are a helpful support agent who resolves customer issues.\n\n"
+            "You are a helpful support agent who resolves customer issues. "
+            "You have tools: lookup_order_status(order_id), "
+            "refund_order(order_id).\n\n"
             "Ground this plan in these specific entities:\n"
             '- order_id="ORD-4421", item="laptop stand", status="delayed"\n\n'
             "Additional instructions: Focus on resolving the order issue "
@@ -544,12 +546,14 @@ class ConversationSynthesizer:
             '{"turns": [\n'
             '  {"turn": 1, "instruction": "Greet support and explain that '
             'order ORD-4421 has not arrived"},\n'
-            '  {"turn": 2, "instruction": "Acknowledge the issue and ask '
-            'for details on order ORD-4421"},\n'
-            '  {"turn": 3, "instruction": "Describe that the laptop stand '
-            'from order ORD-4421 is late"},\n'
-            '  {"turn": 4, "instruction": "Confirm the delay on order '
-            'ORD-4421 and offer a resolution"}\n'
+            '  {"turn": 2, "instruction": "Acknowledge the issue and call '
+            "lookup_order_status with the order_id the customer just gave "
+            'to retrieve current status"},\n'
+            '  {"turn": 3, "instruction": "Confirm the laptop stand from '
+            'order ORD-4421 is the one in question and ask what can be done"},\n'
+            '  {"turn": 4, "instruction": "Report the status returned by '
+            "the tool, then call refund_order using the same order_id and "
+            'confirm the resolution to the customer"}\n'
             "]}"
         )
 
@@ -594,11 +598,22 @@ class ConversationSynthesizer:
             base_prompt += (
                 "\nGround this plan in these specific entities:\n"
                 f"{block}\n"
-                "Every turn instruction that references one of these entities "
-                "MUST spell out the concrete identifier verbatim (e.g. write "
-                "'book B007', not 'the book'). The user persona cannot see "
-                "this list — only text you write into each instruction "
-                "reaches them.\n"
+                "Grounding rules (role-aware):\n"
+                "- USER turn instructions MAY inline concrete identifiers "
+                "from the list above (e.g. 'order ORD-4421 is late', "
+                "'book B007'). The user persona cannot see this list, so "
+                "identifiers the user should mention must be written into "
+                "their turn instruction.\n"
+                "- ASSISTANT turn instructions MUST NOT pre-resolve or "
+                "pre-state any tool output — no identifiers, statuses, "
+                "borrower names, due dates, or other facts the assistant "
+                "would normally look up. Reference entities by what the "
+                "user said (e.g. the title) and describe which TOOL the "
+                "assistant should call to resolve or verify. Example — "
+                "write 'call lookup_book_status with the book_id from the "
+                "catalog', not 'tell the user book B007 is checked out'.\n"
+                "- The planner's job for assistant turns is to probe the "
+                "right tool usage, not to do the tool's work.\n"
             )
 
         if multiturn_attribute.conversation_planner:

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -44,12 +44,13 @@ from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.utils import (
     TOOL_CALL_RE,
+    canonicalize_tool_call_bodies,
     close_dangling_tool_call,
     strip_tool_call_blocks,
     truncate_after_last_tool_call,
 )
 from oumi.utils.logging import logger
-from oumi.utils.str_utils import extract_json
+from oumi.utils.str_utils import extract_json, repair_json_braces
 
 _FORCED_FINALIZE_NUDGE = (
     "You have reached the tool-call limit. Do NOT emit any more "
@@ -828,6 +829,7 @@ class ConversationSynthesizer:
             for i, text in zip(active, texts):
                 text = close_dangling_tool_call(text)
                 text = truncate_after_last_tool_call(text)
+                text = canonicalize_tool_call_bodies(text)
                 turn_messages[i].append(Message(role=Role.ASSISTANT, content=text))
                 if self._is_final_response(text):
                     done[i] = True
@@ -892,7 +894,15 @@ class ConversationSynthesizer:
         try:
             parsed = json.loads(body)
         except json.JSONDecodeError as e:
-            return _tool_error_msg(f"Malformed tool_call JSON: {e}")
+            # Retry via brace repair to recover from stop-sequence truncation
+            # (missing closing braces) and over-emission (trailing }}).
+            repaired = repair_json_braces(body)
+            if repaired is None:
+                return _tool_error_msg(f"Malformed tool_call JSON: {e}")
+            logger.debug(
+                "Tool-call JSON repaired (len %d -> %d).", len(body), len(repaired)
+            )
+            parsed = json.loads(repaired)
         if not isinstance(parsed, dict):
             return _tool_error_msg("tool_call body must be a JSON object")
 

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -964,13 +964,7 @@ class ConversationSynthesizer:
             return _tool_error_msg(f"Tool '{name}' raised: {e}")
 
         output = result.output
-
-        if output is None:
-            content = ""
-        elif isinstance(output, str):
-            content = output
-        else:
-            content = json.dumps(output)
+        content = output if isinstance(output, str) else json.dumps(output)
         return _tool_result_message(content)
 
     def _build_tool_dispatch(

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
 from oumi.core.configs.params.grounding_params import GroundingFact
+from oumi.utils.str_utils import repair_json_braces
 
 TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 
@@ -44,6 +46,36 @@ def truncate_after_last_tool_call(text: str) -> str:
     if last_close == -1:
         return text
     return text[: last_close + len("</tool_call>")]
+
+
+def canonicalize_tool_call_bodies(text: str) -> str:
+    """Replace each ``<tool_call>`` body with a canonical JSON re-serialization.
+
+    Models occasionally emit malformed JSON inside tool calls — most commonly
+    an extra trailing ``}`` (``}}}``) or a missing close when the stop
+    sequence fires early. Without this pass, the malformation is persisted
+    verbatim into the output dataset (it would only be repaired transiently
+    during tool execution). Downstream consumers of the dataset would then
+    need to re-implement the repair.
+
+    For each ``<tool_call>...</tool_call>`` block, this function attempts to
+    brace-repair the body and, on success, substitutes it with the compact
+    ``json.dumps`` form. Bodies that cannot be repaired are left untouched;
+    the tool-executor surfaces a structured error message for those.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        body = match.group(1).strip()
+        repaired = repair_json_braces(body)
+        if repaired is None:
+            return match.group(0)
+        try:
+            parsed = json.loads(repaired)
+        except json.JSONDecodeError:
+            return match.group(0)
+        return f"<tool_call>{json.dumps(parsed)}</tool_call>"
+
+    return TOOL_CALL_RE.sub(_replace, text)
 
 
 def _format_grounding_value(value: Any) -> str:

--- a/src/oumi/utils/str_utils.py
+++ b/src/oumi/utils/str_utils.py
@@ -183,6 +183,87 @@ def extract_json(text: str, expected_type: type | None = list) -> dict | list | 
     return None
 
 
+def repair_json_braces(text: str) -> str | None:
+    """Repair unbalanced ``{}`` / ``[]`` in a JSON string.
+
+    Targets two failure modes common to LLM output truncated at stop
+    sequences or token limits:
+
+    - **Extra trailing closes** (``{...}}``): truncate to the last index
+      where ``{`` / ``[`` depth returned to zero.
+    - **Missing closes** (``{...``): append the needed closers in the
+      correct reverse-open order (tracked as a stack, not a counter, so
+      ``{"a": [1, 2`` becomes ``{"a": [1, 2]}``).
+
+    The scanner is string-aware — ``{`` / ``}`` / ``[`` / ``]`` inside
+    JSON string literals are ignored (respecting ``\\"`` escapes). Non-
+    structural malformations (unquoted keys, single quotes, trailing
+    commas, unescaped quotes inside strings) are NOT handled; those
+    require guessing intent and tend to regress more often than they
+    help. If ``text`` still fails to parse after a brace repair attempt,
+    returns ``None``.
+
+    Args:
+        text: Candidate JSON. May be valid, have extra trailing closes,
+            or be truncated before its closing bracket(s).
+
+    Returns:
+        The minimal brace-repaired string that parses with ``json.loads``,
+        or ``None`` if no such repair exists. When the input already
+        parses, it is returned unchanged.
+    """
+    try:
+        json.loads(text)
+        return text
+    except json.JSONDecodeError:
+        pass
+
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    last_balanced_end = 0
+    extra_close_at: int | None = None
+
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            stack.append("}")
+        elif ch == "[":
+            stack.append("]")
+        elif ch in "}]":
+            if not stack or stack[-1] != ch:
+                extra_close_at = i
+                break
+            stack.pop()
+            if not stack:
+                last_balanced_end = i + 1
+
+    if extra_close_at is not None:
+        if last_balanced_end == 0:
+            return None
+        repaired = text[:last_balanced_end]
+    elif stack:
+        repaired = text + "".join(reversed(stack))
+    else:
+        return None
+
+    try:
+        json.loads(repaired)
+    except json.JSONDecodeError:
+        return None
+    return repaired
+
+
 def get_editable_install_override_env_var() -> bool:
     """Returns whether OUMI_FORCE_EDITABLE_INSTALL env var is set to a truthy value."""
     s = os.environ.get("OUMI_FORCE_EDITABLE_INSTALL", "")

--- a/src/oumi/utils/str_utils.py
+++ b/src/oumi/utils/str_utils.py
@@ -184,7 +184,7 @@ def extract_json(text: str, expected_type: type | None = list) -> dict | list | 
 
 
 def repair_json_braces(text: str) -> str | None:
-    """Repair unbalanced ``{}`` / ``[]`` in a JSON string.
+    r"""Repair unbalanced ``{}`` / ``[]`` in a JSON string.
 
     Targets two failure modes common to LLM output truncated at stop
     sequences or token limits:
@@ -196,7 +196,7 @@ def repair_json_braces(text: str) -> str | None:
       ``{"a": [1, 2`` becomes ``{"a": [1, 2]}``).
 
     The scanner is string-aware — ``{`` / ``}`` / ``[`` / ``]`` inside
-    JSON string literals are ignored (respecting ``\\"`` escapes). Non-
+    JSON string literals are ignored (respecting ``\"`` escapes). Non-
     structural malformations (unquoted keys, single quotes, trailing
     commas, unescaped quotes inside strings) are NOT handled; those
     require guessing intent and tend to regress more often than they

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1421,7 +1421,8 @@ def test_create_planner_prompt_injects_grounding_block_when_facts_present(
     assert "Ground this plan in these specific entities" in planner_user_msg
     assert '- id="42", title="Dune"' in planner_user_msg
     assert '- id="7", title="LotR"' in planner_user_msg
-    assert "spell out the concrete identifier verbatim" in planner_user_msg
+    assert "USER turn instructions MAY inline concrete identifiers" in planner_user_msg
+    assert "ASSISTANT turn instructions MUST NOT pre-resolve" in planner_user_msg
     assert "user persona cannot see this list" in planner_user_msg
 
 
@@ -2558,7 +2559,10 @@ def test_create_planner_prompt_byte_identical_when_no_grounding(
     # the example_request still mentions "Ground this plan" once as part of
     # the few-shot demo, but the runtime base prompt must not include the
     # grounded section.
-    assert "spell out the concrete identifier verbatim" not in planner_user_msg
+    assert (
+        "USER turn instructions MAY inline concrete identifiers" not in planner_user_msg
+    )
+    assert "ASSISTANT turn instructions MUST NOT pre-resolve" not in planner_user_msg
     assert "user persona cannot see this list" not in planner_user_msg
     assert "{grounding_facts}" not in planner_user_msg
 
@@ -2707,3 +2711,67 @@ def testcanonicalize_tool_call_bodies_handles_multiple_blocks():
     assert out.count("</tool_call>") == 2
     assert '{"name": "a", "arguments": {"id": "1"}}' in out
     assert '{"name": "b", "arguments": {"id": "2"}}' in out
+
+
+
+def test_parse_plan_unwraps_openai_object_form(mock_inference_config):
+    """OpenAI structured-output returns ``{"turns": [...]}``; unwrap it."""
+    with patch(
+        "oumi.core.synthesis.conversation_synthesizer.build_inference_engine"
+    ) as _:
+        synthesizer = ConversationSynthesizer(
+            GeneralSynthesisParams(),
+            mock_inference_config,
+        )
+
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "Greet"},'
+        '{"turn": 2, "instruction": "Answer"}'
+        "]}"
+    )
+    result = synthesizer._parse_plan(plan, target_turns=2)
+    assert result == ["Greet", "Answer"]
+
+
+def test_create_planner_prompt_example_models_role_aware_grounding(
+    mock_inference_config,
+):
+    """Few-shot example: user turns inline IDs, assistant turns describe tool calls."""
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    attr = _tool_multiturn_attr()
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+    }
+    conversation = synth._create_planner_prompt(attr, sample)
+
+    example_request = conversation.messages[1].content
+    example_response = conversation.messages[2].content
+    assert isinstance(example_request, str)
+    assert isinstance(example_response, str)
+    assert "Ground this plan in these specific entities" in example_request
+    assert 'order_id="ORD-4421"' in example_request
+
+    plan = json.loads(example_response)
+    turns_by_num = {t["turn"]: t["instruction"] for t in plan["turns"]}
+
+    user_turns_with_id = sum(
+        1 for n, inst in turns_by_num.items() if n % 2 == 1 and "ORD-4421" in inst
+    )
+    assert user_turns_with_id >= 1, "user turn should mention the ID verbatim"
+
+    assistant_instructions = [inst for n, inst in turns_by_num.items() if n % 2 == 0]
+    assert any(
+        "lookup_order_status" in inst or "refund_order" in inst
+        for inst in assistant_instructions
+    ), "assistant turns should describe tool calls"
+
+    assistant_turn_2 = turns_by_num[2]
+    assert "ORD-4421" not in assistant_turn_2, (
+        "assistant turn 2 must not pre-resolve the order_id — it should come "
+        "from the user or the tool"
+    )

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2417,6 +2417,51 @@ def test_run_assistant_turn_self_corrects_after_invalid_arguments(
 # --- end-to-end synthesize with tools ---
 
 
+def test_run_assistant_turn_continuation_replaces_plan_instruction(
+    mock_inference_config,
+):
+    """After the first tool call, subsequent prompts use the continuation
+    directive instead of re-injecting the original plan instruction.
+
+    Without this redirect, the assistant tends to interpret the plan
+    instruction as license to fire more tool calls — driving up the
+    extra-content failure mode the synth pipeline is supposed to avoid.
+    """
+    env_config = _tool_env_config()
+    engine = _scripted_inference_engine(
+        [
+            ['<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'],
+            ["The status is ok."],
+        ]
+    )
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=env_config, inference_engine=engine
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    plan_instruction = "Call lookup to check the order status"
+    msgs = synth._run_assistant_turn(
+        samples=[{"target_turns": 2, "parsed_turn_plans": ["", plan_instruction]}],
+        sample_indices=[0],
+        histories=[[]],
+        current_turn=2,
+        multiturn_attribute=_tool_multiturn_attr(),
+        tool_dispatch=dispatch,
+    )
+
+    assert engine.infer.call_count == 2
+
+    first_prompt = engine.infer.call_args_list[0].args[0][0]
+    first_trailing = first_prompt.messages[-1].content
+    assert plan_instruction in first_trailing
+
+    second_prompt = engine.infer.call_args_list[1].args[0][0]
+    second_trailing = second_prompt.messages[-1].content
+    assert plan_instruction not in second_trailing
+    assert "Do NOT repeat a tool call" in second_trailing
+
+    assert msgs[0][-1].content == "The status is ok."
+
+
 def test_synthesize_end_to_end_with_tool_use(mock_inference_config):
     env_config = _tool_env_config()
     plan_json = (

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2758,7 +2758,6 @@ def testcanonicalize_tool_call_bodies_handles_multiple_blocks():
     assert '{"name": "b", "arguments": {"id": "2"}}' in out
 
 
-
 def test_parse_plan_unwraps_openai_object_form(mock_inference_config):
     """OpenAI structured-output returns ``{"turns": [...]}``; unwrap it."""
     with patch(

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2622,3 +2622,88 @@ def test_end_to_end_grounded_conversation_uses_sampled_entity_ids(
         fact_id = fact.data["id"]
         assert fact_id in configured_ids
         assert f'id="{fact_id}"' in planner_prompt
+
+
+# --- JSON brace repair: tool-call recovery ---
+
+
+def test_execute_tool_calls_recovers_from_trailing_extra_brace(mock_inference_config):
+    """Tool-call bodies with an extra ``}}`` (seen in synth output) execute."""
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    response = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}}</tool_call>'
+    messages = synth._execute_tool_calls(response, dispatch)
+    assert len(messages) == 1
+    assert json.loads(_unwrap_tool_result(messages[0].content)) == {"status": "ok"}
+
+
+def test_execute_tool_calls_recovers_from_missing_close_brace(mock_inference_config):
+    """Stop-sequence truncation that drops a closing ``}`` is repaired."""
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_tool_env_config()
+    )
+    dispatch = synth._build_tool_dispatch(_tool_multiturn_attr())
+    response = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}</tool_call>'
+    messages = synth._execute_tool_calls(response, dispatch)
+    assert len(messages) == 1
+    assert json.loads(_unwrap_tool_result(messages[0].content)) == {"status": "ok"}
+
+
+def testcanonicalize_tool_call_bodies_strips_extra_brace():
+    """The observed ``}}}`` malformation is repaired into canonical JSON."""
+    from oumi.environments.utils import canonicalize_tool_call_bodies
+
+    text = (
+        '<tool_call>{"name": "lookup_book_status", '
+        '"arguments": {"book_id": "B008"}}}</tool_call>'
+    )
+    out = canonicalize_tool_call_bodies(text)
+    assert "}}}" not in out
+    assert out == (
+        "<tool_call>"
+        '{"name": "lookup_book_status", "arguments": {"book_id": "B008"}}'
+        "</tool_call>"
+    )
+
+
+def testcanonicalize_tool_call_bodies_appends_missing_close():
+    from oumi.environments.utils import canonicalize_tool_call_bodies
+
+    text = '<tool_call>{"name": "lookup", "arguments": {"id": "01"}</tool_call>'
+    out = canonicalize_tool_call_bodies(text)
+    assert out == (
+        '<tool_call>{"name": "lookup", "arguments": {"id": "01"}}</tool_call>'
+    )
+
+
+def testcanonicalize_tool_call_bodies_leaves_unfixable_body_intact():
+    """Non-structural breakage (unquoted keys) is left for the executor."""
+    from oumi.environments.utils import canonicalize_tool_call_bodies
+
+    text = "<tool_call>{not valid at all}</tool_call>"
+    assert canonicalize_tool_call_bodies(text) == text
+
+
+def testcanonicalize_tool_call_bodies_noop_when_no_calls_present():
+    from oumi.environments.utils import canonicalize_tool_call_bodies
+
+    text = "Just a plain assistant reply, nothing to do here."
+    assert canonicalize_tool_call_bodies(text) == text
+
+
+def testcanonicalize_tool_call_bodies_handles_multiple_blocks():
+    from oumi.environments.utils import canonicalize_tool_call_bodies
+
+    text = (
+        '<tool_call>{"name": "a", "arguments": {"id": "1"}}}</tool_call>'
+        " some prose "
+        '<tool_call>{"name": "b", "arguments": {"id": "2"}</tool_call>'
+    )
+    out = canonicalize_tool_call_bodies(text)
+    assert "}}}" not in out
+    assert out.count("<tool_call>") == 2
+    assert out.count("</tool_call>") == 2
+    assert '{"name": "a", "arguments": {"id": "1"}}' in out
+    assert '{"name": "b", "arguments": {"id": "2"}}' in out

--- a/tests/unit/utils/test_str_utils.py
+++ b/tests/unit/utils/test_str_utils.py
@@ -10,6 +10,7 @@ from oumi.utils.str_utils import (
     compute_utf8_len,
     extract_json,
     get_editable_install_override_env_var,
+    repair_json_braces,
     sanitize_run_name,
     set_oumi_install_editable,
     str_to_bool,
@@ -317,3 +318,76 @@ def test_extract_json_no_json():
 def test_extract_json_any_type():
     assert extract_json("[1, 2]", expected_type=None) == [1, 2]
     assert extract_json('Result: {"a": 1}', expected_type=None) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# repair_json_braces
+# ---------------------------------------------------------------------------
+
+
+def test_repair_json_braces_passes_valid_input_through():
+    text = '{"name": "lookup", "arguments": {"book_id": "B001"}}'
+    assert repair_json_braces(text) == text
+
+
+def test_repair_json_braces_strips_single_trailing_close():
+    """The exact failure mode observed in synth output: one extra ``}``."""
+    text = '{"name": "lookup_book_status", "arguments": {"book_id": "B008"}}}'
+    repaired = repair_json_braces(text)
+    assert repaired == (
+        '{"name": "lookup_book_status", "arguments": {"book_id": "B008"}}'
+    )
+
+
+def test_repair_json_braces_strips_many_trailing_closes():
+    text = '{"a": 1}}}}}'
+    assert repair_json_braces(text) == '{"a": 1}'
+
+
+def test_repair_json_braces_appends_missing_object_close():
+    """Stop-sequence truncation often cuts just before the final ``}``."""
+    text = '{"name": "lookup", "arguments": {"book_id": "B001"}'
+    repaired = repair_json_braces(text)
+    assert repaired == ('{"name": "lookup", "arguments": {"book_id": "B001"}}')
+
+
+def test_repair_json_braces_appends_missing_array_close():
+    text = '{"items": [1, 2, 3'
+    assert repair_json_braces(text) == '{"items": [1, 2, 3]}'
+
+
+def test_repair_json_braces_appends_mixed_closes_in_reverse_open_order():
+    """Reverse-open order matters: ``{"a": [...`` needs ``]}`` not ``}]``."""
+    text = '{"a": [1, 2'
+    assert repair_json_braces(text) == '{"a": [1, 2]}'
+
+
+def test_repair_json_braces_ignores_braces_inside_strings():
+    """``}`` inside a string literal must not count as a close."""
+    text = '{"msg": "hello }world{"}'
+    assert repair_json_braces(text) == text
+
+
+def test_repair_json_braces_handles_escaped_quotes_in_strings():
+    text = r'{"msg": "she said \"hi\""}'
+    assert repair_json_braces(text) == text
+
+
+def test_repair_json_braces_returns_none_for_non_structural_breakage():
+    """Unquoted keys are out of scope — sanitizer gives up rather than guess."""
+    assert repair_json_braces("{a: 1}") is None
+
+
+def test_repair_json_braces_returns_none_for_nonsense():
+    assert repair_json_braces("not json at all") is None
+
+
+def test_repair_json_braces_handles_valid_nested_structures():
+    text = '{"outer": {"inner": [1, {"k": "v"}]}}'
+    assert repair_json_braces(text) == text
+
+
+def test_repair_json_braces_truncates_after_last_balanced_point():
+    """Extra close after a balanced prefix keeps the prefix."""
+    text = '{"a": 1}}extra garbage'
+    assert repair_json_braces(text) == '{"a": 1}'


### PR DESCRIPTION
# Description

Part of the **Deterministic Environment** PR chain (Phase 6 of 6) - Stage: robustness & final polish

**What changed**: Add `repair_json_braces()` utility for LLM-truncated JSON (string-aware with escape handling), restructure planner JSON schema to `{"turns": [...]}` wrapper, and refine planner grounding rules.

**Why**: LLMs frequently truncate JSON with mismatched braces — the repair utility handles both extra and missing closing braces. The schema restructure gives the planner a cleaner contract, and the grounding rule refinements ensure role-aware fact usage.

## PR Chain

1. Planner guided decoding & tool schema
2. Grounding types, config & infrastructure
3. Grounding in environments
4. Wire grounding into synthesis pipeline
5. Tool use robustness & grounding polish
6. **JSON brace repair & planner refinement** (this PR)

## Related issues

Part of deterministic environment grounding work (replaces #2384)

## Before submitting
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?