### PR TITLE
feat(deploy): typed FireworksConflictError

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -56,7 +56,10 @@ from oumi.deploy.fireworks_api import (
     GatewayPEFTDetails,
     GatewayPrepareModelBody,
 )
-from oumi.deploy.fireworks_errors import classify_fireworks_invalid_request
+from oumi.deploy.fireworks_errors import (
+    FireworksConflictError,
+    classify_fireworks_invalid_request,
+)
 from oumi.deploy.utils import raise_api_error
 
 logger = logging.getLogger(__name__)
@@ -738,17 +741,23 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         )
 
         if response.is_error:
+            if response.status_code == 409:
+                # Benign under concurrency: another caller created the same
+                # model first. Surface as a typed error so the caller can handle
+                # it accordingly.
+                logger.info("Model '%s' already exists (409).", model_id)
+                raise FireworksConflictError(
+                    detail=response.text or "model already exists",
+                    status_code=409,
+                    method="POST",
+                    url=str(response.request.url),
+                    context=f"create model resource '{model_id}'",
+                )
             logger.error(
                 "Fireworks API error response (HTTP %d): %s",
                 response.status_code,
                 response.text,
             )
-            if response.status_code == 409:
-                logger.error(
-                    "Model ID '%s' already exists. "
-                    "Delete it manually or use a different name.",
-                    model_id,
-                )
             self._check_response(response, f"create model resource '{model_id}'")
 
         created = GatewayModel.model_validate(response.json())

--- a/src/oumi/deploy/fireworks_errors.py
+++ b/src/oumi/deploy/fireworks_errors.py
@@ -14,24 +14,16 @@
 
 """Fireworks-specific typed errors and 4xx classifier.
 
-These subclass :class:`oumi.deploy.errors.DeployInvalidRequestError` so
-consumers can still catch the generic base, but they expose Fireworks-only
-failure modes that are detected via Fireworks-specific detail strings.
+Two patterns:
 
-Add new Fireworks error types here as they're discovered. Each new type
-needs:
-
-1. A subclass of :class:`DeployInvalidRequestError` below.
-2. A signature check in :func:`classify_fireworks_invalid_request`.
-3. One unit test for the classifier (detail string → class) in
-   ``tests/unit/deploy/test_fireworks_errors.py``.
-
-The classifier is wired into :class:`FireworksDeploymentClient` via the
-``classify_4xx`` hook on :func:`oumi.deploy.utils.check_response`, so no
-shared-module changes are required when extending.
+- 400/422: subclass :class:`DeployInvalidRequestError`, routed by
+  :func:`classify_fireworks_invalid_request` (used as the ``classify_4xx``
+  hook in :func:`oumi.deploy.utils.check_response`).
+- Other 4xx (e.g. 409): subclass :class:`DeployApiError` and raise
+  inline from the client where the status is detected.
 """
 
-from oumi.deploy.errors import DeployInvalidRequestError
+from oumi.deploy.errors import DeployApiError, DeployInvalidRequestError
 
 
 class FireworksUnsupportedHardwareError(DeployInvalidRequestError):
@@ -55,6 +47,16 @@ class FireworksAdapterMismatchError(DeployInvalidRequestError):
     """HTTP 400 — Fireworks rejected an adapter mismatched with its base model.
 
     Detected on responses whose detail begins with ``"LoRA validation failed"``.
+    """
+
+
+class FireworksConflictError(DeployApiError):
+    """HTTP 409 — model resource already exists on Fireworks.
+
+    Concurrent callers that hit ``POST /v1/accounts/{id}/models`` for the
+    same model ID race; the loser sees 409. Catch this to wait for the
+    winner (e.g. poll :meth:`FireworksDeploymentClient.get_model`) instead
+    of retrying.
     """
 
 

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -723,6 +723,42 @@ class TestGetModel:
             assert await client.get_model("missing-model") is None
 
 
+class TestCreateModelResourceConflict:
+    """409 → FireworksConflictError."""
+
+    @staticmethod
+    def _make_client() -> FireworksDeploymentClient:
+        return FireworksDeploymentClient(api_key="test-key", account_id="test-account")
+
+    @pytest.mark.asyncio
+    async def test_create_model_resource_409_raises_typed(self):
+        from oumi.deploy.errors import DeployApiError
+        from oumi.deploy.fireworks_errors import FireworksConflictError
+
+        client = self._make_client()
+        response = MagicMock()
+        response.status_code = 409
+        response.is_error = True
+        response.is_success = False
+        response.text = "model already exists"
+        response.request = MagicMock(
+            url="https://api.fireworks.ai/v1/accounts/test-account/models"
+        )
+
+        with patch.object(client._client, "post", new=AsyncMock(return_value=response)):
+            with pytest.raises(FireworksConflictError) as exc_info:
+                await client._create_model_resource(
+                    "my-model",
+                    ModelType.FULL,
+                    None,
+                    None,
+                    huggingface_files=["config.json"],
+                )
+        assert exc_info.value.status_code == 409
+        # Existing ``except DeployApiError`` handlers must still catch this.
+        assert isinstance(exc_info.value, DeployApiError)
+
+
 class TestUploadModelFromInventory:
     """Tests for upload_model_with_resolver and _upload_model_files_with_resolver."""
 


### PR DESCRIPTION
# Description

Adds `FireworksConflictError(DeployApiError)`, raised inline by `_create_model_resource` on HTTP 409. Lets concurrent callers branch on "model already exists" cleanly (e.g. wait via `get_model` polling) instead of getting the bare `DeployApiError` we raised before. Existing `except DeployApiError` handlers still catch it. Also drops the misleading "delete it manually" ERROR log on 409 because under concurrency the conflict is benign.

## Related issues

Towards [LOU-1578](https://linear.app/oumi/issue/LOU-1578)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.