### PR TITLE
Wire tool calling through RemoteInferenceEngine

### DIFF
--- a/configs/apis/openai/infer_gpt_4o_tool_calling.yaml
+++ b/configs/apis/openai/infer_gpt_4o_tool_calling.yaml
@@ -1,0 +1,35 @@
+# OpenAI Chat Completions inference config with tool calling.
+#
+# Sends ``Conversation.tools`` (OpenAI function-calling schema) on every
+# request and parses ``message.tool_calls`` out of the response into
+# structured ``Message.tool_calls``.
+#
+# Requirements:
+#   - Set the ``OPENAI_API_KEY`` environment variable.
+#
+# Usage:
+#   oumi infer -i -c configs/apis/openai/infer_gpt_4o_tool_calling.yaml
+#
+# The input JSONL should carry a top-level ``tools`` field on each
+# conversation (OpenAI function-calling schema). Output messages will
+# populate ``tool_calls`` when the model emits a structured call, and
+# ``metadata.finish_reason`` will be set to ``tool_calls``.
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "gpt-4o"
+
+engine: OPENAI
+
+generation:
+  max_new_tokens: 4096
+  temperature: 0.3
+  # Let the model decide whether to call a tool. Other valid values:
+  # "none" (force a text reply), "required" (force a tool call), or
+  # {"type": "function", "function": {"name": "..."}} to force a
+  # specific tool.
+  tool_choice: "auto"

--- a/src/oumi/core/configs/params/generation_params.py
+++ b/src/oumi/core/configs/params/generation_params.py
@@ -130,6 +130,25 @@ class GenerationParams(BaseParams):
     format (e.g., reasoning tokens, tool call markers).
     """
 
+    # Should be Union[str, dict[str, Any], None], but omegaconf does not
+    # support unions of containers, so we widen to Any.
+    tool_choice: Any | None = None
+    """Controls how the model selects tools when ``Conversation.tools`` is set.
+
+    Uses the OpenAI value space: ``"none"``, ``"auto"``, ``"required"``, or
+    ``{"type": "function", "function": {"name": "..."}}``. Default ``None``
+    omits the field from the request, letting the API apply its own default
+    (``"auto"`` when tools are present). Engines targeting non-OpenAI providers
+    (e.g. Anthropic) translate this value to the provider's wire shape.
+    """
+
+    parallel_tool_calls: bool = True
+    """Whether the model may emit multiple tool calls in one response.
+
+    OpenAI-specific. Default ``True`` matches the OpenAI API default; the
+    request body only carries the field when explicitly set to ``False``.
+    """
+
     def __post_init__(self):
         """Validates generation-specific parameters."""
         if self.batch_size is not None and self.batch_size < 1:

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -506,15 +506,13 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         message = response["choices"][0].get("message")
         if not message:
             raise RuntimeError(f"No message found in API response: {response}")
-        raw_content = message.get("content")
+        content = message.get("content")
         tool_calls = message.get("tool_calls")
-        # OpenAI emits content=null on assistant messages that only carry
-        # tool_calls. Preserve None so Message can reconstruct the typed
-        # ToolCalls without forcing an empty string body.
-        if tool_calls:
-            content = raw_content
-        else:
-            content = raw_content or ""
+        # Message requires at least one of content/tool_calls. The OpenAI wire
+        # format uses content=null on tool-only assistant turns, which Message
+        # accepts; only fall back to "" when there are no tool_calls either.
+        if content is None and not tool_calls:
+            content = ""
         metadata = dict(original_conversation.metadata)
         usage = self._extract_usage_from_response(response)
         if usage is not None:

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -56,7 +56,6 @@ from oumi.inference.adaptive_concurrency_controller import AdaptiveConcurrencyCo
 from oumi.inference.adaptive_semaphore import PoliteAdaptiveSemaphore
 from oumi.inference.rate_limiter import RateLimiter, UsageTracker
 from oumi.utils.conversation_utils import (
-    convert_message_to_json_content_list,
     create_list_of_message_json_dicts,
 )
 from oumi.utils.http import (
@@ -368,16 +367,25 @@ class RemoteInferenceEngine(BaseInferenceEngine):
 
         api_input = {
             "model": model_params.model_name,
-            "messages": [
-                {
-                    "content": convert_message_to_json_content_list(message),
-                    "role": message.role.value,
-                }
-                for message in conversation.messages
-            ],
+            "messages": self._get_list_of_message_json_dicts(
+                conversation.messages,
+                group_adjacent_same_role_turns=False,
+            ),
             "n": 1,  # Number of completions to generate for each prompt.
             **generation_params_dict,
         }
+
+        if conversation.tools:
+            api_input["tools"] = [
+                tool.model_dump(mode="json", exclude_none=True)
+                for tool in conversation.tools
+            ]
+        if generation_params.tool_choice is not None:
+            api_input["tool_choice"] = generation_params.tool_choice
+        # Default parallel_tool_calls=True matches the OpenAI API default; only
+        # send the field when explicitly disabled.
+        if generation_params.parallel_tool_calls is False:
+            api_input["parallel_tool_calls"] = False
 
         if generation_params.guided_decoding:
             json_schema = generation_params.guided_decoding.json
@@ -498,7 +506,15 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         message = response["choices"][0].get("message")
         if not message:
             raise RuntimeError(f"No message found in API response: {response}")
-        content = message.get("content") or ""
+        raw_content = message.get("content")
+        tool_calls = message.get("tool_calls")
+        # OpenAI emits content=null on assistant messages that only carry
+        # tool_calls. Preserve None so Message can reconstruct the typed
+        # ToolCalls without forcing an empty string body.
+        if tool_calls:
+            content = raw_content
+        else:
+            content = raw_content or ""
         metadata = dict(original_conversation.metadata)
         usage = self._extract_usage_from_response(response)
         if usage is not None:
@@ -512,10 +528,12 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                 Message(
                     content=content,
                     role=Role(message["role"]),
+                    tool_calls=tool_calls,
                 ),
             ],
             metadata=metadata,
             conversation_id=original_conversation.conversation_id,
+            tools=original_conversation.tools,
         )
 
     def _get_api_key(self, remote_params: RemoteParams) -> str | None:
@@ -839,11 +857,13 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             "logit_bias",
             "max_new_tokens",
             "min_p",
+            "parallel_tool_calls",
             "presence_penalty",
             "seed",
             "stop_strings",
             "stop_token_ids",
             "temperature",
+            "tool_choice",
             "top_p",
         }
 

--- a/tests/unit/inference/test_openai_inference_engine.py
+++ b/tests/unit/inference/test_openai_inference_engine.py
@@ -2,9 +2,25 @@ import pytest
 
 from oumi.core.configs import GenerationParams, ModelParams, RemoteParams
 from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import ToolDefinition
 from oumi.inference.openai_inference_engine import (
     OpenAIInferenceEngine,
     _is_reasoning_model,
+)
+
+_WEATHER_TOOL = ToolDefinition.model_validate(
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
 )
 
 
@@ -137,3 +153,33 @@ def test_default_params(
 def test_is_reasoning_model(model_name: str, expected: bool):
     """Test _is_reasoning_model correctly identifies reasoning models."""
     assert _is_reasoning_model(model_name) == expected
+
+
+def test_reasoning_model_does_not_drop_tool_fields():
+    """Reasoning-model overrides (temperature, logit_bias) preserve tool fields."""
+    engine = OpenAIInferenceEngine(
+        model_params=ModelParams(model_name="o1"),
+        remote_params=RemoteParams(api_key="x", api_url="<placeholder>"),
+        generation_params=GenerationParams(
+            max_new_tokens=64,
+            tool_choice="auto",
+            parallel_tool_calls=False,
+        ),
+    )
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="weather?")],
+    )
+
+    api_input = engine._convert_conversation_to_api_input(
+        conversation, engine._generation_params, engine._model_params
+    )
+    # Reasoning-model overrides apply.
+    assert api_input["temperature"] == 1.0
+    assert "logit_bias" not in api_input
+    # Tool fields are not dropped.
+    assert api_input["tools"] == [
+        _WEATHER_TOOL.model_dump(mode="json", exclude_none=True)
+    ]
+    assert api_input["tool_choice"] == "auto"
+    assert api_input["parallel_tool_calls"] is False

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -30,6 +30,7 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import ToolCall, ToolDefinition
 from oumi.inference import RemoteInferenceEngine
 from oumi.inference.remote_inference_engine import BatchStatus
 from oumi.utils.conversation_utils import (
@@ -919,10 +920,12 @@ def test_infer_online_multiple_requests():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
+        content = messages[0].get("content", "")
         if not content:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
+        conversation_id = (
+            content if isinstance(content, str) else content[0].get("text")
+        )
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1039,10 +1042,12 @@ def test_infer_online_multiple_requests_politeness():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
+        content = messages[0].get("content", "")
         if not content:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
+        conversation_id = (
+            content if isinstance(content, str) else content[0].get("text")
+        )
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1181,10 +1186,12 @@ def test_infer_online_multiple_requests_politeness_multiple_workers():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
+        content = messages[0].get("content", "")
         if not content:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
+        conversation_id = (
+            content if isinstance(content, str) else content[0].get("text")
+        )
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1365,10 +1372,12 @@ def test_infer_from_file_to_file():
             messages = request.get("messages", [])
             if not messages:
                 raise ValueError("No messages in request")
-            content = messages[0].get("content", [])
+            content = messages[0].get("content", "")
             if not content:
                 raise ValueError("No content in message")
-            conversation_id = content[0].get("text")
+            conversation_id = (
+                content if isinstance(content, str) else content[0].get("text")
+            )
 
             if response := response_by_conversation_id.get(conversation_id):
                 # Extract status and payload from the response dict
@@ -1496,10 +1505,12 @@ def test_infer_from_file_to_file_failure_midway():
             messages = request.get("messages", [])
             if not messages:
                 raise ValueError("No messages in request")
-            content = messages[0].get("content", [])
+            content = messages[0].get("content", "")
             if not content:
                 raise ValueError("No content in message")
-            conversation_id = content[0].get("text")
+            conversation_id = (
+                content if isinstance(content, str) else content[0].get("text")
+            )
 
             if response := response_by_conversation_id.get(conversation_id):
                 # Extract status and payload from the response dict
@@ -3823,3 +3834,191 @@ def test_rate_limiter_record_usage_called_after_response():
             )
 
     mock_record.assert_called_once_with(input_tokens=25, output_tokens=10)
+
+
+#
+# Tool-calling tests
+#
+_WEATHER_TOOL_DICT: Final = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+_WEATHER_TOOL: Final = ToolDefinition.model_validate(_WEATHER_TOOL_DICT)
+
+
+def _capture_request_body() -> tuple[Any, Any]:
+    """Returns (callback, captured) where captured["body"] receives the JSON body."""
+    captured: dict[str, Any] = {}
+
+    def callback(url: str, **kwargs: Any) -> CallbackResult:
+        captured["body"] = kwargs.get("json", {})
+        return CallbackResult(
+            status=200,
+            payload={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    return callback, captured
+
+
+def test_request_body_includes_tools():
+    """Conversation.tools is dumped to the OpenAI wire shape on the request."""
+    callback, captured = _capture_request_body()
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        conversation = Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="weather in Tokyo?")],
+        )
+        engine.infer([conversation], _get_default_inference_config())
+
+    assert captured["body"]["tools"] == [_WEATHER_TOOL_DICT]
+
+
+def test_request_body_includes_tool_choice():
+    """tool_choice lands on the request when set; absent when None."""
+    callback, captured = _capture_request_body()
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback, repeat=True)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        conversation = Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="hi")],
+        )
+        # Default: not present.
+        engine.infer([conversation], _get_default_inference_config())
+        assert "tool_choice" not in captured["body"]
+
+        # Explicit value lands as-is.
+        config = _get_default_inference_config()
+        config.generation.tool_choice = "auto"
+        engine.infer([conversation], config)
+        assert captured["body"]["tool_choice"] == "auto"
+
+
+def test_request_body_includes_parallel_tool_calls():
+    """parallel_tool_calls=False is forwarded; True (default) is omitted."""
+    callback, captured = _capture_request_body()
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback, repeat=True)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        conversation = Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="hi")],
+        )
+        engine.infer([conversation], _get_default_inference_config())
+        assert "parallel_tool_calls" not in captured["body"]
+
+        config = _get_default_inference_config()
+        config.generation.parallel_tool_calls = False
+        engine.infer([conversation], config)
+        assert captured["body"]["parallel_tool_calls"] is False
+
+
+def test_request_forwards_tool_calls_and_tool_call_id():
+    """Multi-turn tool messages survive the round-trip into the request body."""
+    callback, captured = _capture_request_body()
+    tool_call_dict = {
+        "id": "call_abc",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+    }
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        conversation = Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[
+                Message(role=Role.USER, content="weather in Tokyo?"),
+                Message(
+                    role=Role.ASSISTANT,
+                    content=None,
+                    tool_calls=[ToolCall.model_validate(tool_call_dict)],
+                ),
+                Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_abc"),
+            ],
+        )
+        engine.infer([conversation], _get_default_inference_config())
+
+    sent = captured["body"]["messages"]
+    assert sent[0]["role"] == "user"
+    assert sent[1]["role"] == "assistant"
+    assert sent[1]["content"] is None
+    assert sent[1]["tool_calls"] == [tool_call_dict]
+    assert sent[2]["role"] == "tool"
+    assert sent[2]["content"] == "22C, sunny"
+    assert sent[2]["tool_call_id"] == "call_abc"
+
+
+def test_response_populates_tool_calls():
+    """An API response with tool_calls produces typed Message.tool_calls."""
+    tool_call_payload = {
+        "id": "call_xyz",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+    }
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=200,
+            payload={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [tool_call_payload],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+        )
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        conversation = Conversation(
+            tools=[_WEATHER_TOOL],
+            messages=[Message(role=Role.USER, content="weather in Paris?")],
+        )
+        results = engine.infer([conversation], _get_default_inference_config())
+
+    assistant = results[0].messages[-1]
+    assert assistant.role == Role.ASSISTANT
+    assert assistant.content is None
+    assert assistant.tool_calls is not None
+    assert [tc.model_dump(mode="json") for tc in assistant.tool_calls] == [
+        tool_call_payload
+    ]
+    assert results[0].metadata["finish_reason"] == "tool_calls"
+    # Tools propagate through to the result so downstream callers can inspect.
+    assert results[0].tools == [_WEATHER_TOOL]


### PR DESCRIPTION
# Description

PR #2397 added tool calling to `VLLMInferenceEngine`. The remote OpenAI-compatible engines do not yet send `Conversation.tools` on the request or parse `tool_calls` from the response, so tool fields are silently dropped on both sides. This PR adds tool-calling support to `RemoteInferenceEngine` (the OpenAI-compatible base class), so the same `Conversation` works on `engine: VLLM` and `engine: OPENAI`.

Providers that do not override `_convert_conversation_to_api_input` — Together, Fireworks, DeepSeek, Cerebras, OpenRouter, Parasail — pick up the new behavior automatically through the base class. `OpenAIInferenceEngine` overrides the method but calls `super()` after tweaking reasoning-model fields, so it inherits too.

Three OpenAI-compatible engines are *not* wired up by this PR and will silently drop tool fields until a follow-up: `SambanovaInferenceEngine` and `RemoteVLLMInferenceEngine` both override `_convert_conversation_to_api_input` without calling `super()` (their request bodies are minor variations of OpenAI chat completions, so a `super()`-based refactor is the natural fix). `SGLangInferenceEngine` uses SGLang's Native API (`text` + `sampling_params`) rather than chat completions, so it needs its own translation layer.

Anthropic, Gemini, Bedrock, and GCP Vertex use different wire formats and are out of scope here. Anthropic tool calling and a related Anthropic multimodal image-shape bug fix ship as stacked follow-ups (see Related issues below).

## Motivation

A previous attempt at remote tool calling landed in commit [`e4f7054`](https://github.com/oumi-ai/oumi/commit/e4f7054c7c2a359e48095e7b6a780689865774e1) on `oelachqar/infer-tool-calling`. Two of its three design choices conflict with where the codebase landed after PR #2397, so we keep one and replace the other two:

- `e4f7054` put tools on `GenerationParams.tools`. PR #2397 puts them on `Conversation.tools`, matching `tokenizer.apply_chat_template(messages, tools=...)` and letting the vLLM engine group conversations by identical tool definitions. We keep `Conversation.tools`.
- `e4f7054` hand-rolled OpenAI message-list construction inside `OpenAIInferenceEngine`. We extend `RemoteInferenceEngine._convert_conversation_to_api_input` once and reuse the existing `create_list_of_message_json_dicts` helper, which already forwards `tool_calls` and `tool_call_id`.
- `e4f7054` introduced typed Pydantic classes in `src/oumi/core/types/tool_call.py`. The current branch already adopts that pattern (commit `de351040`), so we use it. We dump typed objects to JSON via `model_dump(mode="json", exclude_none=True)` at API boundaries and let Pydantic validate response-side tool calls into typed `ToolCall` instances.

## What changed

### `GenerationParams`

- Added `tool_choice: Any | None = None`. Accepts the OpenAI value space (`"none"`, `"auto"`, `"required"`, or a `{"type": "function", "function": {"name": "..."}}` dict). Engines targeting non-OpenAI providers translate.
- Added `parallel_tool_calls: bool = True`. Default matches the OpenAI default; only sent on the request when explicitly set to `False`.
- `tool_choice` is annotated `Any` because omegaconf does not support unions of containers. Same workaround as `GuidedDecodingParams.json`.

### `RemoteInferenceEngine` (base class)

- Request side: replaces the inline message-list comprehension with `create_list_of_message_json_dicts(group_adjacent_same_role_turns=False)`. That helper already forwards `tool_calls` and `tool_call_id` and emits `content: null` for tool-only assistant turns.
- When `Conversation.tools` is non-empty, dumps each `ToolDefinition` to its OpenAI-format dict and adds it to the request.
- When `tool_choice` is set, forwards it verbatim. When `parallel_tool_calls` is `False`, forwards it (otherwise omits to keep the request minimal).
- Response side: reads `message.tool_calls` and lets Pydantic coerce into `list[ToolCall]`. Propagates `Conversation.tools` onto the result.
- `get_supported_params` extended with `tool_choice` and `parallel_tool_calls`.

`OpenAIInferenceEngine` requires no code change. Its reasoning-model override mutates `temperature` and `logit_bias` and then calls `super()`, so the base-class change flows through.

### Examples

- `configs/apis/openai/infer_gpt_4o_tool_calling.yaml`

### Tests

- 5 new tests on `RemoteInferenceEngine`: request body shape (tools, tool_choice, parallel_tool_calls), assistant tool-call round-trip, response parsing into typed `Message.tool_calls`.
- 1 new test on `OpenAIInferenceEngine` confirming the reasoning-model temperature override does not drop tool fields.
- Existing tests inspecting the message wire shape are updated for the new primitive-string content emitted by the helper.

## Out of scope

Anthropic, Gemini, Bedrock, GCP Vertex, SGLang custom protocols, tool streaming, batch-API tool-calling tests (the OpenAI batch path inherits the new request shape).

## Related issues

Stacks on top of #2397. The Anthropic side ships as two stacked follow-ups:

- Anthropic multimodal image block-shape bug fix (will be opened next, stacked on this PR).
- Anthropic tool calling (will be opened after, stacked on the image-fix PR).

Not closing a specific tracked issue.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.