### PR TITLE
fix(deploy): classify gpt-oss 'requires one of' as FireworksUnsupportedHardwareError

### DIFF
--- a/src/oumi/deploy/fireworks_errors.py
+++ b/src/oumi/deploy/fireworks_errors.py
@@ -38,7 +38,16 @@ class FireworksUnsupportedHardwareError(DeployInvalidRequestError):
     """HTTP 400 — Fireworks rejected an unsupported model/hardware pair.
 
     Detected on responses whose detail begins with ``"invalid deployment"``
-    and contains ``"is not supported on"``.
+    and contains either:
+
+    - ``"is not supported on"`` (e.g. ``"model type qwen3 is not supported
+      on NVIDIA_A100_80GB"``), or
+    - ``"requires one of"`` (e.g. ``"model type gpt_oss requires one of:
+      NVIDIA_H100_80GB, NVIDIA_B200_180GB, ..."``).
+
+    Both phrasings mean the same thing semantically — the requested
+    accelerator is incompatible with the model — and consumers fall back
+    to the next accelerator on either.
     """
 
 
@@ -66,7 +75,9 @@ def classify_fireworks_invalid_request(
         The matching :class:`DeployInvalidRequestError` subclass, or the
         base class when no signature applies.
     """
-    if detail.startswith("invalid deployment") and "is not supported on" in detail:
+    if detail.startswith("invalid deployment") and (
+        "is not supported on" in detail or "requires one of" in detail
+    ):
         return FireworksUnsupportedHardwareError
     if detail.startswith("LoRA validation failed"):
         return FireworksAdapterMismatchError

--- a/tests/unit/deploy/test_fireworks_errors.py
+++ b/tests/unit/deploy/test_fireworks_errors.py
@@ -52,6 +52,20 @@ class TestClassifyFireworksInvalidRequest:
             is FireworksUnsupportedHardwareError
         )
 
+    def test_unsupported_hardware_requires_one_of_signature(self):
+        """Variant emitted for newer model families (e.g. gpt-oss): instead of
+        naming the rejected accelerator, Fireworks lists the allowed ones.
+        """
+        detail = (
+            "invalid deployment: model type gpt_oss requires one of: "
+            "NVIDIA_H100_80GB, NVIDIA_B200_180GB, NVIDIA_GB200, "
+            "NVIDIA_B300_288GB, NVIDIA_H200_141GB"
+        )
+        assert (
+            classify_fireworks_invalid_request(detail)
+            is FireworksUnsupportedHardwareError
+        )
+
     def test_adapter_mismatch_signature(self):
         detail = (
             "LoRA validation failed: LoRA keys reference non-existent base "
@@ -120,6 +134,27 @@ class TestFireworksClassifierWiring:
         rendered = str(exc)
         # Provider-specific detail preserved; method/URL must NOT leak
         assert "NVIDIA_A100_80GB" in rendered
+        assert "POST" not in rendered
+        assert "fireworks.ai" not in rendered
+
+    def test_unsupported_hardware_requires_one_of_wires_through(self):
+        detail = (
+            "invalid deployment: model type gpt_oss requires one of: "
+            "NVIDIA_H100_80GB, NVIDIA_B200_180GB, NVIDIA_GB200, "
+            "NVIDIA_B300_288GB, NVIDIA_H200_141GB"
+        )
+        resp = _make_response(400, {"message": detail})
+        with pytest.raises(FireworksUnsupportedHardwareError) as exc_info:
+            raise_api_error(
+                resp,
+                "create endpoint for model 'foo'",
+                classify_4xx=classify_fireworks_invalid_request,
+            )
+        exc = exc_info.value
+        assert exc.status_code == 400
+        assert exc.detail == detail
+        rendered = str(exc)
+        assert "NVIDIA_H100_80GB" in rendered
         assert "POST" not in rendered
         assert "fireworks.ai" not in rendered
 


### PR DESCRIPTION
# Description

Fireworks rejects `gpt-oss` deployments on incompatible accelerators with the detail string:

```
invalid deployment: model type gpt_oss requires one of: NVIDIA_H100_80GB, NVIDIA_B200_180GB, NVIDIA_GB200, NVIDIA_B300_288GB, NVIDIA_H200_141GB
```

`classify_fireworks_invalid_request` only matched the older `"is not supported on <GPU>"` phrasing, so this variant fell through to the base `DeployInvalidRequestError`. Downstream consumers gate hardware fallback on `FireworksUnsupportedHardwareError`, so an A100 attempt for `gpt-oss-20b` failed terminally instead of falling back to H100.

## Related issues

Fixes [LOU-1658](https://linear.app/oumi/issue/LOU-1658)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?