### PR TITLE
feat(deploy)!: typed exception hierarchy for deployment provider errors

### DIFF
--- a/src/oumi/deploy/errors.py
+++ b/src/oumi/deploy/errors.py
@@ -1,0 +1,95 @@
+# Copyright 2026 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-neutral typed exception hierarchy for deployment API errors.
+
+Raised by :func:`oumi.deploy.utils.raise_api_error` when a deployment
+provider's control plane returns an error response. Catch
+:class:`DeployApiError` (or a specific subclass) to branch on
+retry-vs-user-error-vs-fallback instead of regex-matching message strings.
+
+``str(exc)`` contains only the operation context and provider-reported
+detail. Request method, URL, account IDs, and other internal attribution
+stay on structured attributes and DEBUG logs.
+
+Hierarchy::
+
+    DeployApiError                  (base)
+    ├── DeployInvalidRequestError   (400 / 422)
+    ├── DeployNotFoundError         (404)
+    ├── DeployRateLimitError        (429)
+    └── DeployTransientError        (5xx — sanitized __str__)
+
+This module is provider-neutral by design. Provider-specific subclasses
+(for example ``FireworksUnsupportedHardwareError``) live next to their
+client implementation — see :mod:`oumi.deploy.fireworks_errors` — and
+are plumbed in via the ``classify_4xx`` hook on
+:func:`~oumi.deploy.utils.raise_api_error`. Do NOT re-export
+provider-specific classes from this module; consumers wanting a
+provider-specific catch should import from the provider's module
+explicitly.
+"""
+
+
+class DeployApiError(Exception):
+    """Base class for typed errors from a deployment provider's API.
+
+    Also used as the concrete class for unclassified 4xx statuses
+    (401/403/409/etc.) where no modeled subclass applies.
+    """
+
+    def __init__(
+        self,
+        *,
+        detail: str,
+        status_code: int,
+        method: str,
+        url: str,
+        context: str,
+    ):
+        """Stores structured attrs; renders ``"Failed to {context}: {detail}"``."""
+        self.detail = detail
+        self.status_code = status_code
+        self.method = method
+        self.url = url
+        self.context = context
+        super().__init__(f"Failed to {context}: {detail}")
+
+
+class DeployInvalidRequestError(DeployApiError):
+    """HTTP 400 / 422 — request rejected (usually user-actionable)."""
+
+
+class DeployNotFoundError(DeployApiError):
+    """HTTP 404 — resource missing."""
+
+
+class DeployRateLimitError(DeployApiError):
+    """HTTP 429 — rate-limited by the provider."""
+
+
+class DeployTransientError(DeployApiError):
+    """HTTP 5xx — server-side / transient error.
+
+    Provider 5xx responses often have empty or uninformative bodies, so
+    :meth:`__str__` returns a sanitized retry message rather than echoing
+    :attr:`detail` (which may be empty). The raw detail, status code,
+    method, and URL remain available on structured attributes for logging.
+    """
+
+    def __str__(self) -> str:
+        """Sanitized retry message; raw detail/status/url remain on attributes."""
+        return (
+            "The deployment service is temporarily unavailable. Please retry shortly."
+        )

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -56,6 +56,7 @@ from oumi.deploy.fireworks_api import (
     GatewayPEFTDetails,
     GatewayPrepareModelBody,
 )
+from oumi.deploy.fireworks_errors import classify_fireworks_invalid_request
 from oumi.deploy.utils import raise_api_error
 
 logger = logging.getLogger(__name__)
@@ -208,9 +209,18 @@ class FireworksDeploymentClient(BaseDeploymentClient):
 
     @staticmethod
     def _check_response(response: httpx.Response, context: str) -> None:
-        """Raises if the response indicates an error."""
+        """Raises if the response indicates an error.
+
+        Threads the Fireworks 4xx classifier so 400/422 responses are
+        refined into Fireworks-specific subclasses when their detail
+        strings match.
+        """
         if not response.is_success:
-            _raise_api_error(response, context=context)
+            _raise_api_error(
+                response,
+                context=context,
+                classify_4xx=classify_fireworks_invalid_request,
+            )
 
     @staticmethod
     async def _notify(

--- a/src/oumi/deploy/fireworks_errors.py
+++ b/src/oumi/deploy/fireworks_errors.py
@@ -1,0 +1,73 @@
+# Copyright 2026 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fireworks-specific typed errors and 4xx classifier.
+
+These subclass :class:`oumi.deploy.errors.DeployInvalidRequestError` so
+consumers can still catch the generic base, but they expose Fireworks-only
+failure modes that are detected via Fireworks-specific detail strings.
+
+Add new Fireworks error types here as they're discovered. Each new type
+needs:
+
+1. A subclass of :class:`DeployInvalidRequestError` below.
+2. A signature check in :func:`classify_fireworks_invalid_request`.
+3. One unit test for the classifier (detail string → class) in
+   ``tests/unit/deploy/test_fireworks_errors.py``.
+
+The classifier is wired into :class:`FireworksDeploymentClient` via the
+``classify_4xx`` hook on :func:`oumi.deploy.utils.check_response`, so no
+shared-module changes are required when extending.
+"""
+
+from oumi.deploy.errors import DeployInvalidRequestError
+
+
+class FireworksUnsupportedHardwareError(DeployInvalidRequestError):
+    """HTTP 400 — Fireworks rejected an unsupported model/hardware pair.
+
+    Detected on responses whose detail begins with ``"invalid deployment"``
+    and contains ``"is not supported on"``.
+    """
+
+
+class FireworksAdapterMismatchError(DeployInvalidRequestError):
+    """HTTP 400 — Fireworks rejected an adapter mismatched with its base model.
+
+    Detected on responses whose detail begins with ``"LoRA validation failed"``.
+    """
+
+
+def classify_fireworks_invalid_request(
+    detail: str,
+) -> type[DeployInvalidRequestError]:
+    """Returns the most specific subclass for a Fireworks 4xx detail string.
+
+    Returns :class:`DeployInvalidRequestError` itself when no signature
+    matches — callers treat that as "fall through to the base class." Never
+    returns ``None`` and never raises.
+
+    Args:
+        detail: The provider-supplied ``detail`` string (already extracted
+            from the response body by :func:`raise_api_error`).
+
+    Returns:
+        The matching :class:`DeployInvalidRequestError` subclass, or the
+        base class when no signature applies.
+    """
+    if detail.startswith("invalid deployment") and "is not supported on" in detail:
+        return FireworksUnsupportedHardwareError
+    if detail.startswith("LoRA validation failed"):
+        return FireworksAdapterMismatchError
+    return DeployInvalidRequestError

--- a/src/oumi/deploy/utils.py
+++ b/src/oumi/deploy/utils.py
@@ -17,10 +17,24 @@
 import logging
 import os
 import re
+from collections.abc import Callable
 
 import httpx
 
+from oumi.deploy.errors import (
+    DeployApiError,
+    DeployInvalidRequestError,
+    DeployNotFoundError,
+    DeployRateLimitError,
+    DeployTransientError,
+)
+
 logger = logging.getLogger(__name__)
+
+# Callable that refines a 4xx (400/422) detail string to a specific subclass.
+# Convention: return DeployInvalidRequestError itself when no provider-specific
+# signature matches. Never return None; never raise.
+InvalidRequestClassifier = Callable[[str], type[DeployInvalidRequestError]]
 
 _HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+$")
 
@@ -129,7 +143,12 @@ def warn_if_private_model_missing_token(
 # ---------------------------------------------------------------------------
 
 
-def raise_api_error(response: httpx.Response, context: str) -> None:
+def raise_api_error(
+    response: httpx.Response,
+    context: str,
+    *,
+    classify_4xx: InvalidRequestClassifier | None = None,
+) -> None:
     """Extract the human-readable message from a provider error response and raise.
 
     Provider APIs (Fireworks, Parasail, etc.) return JSON bodies on errors in
@@ -140,16 +159,42 @@ def raise_api_error(response: httpx.Response, context: str) -> None:
         {"message": "...", "code": 400}
         {"detail": "..."}
 
+    The HTTP status code selects a typed subclass of
+    :class:`~oumi.deploy.errors.DeployApiError`. The raised exception's
+    string form contains only ``context`` and ``detail`` — the request
+    method, URL, and body are attached as structured attributes and logged
+    at DEBUG level so internal attribution never leaks into user-facing
+    error messages.
+
+    Provider-specific 4xx sub-types (for example Fireworks'
+    ``FireworksUnsupportedHardwareError``) live in the provider's module.
+    Callers pass an ``classify_4xx`` function to refine 400/422 responses
+    by detail-string signature. By convention the classifier returns
+    :class:`DeployInvalidRequestError` itself when no signature matches.
+
     Args:
         response: The failed HTTP response.
         context: Short description of the operation that failed (used in the
             raised message, e.g. ``"create deployment 'my-ep'"``).
+        classify_4xx: Optional provider-specific classifier for 400/422
+            responses. Called with the extracted detail string; must return
+            a :class:`DeployInvalidRequestError` subclass (or the base class
+            itself when no provider-specific signature matches). Only
+            consulted for 400/422 — other statuses use the generic mapping.
 
     Raises:
-        ValueError: Always, with a message that includes the API error detail,
-            HTTP status code, and the original request method + URL.
-            The request body is logged at DEBUG level (not included in the
-            exception) to avoid leaking sensitive payloads into error messages.
+        DeployNotFoundError: Response status is 404.
+        DeployRateLimitError: Response status is 429.
+        DeployInvalidRequestError: Response status is 400 or 422. May be
+            a more specific subclass when ``classify_4xx`` is provided and
+            recognizes the detail.
+        DeployTransientError: Response status is 5xx.
+        DeployApiError: Any other 4xx status (401/403/409/etc.) — handled
+            via the base class since the appropriate disposition depends on
+            the specific code and no modeled subclass applies.
+        ValueError: ``raise_api_error`` was called on a non-error response
+            (status ``< 400``). Indicates a caller bug — :func:`check_response`
+            is supposed to gate this path on ``not response.is_success``.
     """
     detail: str
     try:
@@ -176,19 +221,61 @@ def raise_api_error(response: httpx.Response, context: str) -> None:
         req_body = req.content.decode("utf-8", errors="replace") or "(empty)"
     except Exception:
         req_body = "(unreadable)"
+    logger.debug(
+        "API error for %s %s (HTTP %d): %s",
+        req.method,
+        req.url,
+        response.status_code,
+        detail,
+    )
     logger.debug("API error request body for %s %s: %s", req.method, req.url, req_body)
-    raise ValueError(
-        f"Failed to {context}: {detail} "
-        f"(HTTP {response.status_code}, {req.method} {req.url})"
+
+    status = response.status_code
+    exc_cls: type[DeployApiError]
+    if status == 404:
+        exc_cls = DeployNotFoundError
+    elif status == 429:
+        exc_cls = DeployRateLimitError
+    elif status in (400, 422):
+        exc_cls = classify_4xx(detail) if classify_4xx else DeployInvalidRequestError
+    elif status >= 500:
+        exc_cls = DeployTransientError
+    elif status >= 400:
+        # Unclassified 4xx (401/403/409/etc.). Use the base class rather
+        # than DeployInvalidRequestError — 401/403 especially are backend
+        # config issues, not user-input errors, and shouldn't be routed to
+        # InvalidArgumentError-style downstream handling.
+        exc_cls = DeployApiError
+    else:
+        raise ValueError(
+            f"raise_api_error called with non-error status {status}; "
+            "check_response should gate on response.is_success."
+        )
+
+    raise exc_cls(
+        detail=detail,
+        status_code=status,
+        method=req.method,
+        url=str(req.url),
+        context=context,
     )
 
 
-def check_response(response: httpx.Response, context: str) -> None:
-    """Raises :class:`ValueError` with API error details if response is not successful.
+def check_response(
+    response: httpx.Response,
+    context: str,
+    *,
+    classify_4xx: InvalidRequestClassifier | None = None,
+) -> None:
+    """Raises a typed :class:`DeployApiError` if the response is not successful.
 
     Args:
         response: The HTTP response to check.
         context: Short description of the operation (passed to :func:`raise_api_error`).
+        classify_4xx: Optional provider-specific 4xx classifier, passed
+            through to :func:`raise_api_error`. See that function for the
+            convention (return :class:`DeployInvalidRequestError` when no
+            signature matches).
     """
     if not response.is_success:
-        raise_api_error(response, context)
+        raise_api_error(response, context, classify_4xx=classify_4xx)

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -19,7 +19,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
 
 from oumi.deploy.base_client import (
@@ -43,7 +42,6 @@ from oumi.deploy.fireworks_client import (
     FireworksInvalidModelIdError,
     _validate_fireworks_model_id,
 )
-from oumi.deploy.utils import raise_api_error
 
 
 class TestFireworksStateMap:
@@ -463,56 +461,6 @@ class TestValidateFireworksModelId:
     def test_starts_with_digit(self):
         with pytest.raises(FireworksInvalidModelIdError, match="begin with a digit"):
             _validate_fireworks_model_id("1-model")
-
-
-class TestRaiseApiError:
-    """Tests for raise_api_error (shared helper in utils)."""
-
-    @staticmethod
-    def _make_response(
-        status_code: int, json_body: dict | None = None, text: str = ""
-    ) -> MagicMock:
-        resp = MagicMock(spec=httpx.Response)
-        resp.status_code = status_code
-        resp.text = text
-        if json_body is not None:
-            resp.json.return_value = json_body
-        else:
-            resp.json.side_effect = Exception("no json")
-        req = MagicMock()
-        req.method = "POST"
-        req.url = "https://api.fireworks.ai/v1/test"
-        req.content = b'{"key": "value"}'
-        resp.request = req
-        return resp
-
-    def test_extracts_nested_error_message(self):
-        resp = self._make_response(
-            400, {"error": {"message": "bad request", "code": "INVALID_ARGUMENT"}}
-        )
-        with pytest.raises(ValueError, match="bad request"):
-            raise_api_error(resp, "create model")
-
-    def test_extracts_top_level_message(self):
-        resp = self._make_response(404, {"message": "not found"})
-        with pytest.raises(ValueError, match="not found"):
-            raise_api_error(resp, "get model")
-
-    def test_falls_back_to_text(self):
-        resp = self._make_response(500, json_body=None, text="internal server error")
-        with pytest.raises(ValueError, match="internal server error"):
-            raise_api_error(resp, "delete model")
-
-    def test_does_not_include_request_body(self):
-        resp = self._make_response(400, {"message": "bad"})
-        with pytest.raises(ValueError) as exc_info:
-            raise_api_error(resp, "test")
-        assert "request body" not in str(exc_info.value)
-
-    def test_includes_http_status_and_method(self):
-        resp = self._make_response(409, {"message": "conflict"})
-        with pytest.raises(ValueError, match=r"HTTP 409.*POST"):
-            raise_api_error(resp, "create")
 
 
 class TestCheckModelSourceSupported:

--- a/tests/unit/deploy/test_fireworks_errors.py
+++ b/tests/unit/deploy/test_fireworks_errors.py
@@ -1,0 +1,144 @@
+# Copyright 2026 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for oumi.deploy.fireworks_errors.
+
+Split into two layers:
+
+1. Pure-function tests of ``classify_fireworks_invalid_request`` — detail
+   string → subclass. Adding a new Fireworks-specific error type is a
+   one-line test here.
+
+2. One wiring integration test per sub-type, exercising the classifier
+   through ``raise_api_error(..., classify_4xx=...)`` to verify the
+   end-to-end FireworksClient path produces the right subclass on a real
+   response shape.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from oumi.deploy.errors import DeployInvalidRequestError
+from oumi.deploy.fireworks_errors import (
+    FireworksAdapterMismatchError,
+    FireworksUnsupportedHardwareError,
+    classify_fireworks_invalid_request,
+)
+from oumi.deploy.utils import raise_api_error
+
+
+class TestClassifyFireworksInvalidRequest:
+    """Pure-function tests — detail string → matching subclass."""
+
+    def test_unsupported_hardware_signature(self):
+        detail = (
+            "invalid deployment: model type qwen3 is not supported on NVIDIA_A100_80GB"
+        )
+        assert (
+            classify_fireworks_invalid_request(detail)
+            is FireworksUnsupportedHardwareError
+        )
+
+    def test_adapter_mismatch_signature(self):
+        detail = (
+            "LoRA validation failed: LoRA keys reference non-existent base "
+            "model parameters: model.vision_tower..."
+        )
+        assert (
+            classify_fireworks_invalid_request(detail) is FireworksAdapterMismatchError
+        )
+
+    def test_invalid_deployment_without_unsupported_on_falls_through(self):
+        """Both markers required — 'invalid deployment' alone is not enough."""
+        detail = "invalid deployment: some other reason"
+        assert classify_fireworks_invalid_request(detail) is DeployInvalidRequestError
+
+    def test_lora_in_middle_is_not_a_match(self):
+        """The signature requires `startswith`, not substring — guards against
+        incidental mentions of `LoRA validation failed` inside other messages.
+        """
+        detail = "prefix text LoRA validation failed trailing"
+        assert classify_fireworks_invalid_request(detail) is DeployInvalidRequestError
+
+    def test_unrelated_400_detail_falls_through(self):
+        assert (
+            classify_fireworks_invalid_request("something else entirely")
+            is DeployInvalidRequestError
+        )
+
+    def test_empty_detail_falls_through(self):
+        assert classify_fireworks_invalid_request("") is DeployInvalidRequestError
+
+
+def _make_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = ""
+    resp.json.return_value = json_body
+    req = MagicMock()
+    req.method = "POST"
+    req.url = "https://api.fireworks.ai/v1/accounts/admin-xyz/models/foo"
+    req.content = b""
+    resp.request = req
+    return resp
+
+
+class TestFireworksClassifierWiring:
+    """Integration tests — classifier flowing through raise_api_error.
+
+    These prove the plumbing holds end-to-end on verbatim production
+    failure-mode response shapes.
+    """
+
+    def test_unsupported_hardware_wires_through(self):
+        detail = (
+            "invalid deployment: model type qwen3 is not supported on NVIDIA_A100_80GB"
+        )
+        resp = _make_response(400, {"message": detail})
+        with pytest.raises(FireworksUnsupportedHardwareError) as exc_info:
+            raise_api_error(
+                resp,
+                "create endpoint for model 'foo'",
+                classify_4xx=classify_fireworks_invalid_request,
+            )
+        exc = exc_info.value
+        assert exc.status_code == 400
+        assert exc.detail == detail
+        rendered = str(exc)
+        # Provider-specific detail preserved; method/URL must NOT leak
+        assert "NVIDIA_A100_80GB" in rendered
+        assert "POST" not in rendered
+        assert "fireworks.ai" not in rendered
+
+    def test_adapter_mismatch_wires_through(self):
+        detail = (
+            "LoRA validation failed: LoRA keys reference non-existent base "
+            "model parameters: model.vision_tower.vision_model.encoder."
+            "layers.6.self_attn.k_proj.weight (from LoRA key: "
+            "base_model.model.model.vision_tower...)"
+        )
+        resp = _make_response(400, {"message": detail})
+        with pytest.raises(FireworksAdapterMismatchError) as exc_info:
+            raise_api_error(
+                resp,
+                "validate upload for model 'foo'",
+                classify_4xx=classify_fireworks_invalid_request,
+            )
+        exc = exc_info.value
+        assert exc.detail == detail
+        rendered = str(exc)
+        assert "POST" not in rendered
+        assert "fireworks.ai" not in rendered

--- a/tests/unit/deploy/test_parasail_client.py
+++ b/tests/unit/deploy/test_parasail_client.py
@@ -31,6 +31,8 @@ from oumi.deploy.base_client import (
     HardwareConfig,
     ModelType,
 )
+from oumi.deploy.errors import DeployInvalidRequestError, DeployNotFoundError
+from oumi.deploy.fireworks_errors import FireworksUnsupportedHardwareError
 from oumi.deploy.parasail_api import (
     DeploymentResponse,
     DeviceConfig,
@@ -758,7 +760,7 @@ class TestParasailDeploymentClient:
 
     @pytest.mark.asyncio
     async def test_http_error_propagates_from_get_endpoint(self):
-        """4xx/5xx from the API surfaces as ValueError with error details."""
+        """4xx/5xx from the API surfaces as a typed DeployApiError subclass."""
         client = ParasailDeploymentClient(api_key="test-key")
         mock_response = MagicMock()
         mock_response.status_code = 404
@@ -778,5 +780,47 @@ class TestParasailDeploymentClient:
                 new_callable=AsyncMock,
                 return_value=mock_response,
             ):
-                with pytest.raises(ValueError, match="deployment not found"):
+                with pytest.raises(DeployNotFoundError, match="deployment not found"):
                     await client.get_endpoint("99999")
+
+    @pytest.mark.asyncio
+    async def test_parasail_400_does_not_produce_fireworks_subtype(self):
+        """Parasail 400 with a Fireworks-signature detail → DeployInvalidRequestError.
+
+        Load-bearing property of the Fireworks/Parasail split: the Fireworks
+        4xx classifier must only run for the Fireworks client. A Parasail
+        response whose detail happens to match a Fireworks signature must
+        still surface as the generic base class, not as a Fireworks-specific
+        subclass.
+        """
+        client = ParasailDeploymentClient(api_key="test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.is_success = False
+        # Verbatim Fireworks-signature detail string
+        mock_response.json.return_value = {
+            "message": (
+                "invalid deployment: model type qwen3 is not supported on "
+                "NVIDIA_A100_80GB"
+            )
+        }
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url = "https://api.parasail.io/api/v1/dedicated/deployments/x"
+        mock_request.content = b""
+        mock_response.request = mock_request
+        mock_response.text = ""
+
+        async with client:
+            with patch.object(
+                client._client,
+                "get",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ):
+                with pytest.raises(DeployInvalidRequestError) as exc_info:
+                    await client.get_endpoint("x")
+
+        exc = exc_info.value
+        assert type(exc) is DeployInvalidRequestError
+        assert not isinstance(exc, FireworksUnsupportedHardwareError)

--- a/tests/unit/deploy/test_utils.py
+++ b/tests/unit/deploy/test_utils.py
@@ -17,12 +17,21 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
+from oumi.deploy.errors import (
+    DeployApiError,
+    DeployInvalidRequestError,
+    DeployNotFoundError,
+    DeployRateLimitError,
+    DeployTransientError,
+)
 from oumi.deploy.utils import (
     check_hf_model_accessibility,
     is_huggingface_repo_id,
     is_huggingface_url,
+    raise_api_error,
     resolve_hf_token,
     warn_if_private_model_missing_token,
 )
@@ -164,3 +173,251 @@ class TestWarnIfPrivateModelMissingToken:
             warn_if_private_model_missing_token("Qwen/Qwen3-4B", "")
 
         assert not any("gated or private" in m for m in caplog.messages)
+
+
+def _make_response(
+    status_code: int,
+    json_body: dict | list | str | None = None,
+    text: str = "",
+    method: str = "POST",
+    url: str = "https://api.fireworks.ai/v1/accounts/admin-xyz/models/foo",
+    json_raises: bool = False,
+) -> MagicMock:
+    """Build a MagicMock httpx.Response for ``raise_api_error`` tests.
+
+    Set *json_raises* to simulate a non-JSON body where ``response.json()``
+    raises; in that case *text* is used as the fallback detail source.
+    """
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = text
+    if json_raises:
+        resp.json.side_effect = ValueError("not json")
+    else:
+        resp.json.return_value = json_body
+    req = MagicMock()
+    req.method = method
+    req.url = url
+    req.content = b'{"key": "value"}'
+    resp.request = req
+    return resp
+
+
+class TestRaiseApiErrorStatusCodeMapping:
+    """raise_api_error picks the typed subclass from the HTTP status."""
+
+    def test_http_500_empty_body(self):
+        """HTTP 500 with empty body → DeployTransientError with sanitized str."""
+        resp = _make_response(
+            500,
+            json_raises=True,
+            text="",
+            url="https://api.fireworks.ai/x:validateUpload",
+        )
+        with pytest.raises(DeployTransientError) as exc_info:
+            raise_api_error(resp, "validate upload for model 'foo'")
+
+        exc = exc_info.value
+        assert exc.detail == "(no details)"
+        assert exc.status_code == 500
+        assert exc.context == "validate upload for model 'foo'"
+        rendered = str(exc)
+        assert rendered == (
+            "The deployment service is temporarily unavailable. Please retry shortly."
+        )
+        # No URL, method, or empty-colon artifact
+        assert "fireworks.ai" not in rendered
+        assert "POST" not in rendered
+
+    def test_http_400_without_classifier_is_base_invalid_request(self):
+        """Without a classify_4xx hook, 400 is the base DeployInvalidRequestError."""
+        resp = _make_response(400, {"message": "some specific provider detail"})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op")
+
+        assert type(exc_info.value) is DeployInvalidRequestError
+        assert exc_info.value.status_code == 400
+
+    def test_classify_4xx_hook_refines_400(self):
+        """A classify_4xx hook selects a provider-specific subclass on 400."""
+
+        class CustomSubclass(DeployInvalidRequestError):
+            pass
+
+        def classifier(detail: str) -> type[DeployInvalidRequestError]:
+            if "magic" in detail:
+                return CustomSubclass
+            return DeployInvalidRequestError
+
+        resp = _make_response(400, {"message": "magic word present"})
+        with pytest.raises(CustomSubclass):
+            raise_api_error(resp, "op", classify_4xx=classifier)
+
+    def test_classify_4xx_hook_fallthrough_when_no_match(self):
+        """Classifier returning the base class → exception is the base class."""
+
+        def classifier(_: str) -> type[DeployInvalidRequestError]:
+            return DeployInvalidRequestError
+
+        resp = _make_response(400, {"message": "no match"})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op", classify_4xx=classifier)
+        assert type(exc_info.value) is DeployInvalidRequestError
+
+    def test_classify_4xx_hook_not_consulted_for_non_4xx(self):
+        """Classifier is only consulted for 400/422 — e.g. 500 ignores it."""
+        calls = []
+
+        def classifier(detail: str) -> type[DeployInvalidRequestError]:
+            calls.append(detail)
+            return DeployInvalidRequestError
+
+        resp = _make_response(500, {"message": "oops"})
+        with pytest.raises(DeployTransientError):
+            raise_api_error(resp, "op", classify_4xx=classifier)
+        assert calls == []
+
+    def test_http_404_not_found(self):
+        resp = _make_response(404, {"message": "model not found"})
+        with pytest.raises(DeployNotFoundError) as exc_info:
+            raise_api_error(resp, "get model 'foo'")
+
+        exc = exc_info.value
+        assert exc.status_code == 404
+        assert exc.detail == "model not found"
+        assert "fireworks.ai" not in str(exc)
+
+    def test_http_429_rate_limit(self):
+        resp = _make_response(
+            429, {"error": {"code": "RATE_LIMITED", "message": "slow down"}}
+        )
+        with pytest.raises(DeployRateLimitError) as exc_info:
+            raise_api_error(resp, "create endpoint")
+
+        exc = exc_info.value
+        assert exc.status_code == 429
+        assert exc.detail == "slow down"
+
+    def test_http_422_is_invalid_request(self):
+        resp = _make_response(422, {"detail": "bad field"})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "update endpoint")
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.parametrize("status", [401, 403, 409, 410, 418])
+    def test_unclassified_4xx_uses_base_class(self, status):
+        """401/403/409/etc. should fall through to the base DeployApiError.
+
+        401/403 in particular are backend-config issues, not user-input
+        errors, so they must NOT be routed through DeployInvalidRequestError.
+        """
+        resp = _make_response(status, {"message": "nope"})
+        with pytest.raises(DeployApiError) as exc_info:
+            raise_api_error(resp, "op")
+
+        exc = exc_info.value
+        # Base class — not any of the modeled subclasses
+        assert type(exc) is DeployApiError
+        assert not isinstance(exc, DeployInvalidRequestError)
+        assert not isinstance(exc, DeployNotFoundError)
+        assert not isinstance(exc, DeployRateLimitError)
+        assert not isinstance(exc, DeployTransientError)
+        assert exc.status_code == status
+
+    def test_non_error_status_raises_value_error(self):
+        """status < 400 means raise_api_error was called on a 2xx/3xx — caller bug."""
+        resp = _make_response(200, {"message": "ok"})
+        with pytest.raises(ValueError, match="non-error status 200"):
+            raise_api_error(resp, "op")
+
+
+class TestRaiseApiErrorBodyParsing:
+    """Body-shape fallbacks (preserve existing behavior)."""
+
+    def test_nested_error_message(self):
+        resp = _make_response(400, {"error": {"message": "x", "code": "INVALID"}})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == "x"
+
+    def test_top_level_message(self):
+        resp = _make_response(400, {"message": "x"})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == "x"
+
+    def test_detail_field(self):
+        resp = _make_response(400, {"detail": "x"})
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == "x"
+
+    def test_non_json_body_falls_back_to_text(self):
+        resp = _make_response(500, json_raises=True, text="raw text from upstream")
+        with pytest.raises(DeployTransientError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == "raw text from upstream"
+
+    def test_json_raises_and_no_text(self):
+        resp = _make_response(500, json_raises=True, text="")
+        with pytest.raises(DeployTransientError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == "(no details)"
+
+    def test_dict_without_known_fields_stringifies(self):
+        body = {"unexpected": "shape"}
+        resp = _make_response(400, body)
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "op")
+        assert exc_info.value.detail == str(body)
+
+
+class TestRaiseApiErrorMessageDoesNotLeakRequestDetails:
+    """str(exc) never includes method, URL, status code, or request body."""
+
+    def test_method_and_url_never_in_message(self):
+        resp = _make_response(
+            400,
+            {"message": "bad request"},
+            method="POST",
+            url="https://api.fireworks.ai/v1/accounts/admin-SECRET/deployments?deploymentId=x",
+        )
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "create endpoint")
+
+        rendered = str(exc_info.value)
+        assert "POST" not in rendered
+        assert "fireworks.ai" not in rendered
+        assert "admin-SECRET" not in rendered
+        assert "HTTP 400" not in rendered
+        assert "deploymentId" not in rendered
+
+    def test_structured_attributes_populated(self):
+        resp = _make_response(
+            400,
+            {"message": "bad"},
+            method="DELETE",
+            url="https://api.fireworks.ai/v1/x",
+        )
+        with pytest.raises(DeployInvalidRequestError) as exc_info:
+            raise_api_error(resp, "ctx")
+
+        exc = exc_info.value
+        assert exc.status_code == 400
+        assert exc.detail == "bad"
+        assert exc.method == "DELETE"
+        assert exc.url == "https://api.fireworks.ai/v1/x"
+        assert exc.context == "ctx"
+
+
+class TestDeployApiErrorHierarchy:
+    """Status-code subclasses inherit from DeployApiError."""
+
+    def test_subclasses_inherit_from_base(self):
+        for cls in (
+            DeployInvalidRequestError,
+            DeployNotFoundError,
+            DeployRateLimitError,
+            DeployTransientError,
+        ):
+            assert issubclass(cls, DeployApiError)


### PR DESCRIPTION
# Description

`raise_api_error` now raises typed `DeployApiError` subclasses selected by HTTP status (`DeployNotFoundError` / `DeployRateLimitError` / `DeployTransientError` / `DeployInvalidRequestError`), instead of a bare `ValueError` that leaked method, URL, and account ID into the message.

`str(exc)` is `"Failed to {context}: {detail}"`. Method, URL, body stay on structured attrs + DEBUG logs.

Provider-specific 4xx sub-types (e.g. `FireworksUnsupportedHardwareError`) live next to their client in `oumi.deploy.fireworks_errors` and are wired in via the `classify_4xx` hook on `raise_api_error`. Adding a new Fireworks-specific type is a local change to `fireworks_errors.py` — no edits to shared code required.

**BREAKING:** catch `oumi.deploy.errors.DeployApiError` (or a subclass) instead of `ValueError`.

## Related issues

Fixes LOU-1616

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.