### PR TITLE
deps: bump torchao lower bound to >=0.16 for peft>=0.19 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "tensorboard>=2.20,<2.21", # Optional, for monitoring training
     "tiktoken>=0.7,<1.0",
     "torch>=2.6,<2.11.0",      # vllm only supports up to torch==2.7
-    "torchao>=0.12,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
+    "torchao>=0.16,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
     "transformers>=4.57,<5.8",


### PR DESCRIPTION
## Summary
- Tighten `torchao` lower bound from `>=0.12` to `>=0.16` so resolvers can't pick a version that fails peft 0.19's runtime check.

## Reason
- `peft>=0.17,<0.20` allows peft 0.19, which calls `is_torchao_available()` and raises `ImportError` when `torchao<0.16`.
- The previous `>=0.12,<0.17` constraint let uv resolve to `torchao==0.15.0`
- The comment above the line already documented the requirement; this PR enforces it.

## Test plan
- [ ] Bump `OUMI_REPO_COMMIT_HASH` in `oumi-ai/api` once merged, redeploy worker, retry a LoRA training run.

Fixes oumi-ai/api LoRA training failures tracked in [LOU-1717](https://linear.app/oumi/issue/LOU-1717).