### PR TITLE
feat(inference): wire native tool calling through RemoteInferenceEngine

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -52,11 +52,11 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
+from oumi.core.types.tool_call import ToolCall
 from oumi.inference.adaptive_concurrency_controller import AdaptiveConcurrencyController
 from oumi.inference.adaptive_semaphore import PoliteAdaptiveSemaphore
 from oumi.inference.rate_limiter import RateLimiter, UsageTracker
 from oumi.utils.conversation_utils import (
-    convert_message_to_json_content_list,
     create_list_of_message_json_dicts,
 )
 from oumi.utils.http import (
@@ -368,16 +368,17 @@ class RemoteInferenceEngine(BaseInferenceEngine):
 
         api_input = {
             "model": model_params.model_name,
-            "messages": [
-                {
-                    "content": convert_message_to_json_content_list(message),
-                    "role": message.role.value,
-                }
-                for message in conversation.messages
-            ],
+            "messages": self._get_list_of_message_json_dicts(
+                conversation.messages, group_adjacent_same_role_turns=False
+            ),
             "n": 1,  # Number of completions to generate for each prompt.
             **generation_params_dict,
         }
+
+        if conversation.tools:
+            api_input["tools"] = [
+                t.model_dump(mode="json", exclude_none=True) for t in conversation.tools
+            ]
 
         if generation_params.guided_decoding:
             json_schema = generation_params.guided_decoding.json
@@ -498,7 +499,18 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         message = response["choices"][0].get("message")
         if not message:
             raise RuntimeError(f"No message found in API response: {response}")
-        content = message.get("content") or ""
+
+        raw_tool_calls = message.get("tool_calls")
+        tool_calls: list[ToolCall] | None = (
+            [ToolCall.model_validate(tc) for tc in raw_tool_calls]
+            if raw_tool_calls
+            else None
+        )
+        # Preserve null content when tool_calls are set (OpenAI's tool-only
+        # assistant turn shape); otherwise coerce to empty string.
+        raw_content = message.get("content")
+        content = raw_content if tool_calls is not None else (raw_content or "")
+
         metadata = dict(original_conversation.metadata)
         usage = self._extract_usage_from_response(response)
         if usage is not None:
@@ -512,6 +524,7 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                 Message(
                     content=content,
                     role=Role(message["role"]),
+                    tool_calls=tool_calls,
                 ),
             ],
             metadata=metadata,

--- a/tests/unit/inference/test_openai_inference_engine.py
+++ b/tests/unit/inference/test_openai_inference_engine.py
@@ -1,7 +1,22 @@
-import pytest
+from typing import Any
 
-from oumi.core.configs import GenerationParams, ModelParams, RemoteParams
+import pytest
+from aioresponses import aioresponses
+
+from oumi.core.configs import (
+    GenerationParams,
+    InferenceConfig,
+    ModelParams,
+    RemoteParams,
+)
 from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    FunctionDefinition,
+    JSONSchema,
+    ToolCall,
+    ToolDefinition,
+)
 from oumi.inference.openai_inference_engine import (
     OpenAIInferenceEngine,
     _is_reasoning_model,
@@ -137,3 +152,153 @@ def test_default_params(
 def test_is_reasoning_model(model_name: str, expected: bool):
     """Test _is_reasoning_model correctly identifies reasoning models."""
     assert _is_reasoning_model(model_name) == expected
+
+
+_OPENAI_TEST_URL = "http://fakeopenai/v1/chat/completions"
+
+
+def _weather_tool() -> ToolDefinition:
+    return ToolDefinition(
+        function=FunctionDefinition(
+            name="get_weather",
+            description="Get the current weather for a city.",
+            parameters=JSONSchema(
+                type="object",
+                properties={"city": JSONSchema(type="string")},
+                required=["city"],
+            ),
+        ),
+    )
+
+
+def test_openai_native_tool_calling_round_trip():
+    """End-to-end: tools forward in request, tool_calls parse from response."""
+    captured: dict[str, Any] = {}
+
+    def callback(url: str, **kwargs: Any):
+        from aioresponses import CallbackResult
+
+        captured["body"] = kwargs.get("json")
+        return CallbackResult(
+            status=200,
+            payload={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_xyz",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "Paris"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+        )
+
+    with aioresponses() as m:
+        m.post(_OPENAI_TEST_URL, callback=callback)
+
+        engine = OpenAIInferenceEngine(
+            model_params=ModelParams(model_name="gpt-4o"),
+            remote_params=RemoteParams(api_url=_OPENAI_TEST_URL, api_key="key"),
+        )
+        tool = _weather_tool()
+        conversation = Conversation(
+            messages=[Message(content="Weather in Paris?", role=Role.USER)],
+            tools=[tool],
+        )
+        result = engine.infer(
+            [conversation],
+            InferenceConfig(generation=GenerationParams(max_new_tokens=5)),
+        )
+
+    # Request side: tools forwarded in OpenAI shape.
+    assert "tools" in captured["body"]
+    assert captured["body"]["tools"] == [
+        tool.model_dump(mode="json", exclude_none=True)
+    ]
+
+    # Response side: tool_calls parsed into structured Message field.
+    assert len(result) == 1
+    assistant = result[0].messages[-1]
+    assert assistant.role == Role.ASSISTANT
+    assert assistant.content is None
+    assert assistant.tool_calls is not None
+    assert len(assistant.tool_calls) == 1
+    tc = assistant.tool_calls[0]
+    assert tc.id == "call_xyz"
+    assert tc.function.name == "get_weather"
+    assert tc.function.arguments == '{"city": "Paris"}'
+    assert result[0].metadata.get("finish_reason") == "tool_calls"
+
+
+def test_openai_multiturn_tool_dialogue_replays_tool_messages():
+    """Assistant tool_calls + Role.TOOL response round-trip into the request body."""
+    captured: dict[str, Any] = {}
+
+    def callback(url: str, **kwargs: Any):
+        from aioresponses import CallbackResult
+
+        captured["body"] = kwargs.get("json")
+        return CallbackResult(
+            status=200,
+            payload={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "It's 18C in Paris.",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    with aioresponses() as m:
+        m.post(_OPENAI_TEST_URL, callback=callback)
+
+        engine = OpenAIInferenceEngine(
+            model_params=ModelParams(model_name="gpt-4o"),
+            remote_params=RemoteParams(api_url=_OPENAI_TEST_URL, api_key="key"),
+        )
+        tool_call = ToolCall(
+            id="call_abc",
+            function=FunctionCall(name="get_weather", arguments='{"city": "Paris"}'),
+        )
+        conversation = Conversation(
+            messages=[
+                Message(content="Weather in Paris?", role=Role.USER),
+                Message(role=Role.ASSISTANT, tool_calls=[tool_call]),
+                Message(
+                    role=Role.TOOL,
+                    tool_call_id="call_abc",
+                    content='{"temp_c": 18}',
+                ),
+            ],
+            tools=[_weather_tool()],
+        )
+        engine.infer(
+            [conversation],
+            InferenceConfig(generation=GenerationParams(max_new_tokens=5)),
+        )
+
+    sent_messages = captured["body"]["messages"]
+    assert len(sent_messages) == 3
+    assert sent_messages[1]["role"] == "assistant"
+    assert sent_messages[1]["content"] is None
+    assert sent_messages[1]["tool_calls"] == [
+        tool_call.model_dump(mode="json", exclude_none=True)
+    ]
+    assert sent_messages[2]["role"] == "tool"
+    assert sent_messages[2]["tool_call_id"] == "call_abc"
+    assert sent_messages[2]["content"] == '{"temp_c": 18}'

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -30,6 +30,13 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    FunctionDefinition,
+    JSONSchema,
+    ToolCall,
+    ToolDefinition,
+)
 from oumi.inference import RemoteInferenceEngine
 from oumi.inference.remote_inference_engine import BatchStatus
 from oumi.utils.conversation_utils import (
@@ -919,10 +926,13 @@ def test_infer_online_multiple_requests():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
-        if not content:
+        content = messages[0].get("content")
+        if isinstance(content, list):
+            conversation_id = content[0].get("text") if content else None
+        else:
+            conversation_id = content
+        if not conversation_id:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1039,10 +1049,13 @@ def test_infer_online_multiple_requests_politeness():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
-        if not content:
+        content = messages[0].get("content")
+        if isinstance(content, list):
+            conversation_id = content[0].get("text") if content else None
+        else:
+            conversation_id = content
+        if not conversation_id:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1181,10 +1194,13 @@ def test_infer_online_multiple_requests_politeness_multiple_workers():
         messages = request.get("messages", [])
         if not messages:
             raise ValueError("No messages in request")
-        content = messages[0].get("content", [])
-        if not content:
+        content = messages[0].get("content")
+        if isinstance(content, list):
+            conversation_id = content[0].get("text") if content else None
+        else:
+            conversation_id = content
+        if not conversation_id:
             raise ValueError("No content in message")
-        conversation_id = content[0].get("text")
 
         if response := response_by_conversation_id.get(conversation_id):
             # Extract status and payload from the response dict
@@ -1365,10 +1381,13 @@ def test_infer_from_file_to_file():
             messages = request.get("messages", [])
             if not messages:
                 raise ValueError("No messages in request")
-            content = messages[0].get("content", [])
-            if not content:
+            content = messages[0].get("content")
+            if isinstance(content, list):
+                conversation_id = content[0].get("text") if content else None
+            else:
+                conversation_id = content
+            if not conversation_id:
                 raise ValueError("No content in message")
-            conversation_id = content[0].get("text")
 
             if response := response_by_conversation_id.get(conversation_id):
                 # Extract status and payload from the response dict
@@ -1496,10 +1515,13 @@ def test_infer_from_file_to_file_failure_midway():
             messages = request.get("messages", [])
             if not messages:
                 raise ValueError("No messages in request")
-            content = messages[0].get("content", [])
-            if not content:
+            content = messages[0].get("content")
+            if isinstance(content, list):
+                conversation_id = content[0].get("text") if content else None
+            else:
+                conversation_id = content
+            if not conversation_id:
                 raise ValueError("No content in message")
-            conversation_id = content[0].get("text")
 
             if response := response_by_conversation_id.get(conversation_id):
                 # Extract status and payload from the response dict
@@ -1968,6 +1990,120 @@ def test_convert_conversation_to_api_input_with_unsupported_schema_type():
         )
 
 
+def _get_weather_tool() -> ToolDefinition:
+    return ToolDefinition(
+        function=FunctionDefinition(
+            name="get_weather",
+            description="Get the current weather for a location.",
+            parameters=JSONSchema(
+                type="object",
+                properties={"city": JSONSchema(type="string")},
+                required=["city"],
+            ),
+        ),
+    )
+
+
+def test_convert_conversation_to_api_input_with_tools():
+    """Conversation.tools is serialized into the OpenAI ``tools`` field."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(), remote_params=RemoteParams(api_url=_TARGET_SERVER)
+    )
+    tool = _get_weather_tool()
+    conversation = Conversation(
+        messages=[Message(content="Weather in Paris?", role=Role.USER)],
+        tools=[tool],
+    )
+
+    result = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=5), _get_default_model_params()
+    )
+
+    assert "tools" in result
+    assert result["tools"] == [tool.model_dump(mode="json", exclude_none=True)]
+
+
+def test_convert_conversation_to_api_input_without_tools_omits_field():
+    """No ``tools`` key when conversation has no tools (avoid sending null)."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(), remote_params=RemoteParams(api_url=_TARGET_SERVER)
+    )
+    conversation = Conversation(
+        messages=[Message(content="Hello", role=Role.USER)],
+    )
+
+    result = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=5), _get_default_model_params()
+    )
+
+    assert "tools" not in result
+
+
+def test_convert_conversation_to_api_input_assistant_tool_calls_propagate():
+    """An assistant message with ``tool_calls`` round-trips into the request payload."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(), remote_params=RemoteParams(api_url=_TARGET_SERVER)
+    )
+    tool_call = ToolCall(
+        id="call_abc123",
+        function=FunctionCall(name="get_weather", arguments='{"city": "Paris"}'),
+    )
+    conversation = Conversation(
+        messages=[
+            Message(content="Weather in Paris?", role=Role.USER),
+            Message(role=Role.ASSISTANT, tool_calls=[tool_call]),
+        ],
+    )
+
+    result = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=5), _get_default_model_params()
+    )
+
+    assistant_msg = result["messages"][-1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] is None
+    assert assistant_msg["tool_calls"] == [
+        tool_call.model_dump(mode="json", exclude_none=True)
+    ]
+
+
+def test_convert_conversation_to_api_input_tool_role_message_propagates():
+    """A ``Role.TOOL`` message with ``tool_call_id`` round-trips into the request."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(), remote_params=RemoteParams(api_url=_TARGET_SERVER)
+    )
+    conversation = Conversation(
+        messages=[
+            Message(content="Weather?", role=Role.USER),
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=[
+                    ToolCall(
+                        id="call_abc123",
+                        function=FunctionCall(
+                            name="get_weather", arguments='{"city": "Paris"}'
+                        ),
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                tool_call_id="call_abc123",
+                content='{"temp_c": 18}',
+            ),
+        ],
+    )
+
+    result = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=5), _get_default_model_params()
+    )
+
+    tool_msg = result["messages"][-1]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == "call_abc123"
+    assert tool_msg["content"] == '{"temp_c": 18}'
+
+
 def test_get_request_headers_no_remote_params():
     engine = RemoteInferenceEngine(
         _get_default_model_params(), remote_params=RemoteParams(api_url=_TARGET_SERVER)
@@ -2112,6 +2248,78 @@ def test_convert_api_output_content_null_returns_empty_string():
     result = engine._convert_api_output_to_conversation(response, original)
     assert result.messages[-1].content == ""
     assert result.messages[-1].role == Role.ASSISTANT
+
+
+def test_convert_api_output_extracts_tool_calls():
+    """Response ``message.tool_calls`` populates ``Message.tool_calls``."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(),
+        remote_params=RemoteParams(api_url=_TARGET_SERVER),
+    )
+    original = Conversation(messages=[Message(content="Weather?", role=Role.USER)])
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assistant_msg = result.messages[-1]
+    assert assistant_msg.role == Role.ASSISTANT
+    assert assistant_msg.tool_calls is not None
+    assert len(assistant_msg.tool_calls) == 1
+    tc = assistant_msg.tool_calls[0]
+    assert tc.id == "call_abc123"
+    assert tc.function.name == "get_weather"
+    assert tc.function.arguments == '{"city": "Paris"}'
+
+
+def test_convert_api_output_with_tool_calls_preserves_null_content():
+    """Tool-only assistant message keeps ``content=None`` (OpenAI wire format)."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(),
+        remote_params=RemoteParams(api_url=_TARGET_SERVER),
+    )
+    original = Conversation(messages=[Message(content="Weather?", role=Role.USER)])
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assistant_msg = result.messages[-1]
+    assert assistant_msg.content is None
+    assert assistant_msg.tool_calls is not None and len(assistant_msg.tool_calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Forwards `Conversation.tools` into the OpenAI-shaped `tools` request field, parses `message.tool_calls` from responses into `Message.tool_calls`, and propagates assistant `tool_calls` + `Role.TOOL` `tool_call_id` on multi-turn replays via the existing `_get_list_of_message_json_dicts` utility (the same helper `VLLMInferenceEngine` uses).

Unblocks native tool calling for the OpenAI-compatible engines that inherit `RemoteInferenceEngine` without overriding `_convert_conversation_to_api_input`: **OpenAI, DeepSeek, Together, Fireworks, OpenRouter, Cerebras, Parasail**.

## Out of scope (follow-up PRs)

- **SambaNova, GCP (Vertex), remote_vllm** — override `_convert_conversation_to_api_input` and build their own request body without calling `super()`. Each needs the same `if conversation.tools` block ported into its override before tool calling works end-to-end.
- **sglang** — uses a non-OpenAI native wire format (`text` + `sampling_params`), so the OpenAI-shaped `tools` field doesn't apply. Needs an engine-specific design.
- **Anthropic, Gemini, Bedrock** — non-OpenAI wire formats (content blocks for `tool_use`/`tool_result`; `functionCall`/`functionResponse` parts) and need engine-specific overrides.

## Wire format note

`_convert_conversation_to_api_input` now uses `_get_list_of_message_json_dicts(group_adjacent_same_role_turns=False)` instead of the hand-rolled inline comprehension. This means single-text-content messages now serialize as `{"content": "Hello"}` (string) instead of `{"content": [{"type": "text", "text": "Hello"}]}` (list). Both are valid per the OpenAI spec; the string form is canonical and matches what `VLLMInferenceEngine` offline already emits. Five internal test mocks that depended on the always-list shape were updated to handle either form.

## Test plan

- [x] 5 new unit tests in `test_remote_inference_engine.py` covering tools serialization, `tool_calls` round-trip on assistant messages, `tool_call_id` round-trip on `Role.TOOL` messages, and tool-call extraction from responses (including `content=None` preservation when tool_calls are present)
- [x] 2 end-to-end tests in `test_openai_inference_engine.py` that capture the request body sent to a mocked OpenAI server and verify both directions through the inheritance chain
- [x] Live verification against OpenAI `gpt-4o-mini`: a fresh tool call (`get_weather` with `{"city":"Paris"}`) and a multi-turn replay where the model consumes a synthetic tool result and produces a natural-language answer ("17°C and partly cloudy")
- [x] Full inference test suite: 440 passed, 26 skipped (excludes GPU-required vLLM/llama_cpp); all 13 OpenAI-compatible subclass test files pass without modification
- [x] `pre-commit run --all-files` clean (ruff, pyright, license headers)