### PR TITLE
[Synth Env] Phase 1: Stateless tool simulation via batched step()

### DIFF
--- a/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+++ b/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
@@ -21,11 +21,15 @@
 #   - Set OPENAI_API_KEY in the environment.
 #
 # Usage:
-#   oumi synth -c configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+#   oumi synth -c oumi://configs/examples/synthesis/mcp_docs_lookup_synth.yaml
 #
 # See Also:
-#   - oumi.environments.synthetic_environment.SyntheticEnvironment
-#   - oumi.core.configs.EnvironmentConfig
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/synth.html
+#   - Config class: oumi.core.configs.SynthesisConfig
+#   - Params class: oumi.core.configs.params.synthesis_params.GeneralSynthesisParams
+#   - Env config class: oumi.core.configs.environment_config.EnvironmentConfig
+#   - SyntheticEnvironment: oumi.environments.synthetic_environment.SyntheticEnvironment
+#   - Other synthesis configs: configs/**/*synth.yaml
 
 strategy: GENERAL
 num_samples: 150

--- a/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+++ b/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
@@ -1,7 +1,13 @@
 # MCP-style Documentation Lookup — Stateless Synthetic Tool-Use Synthesis
 #
 # Generates multi-turn conversations between a developer asking how to use a
-# library and an assistant that answers via three MCP-style stateless tools:
+# library and an assistant that answers via three MCP-style stateless tools.
+# The tool set is modeled on Context7 (https://context7.com/), a multi-library
+# documentation MCP: developers reference libraries by free-form name, the
+# server resolves each name to a canonical `library_id`, and docs/examples
+# are then queried per resolved id. `resolve_library_id` is the entry point
+# that makes the multi-library framing work — without it the assistant would
+# have to invent or guess ids.
 #
 #   1. `resolve_library_id` — turns a library NAME (e.g. "react") into a
 #      canonical `library_id` (e.g. "/facebook/react").

--- a/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+++ b/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
@@ -1,0 +1,358 @@
+# MCP-style Documentation Lookup — Stateless Synthetic Tool-Use Synthesis
+#
+# Generates multi-turn conversations between a developer asking how to use a
+# library and an assistant that answers via three MCP-style stateless tools:
+#
+#   1. `resolve_library_id` — turns a library NAME (e.g. "react") into a
+#      canonical `library_id` (e.g. "/facebook/react").
+#   2. `query_docs`         — returns documentation snippets for a topic
+#      under a resolved `library_id`.
+#   3. `search_examples`    — returns runnable example code for a topic
+#      under a resolved `library_id`.
+#
+# This config exercises the new SyntheticEnvironment: tool outputs are
+# *simulated* by the same LLM that drives planner/assistant — there are no
+# pre-declared deterministic outputs. Each tool defines an `output_schema`
+# that we use as guided-decoding JSON schema, so the simulator must produce
+# valid structured output. Because the env is stateless (no `state_params`),
+# results are cached by (tool_id, arguments).
+#
+# Requirements:
+#   - Set OPENAI_API_KEY in the environment.
+#
+# Usage:
+#   oumi synth -c configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+#
+# See Also:
+#   - oumi.environments.synthetic_environment.SyntheticEnvironment
+#   - oumi.core.configs.EnvironmentConfig
+
+strategy: GENERAL
+num_samples: 150
+output_path: mcp_docs_lookup_dataset.jsonl
+
+environment_config:
+  environments:
+    - id: docs_lookup
+      env_type: synthetic
+      name: Docs Lookup
+      description: MCP-style documentation lookup tools (LLM-simulated).
+      env_kwargs:
+        system_prompt: |
+          You are simulating an MCP-style documentation server that resolves
+          library names to canonical IDs and returns documentation snippets
+          and example code. Every response MUST be a JSON object that exactly
+          matches the requested tool's output_schema. Do not include prose,
+          markdown, or commentary outside the JSON. Be plausible and concise:
+          a few snippets / examples per call, real-feeling library IDs (use
+          `/<owner>/<repo>` style for GitHub-hosted libraries), and code
+          that would actually compile/run.
+        cache_by_input: true
+      tools:
+        - id: resolve_library_id
+          name: Resolve Library ID
+          description: >-
+            Resolve a free-form library or framework name (e.g. "react",
+            "next.js", "react query") into a canonical `library_id` string
+            (e.g. "/facebook/react"). When the name is ambiguous, return up
+            to 3 plausible candidates with short descriptions.
+          parameters:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Library or framework name as the developer would say it.
+            required:
+              - name
+          output_schema:
+            type: object
+            properties:
+              library_id:
+                type: string
+                description: Canonical id of the best match (e.g. "/facebook/react").
+              candidates:
+                type: array
+                description: Other plausible matches.
+                items:
+                  type: object
+                  properties:
+                    library_id:
+                      type: string
+                    description:
+                      type: string
+                  required: [library_id, description]
+            required: [library_id, candidates]
+
+        - id: query_docs
+          name: Query Docs
+          description: >-
+            Return up to 5 documentation snippets matching `query` for the
+            given `library_id`. Each snippet has a title, a short prose
+            description, and an optional code excerpt.
+          parameters:
+            type: object
+            properties:
+              library_id:
+                type: string
+                description: Canonical library id from `resolve_library_id`.
+              query:
+                type: string
+                description: What the developer is trying to find out.
+            required:
+              - library_id
+              - query
+          output_schema:
+            type: object
+            properties:
+              snippets:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    code:
+                      type: string
+                  required: [title, description]
+            required: [snippets]
+
+        - id: search_examples
+          name: Search Examples
+          description: >-
+            Return up to 4 runnable example snippets demonstrating `topic`
+            under the given `library_id`. Each example has a one-line
+            description and a code block.
+          parameters:
+            type: object
+            properties:
+              library_id:
+                type: string
+                description: Canonical library id from `resolve_library_id`.
+              topic:
+                type: string
+                description: The technique or feature to demonstrate.
+            required:
+              - library_id
+              - topic
+          output_schema:
+            type: object
+            properties:
+              examples:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                    code:
+                      type: string
+                  required: [description, code]
+            required: [examples]
+
+strategy_params:
+  sampled_attributes:
+    - id: developer_experience
+      name: Developer Experience
+      description: How experienced the developer is
+      possible_values:
+        - id: beginner
+          name: Beginner
+          description: New to programming or new to this language; asks fundamental questions
+          sample_rate: 0.25
+        - id: intermediate
+          name: Intermediate
+          description: Comfortable with the language; asks about specific APIs or patterns
+          sample_rate: 0.45
+        - id: senior
+          name: Senior Engineer
+          description: Deep experience; asks targeted questions about edge cases, perf, internals
+          sample_rate: 0.20
+        - id: ml_engineer
+          name: ML/AI Engineer
+          description: Domain-specialized; asks about training loops, distributed setup, GPU usage
+          sample_rate: 0.10
+
+    - id: query_intent
+      name: Query Intent
+      description: What the developer wants out of this conversation
+      possible_values:
+        - id: getting_started
+          name: Getting Started
+          description: New to a library; wants minimal setup + hello-world snippet
+        - id: api_reference
+          name: API Reference Lookup
+          description: Knows the library; needs the exact signature / config of one specific function
+        - id: example_request
+          name: Example Code Request
+          description: Wants a concrete code example of a specific feature or pattern
+        - id: ambiguous_name
+          name: Ambiguous Library Name
+          description: References a library by an ambiguous nickname; needs disambiguation first
+        - id: comparison
+          name: Library Comparison
+          description: Mentions two libraries and wants to know how they relate or differ on a topic
+        - id: migration
+          name: Migration Question
+          description: Migrating between versions / libraries; needs the new equivalent of an old API
+        - id: debugging
+          name: Debugging Lookup
+          description: Has an error or unexpected behavior; wants to find the doc page that explains it
+
+    - id: tone
+      name: Developer Tone
+      description: The tone the developer brings to the conversation
+      possible_values:
+        - id: focused
+          name: Focused
+          description: Direct, to-the-point; no small talk
+        - id: chatty
+          name: Chatty
+          description: Adds context about their project, mentions what they tried
+        - id: rushed
+          name: Rushed
+          description: Short messages; wants the answer in one shot
+        - id: skeptical
+          name: Skeptical
+          description: Doubts the answer; asks follow-ups, wants source links
+        - id: stuck
+          name: Stuck
+          description: Has tried several things; mildly frustrated, wants progress
+
+  generated_attributes:
+    - id: developer_name
+      instruction_messages:
+        - role: SYSTEM
+          content: |
+            Generate a realistic first name only. Output just the name, nothing else.
+        - role: USER
+          content: |
+            Generate a common developer first name.
+
+  multiturn_attributes:
+    - id: docs_lookup_conversation
+      min_turns: 2
+      max_turns: 5
+      available_environments:
+        - docs_lookup
+      available_tools:
+        - resolve_library_id
+        - query_docs
+        - search_examples
+      max_consecutive_tool_turns: 4
+
+      conversation_planner: |
+        The developer's intent is "{query_intent.name}":
+        {query_intent.description}
+
+        Plan turn instructions according to the intent:
+        - Whenever the developer mentions a library by NAME, the assistant
+          MUST call `resolve_library_id` first to obtain the canonical
+          `library_id` before any `query_docs` / `search_examples` call.
+          Never invent a library_id.
+        - For "Ambiguous Library Name": expect `resolve_library_id` to
+          return multiple candidates. The assistant should ask a brief
+          clarifying question and resolve in a later turn.
+        - For "Example Code Request": chain
+          `resolve_library_id` → `search_examples`.
+        - For "API Reference Lookup", "Getting Started", "Debugging
+          Lookup": chain `resolve_library_id` → `query_docs` (and
+          optionally a follow-up `query_docs` for a sub-topic).
+        - For "Library Comparison": resolve BOTH library names in one
+          assistant turn, then `query_docs` against each.
+        - For "Migration Question": `resolve_library_id` (target lib) →
+          `query_docs` for the new equivalent.
+
+        Use action verbs ("call `resolve_library_id` for ...", "call
+        `query_docs` with library_id and ...") rather than soft phrasing.
+
+      role_instruction_messages:
+        USER: |
+          You are {developer_name}, a {developer_experience.name} developer
+          asking a documentation assistant for help.
+
+          Your background: {developer_experience.description}
+          Your tone: {tone.name} — {tone.description}
+          What you want: {query_intent.description}
+
+          Guidelines:
+          - You only know libraries by NAME (e.g. "react", "next.js",
+            "tensorflow"). You do NOT know canonical library IDs (the
+            "/facebook/react" form). Always refer to libraries by name.
+          - You have NO access to documentation yourself — only the
+            assistant does. Don't pretend to know API signatures, config
+            options, or behavior until the assistant has shared them.
+          - Keep messages natural and matched to your tone. Focused/rushed
+            developers stay terse; chatty ones add project context;
+            skeptical ones push back; stuck ones describe what they tried.
+          - Vary openings: not every conversation starts with "Hi" — many
+            developers paste an error, name a library, or jump straight in.
+          - Do not break character or reference the simulation.
+
+          If this is your first message, open in whatever way fits your
+          tone, then state what you want.
+
+          Output only your message, nothing else.
+
+        ASSISTANT: |
+          You are DocBot, a documentation lookup assistant powered by three
+          tools:
+
+          1. `resolve_library_id(name)` — turns a library NAME into a
+             canonical `library_id`. May return multiple `candidates` if
+             the name is ambiguous.
+          2. `query_docs(library_id, query)` — returns documentation
+             snippets for a topic under a resolved library.
+          3. `search_examples(library_id, topic)` — returns runnable
+             example code for a topic under a resolved library.
+
+          Standard flows:
+          - User mentions a library by name → ALWAYS call
+            `resolve_library_id` first; never invent or guess a
+            `library_id`.
+          - User wants explanation/setup/API → resolve, then `query_docs`.
+          - User wants concrete code → resolve, then `search_examples`.
+          - User mentions two libraries (comparison/migration) → resolve
+            both in the SAME assistant turn before any `query_docs`.
+          - If `resolve_library_id` returns ambiguous `candidates`, ask
+            the user a short clarifying question and resolve again in a
+            later turn — do NOT guess.
+
+          Rules:
+          - ALWAYS use the tools for any concrete API, config, or example
+            answer. Never fabricate function names, signatures, options,
+            or version numbers.
+          - Quote tool results when you summarize — don't paraphrase a
+            snippet's `code` field; copy it verbatim into a fenced code
+            block.
+          - When the user asks a follow-up that doesn't need new info,
+            answer directly without re-calling tools.
+          - Keep responses tight: one short paragraph + relevant code if
+            applicable. Long flat documentation dumps are bad UX.
+
+          Follow the plan's direction for this turn. Output only your
+          response.
+
+      output_system_prompt: |
+        You are DocBot, a documentation lookup assistant. You have three
+        tools: `resolve_library_id`, `query_docs`, `search_examples`.
+        Always resolve a library NAME to its canonical `library_id` before
+        querying docs or examples for it. Quote tool results verbatim
+        for code; never invent function signatures or options.
+
+  passthrough_attributes:
+    - docs_lookup_conversation
+    - docs_lookup_conversation_plan
+
+inference_config:
+  model:
+    model_name: gpt-4o-mini
+  engine: OPENAI
+  generation:
+    max_new_tokens: 2048
+    temperature: 0.7
+    top_p: 0.9
+  remote_params:
+    num_workers: 30
+    politeness_policy: 60

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -29,8 +29,13 @@ from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
     MultiTurnAttribute,
 )
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolLookupError,
+    ToolParams,
+)
 from oumi.core.synthesis.attribute_formatter import AttributeFormatter
+from oumi.core.synthesis.tool_router import ToolRouter
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
     Conversation,
@@ -94,20 +99,17 @@ class ConversationSynthesizer:
                 f"not support it. Use one of: {supported}."
             )
 
-        self._tool_dispatch: dict[str, BaseEnvironment] = {}
+        self._router: ToolRouter | None = None
         if self._environment_config is not None:
-            tool_env_map = self._environment_config.tool_environment_map
-            reachable_env_ids = set(tool_env_map.values())
-            envs_by_id: dict[str, BaseEnvironment] = {}
-            for env_params in self._environment_config.environments:
-                if env_params.id not in reachable_env_ids:
-                    continue
-                env = build_environment(env_params)
-                if isinstance(env, SyntheticEnvironment):
-                    env.attach_inference(self._inference_engine, inference_config)
-                envs_by_id[env_params.id] = env
-            for tool_id, env_id in tool_env_map.items():
-                self._tool_dispatch[tool_id] = envs_by_id[env_id]
+            self._router = ToolRouter.from_environment_config(
+                self._environment_config,
+                on_env_built=self._wire_inference,
+            )
+
+    def _wire_inference(self, env: BaseEnvironment) -> None:
+        """Inject the synthesizer's engine + base config into synthetic envs."""
+        if isinstance(env, SyntheticEnvironment):
+            env.attach_inference(self._inference_engine, self._inference_config)
 
     def _resolve_available_tools(
         self, multiturn_attribute: MultiTurnAttribute
@@ -150,43 +152,33 @@ class ConversationSynthesizer:
     def _dispatch_tool_calls(self, tool_calls: list[ToolCall]) -> list[Message]:
         """Dispatch a batch of tool calls; returns one TOOL message per call.
 
-        Calls bound to the same environment are folded into one ``step()``
-        invocation so environments that benefit from batching (e.g. LLM-backed
-        simulators) can amortize backend cost. If a batched ``step()`` raises,
-        the dispatcher falls back to per-call dispatch within that group so
-        individual errors stay attributed.
+        Validates each call via the router, then groups surviving calls by env
+        and routes each group in one batched ``env.step()``. If the batched
+        route raises, falls back to per-call routing so individual errors stay
+        attributed.
         """
+        assert self._router is not None, "tool calls require an environment_config"
         results: list[Message | None] = [None] * len(tool_calls)
         groups: dict[int, list[tuple[int, ToolCall, dict[str, Any]]]] = {}
         for idx, tc in enumerate(tool_calls):
-            name = tc.function.name
             try:
-                arguments = json.loads(tc.function.arguments)
-            except json.JSONDecodeError as exc:
-                results[idx] = self._tool_error(
-                    tc, f"Malformed tool_call arguments: {exc}"
+                arguments = self._router.parse_and_validate_arguments(
+                    tc.function.name, tc.function.arguments
                 )
+            except (ToolArgumentError, ToolLookupError) as exc:
+                results[idx] = self._tool_error(tc, str(exc))
                 continue
-            if not isinstance(arguments, dict):
-                results[idx] = self._tool_error(
-                    tc, "tool_call arguments must be a JSON object"
-                )
-                continue
-            environment = self._tool_dispatch.get(name)
-            if environment is None:
-                results[idx] = self._tool_error(tc, f"Unknown tool '{name}'")
-                continue
-            groups.setdefault(id(environment), []).append((idx, tc, arguments))
+            env = self._router.tool_to_env[tc.function.name]
+            groups.setdefault(id(env), []).append((idx, tc, arguments))
 
         for group in groups.values():
-            environment = self._tool_dispatch[group[0][1].function.name]
             calls = [(tc.function.name, args) for _, tc, args in group]
             try:
-                outputs = environment.step(calls)
+                outputs = self._router.route_batch(calls)
             except Exception:
                 for idx, tc, args in group:
                     try:
-                        [single] = environment.step([(tc.function.name, args)])
+                        [single] = self._router.route_batch([(tc.function.name, args)])
                     except Exception as exc:
                         results[idx] = self._tool_error(
                             tc, f"Tool '{tc.function.name}' raised: {exc}"

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -40,6 +40,7 @@ from oumi.core.types.conversation import (
 from oumi.core.types.tool_call import ToolCall, ToolDefinition, ToolResult
 from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.synthetic_environment import SyntheticEnvironment
 from oumi.environments.utils import describe_grounding_default
 from oumi.inference.native_tool_calling import (
     NATIVE_TOOL_CALLING_ENGINES,
@@ -97,11 +98,14 @@ class ConversationSynthesizer:
         if self._environment_config is not None:
             tool_env_map = self._environment_config.tool_environment_map
             reachable_env_ids = set(tool_env_map.values())
-            envs_by_id: dict[str, BaseEnvironment] = {
-                env_params.id: build_environment(env_params)
-                for env_params in self._environment_config.environments
-                if env_params.id in reachable_env_ids
-            }
+            envs_by_id: dict[str, BaseEnvironment] = {}
+            for env_params in self._environment_config.environments:
+                if env_params.id not in reachable_env_ids:
+                    continue
+                env = build_environment(env_params)
+                if isinstance(env, SyntheticEnvironment):
+                    env.attach_inference(self._inference_engine, inference_config)
+                envs_by_id[env_params.id] = env
             for tool_id, env_id in tool_env_map.items():
                 self._tool_dispatch[tool_id] = envs_by_id[env_id]
 

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -15,6 +15,7 @@
 import dataclasses
 import json
 import random
+from typing import Any
 
 from oumi.builders.environments import build_environment
 from oumi.builders.inference_engines import build_inference_engine
@@ -36,7 +37,7 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
-from oumi.core.types.tool_call import ToolCall, ToolDefinition
+from oumi.core.types.tool_call import ToolCall, ToolDefinition, ToolResult
 from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.utils import describe_grounding_default
@@ -129,24 +130,8 @@ class ConversationSynthesizer:
             return ""
         return msg.content
 
-    def _run_tool_call(self, tool_call: ToolCall) -> Message:
-        """Dispatch a tool call; failures become a TOOL message with an error."""
-        name = tool_call.function.name
-        try:
-            arguments = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError as exc:
-            return self._tool_error(tool_call, f"Malformed tool_call arguments: {exc}")
-        if not isinstance(arguments, dict):
-            return self._tool_error(
-                tool_call, "tool_call arguments must be a JSON object"
-            )
-        environment = self._tool_dispatch.get(name)
-        if environment is None:
-            return self._tool_error(tool_call, f"Unknown tool '{name}'")
-        try:
-            result = environment.step(name, arguments)
-        except Exception as exc:
-            return self._tool_error(tool_call, f"Tool '{name}' raised: {exc}")
+    @staticmethod
+    def _tool_message(tool_call: ToolCall, result: ToolResult) -> Message:
         content = (
             result.output
             if isinstance(result.output, str)
@@ -157,6 +142,59 @@ class ConversationSynthesizer:
             tool_call_id=tool_call.id,
             content=content,
         )
+
+    def _dispatch_tool_calls(self, tool_calls: list[ToolCall]) -> list[Message]:
+        """Dispatch a batch of tool calls; returns one TOOL message per call.
+
+        Calls bound to the same environment are folded into one ``step()``
+        invocation so environments that benefit from batching (e.g. LLM-backed
+        simulators) can amortize backend cost. If a batched ``step()`` raises,
+        the dispatcher falls back to per-call dispatch within that group so
+        individual errors stay attributed.
+        """
+        results: list[Message | None] = [None] * len(tool_calls)
+        groups: dict[int, list[tuple[int, ToolCall, dict[str, Any]]]] = {}
+        for idx, tc in enumerate(tool_calls):
+            name = tc.function.name
+            try:
+                arguments = json.loads(tc.function.arguments)
+            except json.JSONDecodeError as exc:
+                results[idx] = self._tool_error(
+                    tc, f"Malformed tool_call arguments: {exc}"
+                )
+                continue
+            if not isinstance(arguments, dict):
+                results[idx] = self._tool_error(
+                    tc, "tool_call arguments must be a JSON object"
+                )
+                continue
+            environment = self._tool_dispatch.get(name)
+            if environment is None:
+                results[idx] = self._tool_error(tc, f"Unknown tool '{name}'")
+                continue
+            groups.setdefault(id(environment), []).append((idx, tc, arguments))
+
+        for group in groups.values():
+            environment = self._tool_dispatch[group[0][1].function.name]
+            calls = [(tc.function.name, args) for _, tc, args in group]
+            try:
+                outputs = environment.step(calls)
+            except Exception:
+                for idx, tc, args in group:
+                    try:
+                        [single] = environment.step([(tc.function.name, args)])
+                    except Exception as exc:
+                        results[idx] = self._tool_error(
+                            tc, f"Tool '{tc.function.name}' raised: {exc}"
+                        )
+                        continue
+                    results[idx] = self._tool_message(tc, single)
+                continue
+            for (idx, tc, _), out in zip(group, outputs):
+                results[idx] = self._tool_message(tc, out)
+
+        assert all(r is not None for r in results), "every call must produce a message"
+        return results  # type: ignore[return-value]
 
     def _validate_roles(self, multiturn_attribute: MultiTurnAttribute) -> None:
         """Validate that required roles have corresponding personas.
@@ -756,8 +794,9 @@ class ConversationSynthesizer:
                         tool_calls=assistant_msg.tool_calls,
                     )
                 )
-                for tc in assistant_msg.tool_calls:
-                    staging[idx].append(self._run_tool_call(tc))
+                staging[idx].extend(
+                    self._dispatch_tool_calls(list(assistant_msg.tool_calls))
+                )
                 round_count[idx] += 1
             else:
                 staging[idx].append(

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -790,9 +790,7 @@ class ConversationSynthesizer:
                         tool_calls=assistant_msg.tool_calls,
                     )
                 )
-                staging[idx].extend(
-                    self._dispatch_tool_calls(list(assistant_msg.tool_calls))
-                )
+                staging[idx].extend(self._dispatch_tool_calls(assistant_msg.tool_calls))
                 round_count[idx] += 1
             else:
                 staging[idx].append(

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -176,6 +176,11 @@ class ConversationSynthesizer:
             try:
                 outputs = self._router.route_batch(calls)
             except Exception:
+                # On batch failure, re-route each call individually so per-call
+                # errors stay attributed. SyntheticEnvironment's in-batch cache
+                # shields earlier successes from re-inference, but calls past
+                # the failing index re-infer. Acceptable for attribution today;
+                # Phase 2's corrective-retry should replace this fallback.
                 for idx, tc, args in group:
                     try:
                         [single] = self._router.route_batch([(tc.function.name, args)])

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -1,0 +1,121 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Routing layer between LLM tool calls and environment-owned tools."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from oumi.builders.environments import build_environment
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolLookupError,
+    ToolParams,
+)
+from oumi.core.types.tool_call import ToolDefinition, ToolResult
+from oumi.environments.base_environment import BaseEnvironment
+
+
+@dataclass
+class ToolRouter:
+    """Routes LLM tool calls to environment-owned tools."""
+
+    tool_specs: list[ToolDefinition]
+    tools_by_id: dict[str, ToolParams]
+    env_by_id: dict[str, BaseEnvironment]
+    tool_to_env: dict[str, BaseEnvironment]
+
+    @classmethod
+    def from_environment_config(
+        cls,
+        env_config: EnvironmentConfig,
+        on_env_built: Callable[[BaseEnvironment], None] | None = None,
+    ) -> ToolRouter:
+        """Build a router from an env config."""
+        tool_env_map = env_config.tool_environment_map
+        reachable_env_ids = set(tool_env_map.values())
+
+        env_by_id: dict[str, BaseEnvironment] = {}
+        for env_params in env_config.environments:
+            if env_params.id not in reachable_env_ids:
+                continue
+            env = build_environment(env_params)
+            if on_env_built is not None:
+                on_env_built(env)
+            env_by_id[env_params.id] = env
+
+        tools_by_id = {tool.id: tool for tool in env_config.all_tools}
+        tool_to_env = {
+            tool_id: env_by_id[env_id] for tool_id, env_id in tool_env_map.items()
+        }
+        tool_specs = [tool.to_tool_definition() for tool in env_config.all_tools]
+
+        return cls(
+            tool_specs=tool_specs,
+            tools_by_id=tools_by_id,
+            env_by_id=env_by_id,
+            tool_to_env=tool_to_env,
+        )
+
+    def parse_and_validate_arguments(
+        self, tool_id: str, raw_arguments: str
+    ) -> dict[str, Any]:
+        """Parse wire JSON args and validate against the tool's parameters schema."""
+        if tool_id not in self.tools_by_id:
+            raise ToolLookupError(
+                f"Unknown tool '{tool_id}'. Known: {sorted(self.tools_by_id)}"
+            )
+        tool = self.tools_by_id[tool_id]
+        try:
+            parsed = json.loads(raw_arguments or "{}")
+        except json.JSONDecodeError as e:
+            raise ToolArgumentError(
+                f"Tool '{tool_id}' arguments are not valid JSON: {e}"
+            ) from e
+        if not isinstance(parsed, dict):
+            raise ToolArgumentError(
+                f"Tool '{tool_id}' arguments must be a JSON object, got "
+                f"{type(parsed).__name__}."
+            )
+        tool.validate_arguments(parsed)
+        return parsed
+
+    def route_batch(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Dispatch a batch of (tool_id, args) pairs; preserves call order."""
+        if not calls:
+            return []
+
+        groups: dict[int, list[tuple[int, str, dict[str, Any]]]] = {}
+        for idx, (tool_id, args) in enumerate(calls):
+            if tool_id not in self.tool_to_env:
+                raise ToolLookupError(
+                    f"Unknown tool '{tool_id}'. Known: {sorted(self.tool_to_env)}"
+                )
+            env = self.tool_to_env[tool_id]
+            groups.setdefault(id(env), []).append((idx, tool_id, args))
+
+        results: list[ToolResult | None] = [None] * len(calls)
+        for group in groups.values():
+            env = self.tool_to_env[group[0][1]]
+            outputs = env.step([(tid, args) for _, tid, args in group])
+            for (idx, _, _), out in zip(group, outputs):
+                results[idx] = out
+
+        assert all(r is not None for r in results)
+        return results  # type: ignore[return-value]

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -1130,7 +1130,12 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         automatically via ``seek``/``tell``.
         """
         with open(file_path, "rb") as f:
-            response = _requests.put(signed_url, data=f, headers=headers, timeout=600)
+            response = _requests.put(
+                signed_url,
+                data=f,
+                headers=cast(dict[str, str | bytes], headers),
+                timeout=600,
+            )
         if not response.ok:
             logger.error(
                 "GCS upload failed (HTTP %d, %s %s): %s",

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -32,8 +32,8 @@ class BaseEnvironment(ABC):
     tool_params_cls: type[ToolParams] = ToolParams
 
     @abstractmethod
-    def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Execute a tool call within this environment."""
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch of tool calls; returns results in the same order."""
 
     def sample_grounding(
         self,

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -90,14 +90,17 @@ class DeterministicEnvironment(BaseEnvironment):
         self._tool_ids = {tool.id for tool in params.tools}
         self._validate_lookup_table()
 
-    def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Resolve a deterministic tool call to its output.
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Resolve a batch of deterministic tool calls to their outputs.
 
         Raises:
-            ValueError: If ``tool_id`` is not declared in this env's tools list.
+            ValueError: If any ``tool_id`` is not declared in this env's tools list.
             ToolLookupError: If no entry in the env's lookup table matches
-                the provided arguments.
+                the provided arguments for any call.
         """
+        return [self._resolve_one(tool_id, args) for tool_id, args in calls]
+
+    def _resolve_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
         if tool_id not in self._tool_ids:
             raise ValueError(
                 f"Tool '{tool_id}' not found in environment '{self._params.id}'. "

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -17,18 +17,27 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jsonschema
 
+from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.generation_params import GenerationParams
+from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
+from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.registry import register_environment
+from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.utils.str_utils import extract_json
+
+if TYPE_CHECKING:
+    from oumi.core.inference.base_inference_engine import BaseInferenceEngine
 
 
 @dataclass
@@ -89,6 +98,17 @@ class SyntheticEnvironment(BaseEnvironment):
             and kwargs.state_params.initial_state is not None
             else None
         )
+        self._engine: BaseInferenceEngine | None = None
+        self._base_inference_config: InferenceConfig | None = None
+
+    def attach_inference(
+        self,
+        engine: BaseInferenceEngine,
+        base_config: InferenceConfig,
+    ) -> None:
+        """Inject the orchestrator's inference engine + base config."""
+        self._engine = engine
+        self._base_inference_config = base_config
 
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> SyntheticEnvironment:
@@ -144,13 +164,135 @@ class SyntheticEnvironment(BaseEnvironment):
         )
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
-        """Execute a batch of synthetic tool calls."""
+        """Execute synthetic tool calls. Cache-misses batched per tool_id.
+
+        Raises:
+            RuntimeError: If ``attach_inference`` was not called.
+            ValueError: If any tool id is unknown.
+            ToolError: On simulator parse failure or output_schema mismatch.
+        """
+        if not calls:
+            return []
         for tool_id, _ in calls:
             self._lookup_tool(tool_id)
-        raise NotImplementedError("SyntheticEnvironment.step() is not implemented yet.")
+        if self._engine is None or self._base_inference_config is None:
+            raise RuntimeError(
+                "SyntheticEnvironment.step called before attach_inference(). "
+                "Wire the synthesizer's engine via attach_inference(engine, "
+                "base_config) before invoking step()."
+            )
 
-    def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Unreachable — ``step`` is overridden directly for batching."""
-        raise NotImplementedError(
-            "SyntheticEnvironment._step_one() is not implemented; use step()."
+        results: list[ToolResult | None] = [None] * len(calls)
+        misses: list[tuple[int, str, dict[str, Any]]] = []
+        for i, (tool_id, args) in enumerate(calls):
+            cached = self._resolve_cached(tool_id, args)
+            if cached is not None:
+                results[i] = cached
+            else:
+                misses.append((i, tool_id, args))
+
+        groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+        for i, tool_id, args in misses:
+            groups.setdefault(tool_id, []).append((i, args))
+
+        for tool_id, group in groups.items():
+            tool = self._lookup_tool(tool_id)
+            convs = [self._build_call_conv(tool, args) for _, args in group]
+            inferred = self._engine.infer(convs, self._simulator_inference_config(tool))
+            if len(inferred) != len(group):
+                raise RuntimeError(
+                    f"Simulator returned {len(inferred)} responses for "
+                    f"{len(group)} calls to '{tool_id}'."
+                )
+            for (idx, args), conv in zip(group, inferred):
+                raw = self._extract_text(conv)
+                result = self._parse_and_validate(raw, tool)
+                self._cache_result(tool_id, args, result)
+                results[idx] = result
+
+        assert all(r is not None for r in results), (
+            "every call must produce a ToolResult"
         )
+        return results  # type: ignore[return-value]
+
+    def _build_simulator_system_prompt(self, tool: ToolParams) -> str:
+        """Compose the simulator system prompt: env persona + tool schema."""
+        return (
+            f"{self._kwargs.system_prompt}\n\n"
+            f"You are simulating the `{tool.id}` tool. Respond ONLY with a "
+            f"JSON object matching the tool's output schema. Do NOT include "
+            f"explanations, markdown, or surrounding prose.\n\n"
+            f"Tool schema:\n{json.dumps(tool.to_llm_schema(), indent=2)}"
+        )
+
+    def _build_call_conv(
+        self, tool: ToolParams, arguments: dict[str, Any]
+    ) -> Conversation:
+        """Build the simulator conversation for one tool call."""
+        user_payload = json.dumps(
+            {"tool": tool.id, "arguments": arguments}, sort_keys=True
+        )
+        return Conversation(
+            messages=[
+                Message(
+                    role=Role.SYSTEM,
+                    content=self._build_simulator_system_prompt(tool),
+                ),
+                Message(role=Role.USER, content=user_payload),
+            ]
+        )
+
+    def _simulator_inference_config(self, tool: ToolParams) -> InferenceConfig:
+        """Overlay guided decoding for the tool's output_schema onto base_config.
+
+        Tools without ``output_schema`` get the permissive ``{"type": "object"}``
+        constraint. Mirrors ``ConversationSynthesizer._planner_inference_config``.
+        """
+        assert self._base_inference_config is not None
+        schema = tool.output_schema or {"type": "object"}
+        base_gen = self._base_inference_config.generation
+        if isinstance(base_gen, GenerationParams):
+            sim_gen = dataclasses.replace(
+                base_gen, guided_decoding=GuidedDecodingParams(json=schema)
+            )
+        else:
+            sim_gen = GenerationParams(
+                guided_decoding=GuidedDecodingParams(json=schema)
+            )
+        return dataclasses.replace(self._base_inference_config, generation=sim_gen)
+
+    @staticmethod
+    def _extract_text(conv: Conversation) -> str:
+        """Pull the simulator's text response from an inferred conversation."""
+        if not conv.messages:
+            return ""
+        content = conv.messages[-1].content
+        return content.strip() if isinstance(content, str) else ""
+
+    @staticmethod
+    def _parse_and_validate(raw: str, tool: ToolParams) -> ToolResult:
+        """Parse simulator output and validate against ``tool.output_schema``."""
+        if not raw:
+            raise ToolError(f"Simulator returned empty response for '{tool.id}'.")
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            extracted = extract_json(raw, expected_type=dict)
+            if extracted is None:
+                raise ToolError(
+                    f"Simulator output for '{tool.id}' is not valid JSON: {raw[:200]!r}"
+                ) from None
+            parsed = extracted
+        if not isinstance(parsed, dict):
+            raise ToolError(
+                f"Simulator output for '{tool.id}' must be a JSON object, "
+                f"got {type(parsed).__name__}."
+            )
+        if tool.output_schema is not None:
+            try:
+                jsonschema.validate(parsed, tool.output_schema)
+            except jsonschema.ValidationError as e:
+                raise ToolError(
+                    f"Simulator output for '{tool.id}' failed schema validation: {e}"
+                ) from e
+        return ToolResult(output=parsed)

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -27,7 +27,6 @@ import jsonschema
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.registry import register_environment
@@ -250,15 +249,10 @@ class SyntheticEnvironment(BaseEnvironment):
         """
         assert self._base_inference_config is not None
         schema = tool.output_schema or {"type": "object"}
-        base_gen = self._base_inference_config.generation
-        if isinstance(base_gen, GenerationParams):
-            sim_gen = dataclasses.replace(
-                base_gen, guided_decoding=GuidedDecodingParams(json=schema)
-            )
-        else:
-            sim_gen = GenerationParams(
-                guided_decoding=GuidedDecodingParams(json=schema)
-            )
+        sim_gen = dataclasses.replace(
+            self._base_inference_config.generation,
+            guided_decoding=GuidedDecodingParams(json=schema),
+        )
         return dataclasses.replace(self._base_inference_config, generation=sim_gen)
 
     @staticmethod

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -257,10 +257,21 @@ class SyntheticEnvironment(BaseEnvironment):
 
     @staticmethod
     def _extract_text(conv: Conversation) -> str:
-        """Pull the simulator's text response from an inferred conversation."""
+        """Pull the simulator's text response from an inferred conversation.
+
+        Returns ``""`` (which forces the ``ToolError`` path in
+        ``_parse_and_validate``) when the last message is not an assistant
+        turn — guards against a passthrough/partial-failure path where the
+        engine returns ``convs`` unchanged and ``messages[-1]`` is still the
+        user payload (itself valid JSON of the form
+        ``{"tool": ..., "arguments": ...}``).
+        """
         if not conv.messages:
             return ""
-        content = conv.messages[-1].content
+        last = conv.messages[-1]
+        if last.role != Role.ASSISTANT:
+            return ""
+        content = last.content
         return content.strip() if isinstance(content, str) else ""
 
     @staticmethod

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -143,7 +143,14 @@ class SyntheticEnvironment(BaseEnvironment):
             f"Available tools: {[tool.id for tool in self._params.tools]}"
         )
 
-    def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Execute a synthetic tool call."""
-        self._lookup_tool(tool_id)
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch of synthetic tool calls."""
+        for tool_id, _ in calls:
+            self._lookup_tool(tool_id)
         raise NotImplementedError("SyntheticEnvironment.step() is not implemented yet.")
+
+    def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        """Unreachable — ``step`` is overridden directly for batching."""
+        raise NotImplementedError(
+            "SyntheticEnvironment._step_one() is not implemented; use step()."
+        )

--- a/tests/unit/builders/test_environments.py
+++ b/tests/unit/builders/test_environments.py
@@ -35,7 +35,7 @@ def test_build_environment_imports_without_explicit_env_package():
         },
     )
     env = build_environment(params)
-    assert env.step("get", {"q": "hi"}) == ToolResult(output={"a": "hi"})
+    assert env.step([("get", {"q": "hi"})]) == [ToolResult(output={"a": "hi"})]
 
 
 def test_build_environment_unknown_env_type_raises():

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1738,16 +1738,16 @@ def _make_env_config(env_id: str, tool_id: str) -> MagicMock:
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_run_tool_call_dispatches_through_env(
+def test_dispatch_tool_calls_routes_through_env(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
 ):
-    """A valid ToolCall produces a Role.TOOL message via env.step()."""
+    """A valid ToolCall produces a Role.TOOL message via batched env.step()."""
     mock_build_inference_engine.return_value = Mock()
 
     fake_env = Mock(spec=BaseEnvironment)
-    fake_env.step.return_value = ToolResult(output={"city": "Paris"})
+    fake_env.step.return_value = [ToolResult(output={"city": "Paris"})]
     mock_build_environment.return_value = fake_env
 
     env_config = _make_env_config("weather", "get_weather")
@@ -1769,17 +1769,60 @@ def test_run_tool_call_dispatches_through_env(
         id="call_1",
         function=FunctionCall(name="get_weather", arguments='{"city": "Paris"}'),
     )
-    msg = synth._run_tool_call(tc)
+    [msg] = synth._dispatch_tool_calls([tc])
 
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "call_1"
     assert msg.content == '{"city": "Paris"}'
-    fake_env.step.assert_called_once_with("get_weather", {"city": "Paris"})
+    fake_env.step.assert_called_once_with([("get_weather", {"city": "Paris"})])
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_run_tool_call_handles_malformed_arguments(
+def test_dispatch_tool_calls_folds_same_env_calls_into_one_step(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+):
+    """Multiple calls to the same env collapse into one batched step()."""
+    mock_build_inference_engine.return_value = Mock()
+
+    fake_env = Mock(spec=BaseEnvironment)
+    fake_env.step.return_value = [
+        ToolResult(output={"i": 0}),
+        ToolResult(output={"i": 1}),
+        ToolResult(output={"i": 2}),
+    ]
+    mock_build_environment.return_value = fake_env
+
+    env_config = _make_env_config("e", "t")
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+
+    tcs = [
+        ToolCall(id=f"c{i}", function=FunctionCall(name="t", arguments=f'{{"i": {i}}}'))
+        for i in range(3)
+    ]
+    msgs = synth._dispatch_tool_calls(tcs)
+    assert [m.tool_call_id for m in msgs] == ["c0", "c1", "c2"]
+    assert [m.content for m in msgs] == ['{"i": 0}', '{"i": 1}', '{"i": 2}']
+    fake_env.step.assert_called_once_with(
+        [("t", {"i": 0}), ("t", {"i": 1}), ("t", {"i": 2})]
+    )
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_dispatch_tool_calls_handles_malformed_arguments(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
@@ -1806,7 +1849,7 @@ def test_run_tool_call_handles_malformed_arguments(
         id="call_x",
         function=FunctionCall(name="t", arguments="{not valid json"),
     )
-    msg = synth._run_tool_call(tc)
+    [msg] = synth._dispatch_tool_calls([tc])
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "call_x"
     assert "Malformed tool_call arguments" in str(msg.content)
@@ -1815,7 +1858,7 @@ def test_run_tool_call_handles_malformed_arguments(
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_run_tool_call_handles_non_dict_arguments(
+def test_dispatch_tool_calls_handles_non_dict_arguments(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
@@ -1841,7 +1884,7 @@ def test_run_tool_call_handles_non_dict_arguments(
     )
 
     tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="[1, 2, 3]"))
-    msg = synth._run_tool_call(tc)
+    [msg] = synth._dispatch_tool_calls([tc])
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "c"
     assert "must be a JSON object" in str(msg.content)
@@ -1850,7 +1893,7 @@ def test_run_tool_call_handles_non_dict_arguments(
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_run_tool_call_handles_unknown_tool(
+def test_dispatch_tool_calls_handles_unknown_tool(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
@@ -1877,7 +1920,7 @@ def test_run_tool_call_handles_unknown_tool(
         id="c",
         function=FunctionCall(name="ghost_tool", arguments="{}"),
     )
-    msg = synth._run_tool_call(tc)
+    [msg] = synth._dispatch_tool_calls([tc])
     assert msg.role == Role.TOOL
     assert "Unknown tool 'ghost_tool'" in str(msg.content)
     fake_env.step.assert_not_called()
@@ -1885,12 +1928,12 @@ def test_run_tool_call_handles_unknown_tool(
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_run_tool_call_handles_env_exception(
+def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
 ):
-    """env.step() raising → error TOOL message, loop stays alive."""
+    """Batched step() raising → fall back to per-call dispatch for attribution."""
     mock_build_inference_engine.return_value = Mock()
     fake_env = Mock(spec=BaseEnvironment)
     fake_env.step.side_effect = RuntimeError("boom")
@@ -1910,7 +1953,7 @@ def test_run_tool_call_handles_env_exception(
     )
 
     tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="{}"))
-    msg = synth._run_tool_call(tc)
+    [msg] = synth._dispatch_tool_calls([tc])
     assert msg.role == Role.TOOL
     assert "Tool 't' raised: boom" in str(msg.content)
 
@@ -1924,7 +1967,9 @@ def test_assistant_turn_loops_on_tool_calls(
 ):
     """Assistant turn loops: tool_calls -> dispatch -> re-infer -> final text."""
     fake_env = Mock(spec=BaseEnvironment)
-    fake_env.step.return_value = ToolResult(output={"answer": 42})
+    fake_env.step.side_effect = lambda calls: [
+        ToolResult(output={"answer": 42}) for _ in calls
+    ]
     mock_build_environment.return_value = fake_env
 
     turn_call_count = {"n": 0}
@@ -2032,7 +2077,7 @@ def test_assistant_turn_caps_at_max_consecutive_tool_turns_then_finalizes(
 ):
     """When max_consecutive_tool_turns is hit, the nudge forces a final text answer."""
     fake_env = Mock(spec=BaseEnvironment)
-    fake_env.step.return_value = ToolResult(output="ok")
+    fake_env.step.side_effect = lambda calls: [ToolResult(output="ok") for _ in calls]
     mock_build_environment.return_value = fake_env
 
     def scripted_infer(prompts, inference_config=None):
@@ -2135,9 +2180,11 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
     mock_build_environment,
     mock_general_synthesis_params,
 ):
-    """A parallel tool_calls batch dispatches in full; cap is on rounds, not calls."""
+    """A parallel tool_calls batch is folded into one step() invocation."""
     fake_env = Mock(spec=BaseEnvironment)
-    fake_env.step.return_value = ToolResult(output={"ok": True})
+    fake_env.step.side_effect = lambda calls: [
+        ToolResult(output={"ok": True}) for _ in calls
+    ]
     mock_build_environment.return_value = fake_env
 
     assistant_turn_count = {"n": 0}
@@ -2220,4 +2267,7 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
             multiturn_attributes=multiturn_attr,
         )
 
-    assert fake_env.step.call_count == 5
+    # 5 parallel tool calls fold into a single batched step() invocation.
+    assert fake_env.step.call_count == 1
+    [call] = fake_env.step.call_args_list
+    assert len(call.args[0]) == 5

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2271,3 +2271,53 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
     assert fake_env.step.call_count == 1
     [call] = fake_env.step.call_args_list
     assert len(call.args[0]) == 5
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesizer_attaches_inference_to_synthetic_env(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+):
+    """SyntheticEnvironments built via _tool_dispatch get attach_inference()."""
+    from oumi.environments.synthetic_environment import SyntheticEnvironment
+
+    mock_engine = Mock()
+    mock_build_inference_engine.return_value = mock_engine
+
+    env_params = EnvironmentParams(
+        id="docs",
+        name="Docs",
+        description="Synthetic docs env",
+        env_type="synthetic",
+        tools=[
+            ToolParams(
+                id="lookup",
+                name="Lookup",
+                description="Look up docs.",
+                parameters={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "required": ["q"],
+                },
+            )
+        ],
+        env_kwargs={"system_prompt": "Simulate the lookup tool."},
+    )
+    env_config = EnvironmentConfig(environments=[env_params])
+
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+
+    env = synth._tool_dispatch["lookup"]
+    assert isinstance(env, SyntheticEnvironment)
+    assert env._engine is mock_engine
+    assert env._base_inference_config is inference_config

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1542,7 +1542,7 @@ def test_init_raises_on_unsupported_engine_with_tools(
         )
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_init_no_error_on_supported_engine_with_tools(
     mock_build_inference_engine,
@@ -1593,7 +1593,7 @@ def test_init_no_error_on_unsupported_engine_without_tools(
     )
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_synthesize_attaches_tools_to_assistant_prompt(
     mock_build_inference_engine,
@@ -1736,7 +1736,7 @@ def _make_env_config(env_id: str, tool_id: str) -> MagicMock:
     return env_config
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_routes_through_env(
     mock_build_inference_engine,
@@ -1777,7 +1777,7 @@ def test_dispatch_tool_calls_routes_through_env(
     fake_env.step.assert_called_once_with([("get_weather", {"city": "Paris"})])
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_folds_same_env_calls_into_one_step(
     mock_build_inference_engine,
@@ -1820,7 +1820,7 @@ def test_dispatch_tool_calls_folds_same_env_calls_into_one_step(
     )
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_handles_malformed_arguments(
     mock_build_inference_engine,
@@ -1852,11 +1852,11 @@ def test_dispatch_tool_calls_handles_malformed_arguments(
     [msg] = synth._dispatch_tool_calls([tc])
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "call_x"
-    assert "Malformed tool_call arguments" in str(msg.content)
+    assert "arguments are not valid JSON" in str(msg.content)
     fake_env.step.assert_not_called()
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_handles_non_dict_arguments(
     mock_build_inference_engine,
@@ -1891,7 +1891,7 @@ def test_dispatch_tool_calls_handles_non_dict_arguments(
     fake_env.step.assert_not_called()
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_handles_unknown_tool(
     mock_build_inference_engine,
@@ -1926,7 +1926,7 @@ def test_dispatch_tool_calls_handles_unknown_tool(
     fake_env.step.assert_not_called()
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
     mock_build_inference_engine,
@@ -1958,7 +1958,7 @@ def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
     assert "Tool 't' raised: boom" in str(msg.content)
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_assistant_turn_loops_on_tool_calls(
     mock_build_inference_engine,
@@ -2068,7 +2068,7 @@ def test_assistant_turn_loops_on_tool_calls(
     assert fake_env.step.call_count == 1
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_assistant_turn_caps_at_max_consecutive_tool_turns_then_finalizes(
     mock_build_inference_engine,
@@ -2173,7 +2173,7 @@ def test_assistant_turn_caps_at_max_consecutive_tool_turns_then_finalizes(
     assert fake_env.step.call_count == 2
 
 
-@patch("oumi.core.synthesis.conversation_synthesizer.build_environment")
+@patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_assistant_turn_dispatches_parallel_batch_unrestricted(
     mock_build_inference_engine,
@@ -2317,7 +2317,8 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
         environment_config=env_config,
     )
 
-    env = synth._tool_dispatch["lookup"]
+    assert synth._router is not None
+    env = synth._router.tool_to_env["lookup"]
     assert isinstance(env, SyntheticEnvironment)
     assert env._engine is mock_engine
     assert env._base_inference_config is inference_config

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -1,0 +1,263 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolLookupError,
+    ToolParams,
+)
+from oumi.core.synthesis.tool_router import ToolRouter
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.deterministic_environment import DeterministicEnvironment
+
+
+def _tool(tool_id: str, schema: dict[str, Any] | None = None) -> ToolParams:
+    return ToolParams(
+        id=tool_id,
+        name=tool_id,
+        description=f"Tool {tool_id}",
+        parameters=schema or {"type": "object"},
+    )
+
+
+def _det_env_params(
+    env_id: str,
+    tools: list[ToolParams],
+    lookup: dict[str, list[dict]] | None = None,
+) -> EnvironmentParams:
+    """Build a DeterministicEnvironment params block with a default identity lookup."""
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"Env {env_id}",
+        env_type="deterministic",
+        tools=tools,
+        env_kwargs={
+            "lookup_table": lookup
+            or {t.id: [{"input": {}, "output": {}}] for t in tools}
+        },
+    )
+
+
+# ---------- from_environment_config ----------
+
+
+def test_from_environment_config_builds_all_fields():
+    tool = _tool("t1")
+    env_config = EnvironmentConfig(environments=[_det_env_params("env1", [tool])])
+
+    router = ToolRouter.from_environment_config(env_config)
+
+    assert set(router.env_by_id) == {"env1"}
+    assert isinstance(router.env_by_id["env1"], DeterministicEnvironment)
+    assert router.tool_to_env["t1"] is router.env_by_id["env1"]
+    assert router.tools_by_id["t1"] is tool
+    assert len(router.tool_specs) == 1
+    assert router.tool_specs[0].function.name == "t1"
+
+
+def test_from_environment_config_invokes_on_env_built_for_each_env():
+    env_config = EnvironmentConfig(
+        environments=[
+            _det_env_params("env1", [_tool("t1")]),
+            _det_env_params("env2", [_tool("t2")]),
+        ]
+    )
+    seen: list[BaseEnvironment] = []
+
+    ToolRouter.from_environment_config(env_config, on_env_built=seen.append)
+
+    assert len(seen) == 2
+    assert all(isinstance(env, DeterministicEnvironment) for env in seen)
+
+
+def test_from_environment_config_routes_tools_across_envs():
+    """Two envs, multiple tools each; every tool resolves to its owning env."""
+    t1, t2, t3 = _tool("t1"), _tool("t2"), _tool("t3")
+    env_config = EnvironmentConfig(
+        environments=[
+            _det_env_params("env1", [t1, t2]),
+            _det_env_params("env2", [t3]),
+        ]
+    )
+
+    router = ToolRouter.from_environment_config(env_config)
+
+    assert router.tool_to_env["t1"] is router.env_by_id["env1"]
+    assert router.tool_to_env["t2"] is router.env_by_id["env1"]
+    assert router.tool_to_env["t3"] is router.env_by_id["env2"]
+    assert {spec.function.name for spec in router.tool_specs} == {"t1", "t2", "t3"}
+
+
+# ---------- parse_and_validate_arguments ----------
+
+
+def _typed_tool(tool_id: str) -> ToolParams:
+    return _tool(
+        tool_id,
+        schema={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+    )
+
+
+def _router_with(*tools: ToolParams) -> ToolRouter:
+    env_config = EnvironmentConfig(environments=[_det_env_params("env1", list(tools))])
+    return ToolRouter.from_environment_config(env_config)
+
+
+def test_parse_and_validate_arguments_happy_path():
+    router = _router_with(_typed_tool("t1"))
+    assert router.parse_and_validate_arguments("t1", '{"q": "hello"}') == {"q": "hello"}
+
+
+def test_parse_and_validate_arguments_unknown_tool_raises_lookup_error():
+    router = _router_with(_typed_tool("t1"))
+    with pytest.raises(ToolLookupError, match="Unknown tool 'ghost'"):
+        router.parse_and_validate_arguments("ghost", '{"q": "x"}')
+
+
+def test_parse_and_validate_arguments_malformed_json_raises_argument_error():
+    router = _router_with(_typed_tool("t1"))
+    with pytest.raises(ToolArgumentError, match="not valid JSON"):
+        router.parse_and_validate_arguments("t1", "{not json")
+
+
+def test_parse_and_validate_arguments_non_dict_raises_argument_error():
+    router = _router_with(_typed_tool("t1"))
+    with pytest.raises(ToolArgumentError, match="must be a JSON object"):
+        router.parse_and_validate_arguments("t1", "[1, 2, 3]")
+
+
+def test_parse_and_validate_arguments_schema_violation_raises_argument_error():
+    """`tool.validate_arguments` rejects payloads missing required fields."""
+    router = _router_with(_typed_tool("t1"))
+    with pytest.raises(ToolArgumentError):
+        router.parse_and_validate_arguments("t1", '{"unrelated": "x"}')
+
+
+def test_parse_and_validate_arguments_empty_string_defaults_to_empty_dict():
+    """Empty raw_arguments → '{}' so tools with no required args pass through."""
+    router = _router_with(_tool("t1", schema={"type": "object"}))
+    assert router.parse_and_validate_arguments("t1", "") == {}
+
+
+# ---------- route_batch ----------
+
+
+def _mock_router(tool_to_env: dict[str, BaseEnvironment]) -> ToolRouter:
+    """Build a ToolRouter directly with mocked envs (skip from_environment_config)."""
+    env_by_id = {f"env_{i}": env for i, env in enumerate(set(tool_to_env.values()))}
+    return ToolRouter(
+        tool_specs=[],
+        tools_by_id={},
+        env_by_id=env_by_id,
+        tool_to_env=tool_to_env,
+    )
+
+
+def test_route_batch_empty_returns_empty():
+    router = _router_with(_tool("t1"))
+    assert router.route_batch([]) == []
+
+
+def test_route_batch_dispatches_through_real_env():
+    """End-to-end: real DeterministicEnvironment lookup via the router."""
+    env_params = _det_env_params(
+        "env1",
+        [_tool("t1")],
+        lookup={"t1": [{"input": {"id": "01"}, "output": {"msg": "ok"}}]},
+    )
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[env_params])
+    )
+
+    [result] = router.route_batch([("t1", {"id": "01"})])
+    assert result == ToolResult(output={"msg": "ok"})
+
+
+def test_route_batch_groups_same_env_into_one_step():
+    fake_env = Mock(spec=BaseEnvironment)
+    fake_env.step.return_value = [
+        ToolResult(output={"i": 0}),
+        ToolResult(output={"i": 1}),
+        ToolResult(output={"i": 2}),
+    ]
+    router = _mock_router({"t1": fake_env, "t2": fake_env})
+
+    results = router.route_batch([("t1", {"i": 0}), ("t2", {"i": 1}), ("t1", {"i": 2})])
+
+    assert [r.output for r in results] == [{"i": 0}, {"i": 1}, {"i": 2}]
+    fake_env.step.assert_called_once_with(
+        [("t1", {"i": 0}), ("t2", {"i": 1}), ("t1", {"i": 2})]
+    )
+
+
+def test_route_batch_splits_across_envs_preserves_order():
+    """Two envs, interleaved calls: one step() per env, output order matches input."""
+    env_a = Mock(spec=BaseEnvironment)
+    env_b = Mock(spec=BaseEnvironment)
+    env_a.step.side_effect = lambda calls: [
+        ToolResult(output={"env": "a", **args}) for _, args in calls
+    ]
+    env_b.step.side_effect = lambda calls: [
+        ToolResult(output={"env": "b", **args}) for _, args in calls
+    ]
+    router = _mock_router({"ta": env_a, "tb": env_b})
+
+    results = router.route_batch(
+        [
+            ("ta", {"i": 0}),  # env_a
+            ("tb", {"i": 1}),  # env_b
+            ("ta", {"i": 2}),  # env_a
+            ("tb", {"i": 3}),  # env_b
+        ]
+    )
+
+    assert [r.output for r in results] == [
+        {"env": "a", "i": 0},
+        {"env": "b", "i": 1},
+        {"env": "a", "i": 2},
+        {"env": "b", "i": 3},
+    ]
+    assert env_a.step.call_count == 1
+    assert env_b.step.call_count == 1
+
+
+def test_route_batch_unknown_tool_raises_before_any_step():
+    """Validation pass surfaces unknown tools before any env.step is invoked."""
+    fake_env = Mock(spec=BaseEnvironment)
+    router = _mock_router({"known": fake_env})
+    with pytest.raises(ToolLookupError, match="Unknown tool 'ghost'"):
+        router.route_batch([("known", {}), ("ghost", {})])
+    fake_env.step.assert_not_called()
+
+
+def test_route_batch_env_exception_propagates():
+    """Fail-fast contract: env.step exceptions are not caught by the router."""
+    fake_env = Mock(spec=BaseEnvironment)
+    fake_env.step.side_effect = RuntimeError("boom")
+    router = _mock_router({"t1": fake_env})
+    with pytest.raises(RuntimeError, match="boom"):
+        router.route_batch([("t1", {})])

--- a/tests/unit/environments/test_base_environment.py
+++ b/tests/unit/environments/test_base_environment.py
@@ -43,8 +43,8 @@ def test_subclass_without_step_cannot_instantiate():
 class _MinimalEnv(BaseEnvironment):
     """Concrete BaseEnvironment subclass that doesn't override grounding hooks."""
 
-    def step(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        return ToolResult(output={})
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        return [ToolResult(output={}) for _ in calls]
 
 
 def test_default_sample_grounding_returns_empty():

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -159,14 +159,23 @@ def test_step_returns_matching_output():
             }
         )
     )
-    assert env.step("tool1", {"id": "01"}) == ToolResult(output={"msg": "pending"})
-    assert env.step("tool1", {"id": "02"}) == ToolResult(output={"msg": "delivered"})
+    assert env.step([("tool1", {"id": "01"})]) == [
+        ToolResult(output={"msg": "pending"})
+    ]
+    assert env.step([("tool1", {"id": "02"})]) == [
+        ToolResult(output={"msg": "delivered"})
+    ]
+    # Batched: order preserved across multiple calls in one invocation.
+    assert env.step([("tool1", {"id": "01"}), ("tool1", {"id": "02"})]) == [
+        ToolResult(output={"msg": "pending"}),
+        ToolResult(output={"msg": "delivered"}),
+    ]
 
 
 def test_step_no_match_raises_with_hint():
     env = DeterministicEnvironment.from_params(_make_params())
     with pytest.raises(ToolLookupError) as excinfo:
-        env.step("tool1", {"id": "99"})
+        env.step([("tool1", {"id": "99"})])
     msg = str(excinfo.value)
     assert "No deterministic output matches" in msg
     assert "tool1" in msg
@@ -180,13 +189,13 @@ def test_step_supports_zero_arg_tool():
             lookup_table={"ping": [ToolLookupEntry(input={}, output={})]},
         )
     )
-    assert env.step("ping", {}) == ToolResult(output={})
+    assert env.step([("ping", {})]) == [ToolResult(output={})]
 
 
 def test_step_unknown_tool_raises():
     env = DeterministicEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
-        env.step("missing", {"id": "01"})
+        env.step([("missing", {"id": "01"})])
 
 
 # --- sample_grounding ---

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -109,10 +109,10 @@ def test_cache_round_trip_stateless_caching():
 def test_step_unknown_tool_raises():
     env = SyntheticEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
-        env.step("missing", {})
+        env.step([("missing", {})])
 
 
 def test_step_known_tool_is_stub():
     env = SyntheticEnvironment.from_params(_make_params())
     with pytest.raises(NotImplementedError, match="not implemented yet"):
-        env.step("answer", {})
+        env.step([("answer", {})])

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock
+
 import pytest
 
+from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.generation_params import GenerationParams
+from oumi.core.configs.params.model_params import ModelParams
+from oumi.core.configs.params.tool_params import ToolError, ToolParams
+from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.synthetic_environment import (
     SyntheticEnvironment,
@@ -112,7 +118,205 @@ def test_step_unknown_tool_raises():
         env.step([("missing", {})])
 
 
-def test_step_known_tool_is_stub():
+def test_step_without_attach_inference_raises():
     env = SyntheticEnvironment.from_params(_make_params())
-    with pytest.raises(NotImplementedError, match="not implemented yet"):
+    with pytest.raises(RuntimeError, match="attach_inference"):
         env.step([("answer", {})])
+
+
+# ---------- step() implementation tests ----------
+
+
+def _typed_tool(**overrides) -> ToolParams:
+    defaults: dict = dict(
+        id="answer",
+        name="Answer",
+        description="Answer FAQs.",
+        parameters={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        },
+    )
+    defaults.update(overrides)
+    return ToolParams(**defaults)
+
+
+def _typed_params() -> EnvironmentParams:
+    return EnvironmentParams(
+        id="faq",
+        name="FAQ",
+        description="FAQ env",
+        env_type="synthetic",
+        tools=[_typed_tool()],
+        env_kwargs={"system_prompt": "Answer FAQs as a JSON tool."},
+    )
+
+
+def _attached_env(infer_returns: list[str]) -> tuple[SyntheticEnvironment, Mock]:
+    """Build an env with a mock engine that drains ``infer_returns`` in order.
+
+    Each call consumed by the simulator pops the next element from the queue,
+    so a single ``infer_returns`` list spans multiple ``env.step`` invocations
+    and multiple within-batch calls.
+    """
+    env = SyntheticEnvironment.from_params(_typed_params())
+    mock_engine = Mock()
+    queue = list(infer_returns)
+
+    def fake_infer(convs, inference_config):
+        out = []
+        for conv in convs:
+            text = queue.pop(0)
+            out.append(
+                Conversation(
+                    messages=conv.messages
+                    + [Message(role=Role.ASSISTANT, content=text)]
+                )
+            )
+        return out
+
+    mock_engine.infer = Mock(side_effect=fake_infer)
+    base_config = InferenceConfig(
+        model=ModelParams(model_name="stub"),
+        generation=GenerationParams(max_new_tokens=32),
+    )
+    env.attach_inference(engine=mock_engine, base_config=base_config)
+    return env, mock_engine
+
+
+def test_step_zero_calls_returns_empty():
+    env, mock = _attached_env([])
+    assert env.step([]) == []
+    assert mock.infer.call_count == 0
+
+
+def test_step_unknown_tool_raises_before_engine_check():
+    """Unknown tool id raises ValueError even when no engine is attached."""
+    env = SyntheticEnvironment.from_params(_typed_params())
+    with pytest.raises(ValueError, match="Tool 'missing' not found"):
+        env.step([("missing", {})])
+
+
+def test_step_happy_path_single_call():
+    env, mock = _attached_env(['{"a": "hello"}'])
+    results = env.step([("answer", {"q": "hi"})])
+    assert results == [ToolResult(output={"a": "hello"})]
+    assert mock.infer.call_count == 1
+
+
+def test_step_batches_same_tool_in_one_infer():
+    env, mock = _attached_env(['{"a": "one"}', '{"a": "two"}'])
+    results = env.step([("answer", {"q": "first"}), ("answer", {"q": "second"})])
+    assert results == [
+        ToolResult(output={"a": "one"}),
+        ToolResult(output={"a": "two"}),
+    ]
+    assert mock.infer.call_count == 1
+    convs_arg = mock.infer.call_args[0][0]
+    assert len(convs_arg) == 2
+
+
+def test_step_cache_hit_short_circuits_inference():
+    env, mock = _attached_env(['{"a": "fresh"}'])
+    first = env.step([("answer", {"q": "hi"})])
+    second = env.step([("answer", {"q": "hi"})])
+    assert first == second
+    assert mock.infer.call_count == 1  # second call hit the cache
+
+
+def test_step_mixed_cache_hit_and_miss():
+    env, mock = _attached_env(['{"a": "first"}', '{"a": "second"}'])
+    env.step([("answer", {"q": "first"})])  # populates cache
+    results = env.step([("answer", {"q": "first"}), ("answer", {"q": "second"})])
+    assert results == [
+        ToolResult(output={"a": "first"}),
+        ToolResult(output={"a": "second"}),
+    ]
+    # 2 infers total: one for first call's miss, one for second call's miss.
+    assert mock.infer.call_count == 2
+    second_batch = mock.infer.call_args_list[1][0][0]
+    assert len(second_batch) == 1  # only the unique miss got inferred
+
+
+def test_step_extracts_json_from_noisy_output():
+    # Surrounding prose around a valid JSON object — extract_json recovers it.
+    env, _ = _attached_env(['Sure! Here is the answer: {"a": "ok"} done.'])
+    results = env.step([("answer", {"q": "x"})])
+    assert results == [ToolResult(output={"a": "ok"})]
+
+
+def test_step_schema_validation_failure_raises_tool_error():
+    env, _ = _attached_env(['{"wrong_field": "oops"}'])  # missing required "a"
+    with pytest.raises(ToolError, match="failed schema validation"):
+        env.step([("answer", {"q": "x"})])
+
+
+def test_step_unparseable_output_raises_tool_error():
+    env, _ = _attached_env(["totally not json at all"])
+    with pytest.raises(ToolError, match="not valid JSON"):
+        env.step([("answer", {"q": "x"})])
+
+
+def test_step_empty_response_raises_tool_error():
+    env, _ = _attached_env([""])
+    with pytest.raises(ToolError, match="empty response"):
+        env.step([("answer", {"q": "x"})])
+
+
+def test_step_no_output_schema_accepts_any_object():
+    """When tool has no output_schema, any JSON object is accepted."""
+    tool = _typed_tool(output_schema=None)
+    params = EnvironmentParams(
+        id="faq",
+        name="FAQ",
+        description="FAQ env",
+        env_type="synthetic",
+        tools=[tool],
+        env_kwargs={"system_prompt": "Answer FAQs."},
+    )
+    env = SyntheticEnvironment.from_params(params)
+    mock_engine = Mock()
+    mock_engine.infer = Mock(
+        return_value=[
+            Conversation(
+                messages=[
+                    Message(role=Role.SYSTEM, content="x"),
+                    Message(role=Role.USER, content="y"),
+                    Message(role=Role.ASSISTANT, content='{"anything": [1, 2]}'),
+                ]
+            )
+        ]
+    )
+    env.attach_inference(
+        engine=mock_engine,
+        base_config=InferenceConfig(model=ModelParams(model_name="stub")),
+    )
+    results = env.step([("answer", {"q": "x"})])
+    assert results == [ToolResult(output={"anything": [1, 2]})]
+
+
+def test_simulator_inference_config_overlays_guided_decoding():
+    env, _ = _attached_env(['{"a": "x"}'])
+    tool = env._lookup_tool("answer")
+    cfg = env._simulator_inference_config(tool)
+    assert cfg.generation is not None
+    assert cfg.generation.guided_decoding is not None
+    assert cfg.generation.guided_decoding.json == tool.output_schema
+
+
+def test_build_call_conv_has_system_and_user_messages():
+    env, _ = _attached_env(['{"a": "x"}'])
+    tool = env._lookup_tool("answer")
+    conv = env._build_call_conv(tool, {"q": "hi"})
+    assert len(conv.messages) == 2
+    assert conv.messages[0].role == Role.SYSTEM
+    assert conv.messages[1].role == Role.USER
+    assert "answer" in str(conv.messages[0].content)
+    user_payload = str(conv.messages[1].content)
+    assert '"tool"' in user_payload and '"answer"' in user_payload


### PR DESCRIPTION
## Summary

**1. Batched `step()` API** — `BaseEnvironment.step` now takes `list[(tool_id, args)] -> list[ToolResult]` instead of single-call. `DeterministicEnvironment` implements its own loop internally; `SyntheticEnvironment` overrides `step` to fold batches into one inference (impl lands in commit 2). The synthesizer's per-call `_run_tool_call` is replaced by `_dispatch_tool_calls`, which validates each call (args parse, type, known tool), groups surviving calls by environment, and batch-dispatches each group via `env.step(...)`. If a batched `step()` raises, the dispatcher falls back to per-call dispatch within that group so individual errors stay attributed.

**2. Stateless synthetic-env step implementation** — `SyntheticEnvironment.step` now executes simulator inference instead of `NotImplementedError`. `attach_inference(engine, base_config)` wires the synthesizer's already-built engine + base config into the env (no separate `InferenceConfig` on `SyntheticEnvironmentKwargs`). Per-tool simulator configs derive from `base_config` by overlaying `GuidedDecodingParams(json=tool.output_schema)`, mirroring `_planner_inference_config`. The synthesizer's tool-dispatch construction grew one `isinstance` check that calls `attach_inference` after `build_environment`. Sanitization is permissive but bounded: `extract_json` salvages a JSON object from prose-wrapped simulator output; empty / unparseable / schema-mismatched outputs raise `ToolError`, which the dispatcher converts into a structured TOOL error message so the agent can self-correct.

**3. ToolRouter** – Unifies tool routing and dispatching of tool calls. Moves logic from conversation_synthesizer.py to tool_router.py.


Adds `configs/examples/synthesis/mcp_docs_lookup_synth.yaml` — an MCP-style stateless docs-lookup config with three typed tools (`resolve_library_id`, `query_docs`, `search_examples`), exercising the new synthetic env end-to-end.

New unit tests for `SyntheticEnvironment.step` (cache hit/miss/mixed, batched dispatch, JSON-from-prose extraction, schema-validation pass/fail, no-output-schema fallback, attach-inference-not-called error) + a wiring test in the synthesizer test file confirming `attach_inference` is invoked for synthetic envs.