### PR TITLE
Support tool definitions and structured tool calls in SFT pipeline

### DIFF
--- a/src/oumi/analyze/base.py
+++ b/src/oumi/analyze/base.py
@@ -101,6 +101,8 @@ class BaseAnalyzer(ABC, Generic[TResult]):
         """
         if isinstance(message.content, str):
             return message.content
+        if message.content is None:
+            return ""
         text_parts = []
         for item in message.content:
             if isinstance(item, ContentItem) and isinstance(item.content, str):

--- a/src/oumi/analyze/base.py
+++ b/src/oumi/analyze/base.py
@@ -14,6 +14,7 @@
 
 """Base analyzer classes for the typed analyzer framework."""
 
+import json
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Generic, TypeVar
 
@@ -89,25 +90,49 @@ class BaseAnalyzer(ABC, Generic[TResult]):
 
     @staticmethod
     def get_text_content(message: Message) -> str:
-        """Extract text content from a message.
+        """Extract a text-content proxy from a message for analysis.
 
-        Handles both simple string content and multimodal content lists.
+        Returns an approximate, model-agnostic string representation
+        suitable for length, regex, and rough token-count analyses — NOT
+        a faithful representation of what a model's tokenizer will see.
+        Different models render tool calls to wildly different token
+        counts via their chat templates (Qwen ``<tool_call>...``, Mistral
+        ``[TOOL_CALLS]``, Llama JSON, Hermes XML, etc.); this helper
+        can't and doesn't try to replicate that. For exact, model-specific
+        counts, apply the model's tokenizer to
+        ``tokenizer.apply_chat_template(messages, tools=...)`` rather than
+        using this proxy.
+
+        The proxy concatenates, separated by single spaces:
+
+        - Simple ``str`` content (returned as-is)
+        - Multimodal content lists (text items joined)
+        - ``tool_calls`` (JSON-stringified via OpenAI wire format)
+
+        Including ``tool_calls`` matters because tool-only assistant
+        turns (``content=None``) would otherwise contribute zero to every
+        length-based metric, systematically under-counting tool-heavy
+        datasets. The JSON form gives them a representative size.
 
         Args:
             message: The message to extract text from.
 
         Returns:
-            The text content as a string.
+            The combined text proxy as a string. Empty if the message has
+            neither content nor tool_calls.
         """
+        parts: list[str] = []
         if isinstance(message.content, str):
-            return message.content
-        if message.content is None:
-            return ""
-        text_parts = []
-        for item in message.content:
-            if isinstance(item, ContentItem) and isinstance(item.content, str):
-                text_parts.append(item.content)
-        return " ".join(text_parts)
+            parts.append(message.content)
+        elif isinstance(message.content, list):
+            for item in message.content:
+                if isinstance(item, ContentItem) and isinstance(item.content, str):
+                    parts.append(item.content)
+        if message.tool_calls:
+            parts.append(
+                json.dumps([tc.model_dump(mode="json") for tc in message.tool_calls])
+            )
+        return " ".join(parts)
 
 
 class MessageAnalyzer(BaseAnalyzer[TResult]):

--- a/src/oumi/analyze/utils/dataframe.py
+++ b/src/oumi/analyze/utils/dataframe.py
@@ -21,7 +21,8 @@ from typing import Any
 import pandas as pd
 from pydantic import BaseModel
 
-from oumi.core.types.conversation import ContentItem, Conversation
+from oumi.analyze.base import BaseAnalyzer
+from oumi.core.types.conversation import Conversation
 
 logger = logging.getLogger(__name__)
 
@@ -155,16 +156,7 @@ def to_message_dataframe(
                 "role": message.role.value,
             }
 
-            if isinstance(message.content, str):
-                row["text_content"] = message.content
-            elif message.content is None:
-                row["text_content"] = ""
-            else:
-                text_parts = []
-                for item in message.content:
-                    if isinstance(item, ContentItem) and isinstance(item.content, str):
-                        text_parts.append(item.content)
-                row["text_content"] = " ".join(text_parts)
+            row["text_content"] = BaseAnalyzer.get_text_content(message)
 
             # Add results from each message-level analyzer
             for analyzer_name, analyzer_results in results.items():

--- a/src/oumi/analyze/utils/dataframe.py
+++ b/src/oumi/analyze/utils/dataframe.py
@@ -157,6 +157,8 @@ def to_message_dataframe(
 
             if isinstance(message.content, str):
                 row["text_content"] = message.content
+            elif message.content is None:
+                row["text_content"] = ""
             else:
                 text_parts = []
                 for item in message.content:

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -162,11 +162,18 @@ class BaseSftDataset(BaseMapDataset, ABC):
                 return {"conversation_json": conversation_json}
             elif self._return_conversations_format == "dict":
                 data = conversation.to_dict()
-                # Ensure `tools` is always present as a top-level key so the
-                # HF dataset schema stays consistent across rows. Without this,
-                # rows whose Conversation has no tools end up missing the key
-                # (exclude_none=True strips it), and `datasets.Dataset.from_generator`
-                # fails with KeyError when mixing tool and non-tool rows.
+                # HF Datasets infers a single arrow struct schema across rows
+                # and requires every top-level key to exist on every row with
+                # the same type. Without this, rows whose Conversation has no
+                # tools end up missing the key (`exclude_none=True` strips it),
+                # and `datasets.Dataset.from_generator` fails with KeyError
+                # when mixing tool and non-tool rows.
+                #
+                # Note that this rule applies at the column level only —
+                # inside a list-of-dicts column like `messages`, items can
+                # have heterogeneous keys (e.g., assistant messages with
+                # `tool_calls`, tool messages with `tool_call_id`, plain
+                # messages with neither), and that's fine.
                 data.setdefault("tools", None)
                 return data
             else:

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -161,7 +161,14 @@ class BaseSftDataset(BaseMapDataset, ABC):
                 conversation_json = conversation.to_json()
                 return {"conversation_json": conversation_json}
             elif self._return_conversations_format == "dict":
-                return conversation.to_dict()
+                data = conversation.to_dict()
+                # Ensure `tools` is always present as a top-level key so the
+                # HF dataset schema stays consistent across rows. Without this,
+                # rows whose Conversation has no tools end up missing the key
+                # (exclude_none=True strips it), and `datasets.Dataset.from_generator`
+                # fails with KeyError when mixing tool and non-tool rows.
+                data.setdefault("tools", None)
+                return data
             else:
                 raise ValueError(
                     f"Invalid return_conversations_format: "

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -161,21 +161,7 @@ class BaseSftDataset(BaseMapDataset, ABC):
                 conversation_json = conversation.to_json()
                 return {"conversation_json": conversation_json}
             elif self._return_conversations_format == "dict":
-                data = conversation.to_dict()
-                # HF Datasets infers a single arrow struct schema across rows
-                # and requires every top-level key to exist on every row with
-                # the same type. Without this, rows whose Conversation has no
-                # tools end up missing the key (`exclude_none=True` strips it),
-                # and `datasets.Dataset.from_generator` fails with KeyError
-                # when mixing tool and non-tool rows.
-                #
-                # Note that this rule applies at the column level only —
-                # inside a list-of-dicts column like `messages`, items can
-                # have heterogeneous keys (e.g., assistant messages with
-                # `tool_calls`, tool messages with `tool_call_id`, plain
-                # messages with neither), and that's fine.
-                data.setdefault("tools", None)
-                return data
+                return self._conversation_to_hf_compatible_dict(conversation)
             else:
                 raise ValueError(
                     f"Invalid return_conversations_format: "
@@ -183,6 +169,25 @@ class BaseSftDataset(BaseMapDataset, ABC):
                     "Supported formats are 'json' and 'dict'."
                 )
         return self.tokenize(conversation)
+
+    def _conversation_to_hf_compatible_dict(self, conversation: Conversation) -> dict:
+        """Convert a Conversation to a dict with an HF-Datasets-stable schema.
+
+        HF Datasets infers a single arrow struct schema across rows and
+        requires every top-level key to exist on every row with the same
+        type. Without forcing `tools` to be present, rows whose Conversation
+        has no tools end up missing the key (`exclude_none=True` strips it),
+        and `datasets.Dataset.from_generator` fails with KeyError when mixing
+        tool and non-tool rows.
+
+        This rule applies at the column level only — inside a list-of-dicts
+        column like `messages`, items can have heterogeneous keys (e.g.,
+        assistant messages with `tool_calls`, tool messages with
+        `tool_call_id`, plain messages with neither), and that's fine.
+        """
+        data = conversation.to_dict()
+        data.setdefault("tools", None)
+        return data
 
     def tokenize(
         self,

--- a/src/oumi/core/types/__init__.py
+++ b/src/oumi/core/types/__init__.py
@@ -42,16 +42,28 @@ from oumi.core.types.conversation import (
     TemplatedMessage,
     Type,
 )
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    FunctionDefinition,
+    ToolCall,
+    ToolDefinition,
+    ToolType,
+)
 from oumi.exceptions import HardwareException
 
 __all__ = [
-    "HardwareException",
     "ContentItem",
     "ContentItemCounts",
     "Conversation",
     "FinishReason",
+    "FunctionCall",
+    "FunctionDefinition",
+    "HardwareException",
     "Message",
     "Role",
-    "Type",
     "TemplatedMessage",
+    "ToolCall",
+    "ToolDefinition",
+    "ToolType",
+    "Type",
 ]

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -537,10 +537,18 @@ class Conversation(pydantic.BaseModel):
         data = self.model_dump(
             mode="json", exclude_unset=True, exclude_defaults=False, exclude_none=True
         )
-        # Preserve `content: null` on assistant messages that only carry
-        # `tool_calls`, matching the OpenAI wire format. `exclude_none=True`
-        # strips `None` globally, which would drop the `content` key and
-        # trip HF chat templates that don't tolerate a missing `content`.
+        self._restore_null_content_on_tool_call_messages(data)
+        return data
+
+    def _restore_null_content_on_tool_call_messages(self, data: dict) -> None:
+        """Re-add ``content: null`` on assistant messages that only carry tool_calls.
+
+        Matches the OpenAI wire format. ``exclude_none=True`` strips
+        ``None`` globally, which would drop the ``content`` key and trip
+        HF chat templates that don't tolerate a missing ``content``.
+
+        Mutates ``data`` in place.
+        """
         msg_dicts = data.get("messages", [])
         assert len(msg_dicts) == len(self.messages), (
             "Pydantic dump produced a different number of messages than "
@@ -549,7 +557,6 @@ class Conversation(pydantic.BaseModel):
         for msg_dict, msg in zip(msg_dicts, self.messages):
             if msg.tool_calls and "content" not in msg_dict:
                 msg_dict["content"] = None
-        return data
 
     def append_id_to_string(self, s: str) -> str:
         """Appends conversation ID to a string.

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -19,6 +19,7 @@ from typing import Any, NamedTuple
 
 import pydantic
 from jinja2 import Template
+from transformers.utils.chat_template_utils import get_json_schema
 
 
 class Role(str, Enum):
@@ -409,8 +410,16 @@ class Conversation(pydantic.BaseModel):
     in a key-value format. It can be used to include any relevant contextual data.
     """
 
-    tools: list[dict] | None = None
+    tools: list[dict | Callable] | None = None
     """Tool definitions available to the model for this conversation.
+
+    Accepts either OpenAI-format dicts or Python callables. Callables are
+    converted to dicts at validation time via
+    ``transformers.utils.chat_template_utils.get_json_schema``, which requires
+    the callable to have a Google-style docstring and type hints on every
+    user-facing argument. After validation, every entry is a dict regardless
+    of the input shape, so persistence (``to_dict()``) and the HF Dataset
+    schema are unaffected.
 
     Uses the OpenAI function-calling schema, e.g.::
 
@@ -423,6 +432,32 @@ class Conversation(pydantic.BaseModel):
     ``SFTTrainer`` forwards to ``tokenizer.apply_chat_template(messages, tools=...)``
     so the model's chat template can render tools natively.
     """
+
+    @pydantic.field_validator("tools", mode="before")
+    @classmethod
+    def _coerce_callable_tools_to_openai_schema(
+        cls, raw_tools: list[dict | Callable] | None
+    ) -> list[dict] | None:
+        """Convert any callable tool definitions to OpenAI-format dicts.
+
+        Pydantic validators run on the input value before final field
+        assignment. We accept callables for ergonomics in inference / agent
+        flows but normalise to dicts so storage stays uniform.
+        """
+        if raw_tools is None:
+            return None
+        coerced_tools: list[dict] = []
+        for tool in raw_tools:
+            if isinstance(tool, dict):
+                coerced_tools.append(tool)
+            elif callable(tool):
+                coerced_tools.append(get_json_schema(tool))
+            else:
+                raise ValueError(
+                    f"Each tool must be a dict (OpenAI schema) or a callable; "
+                    f"got {type(tool).__name__}."
+                )
+        return coerced_tools
 
     def __getitem__(self, idx: int) -> Message:
         """Gets the message at the specified index.

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -228,31 +228,57 @@ class Message(pydantic.BaseModel):
         Optional[str]: The unique identifier of the message, if set; otherwise None.
     """
 
-    content: str | list[ContentItem]
+    content: str | list[ContentItem] | None = None
     """Content of the message.
 
     For text messages, `content` can be set to a string value.
     For multimodal messages, `content` should be a list of content items of
     potentially different types e.g., text and image.
+    May be ``None`` on assistant messages that only contain ``tool_calls``
+    (OpenAI tool-calling wire format).
     """
 
     role: Role
     """The role of the entity sending the message (e.g., user, assistant, system)."""
 
+    tool_calls: list[dict] | None = None
+    """Structured tool calls emitted by an assistant message.
+
+    Uses the OpenAI function-calling wire format, e.g.::
+
+        [{"id": "call_abc", "type": "function",
+          "function": {"name": "get_weather", "arguments": "{...}"}}]
+
+    Only set on assistant messages. The chat template renders these via
+    ``tokenizer.apply_chat_template(messages, tools=...)``.
+    """
+
+    tool_call_id: str | None = None
+    """Identifier linking a tool response message to the call it responds to.
+
+    Only set on messages with ``role == 'tool'``, matching the ``id`` of a
+    prior assistant ``tool_calls`` entry.
+    """
+
     def model_post_init(self, __context) -> None:
         """Post-initialization method for the Message model.
 
         This method is automatically called after the model is initialized.
-        It performs additional validation to ensure that either content or binary
-        is provided for the message.
+        It validates that the message has at least one of ``content`` or
+        ``tool_calls`` and that ``content``, when set, is a string or list.
 
         Raises:
-            ValueError: If both content and binary are None.
+            ValueError: If both ``content`` and ``tool_calls`` are ``None``,
+                or if ``content`` has an unsupported type.
         """
-        if not isinstance(self.content, str | list):
+        if self.content is None and not self.tool_calls:
+            raise ValueError(
+                "Message must have at least one of `content` or `tool_calls`."
+            )
+        if self.content is not None and not isinstance(self.content, str | list):
             raise ValueError(
                 f"Unexpected content type: {type(self.content)}. "
-                f"Must by a Python string or a list."
+                f"Must be a Python string, a list, or None."
             )
 
     def _iter_content_items(
@@ -383,6 +409,21 @@ class Conversation(pydantic.BaseModel):
     in a key-value format. It can be used to include any relevant contextual data.
     """
 
+    tools: list[dict] | None = None
+    """Tool definitions available to the model for this conversation.
+
+    Uses the OpenAI function-calling schema, e.g.::
+
+        [{"type": "function",
+          "function": {"name": "get_weather",
+                       "description": "...",
+                       "parameters": {...}}}]
+
+    When set, ``to_dict()`` emits ``tools`` as a top-level key, which TRL's
+    ``SFTTrainer`` forwards to ``tokenizer.apply_chat_template(messages, tools=...)``
+    so the model's chat template can render tools natively.
+    """
+
     def __getitem__(self, idx: int) -> Message:
         """Gets the message at the specified index.
 
@@ -452,9 +493,17 @@ class Conversation(pydantic.BaseModel):
 
     def to_dict(self):
         """Converts the conversation to a dictionary."""
-        return self.model_dump(
+        data = self.model_dump(
             mode="json", exclude_unset=True, exclude_defaults=False, exclude_none=True
         )
+        # Preserve `content: null` on assistant messages that only carry
+        # `tool_calls`, matching the OpenAI wire format. `exclude_none=True`
+        # strips `None` globally, which would drop the `content` key and
+        # trip HF chat templates that don't tolerate a missing `content`.
+        for msg_dict, msg in zip(data.get("messages", []), self.messages):
+            if msg.tool_calls and "content" not in msg_dict:
+                msg_dict["content"] = None
+        return data
 
     def append_id_to_string(self, s: str) -> str:
         """Appends conversation ID to a string.

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -21,6 +21,8 @@ import pydantic
 from jinja2 import Template
 from transformers.utils.chat_template_utils import get_json_schema
 
+from oumi.core.types.tool_call import ToolCall, ToolDefinition
+
 
 class Role(str, Enum):
     """Role of the entity sending the message."""
@@ -242,16 +244,18 @@ class Message(pydantic.BaseModel):
     role: Role
     """The role of the entity sending the message (e.g., user, assistant, system)."""
 
-    tool_calls: list[dict] | None = None
+    tool_calls: list[ToolCall] | None = None
     """Structured tool calls emitted by an assistant message.
 
-    Uses the OpenAI function-calling wire format, e.g.::
+    Uses the OpenAI function-calling wire format. Pydantic auto-coerces
+    dict input (e.g., from JSONL) into ``ToolCall`` instances::
 
         [{"id": "call_abc", "type": "function",
           "function": {"name": "get_weather", "arguments": "{...}"}}]
 
     Only set on assistant messages. The chat template renders these via
-    ``tokenizer.apply_chat_template(messages, tools=...)``.
+    ``tokenizer.apply_chat_template(messages, tools=...)``; serialization
+    (``to_dict()`` / ``to_json()``) emits them in the OpenAI dict shape.
     """
 
     tool_call_id: str | None = None
@@ -269,12 +273,14 @@ class Message(pydantic.BaseModel):
         ``tool_calls`` and that ``content``, when set, is a string or list.
 
         Raises:
-            ValueError: If both ``content`` and ``tool_calls`` are ``None``,
-                or if ``content`` has an unsupported type.
+            ValueError: If ``content`` is ``None`` and ``tool_calls`` is
+                missing or empty, or if ``content`` has an unsupported type.
         """
         if self.content is None and not self.tool_calls:
             raise ValueError(
-                "Message must have at least one of `content` or `tool_calls`."
+                "Message must have at least one of `content` (string/list) "
+                "or a non-empty `tool_calls`. An empty list of tool calls "
+                "is not valid."
             )
         if self.content is not None and not isinstance(self.content, str | list):
             raise ValueError(
@@ -410,16 +416,15 @@ class Conversation(pydantic.BaseModel):
     in a key-value format. It can be used to include any relevant contextual data.
     """
 
-    tools: list[dict | Callable] | None = None
+    tools: list[ToolDefinition] | None = None
     """Tool definitions available to the model for this conversation.
 
-    Accepts either OpenAI-format dicts or Python callables. Callables are
-    converted to dicts at validation time via
-    ``transformers.utils.chat_template_utils.get_json_schema``, which requires
-    the callable to have a Google-style docstring and type hints on every
-    user-facing argument. After validation, every entry is a dict regardless
-    of the input shape, so persistence (``to_dict()``) and the HF Dataset
-    schema are unaffected.
+    Accepts ``ToolDefinition`` instances, OpenAI-format dicts, or Python
+    callables on input. Callables are converted via
+    ``transformers.utils.chat_template_utils.get_json_schema`` (which
+    requires a Google-style docstring and type hints on every user-facing
+    argument) and dicts are validated by Pydantic into ``ToolDefinition``.
+    After construction, every entry is a ``ToolDefinition`` instance.
 
     Uses the OpenAI function-calling schema, e.g.::
 
@@ -428,34 +433,35 @@ class Conversation(pydantic.BaseModel):
                        "description": "...",
                        "parameters": {...}}}]
 
-    When set, ``to_dict()`` emits ``tools`` as a top-level key, which TRL's
+    When set, ``to_dict()`` emits ``tools`` as a top-level key (in dict
+    form, via Pydantic's ``model_dump(mode="json")``), which TRL's
     ``SFTTrainer`` forwards to ``tokenizer.apply_chat_template(messages, tools=...)``
     so the model's chat template can render tools natively.
     """
 
     @pydantic.field_validator("tools", mode="before")
     @classmethod
-    def _coerce_callable_tools_to_openai_schema(
-        cls, raw_tools: list[dict | Callable] | None
-    ) -> list[dict] | None:
-        """Convert any callable tool definitions to OpenAI-format dicts.
+    def _coerce_tools_input(cls, raw_tools: list[Any] | None) -> list[Any] | None:
+        """Normalize each tool input to a shape Pydantic can validate.
 
-        Pydantic validators run on the input value before final field
-        assignment. We accept callables for ergonomics in inference / agent
-        flows but normalise to dicts so storage stays uniform.
+        Runs in ``mode="before"`` so we can intercept callables (which
+        Pydantic doesn't know how to validate into ``ToolDefinition``)
+        and convert them via ``get_json_schema``. ``ToolDefinition``
+        instances and dicts pass through; Pydantic's main validator
+        coerces dicts into ``ToolDefinition`` after this hook returns.
         """
         if raw_tools is None:
             return None
-        coerced_tools: list[dict] = []
+        coerced_tools: list[Any] = []
         for tool in raw_tools:
-            if isinstance(tool, dict):
+            if isinstance(tool, ToolDefinition) or isinstance(tool, dict):
                 coerced_tools.append(tool)
             elif callable(tool):
                 coerced_tools.append(get_json_schema(tool))
             else:
                 raise ValueError(
-                    f"Each tool must be a dict (OpenAI schema) or a callable; "
-                    f"got {type(tool).__name__}."
+                    f"Each tool must be a ToolDefinition, dict (OpenAI "
+                    f"schema), or a callable; got {type(tool).__name__}."
                 )
         return coerced_tools
 
@@ -535,7 +541,12 @@ class Conversation(pydantic.BaseModel):
         # `tool_calls`, matching the OpenAI wire format. `exclude_none=True`
         # strips `None` globally, which would drop the `content` key and
         # trip HF chat templates that don't tolerate a missing `content`.
-        for msg_dict, msg in zip(data.get("messages", []), self.messages):
+        msg_dicts = data.get("messages", [])
+        assert len(msg_dicts) == len(self.messages), (
+            "Pydantic dump produced a different number of messages than "
+            f"the source ({len(msg_dicts)} vs {len(self.messages)})."
+        )
+        for msg_dict, msg in zip(msg_dicts, self.messages):
             if msg.tool_calls and "content" not in msg_dict:
                 msg_dict["content"] = None
         return data

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -1,0 +1,129 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data structures for function/tool calling in LLM APIs.
+
+These models use ``extra="allow"`` so unknown keys round-trip through
+serialization unchanged. This matters for two reasons: (1) OpenAI may
+add new fields to the tool wire format over time, and (2)
+``transformers.utils.chat_template_utils.get_json_schema`` produces a
+richer schema (e.g., a top-level ``return`` block on
+``FunctionDefinition``) than the OpenAI Chat Completions API itself
+defines, and chat templates may consume those extras. Dropping unknown
+keys at validation time would silently lose information that
+downstream code relies on.
+"""
+
+from enum import Enum
+from typing import Any
+
+import pydantic
+
+
+class ToolType(str, Enum):
+    """Type of tool available to the model."""
+
+    FUNCTION = "function"
+    """A callable function that the model can invoke."""
+
+    def __str__(self) -> str:
+        """Return the string representation of the ToolType enum."""
+        return self.value
+
+
+class FunctionDefinition(pydantic.BaseModel):
+    """Definition of a function that can be called by the model."""
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+
+    name: str
+    """The name of the function to be called.
+
+    Must be a-z, A-Z, 0-9, underscores and dashes, with a maximum
+    length of 64.
+    """
+
+    description: str | None = None
+    """A description of what the function does.
+
+    Used by the model to choose when and how to call the function.
+    """
+
+    parameters: dict[str, Any] | None = None
+    """The parameters the function accepts, as a JSON Schema object.
+
+    See https://json-schema.org/understanding-json-schema/ for the
+    format. To describe a function that accepts no parameters,
+    provide ``{"type": "object", "properties": {}}``.
+    """
+
+    strict: bool | None = None
+    """Whether to enable strict schema adherence in the generated call.
+
+    If true, the model will follow the exact schema provided in
+    ``parameters``. Only supported by OpenAI gpt-4o and later;
+    ignored by other providers.
+    """
+
+
+class ToolDefinition(pydantic.BaseModel):
+    """Definition of a tool available to the model."""
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+
+    type: ToolType = ToolType.FUNCTION
+    """The type of the tool. Currently only ``function`` is supported.
+
+    Defaulted for ergonomics — when a second tool type lands, drop
+    the default to force callers to be explicit.
+    """
+
+    function: FunctionDefinition
+    """The function definition."""
+
+
+class FunctionCall(pydantic.BaseModel):
+    """A function call made by the model."""
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+
+    name: str
+    """The name of the function being called."""
+
+    arguments: str
+    """The arguments to call the function with, as a JSON string.
+
+    OpenAI wire format keeps this as an unparsed JSON-encoded string
+    (NOT a dict). Some providers return malformed JSON; downstream
+    code is responsible for parsing and handling errors.
+    """
+
+
+class ToolCall(pydantic.BaseModel):
+    """A tool call emitted by the model."""
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+
+    id: str
+    """The ID of the tool call.
+
+    Used to match a tool response message back to the call that
+    requested it (via ``Message.tool_call_id``).
+    """
+
+    type: ToolType = ToolType.FUNCTION
+    """The type of tool call. Defaulted; see ``ToolDefinition.type``."""
+
+    function: FunctionCall
+    """The function the model called."""

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -26,9 +26,56 @@ downstream code relies on.
 """
 
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 import pydantic
+
+# The seven primitive types defined by JSON Schema.
+JSONSchemaType = Literal[
+    "object", "string", "number", "integer", "boolean", "array", "null"
+]
+
+
+class JSONSchema(pydantic.BaseModel):
+    """A JSON Schema object describing the shape of a value.
+
+    Models the subset of JSON Schema commonly used in LLM tool
+    definitions. ``extra="allow"`` lets less-common keywords
+    (``$ref``, ``$defs``, ``additionalProperties``, ``anyOf``, numeric
+    constraints, etc.) round-trip unchanged, matching the rest of this
+    module — see the module docstring for why round-tripping matters.
+    """
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+
+    type: JSONSchemaType | list[JSONSchemaType] | None = None
+    """JSON type(s) of this value. A list expresses a union
+    (e.g., ``["string", "null"]`` for a nullable string).
+    """
+
+    description: str | None = None
+    """Human-readable description, used by the model to choose values."""
+
+    title: str | None = None
+    """Short human-readable label."""
+
+    properties: dict[str, "JSONSchema"] | None = None
+    """For ``type="object"``: schema for each named property."""
+
+    required: list[str] | None = None
+    """For ``type="object"``: names of properties that must be present."""
+
+    items: "JSONSchema | None" = None
+    """For ``type="array"``: schema for array elements."""
+
+    enum: list[Any] | None = None
+    """Restricts the value to a fixed set of allowed values."""
+
+    default: Any = None
+    """Default value used when the field is omitted."""
+
+    format: str | None = None
+    """Semantic format hint (e.g., ``"date-time"``, ``"email"``)."""
 
 
 class ToolType(str, Enum):
@@ -60,7 +107,7 @@ class FunctionDefinition(pydantic.BaseModel):
     Used by the model to choose when and how to call the function.
     """
 
-    parameters: dict[str, Any] | None = None
+    parameters: JSONSchema | None = None
     """The parameters the function accepts, as a JSON Schema object.
 
     See https://json-schema.org/understanding-json-schema/ for the

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -209,6 +209,8 @@ def convert_message_to_json_content(
     """
     if isinstance(message.content, str):
         return message.content
+    if message.content is None:
+        return ""
 
     assert isinstance(message.content, list)
     return convert_content_items_to_json_list(message.content_items)

--- a/tests/e2e/test_batch_inference.py
+++ b/tests/e2e/test_batch_inference.py
@@ -117,7 +117,8 @@ def test_openai_batch_inference():
     for result in results:
         assert len(result.messages) > 0
         assert result.messages[-1].role == Role.ASSISTANT
-        assert len(result.messages[-1].content) > 0
+        last_content = result.messages[-1].content
+        assert last_content is not None and len(last_content) > 0
 
 
 # =============================================================================
@@ -157,7 +158,8 @@ def test_parasail_batch_inference():
     for result in results:
         assert len(result.messages) > 0
         assert result.messages[-1].role == Role.ASSISTANT
-        assert len(result.messages[-1].content) > 0
+        last_content = result.messages[-1].content
+        assert last_content is not None and len(last_content) > 0
 
 
 # =============================================================================
@@ -197,7 +199,8 @@ def test_anthropic_batch_inference():
     for result in results:
         assert len(result.messages) > 0
         assert result.messages[-1].role == Role.ASSISTANT
-        assert len(result.messages[-1].content) > 0
+        last_content = result.messages[-1].content
+        assert last_content is not None and len(last_content) > 0
 
 
 # =============================================================================
@@ -239,7 +242,8 @@ def test_together_batch_inference():
     for result in results:
         assert len(result.messages) > 0
         assert result.messages[-1].role == Role.ASSISTANT
-        assert len(result.messages[-1].content) > 0
+        last_content = result.messages[-1].content
+        assert last_content is not None and len(last_content) > 0
 
 
 # =============================================================================
@@ -284,4 +288,5 @@ def test_fireworks_batch_inference():
     for result in results:
         assert len(result.messages) > 0
         assert result.messages[-1].role == Role.ASSISTANT
-        assert len(result.messages[-1].content) > 0
+        last_content = result.messages[-1].content
+        assert last_content is not None and len(last_content) > 0

--- a/tests/integration/infer/test_vllm_inference_engine.py
+++ b/tests/integration/infer/test_vllm_inference_engine.py
@@ -30,6 +30,7 @@ def test_qwen_think_block_with_enable_thinking_true():
     outputs = engine.infer([convo], inference_config=inference_config)
     output = outputs[-1].messages[-1].content
     print(output)
+    assert isinstance(output, str)
     assert "<think>" in output
 
 
@@ -47,4 +48,5 @@ def test_qwen_no_think_block_with_enable_thinking_false():
     outputs = engine.infer([convo], inference_config=inference_config)
     output = outputs[-1].messages[-1].content
     print(output)
+    assert isinstance(output, str)
     assert "<think>" not in output

--- a/tests/unit/analyze/test_base.py
+++ b/tests/unit/analyze/test_base.py
@@ -1,0 +1,78 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for BaseAnalyzer.get_text_content tool-call handling."""
+
+from oumi.analyze.base import BaseAnalyzer
+from oumi.core.types.conversation import ContentItem, Message, Role, Type
+from oumi.core.types.tool_call import FunctionCall, ToolCall
+
+
+def _tool_call() -> ToolCall:
+    return ToolCall(
+        id="call_abc",
+        function=FunctionCall(name="get_weather", arguments='{"city": "SF"}'),
+    )
+
+
+def test_get_text_content_string_content_unchanged():
+    """Plain string content returns as-is (no tool_calls path)."""
+    msg = Message(role=Role.ASSISTANT, content="Hello there")
+    assert BaseAnalyzer.get_text_content(msg) == "Hello there"
+
+
+def test_get_text_content_multimodal_text_items_joined():
+    """List content with text items returns the joined text."""
+    msg = Message(
+        role=Role.USER,
+        content=[
+            ContentItem(type=Type.TEXT, content="part one"),
+            ContentItem(type=Type.TEXT, content="part two"),
+        ],
+    )
+    assert BaseAnalyzer.get_text_content(msg) == "part one part two"
+
+
+def test_get_text_content_stringifies_tool_calls_when_content_none():
+    """Tool-only assistant turns contribute their tool_calls to text analyses."""
+    msg = Message(role=Role.ASSISTANT, content=None, tool_calls=[_tool_call()])
+    text = BaseAnalyzer.get_text_content(msg)
+    # Function name and argument substring both survive into the proxy form
+    # so token-count and regex analyses see them.
+    assert "get_weather" in text
+    assert "SF" in text
+
+
+def test_get_text_content_concats_text_and_tool_calls():
+    """Mixed `content` (str) + `tool_calls` turns include both in the output."""
+    msg = Message(
+        role=Role.ASSISTANT,
+        content="Let me check that.",
+        tool_calls=[_tool_call()],
+    )
+    text = BaseAnalyzer.get_text_content(msg)
+    assert "Let me check that." in text
+    assert "get_weather" in text
+
+
+def test_get_text_content_concats_multimodal_content_and_tool_calls():
+    """List-content + tool_calls also concatenates."""
+    msg = Message(
+        role=Role.ASSISTANT,
+        content=[ContentItem(type=Type.TEXT, content="Checking…")],
+        tool_calls=[_tool_call()],
+    )
+    text = BaseAnalyzer.get_text_content(msg)
+    assert "Checking…" in text
+    assert "get_weather" in text

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -388,11 +388,13 @@ def test_planner_prompt_includes_role_context(
     assert planner.messages[3].role == Role.USER
 
     user_message = planner.messages[3].content
+    assert isinstance(user_message, str)
     assert "Role context:" in user_message
     assert "You are a frustrated customer." in user_message
     assert "You are a helpful agent." in user_message
 
     example_response = planner.messages[2].content
+    assert isinstance(example_response, str)
     assert "```json" in example_response
     assert '"turn": 1' in example_response
     assert '"instruction"' in example_response

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -3,6 +3,10 @@ from typing import Final, cast
 
 import pydantic
 import pytest
+from transformers.utils.chat_template_utils import (
+    DocstringParsingException,
+    get_json_schema,
+)
 
 from oumi.core.types.conversation import (
     ContentItem,
@@ -1154,3 +1158,82 @@ def test_conversation_roundtrip_openai_tool_format():
     assert out["messages"][1]["content"] is None
     assert out["messages"][1]["tool_calls"] == [_TOOL_CALL]
     assert out["messages"][2]["tool_call_id"] == "call_abc"
+
+
+# -----------------------------------------------------------------------------
+# Callable tool definitions (auto-converted to OpenAI schema dicts)
+# -----------------------------------------------------------------------------
+
+
+def _typed_get_weather(city: str) -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: The city to fetch weather for.
+
+    Returns:
+        A short weather description.
+    """
+    return f"Sunny in {city}"
+
+
+def test_conversation_tools_accepts_callable_and_coerces_to_openai_dict():
+    """A callable tool input is converted to its OpenAI-schema dict at validation."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="Weather?")],
+        tools=[_typed_get_weather],
+    )
+    assert conv.tools is not None
+    assert len(conv.tools) == 1
+    assert isinstance(conv.tools[0], dict)
+    assert conv.tools[0] == get_json_schema(_typed_get_weather)
+
+
+def test_conversation_tools_accepts_mixed_dicts_and_callables():
+    """Mixed input of dict + callable both end up as dicts after validation."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="Hi")],
+        tools=[_TOOL_DEF_GET_WEATHER, _typed_get_weather],
+    )
+    assert conv.tools is not None
+    assert all(isinstance(tool, dict) for tool in conv.tools)
+    assert conv.tools[0] == _TOOL_DEF_GET_WEATHER
+    assert conv.tools[1] == get_json_schema(_typed_get_weather)
+
+
+def test_conversation_tools_callable_without_docstring_raises_clear_error():
+    """get_json_schema requires a docstring; missing one raises a clear error.
+
+    Transformers' ``DocstringParsingException`` propagates through the
+    validator unchanged so the user sees the original informative message.
+    """
+
+    def no_docstring_func(x: int) -> int:
+        return x
+
+    with pytest.raises(DocstringParsingException, match="docstring"):
+        Conversation(
+            messages=[Message(role=Role.USER, content="Hi")],
+            tools=[no_docstring_func],
+        )
+
+
+def test_conversation_tools_rejects_non_dict_non_callable():
+    """Items that are neither dict nor callable are rejected with a clear message."""
+    with pytest.raises(pydantic.ValidationError, match="dict.*callable"):
+        Conversation(
+            messages=[Message(role=Role.USER, content="Hi")],
+            tools=[123],  # type: ignore[list-item]
+        )
+
+
+def test_conversation_tools_callable_round_trips_via_to_dict():
+    """Construct with callable, dump to dict, reload — the dict form is stable."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="Hi")],
+        tools=[_typed_get_weather],
+    )
+    dumped = conv.to_dict()
+    restored = Conversation.from_dict(dumped)
+    assert restored.tools == conv.tools  # both are dict lists
+    assert all(isinstance(tool, dict) for tool in restored.tools or [])

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -1340,7 +1340,7 @@ def test_typed_field_access_on_conversation_tools():
     assert conv.tools is not None
     assert conv.tools[0].function.name == "get_weather"
     assert conv.tools[0].function.parameters is not None
-    assert conv.tools[0].function.parameters["required"] == ["city"]
+    assert conv.tools[0].function.parameters.required == ["city"]
 
 
 def test_typed_field_access_on_message_tool_calls():

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -17,6 +17,7 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import ToolCall, ToolDefinition
 from oumi.utils.image_utils import load_image_png_bytes_from_path
 
 _SMALL_B64_IMAGE: Final[str] = (
@@ -1010,7 +1011,7 @@ def test_conversation_messages_to_dict_list_hf_compatible():
 # -----------------------------------------------------------------------------
 
 
-_TOOL_DEF_GET_WEATHER = {
+_TOOL_DEF_GET_WEATHER_DICT = {
     "type": "function",
     "function": {
         "name": "get_weather",
@@ -1023,18 +1024,26 @@ _TOOL_DEF_GET_WEATHER = {
     },
 }
 
-_TOOL_CALL = {
+_TOOL_CALL_DICT = {
     "id": "call_abc",
     "type": "function",
     "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
 }
+
+# Typed fixtures for direct constructor calls. The dict variants stay
+# around to test the legacy-input / model_validate path.
+_TOOL_DEF_GET_WEATHER = ToolDefinition.model_validate(_TOOL_DEF_GET_WEATHER_DICT)
+_TOOL_CALL = ToolCall.model_validate(_TOOL_CALL_DICT)
 
 
 def test_message_with_tool_calls_allows_none_content():
     """Assistant tool-call messages may have content=None (OpenAI format)."""
     msg = Message(role=Role.ASSISTANT, content=None, tool_calls=[_TOOL_CALL])
     assert msg.content is None
-    assert msg.tool_calls == [_TOOL_CALL]
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].id == "call_abc"
+    assert msg.tool_calls[0].function.name == "get_weather"
 
 
 def test_message_tool_message_has_tool_call_id():
@@ -1047,7 +1056,7 @@ def test_message_tool_message_has_tool_call_id():
 
 def test_message_rejects_none_content_without_tool_calls():
     """A message must have at least one of content or tool_calls."""
-    with pytest.raises(ValueError, match="at least one of `content` or `tool_calls`"):
+    with pytest.raises(ValueError, match="at least one of `content`"):
         Message(role=Role.ASSISTANT)
 
 
@@ -1059,7 +1068,8 @@ def test_message_allows_content_with_tool_calls():
         tool_calls=[_TOOL_CALL],
     )
     assert msg.content == "Let me check that for you."
-    assert msg.tool_calls == [_TOOL_CALL]
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0].function.name == "get_weather"
 
 
 def test_conversation_accepts_top_level_tools():
@@ -1068,7 +1078,9 @@ def test_conversation_accepts_top_level_tools():
         messages=[Message(role=Role.USER, content="Hi")],
         tools=[_TOOL_DEF_GET_WEATHER],
     )
-    assert conv.tools == [_TOOL_DEF_GET_WEATHER]
+    assert conv.tools is not None
+    assert len(conv.tools) == 1
+    assert conv.tools[0].function.name == "get_weather"
 
 
 def test_conversation_to_dict_includes_tools():
@@ -1079,7 +1091,8 @@ def test_conversation_to_dict_includes_tools():
     )
     data = conv.to_dict()
     assert "tools" in data
-    assert data["tools"] == [_TOOL_DEF_GET_WEATHER]
+    # to_dict() emits dict wire format regardless of typed-class storage.
+    assert data["tools"] == [_TOOL_DEF_GET_WEATHER_DICT]
 
 
 def test_conversation_to_dict_omits_tools_when_absent():
@@ -1105,7 +1118,7 @@ def test_conversation_to_dict_preserves_null_content_on_tool_call_message():
     # Tool-call message keeps `content` key with None value.
     assert "content" in msgs[1]
     assert msgs[1]["content"] is None
-    assert msgs[1]["tool_calls"] == [_TOOL_CALL]
+    assert msgs[1]["tool_calls"] == [_TOOL_CALL_DICT]
     # Tool response keeps tool_call_id.
     assert msgs[2]["tool_call_id"] == "call_abc"
     # Regular messages unaffected.
@@ -1136,7 +1149,7 @@ def test_conversation_roundtrip_openai_tool_format():
             {
                 "role": "assistant",
                 "content": None,
-                "tool_calls": [_TOOL_CALL],
+                "tool_calls": [_TOOL_CALL_DICT],
             },
             {
                 "role": "tool",
@@ -1145,18 +1158,21 @@ def test_conversation_roundtrip_openai_tool_format():
             },
             {"role": "assistant", "content": "It's 65 in SF."},
         ],
-        "tools": [_TOOL_DEF_GET_WEATHER],
+        "tools": [_TOOL_DEF_GET_WEATHER_DICT],
     }
     conv = Conversation.model_validate(raw)
-    assert conv.tools == [_TOOL_DEF_GET_WEATHER]
-    assert conv.messages[1].tool_calls == [_TOOL_CALL]
+    assert conv.tools is not None
+    assert conv.tools[0].function.name == "get_weather"
+    assert conv.messages[1].tool_calls is not None
+    assert conv.messages[1].tool_calls[0].id == "call_abc"
     assert conv.messages[1].content is None
     assert conv.messages[2].tool_call_id == "call_abc"
 
+    # to_dict() output is the dict wire format; compare directly.
     out = conv.to_dict()
     assert out["tools"] == raw["tools"]
     assert out["messages"][1]["content"] is None
-    assert out["messages"][1]["tool_calls"] == [_TOOL_CALL]
+    assert out["messages"][1]["tool_calls"] == [_TOOL_CALL_DICT]
     assert out["messages"][2]["tool_call_id"] == "call_abc"
 
 
@@ -1178,27 +1194,35 @@ def _typed_get_weather(city: str) -> str:
 
 
 def test_conversation_tools_accepts_callable_and_coerces_to_openai_dict():
-    """A callable tool input is converted to its OpenAI-schema dict at validation."""
+    """A callable tool input is converted to a ToolDefinition at validation."""
     conv = Conversation(
         messages=[Message(role=Role.USER, content="Weather?")],
-        tools=[_typed_get_weather],
+        tools=[_typed_get_weather],  # type: ignore[list-item]
     )
     assert conv.tools is not None
     assert len(conv.tools) == 1
-    assert isinstance(conv.tools[0], dict)
-    assert conv.tools[0] == get_json_schema(_typed_get_weather)
+    assert isinstance(conv.tools[0], ToolDefinition)
+    # The dumped form matches what get_json_schema produces.
+    assert conv.tools[0].model_dump(mode="json", exclude_none=True) == get_json_schema(
+        _typed_get_weather
+    )
 
 
 def test_conversation_tools_accepts_mixed_dicts_and_callables():
-    """Mixed input of dict + callable both end up as dicts after validation."""
-    conv = Conversation(
-        messages=[Message(role=Role.USER, content="Hi")],
-        tools=[_TOOL_DEF_GET_WEATHER, _typed_get_weather],
+    """Mixed input of dict + callable both end up as ToolDefinition instances."""
+    conv = Conversation.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hi"}],
+            # Mix dict input with a callable; the validator handles both.
+            "tools": [_TOOL_DEF_GET_WEATHER_DICT, _typed_get_weather],
+        }
     )
     assert conv.tools is not None
-    assert all(isinstance(tool, dict) for tool in conv.tools)
-    assert conv.tools[0] == _TOOL_DEF_GET_WEATHER
-    assert conv.tools[1] == get_json_schema(_typed_get_weather)
+    assert all(isinstance(tool, ToolDefinition) for tool in conv.tools)
+    assert conv.tools[0].function.name == "get_weather"
+    assert conv.tools[1].model_dump(mode="json", exclude_none=True) == get_json_schema(
+        _typed_get_weather
+    )
 
 
 def test_conversation_tools_callable_without_docstring_raises_clear_error():
@@ -1214,7 +1238,7 @@ def test_conversation_tools_callable_without_docstring_raises_clear_error():
     with pytest.raises(DocstringParsingException, match="docstring"):
         Conversation(
             messages=[Message(role=Role.USER, content="Hi")],
-            tools=[no_docstring_func],
+            tools=[no_docstring_func],  # type: ignore[list-item]
         )
 
 
@@ -1228,12 +1252,101 @@ def test_conversation_tools_rejects_non_dict_non_callable():
 
 
 def test_conversation_tools_callable_round_trips_via_to_dict():
-    """Construct with callable, dump to dict, reload — the dict form is stable."""
+    """Construct with callable, dump to dict, reload — the typed form is stable."""
     conv = Conversation(
         messages=[Message(role=Role.USER, content="Hi")],
-        tools=[_typed_get_weather],
+        tools=[_typed_get_weather],  # type: ignore[list-item]
     )
     dumped = conv.to_dict()
     restored = Conversation.from_dict(dumped)
-    assert restored.tools == conv.tools  # both are dict lists
-    assert all(isinstance(tool, dict) for tool in restored.tools or [])
+    # Both are list[ToolDefinition]; Pydantic's frozen-model __eq__ compares
+    # field values, so the typed objects compare equal across the round-trip.
+    assert restored.tools == conv.tools
+    assert all(isinstance(tool, ToolDefinition) for tool in restored.tools or [])
+
+
+# -----------------------------------------------------------------------------
+# Typed-class validation wins (the reason for the typed amendment)
+# -----------------------------------------------------------------------------
+
+
+def test_message_tool_call_missing_id_raises_at_construction():
+    """Pydantic catches a missing required field on ToolCall at construction."""
+    with pytest.raises(pydantic.ValidationError, match="id"):
+        Message.model_validate(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        # missing "id"
+                        "type": "function",
+                        "function": {"name": "x", "arguments": "{}"},
+                    }
+                ],
+            }
+        )
+
+
+def test_tool_definition_missing_function_name_raises_at_construction():
+    """Pydantic catches a missing function.name on ToolDefinition at construction."""
+    with pytest.raises(pydantic.ValidationError, match="name"):
+        Conversation.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "tools": [{"type": "function", "function": {}}],
+            }
+        )
+
+
+def test_message_rejects_empty_tool_calls_with_none_content():
+    """Empty tool_calls list with no content is rejected with a sharper error."""
+    with pytest.raises(ValueError, match="non-empty"):
+        Message(role=Role.ASSISTANT, content=None, tool_calls=[])
+
+
+def test_to_dict_byte_identical_to_dict_input_for_tool_round_trip():
+    """Round-trip dict → Conversation → to_dict produces identical bytes.
+
+    Locks in the wire-format compatibility property the typed-class
+    amendment is meant to preserve: anything you load from JSONL dumps
+    back the same way, regardless of the typed storage shape.
+    """
+    raw = {
+        "messages": [
+            {"role": "user", "content": "Weather in SF?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [_TOOL_CALL_DICT],
+            },
+            {
+                "role": "tool",
+                "content": '{"temp": 65}',
+                "tool_call_id": "call_abc",
+            },
+        ],
+        "tools": [_TOOL_DEF_GET_WEATHER_DICT],
+    }
+    assert Conversation.model_validate(raw).to_dict() == raw
+
+
+def test_typed_field_access_on_conversation_tools():
+    """The typed-class win: attribute access works without dict subscripts."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="x")],
+        tools=[_TOOL_DEF_GET_WEATHER],
+    )
+    assert conv.tools is not None
+    assert conv.tools[0].function.name == "get_weather"
+    assert conv.tools[0].function.parameters is not None
+    assert conv.tools[0].function.parameters["required"] == ["city"]
+
+
+def test_typed_field_access_on_message_tool_calls():
+    """The typed-class win: attribute access on tool_calls works the same way."""
+    msg = Message(role=Role.ASSISTANT, content=None, tool_calls=[_TOOL_CALL])
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0].id == "call_abc"
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert msg.tool_calls[0].function.arguments == '{"city": "SF"}'

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -999,3 +999,158 @@ def test_conversation_messages_to_dict_list_hf_compatible():
     assert msg_dicts[1].get("content") == "Hello!"
     assert msg_dicts[2].get("role") == "user"
     assert msg_dicts[2].get("content") == "How are you?"
+
+
+# -----------------------------------------------------------------------------
+# Tool definitions + structured tool_calls (OpenAI format)
+# -----------------------------------------------------------------------------
+
+
+_TOOL_DEF_GET_WEATHER = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+_TOOL_CALL = {
+    "id": "call_abc",
+    "type": "function",
+    "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+}
+
+
+def test_message_with_tool_calls_allows_none_content():
+    """Assistant tool-call messages may have content=None (OpenAI format)."""
+    msg = Message(role=Role.ASSISTANT, content=None, tool_calls=[_TOOL_CALL])
+    assert msg.content is None
+    assert msg.tool_calls == [_TOOL_CALL]
+
+
+def test_message_tool_message_has_tool_call_id():
+    """Tool response messages carry a tool_call_id linking to the prior call."""
+    msg = Message(role=Role.TOOL, content='{"temp": 65}', tool_call_id="call_abc")
+    assert msg.role == Role.TOOL
+    assert msg.content == '{"temp": 65}'
+    assert msg.tool_call_id == "call_abc"
+
+
+def test_message_rejects_none_content_without_tool_calls():
+    """A message must have at least one of content or tool_calls."""
+    with pytest.raises(ValueError, match="at least one of `content` or `tool_calls`"):
+        Message(role=Role.ASSISTANT)
+
+
+def test_message_allows_content_with_tool_calls():
+    """Assistant messages can have both content and tool_calls (pre-text + call)."""
+    msg = Message(
+        role=Role.ASSISTANT,
+        content="Let me check that for you.",
+        tool_calls=[_TOOL_CALL],
+    )
+    assert msg.content == "Let me check that for you."
+    assert msg.tool_calls == [_TOOL_CALL]
+
+
+def test_conversation_accepts_top_level_tools():
+    """Conversation.tools stores the OpenAI-format tool definitions."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="Hi")],
+        tools=[_TOOL_DEF_GET_WEATHER],
+    )
+    assert conv.tools == [_TOOL_DEF_GET_WEATHER]
+
+
+def test_conversation_to_dict_includes_tools():
+    """to_dict() emits `tools` as a top-level key so TRL picks it up."""
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="Hi")],
+        tools=[_TOOL_DEF_GET_WEATHER],
+    )
+    data = conv.to_dict()
+    assert "tools" in data
+    assert data["tools"] == [_TOOL_DEF_GET_WEATHER]
+
+
+def test_conversation_to_dict_omits_tools_when_absent():
+    """Backward compat: non-tool conversations don't grow a `tools` key."""
+    conv = Conversation(messages=[Message(role=Role.USER, content="Hi")])
+    data = conv.to_dict()
+    assert "tools" not in data
+
+
+def test_conversation_to_dict_preserves_null_content_on_tool_call_message():
+    """Tool-call assistant messages keep `content: null` (OpenAI wire format)."""
+    conv = Conversation(
+        messages=[
+            Message(role=Role.USER, content="Weather in SF?"),
+            Message(role=Role.ASSISTANT, content=None, tool_calls=[_TOOL_CALL]),
+            Message(role=Role.TOOL, content='{"temp": 65}', tool_call_id="call_abc"),
+            Message(role=Role.ASSISTANT, content="It's 65 in SF."),
+        ],
+        tools=[_TOOL_DEF_GET_WEATHER],
+    )
+    data = conv.to_dict()
+    msgs = data["messages"]
+    # Tool-call message keeps `content` key with None value.
+    assert "content" in msgs[1]
+    assert msgs[1]["content"] is None
+    assert msgs[1]["tool_calls"] == [_TOOL_CALL]
+    # Tool response keeps tool_call_id.
+    assert msgs[2]["tool_call_id"] == "call_abc"
+    # Regular messages unaffected.
+    assert msgs[0]["content"] == "Weather in SF?"
+    assert msgs[3]["content"] == "It's 65 in SF."
+
+
+def test_conversation_to_dict_plain_messages_have_no_extra_null_keys():
+    """Backward compat: plain messages don't gain null tool_calls/tool_call_id."""
+    conv = Conversation(
+        messages=[
+            Message(role=Role.USER, content="Hi"),
+            Message(role=Role.ASSISTANT, content="Hello!"),
+        ]
+    )
+    data = conv.to_dict()
+    for msg in data["messages"]:
+        assert "tool_calls" not in msg
+        assert "tool_call_id" not in msg
+        assert msg["content"] is not None
+
+
+def test_conversation_roundtrip_openai_tool_format():
+    """Dict → Conversation → dict preserves all tool-calling fields."""
+    raw = {
+        "messages": [
+            {"role": "user", "content": "Weather in SF?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [_TOOL_CALL],
+            },
+            {
+                "role": "tool",
+                "content": '{"temp": 65}',
+                "tool_call_id": "call_abc",
+            },
+            {"role": "assistant", "content": "It's 65 in SF."},
+        ],
+        "tools": [_TOOL_DEF_GET_WEATHER],
+    }
+    conv = Conversation.model_validate(raw)
+    assert conv.tools == [_TOOL_DEF_GET_WEATHER]
+    assert conv.messages[1].tool_calls == [_TOOL_CALL]
+    assert conv.messages[1].content is None
+    assert conv.messages[2].tool_call_id == "call_abc"
+
+    out = conv.to_dict()
+    assert out["tools"] == raw["tools"]
+    assert out["messages"][1]["content"] is None
+    assert out["messages"][1]["tool_calls"] == [_TOOL_CALL]
+    assert out["messages"][2]["tool_call_id"] == "call_abc"

--- a/tests/unit/datasets/test_huggingface_vision_dataset.py
+++ b/tests/unit/datasets/test_huggingface_vision_dataset.py
@@ -537,7 +537,9 @@ def test_transform_conversation_with_url(
     conversation = dataset.transform_conversation(sample_dataset_example_with_url)
 
     # Check image content item
-    image_item = conversation.messages[0].content[0]
+    content = conversation.messages[0].content
+    assert isinstance(content, list)
+    image_item = content[0]
     assert isinstance(image_item, ContentItem)
     assert image_item.type == Type.IMAGE_URL
     assert image_item.content == "https://example.com/image.jpg"


### PR DESCRIPTION
# Description

Adds first-class support for OpenAI-format tool definitions and structured tool calls in the Oumi `Conversation` / `Message` schema, so TRL's `SFTTrainer` can forward them to `tokenizer.apply_chat_template(messages, tools=...)`. The target model's chat template then renders tools in its native format (Qwen `<tools>` XML, Llama JSON, Mistral `[TOOL_CALLS]`, etc.), which lets the **same training data be portable across tool-capable models** instead of being locked to one pre-baked format.

## Motivation

Today, training on tool-call data in Oumi requires manual pre-formatting tool definitions and tool calls into message `content` as text. This is very error prone as users will need to understand the idiosyncrasies of each model's chat template.

After this change, users will store a universal format (JSONL row can carry OpenAI-wire-format structured tools and calls). This will be formatted into the model's native representation string by `apply_chat_template`. Flow: `TextSftJsonLinesDataset` with `return_conversations=True, format="dict"` → TRL `SFTTrainer` → `apply_chat_template(messages, tools=example["tools"])`

```json
{
  "messages": [
    {"role": "user", "content": "Weather in SF?"},
    {"role": "assistant", "content": null,
     "tool_calls": [{"id": "call_abc", "type": "function",
                     "function": {"name": "get_weather", "arguments": "{\"city\": \"SF\"}"}}]},
    {"role": "tool", "content": "{\"temp\": 65}", "tool_call_id": "call_abc"},
    {"role": "assistant", "content": "It's 65 in SF."}
  ],
  "tools": [{"type": "function", "function": {"name": "get_weather", "...": "..."}}]
}
```

## What changes

**`src/oumi/core/types/conversation.py`**
- `Conversation.tools: list[dict | Callable] | None` — new top-level field. Accepts OpenAI-format dicts; callables are coerced to dicts at validation time via `transformers.utils.chat_template_utils.get_json_schema` (Pydantic `field_validator(mode="before")`). After validation every entry is a dict, so persistence is uniform.
- `Message.tool_calls: list[dict] | None` — structured calls on assistant messages.
- `Message.tool_call_id: str | None` — links tool responses to the call they answer.
- `Message.content` is now `str | list[ContentItem] | None`; a message is valid when it has at least one of `content` or `tool_calls`.
- `Conversation.to_dict()` post-processes the dump so `content: null` is preserved on messages with `tool_calls`. Without this, `exclude_none=True` drops the key and some chat templates choke on the missing field.

**`src/oumi/core/datasets/base_sft_dataset.py`**
- `transform()` with `return_conversations=True, format="dict"` always emits a top-level `tools` key (None when absent) so HF Dataset schema stays uniform when mixing tool and non-tool rows.

**Defensive updates for `content=None`**
- `src/oumi/analyze/base.py`, `src/oumi/analyze/utils/dataframe.py`, `src/oumi/utils/conversation_utils.py`: return empty string on `None` content in text-extraction helpers rather than erroring.

## Backward compatibility

This change does not break older data formats, `to_dict()` consumers, and `Conversation`/`Message` constructions and is backward compatible.  

| Concern | Status | Why |
|---|---|---|
| Old JSONL loads correctly | ✅ | `Conversation.model_validate` populates known fields; missing `tools`/`tool_calls`/`tool_call_id` default to `None`. |
| Old `to_dict()` output shape preserved | ✅ | `exclude_none=True` strips the new optional fields when they're `None`. The post-process loop only restores `content: null` when `msg.tool_calls` is truthy, so plain messages are untouched. |
| Old `Conversation(messages=[…])` / `Message(role=…, content=…)` constructions | ✅ | New fields are all `Optional` with `None` defaults. `model_post_init` requires *one of* `content` or `tool_calls`, which old messages always satisfy because they always have content. |
| Old code passing `list[dict]` as `Conversation.tools` | ✅ | Validator's first branch is `if isinstance(tool, dict): pass through`. No transformation. |
| Old TRL training pipelines | ✅ | Per-row HF dataset gains a `tools: null` column for non-tool rows; `example.get("tools")` returns `None`; `apply_chat_template` is called without tools → identical rendering to before. |
| Type-hint compatibility | ✅ | `Message.content` widened from `str \| list[ContentItem]` to `str \| list[ContentItem] \| None`. Existing callers pass valid subtypes. We also widened `Conversation.tools` to `list[dict \| Callable] \| None`; old `list[dict]` callers still satisfy. |

Concrete legacy-format tests in the suite that we kept passing unmodified:
- `test_conversation_to_dict_legacy`
- `test_conversation_from_dict_legacy`
- `test_roundtrip_dict_legacy`
- `test_roundtrip_json_legacy`
- `test_conversation_to_dict_plain_messages_have_no_extra_null_keys`

The four test files we *did* modify needed only one-line `isinstance` / None narrowing because pyright (correctly) tightened type inference once `Message.content` became `Optional`. None of them changed behavior.

**Test runs to validate compatibility**:
- `tests/unit/core/types/test_conversation.py`: 72 passed (57 pre-existing + 15 new)
- Broader unit suite (`tests/unit/core/`, `tests/unit/utils/`, `tests/unit/datasets/`, `tests/unit/analyze/`): 2371 passed, 0 failed.

## A note on data heterogeneity (column vs list-item level)

Why does the pipeline need `setdefault("tools", None)` to make the top-level `tools` column uniform across rows, but **not** force `tool_calls: null` on plain messages?

This is forced by **HuggingFace Dataset's schema inference rules**, which are different at the column level vs the list-item level:

| Level | Schema mode | Heterogeneity allowed? |
|---|---|---|
| Top-level columns | Strict arrow struct — one schema per column, valid for every row | **No** — column must exist in every row with the same type |
| Items inside a `List(Json)` column | Dynamic JSON — each item is a JSON-serializable dict, no fixed inner schema | **Yes** — each item can have different keys |

**Practical implication for users**: a single `Conversation` can have a mix of message shapes (system, user, plain assistant, tool-call assistant, tool response, plain assistant, …). All within one row. The pipeline handles it natively — verified end-to-end with the glaive multi-turn split where assistant messages alternate between tool-call and text within the same conversation.

## What's out of scope

- **Oumi-direct tokenization path** (`BaseSftDataset.tokenize()`) does not yet pass `tools=` to `apply_chat_template`. This PR only wires the TRL_SFT + `return_conversations=True` path end-to-end. Can follow up.
- **TRL_GRPO and other trainers** similarly unchanged.
- **Format conversion** is NOT done inside Oumi — users supply data already in OpenAI wire format. Callable inputs are normalized to OpenAI-format dicts via `get_json_schema`; no other coercion.

## Verification done

| # | Check | Result |
|---|---|---|
| 1 | **Unit tests** — 15 new + entire pre-existing suite | **2371 passed, 0 failed** |
| 2 | **Byte-diff** of `to_dict()` on 100 real legacy rows | **Single difference**: `tools: null` added at top level. Every other byte is identical. |
| 3 | **50-step smoke training** on legacy data, branch | **Converges normally** (loss 1.062 → 0.812). No errors. |
| 4 | **Side-by-side parity** vs main, identical seeds | **Max loss diff = 0.0004** across 11 logged steps. Grad-norm parity. |

## Related issues

Fixes # (issue)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
