### PR TITLE
Wire tool calling through the local VLLMInferenceEngine

### DIFF
--- a/configs/recipes/qwen3_coder/inference/30b_a3b_instruct_vllm_tool_calling_infer.yaml
+++ b/configs/recipes/qwen3_coder/inference/30b_a3b_instruct_vllm_tool_calling_infer.yaml
@@ -1,0 +1,40 @@
+# vLLM Inference config for Qwen3-Coder-30B-A3B-Instruct with tool calling.
+#
+# Adds a Qwen-aware tool-call parser so the model's emitted tool calls are
+# parsed into structured `Message.tool_calls` rather than left as raw
+# <tool_call>...</tool_call> tokens in the response text.
+#
+# Requirements:
+#   - Run `pip install oumi[gpu]`
+#
+# Usage:
+#   oumi infer -i -c configs/recipes/qwen3_coder/inference/30b_a3b_instruct_vllm_tool_calling_infer.yaml
+#
+# The input JSONL should carry a top-level "tools" field on each conversation
+# (OpenAI function-calling schema). Output messages will populate "tool_calls"
+# when the model emits a structured call, and "finish_reason" will be set to
+# "tool_calls".
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  # vLLM ships several Qwen tool-call parsers; the right one depends on the
+  # exact Qwen variant. "hermes" works for Qwen3 instruct/chat variants that
+  # emit <tool_call>...</tool_call>. For coder-specific XML-style tags, try
+  # "qwen3_xml" or "qwen3_coder".
+  tool_call_parser: "hermes"
+
+generation:
+  max_new_tokens: 4096
+  temperature: 0.3
+  top_p: 0.9
+
+engine: VLLM

--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -226,6 +226,20 @@ class ModelParams(BaseParams):
     This is used to specify the version of the model to use.
     """
 
+    tool_call_parser: str | None = None
+    """Name of a vLLM tool-call parser to apply to assistant outputs.
+
+    When set, the local ``VLLMInferenceEngine`` instantiates the matching
+    parser from ``vllm.tool_parsers`` (e.g. ``"hermes"``, ``"qwen3_xml"``,
+    ``"llama4_pythonic"``, ``"mistral"``), runs it over the model's output
+    text, and populates ``Message.tool_calls`` on the returned message
+    instead of leaving the tool-call tokens as raw text. ``finish_reason``
+    is set to ``tool_calls`` when calls are extracted.
+
+    Has no effect on engines other than vLLM. Tied to vLLM internals;
+    available parsers depend on the installed vLLM version.
+    """
+
     def __post_init__(self):
         """Populate additional params."""
         self.torch_dtype = None

--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -530,8 +530,15 @@ class VLLMInferenceEngine(BaseInferenceEngine):
             tool_calls_payload: list[dict] | None = None
 
             if self._tool_parser is not None:
-                # Some parsers read `request.tool_choice` even from the
+                # Some parsers read `request.tool_choice` from the
                 # non-streaming entry point; pass a stub so they don't crash.
+                # vLLM offline `LLM.chat()` has no `tool_choice` knob, so
+                # "auto" is the only honest value — it matches OpenAI's
+                # default-when-unset and the offline reality of "model
+                # decides based on the rendered tools". Other values would
+                # mislead the parser ("none" would drop real calls;
+                # "required" or a specific function would force/filter
+                # interpretations the model didn't actually make).
                 stub = SimpleNamespace(
                     tool_choice="auto",
                     tools=(conversation.tools or []),

--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -28,6 +28,7 @@ from oumi.builders import build_tokenizer
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
 from oumi.core.inference import BaseInferenceEngine
 from oumi.core.types.conversation import Conversation, FinishReason, Message, Role
+from oumi.core.types.tool_call import ToolCall
 from oumi.utils.conversation_utils import create_list_of_message_json_dicts
 from oumi.utils.logging import logger
 from oumi.utils.model_caching import get_local_filepath_for_gguf
@@ -487,9 +488,11 @@ class VLLMInferenceEngine(BaseInferenceEngine):
     ) -> list[tuple[list[int], list[dict] | None]]:
         """Groups conversation indices by identical tool definitions.
 
-        Tools come from ``Conversation.tools`` (post-validation always a list
-        of OpenAI-schema dicts, or ``None``). vLLM's ``LLM.chat(tools=...)``
-        kwarg is batch-global, so heterogeneous batches must be split.
+        Tools come from ``Conversation.tools`` (post-validation a list of
+        ``ToolDefinition`` Pydantic models, or ``None``). vLLM's
+        ``LLM.chat(tools=...)`` kwarg expects OpenAI-format dicts and is
+        batch-global, so we dump to dicts up front and split heterogeneous
+        batches.
 
         Returns:
             A list of ``(indices, tools)`` tuples in the order each unique
@@ -498,13 +501,15 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         groups: list[tuple[list[int], list[dict] | None]] = []
         key_to_group: dict[str, int] = {}
         for i, conv in enumerate(conversations):
-            # `Conversation.tools` is `list[dict] | None` after validation;
-            # cast keeps pyright happy without affecting runtime behavior.
-            tools = cast("list[dict] | None", conv.tools)
+            tools: list[dict] | None = (
+                None
+                if conv.tools is None
+                else [t.model_dump(mode="json", exclude_none=True) for t in conv.tools]
+            )
             if tools is None:
                 key = "__none__"
             else:
-                key = json.dumps(tools, sort_keys=True, default=str)
+                key = json.dumps(tools, sort_keys=True)
             if key not in key_to_group:
                 key_to_group[key] = len(groups)
                 groups.append(([], tools))
@@ -527,7 +532,7 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         for completion in chat_response.outputs:
             text = completion.text
             content: str | None = text
-            tool_calls_payload: list[dict] | None = None
+            tool_calls_payload: list[ToolCall] | None = None
 
             if self._tool_parser is not None:
                 # Some parsers read `request.tool_choice` from the
@@ -541,7 +546,10 @@ class VLLMInferenceEngine(BaseInferenceEngine):
                 # interpretations the model didn't actually make).
                 stub = SimpleNamespace(
                     tool_choice="auto",
-                    tools=(conversation.tools or []),
+                    tools=[
+                        t.model_dump(mode="json", exclude_none=True)
+                        for t in (conversation.tools or [])
+                    ],
                 )
                 try:
                     extracted = self._tool_parser.extract_tool_calls(
@@ -557,7 +565,8 @@ class VLLMInferenceEngine(BaseInferenceEngine):
 
                 if extracted is not None and getattr(extracted, "tools_called", False):
                     tool_calls_payload = [
-                        tc.model_dump() for tc in extracted.tool_calls
+                        ToolCall.model_validate(tc.model_dump())
+                        for tc in extracted.tool_calls
                     ]
                     # Empty leading content is rendered as `None` to match
                     # the OpenAI wire format for tool-only assistant turns.

--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -15,8 +15,10 @@
 from __future__ import annotations
 
 import copy
+import json
 import math
 import warnings
+from types import SimpleNamespace
 from typing import cast, get_args
 
 import torch
@@ -64,9 +66,30 @@ try:
         from vllm.sampling_params import (  # pyright: ignore[reportMissingImports]
             GuidedDecodingParams as VLLMGuidedDecodingParams,  # pyright: ignore[reportAttributeAccessIssue]
         )
+
+    # Tool-call parsers ship at vllm.tool_parsers in 0.14+; earlier versions
+    # exposed them at vllm.entrypoints.openai.tool_parsers. Guard both paths.
+    try:
+        from vllm.tool_parsers import (  # pyright: ignore[reportMissingImports]
+            ToolParserManager,
+        )
+
+        _VLLM_TOOL_PARSERS_AVAILABLE = True
+    except ImportError:
+        try:
+            from vllm.entrypoints.openai.tool_parsers import (  # pyright: ignore[reportMissingImports]
+                ToolParserManager,
+            )
+
+            _VLLM_TOOL_PARSERS_AVAILABLE = True
+        except ImportError:
+            ToolParserManager = None  # type: ignore[assignment]
+            _VLLM_TOOL_PARSERS_AVAILABLE = False
 except ModuleNotFoundError:
     vllm = None
     _VLLM_V0_12 = False
+    ToolParserManager = None  # type: ignore[assignment]
+    _VLLM_TOOL_PARSERS_AVAILABLE = False
 
 
 class VLLMInferenceEngine(BaseInferenceEngine):
@@ -83,6 +106,7 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         gpu_memory_utilization: float = 0.9,
         enforce_eager: bool = True,
         max_num_seqs: int | None = None,
+        tool_call_parser: str | None = None,
     ):
         """Initializes the inference Engine.
 
@@ -99,6 +123,14 @@ class VLLMInferenceEngine(BaseInferenceEngine):
             enforce_eager: Whether to enforce eager execution. Defaults to True.
                 If False, will use eager mode and CUDA graph in hybrid mode.
             max_num_seqs: Maximum number of sequences per iteration.
+            tool_call_parser: Optional name of a vLLM tool-call parser
+                (e.g. ``"hermes"``, ``"qwen3_xml"``, ``"llama4_pythonic"``,
+                ``"mistral"``). When set, the engine parses the model's
+                output text into ``Message.tool_calls`` and sets
+                ``finish_reason`` to ``tool_calls``. If left ``None``, falls
+                back to ``model_params.tool_call_parser``. Tied to vLLM
+                internals; available parsers depend on the installed
+                vLLM version.
         """
         super().__init__(model_params=model_params, generation_params=generation_params)
 
@@ -241,6 +273,24 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         if not _VLLM_V0_12:
             self._llm.set_tokenizer(self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
+        # Optional tool-call parser. Direct kwarg wins over model_params.
+        parser_name = tool_call_parser or model_params.tool_call_parser
+        self._tool_parser = None
+        if parser_name is not None:
+            if not _VLLM_TOOL_PARSERS_AVAILABLE:
+                raise RuntimeError(
+                    "vLLM tool parsers are not available in this vLLM version. "
+                    "Upgrade vLLM or unset `tool_call_parser`."
+                )
+            try:
+                parser_cls = ToolParserManager.get_tool_parser(parser_name)  # pyright: ignore[reportOptionalMemberAccess]
+            except KeyError as e:
+                raise ValueError(
+                    f"Unknown vLLM tool_call_parser '{parser_name}'."
+                ) from e
+            self._tool_parser = parser_cls(self._tokenizer)  # pyright: ignore[reportArgumentType]
+            logger.info(f"VLLM engine will parse tool calls with '{parser_name}'.")
+
     @staticmethod
     def _normalize_vllm_finish_reason(raw_reason: str | None) -> FinishReason | None:
         """Normalize vLLM finish_reason string to FinishReason enum."""
@@ -267,15 +317,19 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         for json_dict in create_list_of_message_json_dicts(
             conversation.messages, group_adjacent_same_role_turns=True
         ):
-            for key in ("role", "content"):
-                if key not in json_dict:
-                    raise RuntimeError(f"The required field '{key}' is missing!")
-            if not isinstance(json_dict["content"], str | list):
+            if "role" not in json_dict:
+                raise RuntimeError("The required field 'role' is missing!")
+            if "content" not in json_dict:
+                raise RuntimeError("The required field 'content' is missing!")
+            content = json_dict["content"]
+            # Assistant messages with only `tool_calls` legitimately have
+            # `content=None` per the OpenAI wire format.
+            if content is not None and not isinstance(content, str | list):
                 raise RuntimeError(
-                    "The 'content' field must be `str` or `list`. "
-                    f"Actual: {type(json_dict['content'])}."
+                    "The 'content' field must be `str`, `list`, or `None`. "
+                    f"Actual: {type(content)}."
                 )
-            result.append({"role": json_dict["role"], "content": json_dict["content"]})
+            result.append(json_dict)  # type: ignore[arg-type]
         return result
 
     def _infer(
@@ -362,38 +416,58 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         if len(vllm_conversations) == 0:
             return []
 
-        enable_tqdm = len(vllm_conversations) >= 2
-
-        # Note: vLLM performs continuous batching under the hood.
-        # We pass all the conversations and let vLLM handle the rest.
-        chat_responses = self._llm.chat(
-            vllm_conversations,
-            sampling_params=sampling_params,
-            lora_request=self._lora_request,
-            use_tqdm=enable_tqdm,
-            chat_template=None,
-            chat_template_content_format="auto",
-            chat_template_kwargs=model_params.chat_template_kwargs,
-        )
+        any_tools = any(c.tools for c in non_skipped_conversations)
+        if not any_tools:
+            # Fast path: single batched call, unchanged from prior behavior.
+            chat_responses = self._llm.chat(
+                vllm_conversations,
+                sampling_params=sampling_params,
+                lora_request=self._lora_request,
+                use_tqdm=(len(vllm_conversations) >= 2),
+                chat_template=None,
+                chat_template_content_format="auto",
+                chat_template_kwargs=model_params.chat_template_kwargs,
+            )
+        else:
+            # vLLM's `chat(tools=...)` applies one tool list to the whole
+            # batch, so we group conversations by identical tools and dispatch
+            # one chat() per group. Original input order is preserved.
+            chat_responses: list = [None] * len(non_skipped_conversations)
+            for indices, group_tools in self._group_by_tools(non_skipped_conversations):
+                group_inputs = [vllm_conversations[i] for i in indices]
+                group_responses = self._llm.chat(
+                    group_inputs,
+                    sampling_params=sampling_params,
+                    lora_request=self._lora_request,
+                    use_tqdm=(len(group_inputs) >= 2),
+                    chat_template=None,
+                    chat_template_content_format="auto",
+                    chat_template_kwargs=model_params.chat_template_kwargs,
+                    tools=group_tools,
+                )
+                for idx, resp in zip(indices, group_responses):
+                    chat_responses[idx] = resp
 
         for conversation, chat_response in zip(
             non_skipped_conversations, chat_responses
         ):
-            new_messages = [
-                Message(content=message.text, role=Role.ASSISTANT)
-                for message in chat_response.outputs
-                if len(chat_response.outputs) > 0
-            ]
+            assert chat_response is not None
+            new_messages, finish_reason_override = self._build_response_messages(
+                conversation, chat_response
+            )
             messages = [
                 *conversation.messages,
                 *new_messages,
             ]
             metadata = dict(conversation.metadata)
             if chat_response.outputs:
-                raw_reason = chat_response.outputs[0].finish_reason
-                finish_reason = self._normalize_vllm_finish_reason(raw_reason)
-                if finish_reason is not None:
-                    metadata["finish_reason"] = finish_reason.value
+                if finish_reason_override is not None:
+                    metadata["finish_reason"] = finish_reason_override.value
+                else:
+                    raw_reason = chat_response.outputs[0].finish_reason
+                    finish_reason = self._normalize_vllm_finish_reason(raw_reason)
+                    if finish_reason is not None:
+                        metadata["finish_reason"] = finish_reason.value
             new_conversation = Conversation(
                 messages=messages,
                 metadata=metadata,
@@ -406,6 +480,91 @@ class VLLMInferenceEngine(BaseInferenceEngine):
             output_conversations.append(new_conversation)
 
         return output_conversations
+
+    @staticmethod
+    def _group_by_tools(
+        conversations: list[Conversation],
+    ) -> list[tuple[list[int], list[dict] | None]]:
+        """Groups conversation indices by identical tool definitions.
+
+        Tools come from ``Conversation.tools`` (post-validation always a list
+        of OpenAI-schema dicts, or ``None``). vLLM's ``LLM.chat(tools=...)``
+        kwarg is batch-global, so heterogeneous batches must be split.
+
+        Returns:
+            A list of ``(indices, tools)`` tuples in the order each unique
+            tools list is first seen.
+        """
+        groups: list[tuple[list[int], list[dict] | None]] = []
+        key_to_group: dict[str, int] = {}
+        for i, conv in enumerate(conversations):
+            # `Conversation.tools` is `list[dict] | None` after validation;
+            # cast keeps pyright happy without affecting runtime behavior.
+            tools = cast("list[dict] | None", conv.tools)
+            if tools is None:
+                key = "__none__"
+            else:
+                key = json.dumps(tools, sort_keys=True, default=str)
+            if key not in key_to_group:
+                key_to_group[key] = len(groups)
+                groups.append(([], tools))
+            groups[key_to_group[key]][0].append(i)
+        return groups
+
+    def _build_response_messages(
+        self,
+        conversation: Conversation,
+        chat_response,
+    ) -> tuple[list[Message], FinishReason | None]:
+        """Builds assistant messages from a vLLM chat response.
+
+        When ``self._tool_parser`` is set, runs it over each completion's
+        text and populates ``Message.tool_calls`` with the extracted payload.
+        On parser failure, falls back to raw text.
+        """
+        new_messages: list[Message] = []
+        finish_reason_override: FinishReason | None = None
+        for completion in chat_response.outputs:
+            text = completion.text
+            content: str | None = text
+            tool_calls_payload: list[dict] | None = None
+
+            if self._tool_parser is not None:
+                # Some parsers read `request.tool_choice` even from the
+                # non-streaming entry point; pass a stub so they don't crash.
+                stub = SimpleNamespace(
+                    tool_choice="auto",
+                    tools=(conversation.tools or []),
+                )
+                try:
+                    extracted = self._tool_parser.extract_tool_calls(
+                        text,
+                        request=stub,  # type: ignore[arg-type]
+                    )
+                except Exception:
+                    logger.exception(
+                        "Tool-call parser %s failed; falling back to raw text.",
+                        type(self._tool_parser).__name__,
+                    )
+                    extracted = None
+
+                if extracted is not None and getattr(extracted, "tools_called", False):
+                    tool_calls_payload = [
+                        tc.model_dump() for tc in extracted.tool_calls
+                    ]
+                    # Empty leading content is rendered as `None` to match
+                    # the OpenAI wire format for tool-only assistant turns.
+                    content = extracted.content or None
+                    finish_reason_override = FinishReason.TOOL_CALLS
+
+            new_messages.append(
+                Message(
+                    content=content,
+                    role=Role.ASSISTANT,
+                    tool_calls=tool_calls_payload,
+                )
+            )
+        return new_messages, finish_reason_override
 
     def infer_online(
         self,

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -216,6 +216,11 @@ def convert_message_to_json_content(
     return convert_content_items_to_json_list(message.content_items)
 
 
+def _has_tool_metadata(message: Message) -> bool:
+    """Whether a message carries tool-calling fields that need 1:1 dict mapping."""
+    return message.tool_calls is not None or message.tool_call_id is not None
+
+
 def create_list_of_message_json_dicts(
     messages: list[Message],
     *,
@@ -223,12 +228,18 @@ def create_list_of_message_json_dicts(
 ) -> list[dict[str, Any]]:
     """Returns a list of JSON dictionaries representing messages.
 
-    Loads image bytes and encodes them as base64.
+    Loads image bytes and encodes them as base64. Forwards ``tool_calls`` and
+    ``tool_call_id`` when set on the source message so tool-aware chat
+    templates can render multi-turn tool use; non-tool-aware templates
+    ignore the extra keys. Messages carrying tool metadata are never grouped
+    with adjacent same-role messages, so per-turn tool fields stay aligned.
 
     Args:
         messages: The input messages.
         group_adjacent_same_role_turns: Whether to pack adjacent messages
-            from the same role into a single element in output list.
+            from the same role into a single element in output list. Messages
+            with ``tool_calls`` or ``tool_call_id`` set are excluded from
+            grouping regardless of this flag.
 
     Returns:
         list[Dict[str, Any]]: The list of messages encoded as nested JSON dicts.
@@ -238,9 +249,11 @@ def create_list_of_message_json_dicts(
     idx = 0
     while idx < num_messages:
         end_idx = idx + 1
-        if group_adjacent_same_role_turns:
-            while end_idx < num_messages and (
-                messages[idx].role == messages[end_idx].role
+        if group_adjacent_same_role_turns and not _has_tool_metadata(messages[idx]):
+            while (
+                end_idx < num_messages
+                and messages[idx].role == messages[end_idx].role
+                and not _has_tool_metadata(messages[end_idx])
             ):
                 end_idx += 1
 
@@ -248,16 +261,26 @@ def create_list_of_message_json_dicts(
             "role": messages[idx].role.value,
         }
         group_size = end_idx - idx
-        if group_size == 1 and messages[idx].contains_single_text_content_item_only():
-            # Set "content" to a primitive string value, which is the common
-            # convention for text-only models.
-            item["content"] = messages[idx].text_content_items[0].content
+        if group_size == 1:
+            msg = messages[idx]
+            if msg.contains_single_text_content_item_only():
+                # Common case: text-only message; emit a primitive string.
+                item["content"] = msg.text_content_items[0].content
+            elif msg.content is None:
+                # Assistant message that only carries tool_calls; OpenAI wire
+                # format uses null content here.
+                item["content"] = None
+            else:
+                item["content"] = convert_message_to_json_content_list(msg)
+            if msg.tool_calls is not None:
+                item["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id is not None:
+                item["tool_call_id"] = msg.tool_call_id
         else:
-            # Set "content" to be a list of dictionaries for more complex cases.
+            # Multi-message group: pack content items into a single list.
             content_list = []
-            while idx < end_idx:
-                content_list.extend(convert_message_to_json_content_list(messages[idx]))
-                idx += 1
+            for j in range(idx, end_idx):
+                content_list.extend(convert_message_to_json_content_list(messages[j]))
             item["content"] = content_list
 
         idx = end_idx

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -273,7 +273,14 @@ def create_list_of_message_json_dicts(
             else:
                 item["content"] = convert_message_to_json_content_list(msg)
             if msg.tool_calls is not None:
-                item["tool_calls"] = msg.tool_calls
+                # Pydantic ToolCall → OpenAI-format dict so downstream
+                # consumers (vLLM, chat templates) get plain JSON-serializable
+                # dicts. `exclude_none` keeps the wire format minimal and
+                # matches the user's original input shape.
+                item["tool_calls"] = [
+                    tc.model_dump(mode="json", exclude_none=True)
+                    for tc in msg.tool_calls
+                ]
             if msg.tool_call_id is not None:
                 item["tool_call_id"] = msg.tool_call_id
         else:

--- a/tests/integration/infer/test_vllm_inference_engine.py
+++ b/tests/integration/infer/test_vllm_inference_engine.py
@@ -1,5 +1,6 @@
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
 from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import ToolDefinition
 from oumi.inference import VLLMInferenceEngine
 from tests.markers import requires_cuda_initialized, requires_gpus
 
@@ -52,18 +53,20 @@ def test_qwen_no_think_block_with_enable_thinking_false():
     assert "<think>" not in output
 
 
-_WEATHER_TOOL = {
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city.",
-        "parameters": {
-            "type": "object",
-            "properties": {"city": {"type": "string"}},
-            "required": ["city"],
+_WEATHER_TOOL = ToolDefinition.model_validate(
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
         },
-    },
-}
+    }
+)
 
 
 @requires_cuda_initialized()
@@ -123,5 +126,5 @@ def test_qwen_tool_call_parser_populates_tool_calls():
     # 0.6B may not always emit a call; the strict gate is the unit-test suite.
     # When it does, verify the parsed payload and finish_reason are correct.
     if assistant.tool_calls:
-        assert assistant.tool_calls[0]["function"]["name"] == "get_weather"
+        assert assistant.tool_calls[0].function.name == "get_weather"
         assert outputs[-1].metadata.get("finish_reason") == "tool_calls"

--- a/tests/integration/infer/test_vllm_inference_engine.py
+++ b/tests/integration/infer/test_vllm_inference_engine.py
@@ -50,3 +50,78 @@ def test_qwen_no_think_block_with_enable_thinking_false():
     print(output)
     assert isinstance(output, str)
     assert "<think>" not in output
+
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+@requires_cuda_initialized()
+@requires_gpus()
+def test_qwen_emits_tool_call_when_tools_provided():
+    """Tools on the conversation flow into the prompt; the model emits a call."""
+    convo = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(
+                role=Role.USER,
+                content="Use the get_weather tool to look up the weather in Tokyo.",
+            )
+        ],
+    )
+    engine = VLLMInferenceEngine(_get_default_model_params(), tensor_parallel_size=1)
+    inference_config = InferenceConfig(
+        generation=GenerationParams(
+            max_new_tokens=128, temperature=0.0, min_p=0.0, seed=42
+        )
+    )
+
+    outputs = engine.infer([convo], inference_config=inference_config)
+    text = outputs[-1].messages[-1].content or ""
+    print(text)
+    # Qwen3 renders Hermes-style <tool_call> tags. 0.6B can be flaky on tool
+    # use, so accept either the explicit tag or a tool-name mention.
+    assert "<tool_call>" in text or "get_weather" in text
+
+
+@requires_cuda_initialized()
+@requires_gpus()
+def test_qwen_tool_call_parser_populates_tool_calls():
+    """tool_call_parser='hermes' parses an emitted call into Message.tool_calls."""
+    convo = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(
+                role=Role.USER,
+                content="Use the get_weather tool to look up the weather in Tokyo.",
+            )
+        ],
+    )
+    engine = VLLMInferenceEngine(
+        _get_default_model_params(),
+        tensor_parallel_size=1,
+        tool_call_parser="hermes",
+    )
+    inference_config = InferenceConfig(
+        generation=GenerationParams(
+            max_new_tokens=128, temperature=0.0, min_p=0.0, seed=42
+        )
+    )
+
+    outputs = engine.infer([convo], inference_config=inference_config)
+    assistant = outputs[-1].messages[-1]
+    # 0.6B may not always emit a call; the strict gate is the unit-test suite.
+    # When it does, verify the parsed payload and finish_reason are correct.
+    if assistant.tool_calls:
+        assert assistant.tool_calls[0]["function"]["name"] == "get_weather"
+        assert outputs[-1].metadata.get("finish_reason") == "tool_calls"

--- a/tests/unit/inference/test_vllm_inference_engine.py
+++ b/tests/unit/inference/test_vllm_inference_engine.py
@@ -1,5 +1,7 @@
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Final
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import jsonlines
@@ -704,3 +706,294 @@ def test_no_passthrough_kwargs_by_default(mock_vllm):
     call_kwargs = mock_vllm.LLM.call_args[1]
     assert "language_model_only" not in call_kwargs
     assert "hf_config_path" not in call_kwargs
+
+
+#
+# Tool-calling tests
+#
+_WEATHER_TOOL: Final = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+_CALENDAR_TOOL: Final = {
+    "type": "function",
+    "function": {
+        "name": "create_event",
+        "description": "Create a calendar event.",
+        "parameters": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+        },
+    },
+}
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_infer_forwards_tools_kwarg(mock_vllm):
+    """Conversation.tools is forwarded to LLM.chat(tools=...)."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+    mock_vllm_instance.chat.return_value = [_create_vllm_output(["ok"], "1")]
+
+    engine = VLLMInferenceEngine(_get_default_model_params())
+    conv = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="weather in Tokyo?")],
+        conversation_id="1",
+    )
+    engine.infer([conv], _get_default_inference_config())
+
+    mock_vllm_instance.chat.assert_called_once()
+    call_kwargs = mock_vllm_instance.chat.call_args.kwargs
+    assert call_kwargs["tools"] == [_WEATHER_TOOL]
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_infer_fast_path_when_no_tools(mock_vllm):
+    """When no conversation has tools, chat() is called once without `tools`."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+    mock_vllm_instance.chat.return_value = [
+        _create_vllm_output(["a"], "1"),
+        _create_vllm_output(["b"], "2"),
+    ]
+
+    engine = VLLMInferenceEngine(_get_default_model_params())
+    convs = [
+        Conversation(
+            messages=[Message(role=Role.USER, content="hi")], conversation_id="1"
+        ),
+        Conversation(
+            messages=[Message(role=Role.USER, content="bye")], conversation_id="2"
+        ),
+    ]
+    engine.infer(convs, _get_default_inference_config())
+
+    assert mock_vllm_instance.chat.call_count == 1
+    assert "tools" not in mock_vllm_instance.chat.call_args.kwargs
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_infer_groups_conversations_by_tools(mock_vllm):
+    """Heterogeneous tool sets dispatch as separate chat() calls in input order."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+
+    # Two groups: T1 used by indices [0, 2], T2 used by [1]. Each group's
+    # response is tagged so the stitched result can be verified to preserve
+    # original (A, B, C) input order.
+    def chat_side_effect(messages, **kwargs):
+        tools = kwargs.get("tools")
+        prefix = "weather" if tools == [_WEATHER_TOOL] else "calendar"
+        return [_create_vllm_output([f"{prefix}-out"], f"{prefix}-id")] * len(messages)
+
+    mock_vllm_instance.chat.side_effect = chat_side_effect
+
+    engine = VLLMInferenceEngine(_get_default_model_params())
+    convs = [
+        Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="A")],
+            conversation_id="A",
+        ),
+        Conversation(
+            tools=[_CALENDAR_TOOL],
+            messages=[Message(role=Role.USER, content="B")],
+            conversation_id="B",
+        ),
+        Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="C")],
+            conversation_id="C",
+        ),
+    ]
+    results = engine.infer(convs, _get_default_inference_config())
+
+    assert mock_vllm_instance.chat.call_count == 2
+    tools_per_call = [
+        call.kwargs.get("tools") for call in mock_vllm_instance.chat.call_args_list
+    ]
+    assert [_WEATHER_TOOL] in tools_per_call
+    assert [_CALENDAR_TOOL] in tools_per_call
+
+    # Original input order is preserved on the way out.
+    assert [r.conversation_id for r in results] == ["A", "B", "C"]
+    # And each conversation got the response for its own tool group.
+    assert results[0].messages[-1].content == "weather-out"
+    assert results[1].messages[-1].content == "calendar-out"
+    assert results[2].messages[-1].content == "weather-out"
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_infer_input_preserves_tool_calls_and_tool_call_id(mock_vllm):
+    """Multi-turn tool-use messages round-trip into the chat() input."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+    mock_vllm_instance.chat.return_value = [_create_vllm_output(["ok"], "1")]
+
+    engine = VLLMInferenceEngine(_get_default_model_params())
+    tool_call = {
+        "id": "call_abc",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+    }
+    conv = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="What's the weather in Tokyo?"),
+            Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+            Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_abc"),
+        ],
+        conversation_id="1",
+    )
+    engine.infer([conv], _get_default_inference_config())
+
+    sent = mock_vllm_instance.chat.call_args.args[0][0]
+    # User message unchanged.
+    assert sent[0]["role"] == "user"
+    # Assistant tool-call message: content=None, tool_calls forwarded.
+    assert sent[1]["role"] == "assistant"
+    assert sent[1]["content"] is None
+    assert sent[1]["tool_calls"] == [tool_call]
+    # Tool response: content + tool_call_id forwarded.
+    assert sent[2]["role"] == "tool"
+    assert sent[2]["content"] == "22C, sunny"
+    assert sent[2]["tool_call_id"] == "call_abc"
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_tool_call_parser_populates_message_tool_calls(mock_vllm):
+    """When tool_call_parser is set, parsed tool calls land on Message.tool_calls."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+    mock_vllm_instance.chat.return_value = [
+        _create_vllm_output(["<tool_call>...</tool_call>"], "1")
+    ]
+
+    # Stub tool call object exposing `.model_dump()`.
+    fake_call = Mock()
+    fake_call.model_dump.return_value = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+    }
+    fake_extracted = SimpleNamespace(
+        tools_called=True,
+        tool_calls=[fake_call],
+        content=None,
+    )
+    parser_instance = Mock()
+    parser_instance.extract_tool_calls.return_value = fake_extracted
+    parser_cls = Mock(return_value=parser_instance)
+    manager = Mock()
+    manager.get_tool_parser.return_value = parser_cls
+
+    with (
+        patch("oumi.inference.vllm_inference_engine.ToolParserManager", manager),
+        patch(
+            "oumi.inference.vllm_inference_engine._VLLM_TOOL_PARSERS_AVAILABLE", True
+        ),
+    ):
+        engine = VLLMInferenceEngine(
+            _get_default_model_params(), tool_call_parser="hermes"
+        )
+
+    conv = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="weather?")],
+        conversation_id="1",
+    )
+    results = engine.infer([conv], _get_default_inference_config())
+
+    assistant = results[0].messages[-1]
+    assert assistant.tool_calls == [fake_call.model_dump.return_value]
+    assert assistant.content is None
+    assert results[0].metadata["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_tool_call_parser_error_falls_back_to_text(mock_vllm):
+    """A parser exception leaves Message.tool_calls=None and keeps raw text."""
+    mock_vllm_instance = Mock()
+    mock_vllm.LLM.return_value = mock_vllm_instance
+    mock_vllm_instance.chat.return_value = [_create_vllm_output(["raw"], "1")]
+
+    parser_instance = Mock()
+    parser_instance.extract_tool_calls.side_effect = RuntimeError("boom")
+    parser_cls = Mock(return_value=parser_instance)
+    manager = Mock()
+    manager.get_tool_parser.return_value = parser_cls
+
+    with (
+        patch("oumi.inference.vllm_inference_engine.ToolParserManager", manager),
+        patch(
+            "oumi.inference.vllm_inference_engine._VLLM_TOOL_PARSERS_AVAILABLE", True
+        ),
+    ):
+        engine = VLLMInferenceEngine(
+            _get_default_model_params(), tool_call_parser="hermes"
+        )
+
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="hi")], conversation_id="1"
+    )
+    results = engine.infer([conv], _get_default_inference_config())
+
+    assistant = results[0].messages[-1]
+    assert assistant.tool_calls is None
+    assert assistant.content == "raw"
+    # Falls back to the raw vLLM finish reason (not overridden to "tool_calls").
+    assert results[0].metadata.get("finish_reason") != "tool_calls"
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_tool_call_parser_unknown_name_raises(mock_vllm):
+    """An unknown parser name raises a clear ValueError."""
+    mock_vllm.LLM.return_value = Mock()
+
+    manager = Mock()
+    manager.get_tool_parser.side_effect = KeyError("not-a-parser")
+
+    with (
+        patch("oumi.inference.vllm_inference_engine.ToolParserManager", manager),
+        patch(
+            "oumi.inference.vllm_inference_engine._VLLM_TOOL_PARSERS_AVAILABLE", True
+        ),
+    ):
+        with pytest.raises(ValueError, match="Unknown vLLM tool_call_parser"):
+            VLLMInferenceEngine(
+                _get_default_model_params(), tool_call_parser="not-a-parser"
+            )
+
+
+@pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
+def test_tool_call_parser_from_model_params(mock_vllm):
+    """`model_params.tool_call_parser` is used when no kwarg is supplied."""
+    mock_vllm.LLM.return_value = Mock()
+
+    manager = Mock()
+    parser_cls = Mock(return_value=Mock())
+    manager.get_tool_parser.return_value = parser_cls
+
+    params = _get_default_model_params()
+    params.tool_call_parser = "hermes"
+
+    with (
+        patch("oumi.inference.vllm_inference_engine.ToolParserManager", manager),
+        patch(
+            "oumi.inference.vllm_inference_engine._VLLM_TOOL_PARSERS_AVAILABLE", True
+        ),
+    ):
+        VLLMInferenceEngine(params)
+
+    manager.get_tool_parser.assert_called_once_with("hermes")

--- a/tests/unit/inference/test_vllm_inference_engine.py
+++ b/tests/unit/inference/test_vllm_inference_engine.py
@@ -11,6 +11,7 @@ import pytest
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Role, Type
+from oumi.core.types.tool_call import ToolCall, ToolDefinition
 from oumi.inference import VLLMInferenceEngine
 from oumi.utils.conversation_utils import base64encode_content_item_image_bytes
 from oumi.utils.image_utils import (
@@ -711,7 +712,7 @@ def test_no_passthrough_kwargs_by_default(mock_vllm):
 #
 # Tool-calling tests
 #
-_WEATHER_TOOL: Final = {
+_WEATHER_TOOL_DICT: Final = {
     "type": "function",
     "function": {
         "name": "get_weather",
@@ -724,7 +725,7 @@ _WEATHER_TOOL: Final = {
     },
 }
 
-_CALENDAR_TOOL: Final = {
+_CALENDAR_TOOL_DICT: Final = {
     "type": "function",
     "function": {
         "name": "create_event",
@@ -736,6 +737,9 @@ _CALENDAR_TOOL: Final = {
         },
     },
 }
+
+_WEATHER_TOOL: Final = ToolDefinition.model_validate(_WEATHER_TOOL_DICT)
+_CALENDAR_TOOL: Final = ToolDefinition.model_validate(_CALENDAR_TOOL_DICT)
 
 
 @pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
@@ -755,7 +759,8 @@ def test_infer_forwards_tools_kwarg(mock_vllm):
 
     mock_vllm_instance.chat.assert_called_once()
     call_kwargs = mock_vllm_instance.chat.call_args.kwargs
-    assert call_kwargs["tools"] == [_WEATHER_TOOL]
+    # Tools are dumped to OpenAI-format dicts before being handed to vLLM.
+    assert call_kwargs["tools"] == [_WEATHER_TOOL_DICT]
 
 
 @pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
@@ -794,7 +799,7 @@ def test_infer_groups_conversations_by_tools(mock_vllm):
     # original (A, B, C) input order.
     def chat_side_effect(messages, **kwargs):
         tools = kwargs.get("tools")
-        prefix = "weather" if tools == [_WEATHER_TOOL] else "calendar"
+        prefix = "weather" if tools == [_WEATHER_TOOL_DICT] else "calendar"
         return [_create_vllm_output([f"{prefix}-out"], f"{prefix}-id")] * len(messages)
 
     mock_vllm_instance.chat.side_effect = chat_side_effect
@@ -823,8 +828,8 @@ def test_infer_groups_conversations_by_tools(mock_vllm):
     tools_per_call = [
         call.kwargs.get("tools") for call in mock_vllm_instance.chat.call_args_list
     ]
-    assert [_WEATHER_TOOL] in tools_per_call
-    assert [_CALENDAR_TOOL] in tools_per_call
+    assert [_WEATHER_TOOL_DICT] in tools_per_call
+    assert [_CALENDAR_TOOL_DICT] in tools_per_call
 
     # Original input order is preserved on the way out.
     assert [r.conversation_id for r in results] == ["A", "B", "C"]
@@ -842,7 +847,7 @@ def test_infer_input_preserves_tool_calls_and_tool_call_id(mock_vllm):
     mock_vllm_instance.chat.return_value = [_create_vllm_output(["ok"], "1")]
 
     engine = VLLMInferenceEngine(_get_default_model_params())
-    tool_call = {
+    tool_call_dict = {
         "id": "call_abc",
         "type": "function",
         "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
@@ -851,7 +856,11 @@ def test_infer_input_preserves_tool_calls_and_tool_call_id(mock_vllm):
         tools=[_WEATHER_TOOL],
         messages=[
             Message(role=Role.USER, content="What's the weather in Tokyo?"),
-            Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[ToolCall.model_validate(tool_call_dict)],
+            ),
             Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_abc"),
         ],
         conversation_id="1",
@@ -861,10 +870,10 @@ def test_infer_input_preserves_tool_calls_and_tool_call_id(mock_vllm):
     sent = mock_vllm_instance.chat.call_args.args[0][0]
     # User message unchanged.
     assert sent[0]["role"] == "user"
-    # Assistant tool-call message: content=None, tool_calls forwarded.
+    # Assistant tool-call message: content=None, tool_calls forwarded as dicts.
     assert sent[1]["role"] == "assistant"
     assert sent[1]["content"] is None
-    assert sent[1]["tool_calls"] == [tool_call]
+    assert sent[1]["tool_calls"] == [tool_call_dict]
     # Tool response: content + tool_call_id forwarded.
     assert sent[2]["role"] == "tool"
     assert sent[2]["content"] == "22C, sunny"
@@ -916,7 +925,13 @@ def test_tool_call_parser_populates_message_tool_calls(mock_vllm):
     results = engine.infer([conv], _get_default_inference_config())
 
     assistant = results[0].messages[-1]
-    assert assistant.tool_calls == [fake_call.model_dump.return_value]
+    # `Message.tool_calls` is `list[ToolCall]` after Pydantic validation;
+    # round-trip through `model_dump` to compare against the OpenAI-format
+    # dict produced by the (mocked) parser.
+    assert assistant.tool_calls is not None
+    assert [tc.model_dump(mode="json") for tc in assistant.tool_calls] == [
+        fake_call.model_dump.return_value
+    ]
     assert assistant.content is None
     assert results[0].metadata["finish_reason"] == "tool_calls"
 

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -11,6 +11,7 @@ from oumi.builders import build_tokenizer
 from oumi.core.configs import ModelParams
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Role, Type
+from oumi.core.types.tool_call import ToolCall
 from oumi.utils.conversation_utils import (
     base64encode_content_item_image_bytes,
     convert_message_to_json_content,
@@ -809,14 +810,18 @@ def test_truncate_text_in_content_items(
 #
 def test_create_list_of_message_json_dicts_forwards_tool_calls():
     """Assistant tool_calls survive into the dict; content=None preserved."""
-    tool_call = {
+    tool_call_dict = {
         "id": "call_abc",
         "type": "function",
         "function": {"name": "get_weather", "arguments": "{}"},
     }
     messages = [
         Message(role=Role.USER, content="weather?"),
-        Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+        Message(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[ToolCall.model_validate(tool_call_dict)],
+        ),
     ]
 
     result = create_list_of_message_json_dicts(
@@ -827,7 +832,7 @@ def test_create_list_of_message_json_dicts_forwards_tool_calls():
     assert result[0] == {"role": "user", "content": "weather?"}
     assert result[1]["role"] == "assistant"
     assert result[1]["content"] is None
-    assert result[1]["tool_calls"] == [tool_call]
+    assert result[1]["tool_calls"] == [tool_call_dict]
 
 
 def test_create_list_of_message_json_dicts_forwards_tool_call_id():

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -802,3 +802,76 @@ def test_truncate_text_in_content_items(
         assert truncated_messages == expected_messages
     else:
         assert truncated_messages == messages
+
+
+#
+# Tool-calling helper tests
+#
+def test_create_list_of_message_json_dicts_forwards_tool_calls():
+    """Assistant tool_calls survive into the dict; content=None preserved."""
+    tool_call = {
+        "id": "call_abc",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": "{}"},
+    }
+    messages = [
+        Message(role=Role.USER, content="weather?"),
+        Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+    ]
+
+    result = create_list_of_message_json_dicts(
+        messages, group_adjacent_same_role_turns=True
+    )
+
+    assert len(result) == 2
+    assert result[0] == {"role": "user", "content": "weather?"}
+    assert result[1]["role"] == "assistant"
+    assert result[1]["content"] is None
+    assert result[1]["tool_calls"] == [tool_call]
+
+
+def test_create_list_of_message_json_dicts_forwards_tool_call_id():
+    """Tool messages carry tool_call_id linking them to the prior call."""
+    messages = [
+        Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_abc"),
+    ]
+
+    result = create_list_of_message_json_dicts(
+        messages, group_adjacent_same_role_turns=True
+    )
+
+    assert result == [
+        {"role": "tool", "content": "22C, sunny", "tool_call_id": "call_abc"}
+    ]
+
+
+def test_create_list_of_message_json_dicts_does_not_group_tool_messages():
+    """Adjacent tool messages stay 1:1 even with grouping enabled."""
+    messages = [
+        Message(role=Role.TOOL, content="r1", tool_call_id="a"),
+        Message(role=Role.TOOL, content="r2", tool_call_id="b"),
+    ]
+
+    result = create_list_of_message_json_dicts(
+        messages, group_adjacent_same_role_turns=True
+    )
+
+    assert len(result) == 2
+    assert result[0] == {"role": "tool", "content": "r1", "tool_call_id": "a"}
+    assert result[1] == {"role": "tool", "content": "r2", "tool_call_id": "b"}
+
+
+def test_create_list_of_message_json_dicts_no_tool_keys_when_unset():
+    """Plain conversations are unchanged: no tool_calls/tool_call_id keys."""
+    messages = [
+        Message(role=Role.USER, content="hi"),
+        Message(role=Role.ASSISTANT, content="hello"),
+    ]
+
+    result = create_list_of_message_json_dicts(
+        messages, group_adjacent_same_role_turns=True
+    )
+
+    for d in result:
+        assert "tool_calls" not in d
+        assert "tool_call_id" not in d


### PR DESCRIPTION
# Description

## Motivation

Support for`Conversation.tools` and `Message.tool_calls` / `Message.tool_call_id` is currently pending for Oumi's data model (#2392). This is sufficient for training but insufficient for inference. In this PR, we start with local VLLMInferenceEngine as it is the core engine used for evaluating OSS models and also key to various rollout dependent training types eg GRPO, OPD. However, tools never reach `vLLM.LLM.chat(...)`, and any tool-call tokens the model emits stay buried as raw text inside `Message.content` because local `VLLMInferenceEngine` ignores them. As a result, the local vLLM engine cannot be used today for tool-calling inference without users reaching into `engine._llm.chat()` directly.

Key changes to support tool calls in vLLM engine:
- `Conversation.tools` is forwarded to `vllm.LLM.chat(tools=...)` so the chat template renders tool definitions natively.
- Multi-turn tool-use messages (`tool_calls` on assistant, `tool_call_id` on tool) round-trip through the prompt converter, so conversations like `user → assistant.tool_call → tool → assistant.text` work.
- An optional `tool_call_parser` (settable on `ModelParams` or as a kwarg) populates structured `Message.tool_calls` on the output and sets `metadata["finish_reason"] = "tool_calls"`, so callers don't have to regex tool-call tags out of `content`.

## Typed Pydantic interop with #2392

#2392 stores `Conversation.tools` as `list[ToolDefinition]` and `Message.tool_calls` as `list[ToolCall]` (typed Pydantic models, not raw dicts). vLLM's offline `LLM.chat(...)` and its tool parsers consume OpenAI-format dicts, so this PR adapts at the boundary:

- `_group_by_tools` dumps `conv.tools` to `list[dict]` once (`model_dump(mode="json", exclude_none=True)`) before grouping and passing to `_llm.chat(tools=...)`.
- `create_list_of_message_json_dicts` dumps `msg.tool_calls` to dicts inside the message dict that vLLM consumes.
- The tool-parser `request` stub gets dicts for `tools=...` so existing parser implementations that read `request.tools` work unchanged.
- Output `Message.tool_calls` is constructed via `ToolCall.model_validate(parser_dict)` so the typed invariant holds on the result side.

`exclude_none=True` keeps the on-the-wire dict shape identical to the user's original input (no `strict: null`, etc.), preserving round-trip equivalence with what reviewers see in JSONL test fixtures.

## Backward compatibility

This change is additive and non-breaking for every existing call site:

- Conversations without `tools` continue to take the original single-batch fast path through `_llm.chat()` — no `tools=` kwarg passed, identical behavior to before.
- Conversations without `tool_calls` / `tool_call_id` on any message continue to render exactly as before — the helper's enrichment only fires when those fields are set.
- The `tool_call_parser` field on `ModelParams` defaults to `None`. With it unset, output messages are constructed exactly as before (raw text in `content`, no `tool_calls` populated, `finish_reason` from vLLM's raw reason).
- Direct kwarg `tool_call_parser=...` on `VLLMInferenceEngine(...)` still wins over `model_params.tool_call_parser` for programmatic users, matching the existing precedence pattern for other engine-construction kwargs.
- The grouping behavior on `create_list_of_message_json_dicts` is preserved for plain conversations; the new "skip grouping when tool metadata is present" rule only kicks in for messages that have `tool_calls` or `tool_call_id` set, which were dropped on the floor before this PR.
- An assistant message with `content=None` (only valid when `tool_calls` is set, per the existing `Message.model_post_init` validator) is now accepted by the vLLM input converter; previously the converter would reject it with `RuntimeError("'content' field must be ...")`. Since no existing call path constructs such a message and feeds it to the engine without also setting `tool_calls`, this strictly widens the accepted input.
- The `vllm.tool_parsers` import is guarded with a try/except fallback to `vllm.entrypoints.openai.tool_parsers` (the pre-0.14 location), and again to `None` if neither is available. Users on older vLLM versions who don't set `tool_call_parser` see no behavior change; users who do set it get a clear `RuntimeError("vLLM tool parsers are not available in this vLLM version")` at construction time.

## Related issues

Fixes # (issue)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
