### PR TITLE
Update transformers to 5.7.0

### DIFF
--- a/configs/recipes/smollm/tuning/135m/tune.yaml
+++ b/configs/recipes/smollm/tuning/135m/tune.yaml
@@ -33,7 +33,7 @@ tuning:
     # Categorical (list format)
     optimizer:
       type: categorical
-      choices: ["adamw_torch", "sgd", "adafactor"]
+      choices: [ "adamw_torch", "sgd", "adafactor" ]
 
     # Log-uniform float
     learning_rate:
@@ -63,7 +63,7 @@ tuning:
   fixed_peft_params:
     q_lora: false
 
-  evaluation_metrics: ["eval_loss", "eval_mean_token_accuracy"]
-  evaluation_direction: ["minimize", "maximize"]
+  evaluation_metrics: [ "eval_loss", "eval_mean_token_accuracy" ]
+  evaluation_direction: [ "minimize", "maximize" ]
   tuner_type: OPTUNA
   tuner_sampler: "RandomSampler"

--- a/configs/recipes/smollm/tuning/135m/tune.yaml
+++ b/configs/recipes/smollm/tuning/135m/tune.yaml
@@ -63,7 +63,11 @@ tuning:
   fixed_peft_params:
     q_lora: false
 
-  evaluation_metrics: [ "eval_loss", "eval_mean_token_accuracy" ]
-  evaluation_direction: [ "minimize", "maximize" ]
+  # eval_mean_token_accuracy is logged by TRL during eval but its log() override
+  # only writes to external loggers (wandb/tensorboard); the metric is not
+  # propagated through Trainer.evaluate()'s return dict, so the tuner can't read
+  # it. Restore once trl#3694 / similar lands.
+  evaluation_metrics: [ "eval_loss" ]
+  evaluation_direction: [ "minimize" ]
   tuner_type: OPTUNA
   tuner_sampler: "RandomSampler"

--- a/configs/recipes/smollm/tuning/135m/tune.yaml
+++ b/configs/recipes/smollm/tuning/135m/tune.yaml
@@ -63,10 +63,10 @@ tuning:
   fixed_peft_params:
     q_lora: false
 
-  # eval_mean_token_accuracy is logged by TRL during eval but its log() override
-  # only writes to external loggers (wandb/tensorboard); the metric is not
-  # propagated through Trainer.evaluate()'s return dict, so the tuner can't read
-  # it. Restore once trl#3694 / similar lands.
+  # TRL>=0.27 regressed SFTTrainer.log() from `logs.update(metrics)` to
+  # `logs = {**logs, **metrics}`, so the metrics no longer flow back through
+  # Trainer.evaluate()'s returned dict (only into external loggers). Restore
+  # eval_mean_token_accuracy once the TRL fix lands. See trl@4cb07d36.
   evaluation_metrics: [ "eval_loss" ]
   evaluation_direction: [ "minimize" ]
   tuner_type: OPTUNA

--- a/configs/recipes/vision/llava_7b/sft/train.yaml
+++ b/configs/recipes/vision/llava_7b/sft/train.yaml
@@ -71,7 +71,10 @@ training:
   gradient_checkpointing_kwargs:
     # Reentrant docs: https://pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.checkpoint
     use_reentrant: False
-  ddp_find_unused_parameters: False
+  # transformers 5.x's Llava forward leaves a contiguous block of params
+  # (~373-390) without grad in some training steps, so DDP needs to traverse
+  # the autograd graph to detect them. Small per-step overhead.
+  ddp_find_unused_parameters: True
   empty_device_cache_steps: 2
   compile: False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ oumi = ["LICENSE", "README.md", "*.jinja"]
 # by default.
 [tool.uv]
 prerelease = "allow"
-override-dependencies = ["transformers>=5.5,<5.6"]
+override-dependencies = ["transformers>=5.5,<5.8"]
 
 [project]
 name = "oumi"
@@ -77,7 +77,7 @@ dependencies = [
     "torchao>=0.12,<0.16",     # Used by transformers
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
-    "transformers>=4.57,<5.7",
+    "transformers>=4.57,<5.8",
     "trl>=0.24,<1.4",
     "typer<0.24.2",             # Used by CLI. Pinned due to sphinxcontrib-typer compatibility. OPE-1806
     "typing_extensions",        # Backports of typing updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ docs = [
 # Useful dependencies when running on GPU
 gpu = [
     "liger-kernel>=0.6,<0.8",
-    "npyproject.tomlidia-ml-py>=13.580,<13.596",
+    "nvidia-ml-py>=13.580,<13.596",
     "bitsandbytes>=0.47,<0.50",     # Used for QLora, and PagedAdam implementation
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "tensorboard>=2.20,<2.21", # Optional, for monitoring training
     "tiktoken>=0.7,<1.0",
     "torch>=2.6,<2.11.0",      # vllm only supports up to torch==2.7
-    "torchao>=0.12,<0.16",     # Used by transformers
+    "torchao>=0.12,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
     "transformers>=4.57,<5.8",
@@ -121,7 +121,7 @@ docs = [
 # Useful dependencies when running on GPU
 gpu = [
     "liger-kernel>=0.6,<0.8",
-    "nvidia-ml-py>=13.580,<13.596",
+    "npyproject.tomlidia-ml-py>=13.580,<13.596",
     "bitsandbytes>=0.47,<0.50",     # Used for QLora, and PagedAdam implementation
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.

--- a/src/oumi/builders/training.py
+++ b/src/oumi/builders/training.py
@@ -73,14 +73,7 @@ def build_trainer(
             hf_args = training_args.to_hf(training_config)
             if verbose and is_world_process_zero():
                 logger.info(pformat(hf_args))
-            hf_trainer = cls(*args, **kwargs, args=hf_args)
-            if cls is trl.SFTTrainer:
-                # PEFT-wrapped models cause transformers' Trainer to set
-                # can_return_loss=False, which makes TRL's SFTTrainer skip its
-                # eval-time _metrics flush (eval_loss, eval_mean_token_accuracy).
-                # See https://github.com/huggingface/trl/issues/3694.
-                hf_trainer.can_return_loss = True
-            trainer = HuggingFaceTrainer(hf_trainer, processor)
+            trainer = HuggingFaceTrainer(cls(*args, **kwargs, args=hf_args), processor)
             if callbacks:
                 # TODO(OPE-250): Define generalizable callback abstraction
                 # Incredibly ugly, but this is the only way to add callbacks that add

--- a/src/oumi/builders/training.py
+++ b/src/oumi/builders/training.py
@@ -73,7 +73,14 @@ def build_trainer(
             hf_args = training_args.to_hf(training_config)
             if verbose and is_world_process_zero():
                 logger.info(pformat(hf_args))
-            trainer = HuggingFaceTrainer(cls(*args, **kwargs, args=hf_args), processor)
+            hf_trainer = cls(*args, **kwargs, args=hf_args)
+            if cls is trl.SFTTrainer:
+                # PEFT-wrapped models cause transformers' Trainer to set
+                # can_return_loss=False, which makes TRL's SFTTrainer skip its
+                # eval-time _metrics flush (eval_loss, eval_mean_token_accuracy).
+                # See https://github.com/huggingface/trl/issues/3694.
+                hf_trainer.can_return_loss = True
+            trainer = HuggingFaceTrainer(hf_trainer, processor)
             if callbacks:
                 # TODO(OPE-250): Define generalizable callback abstraction
                 # Incredibly ugly, but this is the only way to add callbacks that add

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -269,6 +269,16 @@ def _create_qwen2_vl_vlm_config() -> InternalModelConfig:
             for feature_name in ("image_grid_thw",)
         }
     )
+    # transformers>=5 ships a Qwen2-VL processor that emits mm_token_type_ids
+    # with a leading batch dimension; strip it for per-example feature
+    # generation so the collator stacks shape [seq_len] -> [B, seq_len]
+    # rather than [1, seq_len] -> [B, 1, seq_len].
+    config.model_input_features["mm_token_type_ids"] = InternalFeatureSpec(
+        name="mm_token_type_ids",
+        required=False,
+        variable_shape=False,
+        first_dim_action=InternalFeatureFirstDimAction.DROP_IF_DUMMY,
+    )
     config.processor_kwargs.update(
         {
             "min_pixels": 256 * 28 * 28,


### PR DESCRIPTION
- Bumped transformers ceiling to include 5.7.0, and torchao to include 0.16.
- Removed `eval_mean_token_accuracy` metric from `configs/recipes/smollm/tuning/135m/tune.yaml`. There's now a bug in this metric being surfaced by transformers/trl.
- Updated Qwen2 VL processor
- Enabled ddp_find_unused_parameters for llava

Ran integration tests