### PR TITLE
Wire tool calling through AnthropicInferenceEngine

### DIFF
--- a/configs/apis/anthropic/infer_claude_sonnet_tool_calling.yaml
+++ b/configs/apis/anthropic/infer_claude_sonnet_tool_calling.yaml
@@ -1,0 +1,38 @@
+# Anthropic Messages inference config with tool calling.
+#
+# Translates ``Conversation.tools`` and ``Message.tool_calls`` between
+# OpenAI's and Anthropic's wire formats so the same conversation works
+# across engines. Includes per-block ``cache_control`` on the last tool
+# definition to enable Anthropic's prompt-caching for the tools section
+# across turns.
+#
+# Requirements:
+#   - Set the ``ANTHROPIC_API_KEY`` environment variable.
+#
+# Usage:
+#   oumi infer -i -c configs/apis/anthropic/infer_claude_sonnet_tool_calling.yaml
+#
+# The input JSONL should carry a top-level ``tools`` field on each
+# conversation (OpenAI function-calling schema; the engine translates to
+# Anthropic shape internally). Output messages will populate
+# ``tool_calls`` when the model emits ``tool_use`` blocks, and
+# ``metadata.finish_reason`` will be set to ``tool_calls``.
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "claude-sonnet-4-5"
+
+engine: ANTHROPIC
+
+generation:
+  max_new_tokens: 4096
+  temperature: 0.3
+  # OpenAI-style values that the engine translates: "auto" → {type: auto},
+  # "required" → {type: any}, "none" → drops the tools field (Anthropic
+  # has no `none` choice), or {"type": "function", "function": {"name":
+  # X}} → {type: tool, name: X}.
+  tool_choice: "auto"

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -33,8 +33,10 @@ from oumi.core.types.conversation import (
     FinishReason,
     Message,
     Role,
+    ToolCall,
     Type,
 )
+from oumi.core.types.tool_call import ToolDefinition
 from oumi.inference.remote_inference_engine import (
     BatchInfo,
     BatchListResponse,
@@ -49,6 +51,11 @@ from oumi.utils.conversation_utils import (
 from oumi.utils.logging import logger
 
 _CONTENT_KEY: str = "content"
+
+_OPENAI_TO_ANTHROPIC_TOOL_CHOICE: dict[str, dict[str, str]] = {
+    "auto": {"type": "auto"},
+    "required": {"type": "any"},
+}
 
 # Anthropic accepts image/jpeg, image/png, image/gif, image/webp for `image`
 # content blocks. https://docs.anthropic.com/en/docs/build-with-claude/vision
@@ -187,7 +194,76 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         # See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
         body["cache_control"] = {"type": "ephemeral"}
 
+        tool_choice = generation_params.tool_choice
+        if conversation.tools:
+            anthropic_tools = self._openai_tools_to_anthropic(conversation.tools)
+            if tool_choice == "none":
+                # Anthropic has no `none` tool_choice — omitting the tools
+                # field entirely is the equivalent.
+                logger.info(
+                    "tool_choice='none' is not directly supported by the "
+                    "Anthropic API; dropping the tools field instead."
+                )
+            else:
+                body["tools"] = anthropic_tools
+                if tool_choice is not None:
+                    body["tool_choice"] = self._translate_tool_choice(tool_choice)
+
         return body
+
+    @staticmethod
+    def _openai_tools_to_anthropic(
+        tools: list[ToolDefinition],
+    ) -> list[dict[str, Any]]:
+        """Translates OpenAI-format tool definitions to Anthropic shape.
+
+        Anthropic uses ``input_schema`` instead of ``parameters`` and lifts
+        ``name`` / ``description`` to the top level (no ``function`` wrapper).
+        Marks the last tool with ``cache_control: {"type": "ephemeral"}`` so
+        Anthropic caches the tools section across turns — tools are typically
+        large static JSON Schema and identical from turn to turn, making them
+        the highest-ROI cache marker.
+        """
+        anthropic_tools: list[dict[str, Any]] = [
+            {
+                "name": tool.function.name,
+                "description": tool.function.description,
+                # ``parameters`` is a typed JSONSchema; dump to the wire-format
+                # dict so Anthropic's ``input_schema`` (and downstream JSON
+                # serialization) gets a plain dict.
+                "input_schema": (
+                    tool.function.parameters.model_dump(mode="json", exclude_none=True)
+                    if tool.function.parameters is not None
+                    else {"type": "object"}
+                ),
+            }
+            for tool in tools
+        ]
+        if anthropic_tools:
+            anthropic_tools[-1]["cache_control"] = {"type": "ephemeral"}
+        return anthropic_tools
+
+    @staticmethod
+    def _translate_tool_choice(tool_choice: str | dict[str, Any]) -> dict[str, Any]:
+        """Translates an OpenAI-format ``tool_choice`` value to Anthropic shape."""
+        if isinstance(tool_choice, str):
+            mapped = _OPENAI_TO_ANTHROPIC_TOOL_CHOICE.get(tool_choice)
+            if mapped is None:
+                raise ValueError(
+                    f"Unsupported tool_choice value '{tool_choice}'. "
+                    "Expected one of: 'auto', 'required', 'none', "
+                    "or a {'type': 'function', 'function': {'name': ...}} dict."
+                )
+            return mapped
+        if isinstance(tool_choice, dict):
+            function = tool_choice.get("function") or {}
+            name = function.get("name")
+            if not name:
+                raise ValueError(
+                    f"tool_choice dict missing function.name: {tool_choice}"
+                )
+            return {"type": "tool", "name": name}
+        raise ValueError(f"Unsupported tool_choice type: {type(tool_choice).__name__}")
 
     @staticmethod
     def _messages_to_anthropic_blocks(
@@ -195,22 +271,26 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
     ) -> list[dict[str, Any]]:
         """Converts non-system messages to Anthropic's role-and-blocks shape.
 
-        Translates each message into a list of content blocks (text, image)
-        and merges adjacent same-role messages into a single turn — Anthropic
-        requires alternating user/assistant turns. For pure-text turns
-        originating from a single ``content: str`` message, the wire shape is
-        collapsed back to ``content: "string"`` to keep the payload tidy;
-        both forms are valid.
+        Translates each message into a list of content blocks (text, image,
+        tool_use, tool_result) and merges adjacent same-role messages into a
+        single turn — Anthropic requires alternating user/assistant turns, and
+        ``Role.TOOL`` collapses to user. For pure-text turns originating from a
+        single ``content: str`` message, the wire shape is collapsed back to
+        ``content: "string"`` to keep the payload tidy; both forms are valid.
         """
         result: list[dict[str, Any]] = []
         idx = 0
         while idx < len(messages):
-            role = messages[idx].role.value
+            role = AnthropicInferenceEngine._effective_anthropic_role(messages[idx])
             blocks: list[dict[str, Any]] = []
             group_start = idx
-            while idx < len(messages) and messages[idx].role.value == role:
+            while (
+                idx < len(messages)
+                and AnthropicInferenceEngine._effective_anthropic_role(messages[idx])
+                == role
+            ):
                 blocks.extend(
-                    AnthropicInferenceEngine._content_to_anthropic_blocks(messages[idx])
+                    AnthropicInferenceEngine._message_to_anthropic_blocks(messages[idx])
                 )
                 idx += 1
             single_msg = messages[group_start]
@@ -224,6 +304,48 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             else:
                 result.append({"role": role, "content": blocks})
         return result
+
+    @staticmethod
+    def _effective_anthropic_role(message: Message) -> str:
+        """Anthropic merges ``Role.TOOL`` messages into ``user`` turns."""
+        return Role.USER.value if message.role == Role.TOOL else message.role.value
+
+    @staticmethod
+    def _message_to_anthropic_blocks(message: Message) -> list[dict[str, Any]]:
+        """Translates one Oumi ``Message`` into a list of Anthropic content blocks."""
+        if message.role == Role.TOOL:
+            tool_result: dict[str, Any] = {
+                "type": "tool_result",
+                "tool_use_id": message.tool_call_id or "",
+            }
+            if isinstance(message.content, str):
+                tool_result["content"] = message.content
+            elif isinstance(message.content, list):
+                tool_result["content"] = [
+                    AnthropicInferenceEngine._content_item_to_anthropic_block(item)
+                    for item in message.content
+                ]
+            else:
+                tool_result["content"] = ""
+            return [tool_result]
+        blocks: list[dict[str, Any]] = []
+        if message.content is not None:
+            blocks.extend(
+                AnthropicInferenceEngine._content_to_anthropic_blocks(message)
+            )
+        if message.role == Role.ASSISTANT and message.tool_calls:
+            for tc in message.tool_calls:
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc.id,
+                        "name": tc.function.name,
+                        "input": json.loads(tc.function.arguments)
+                        if tc.function.arguments
+                        else {},
+                    }
+                )
+        return blocks
 
     @staticmethod
     def _content_to_anthropic_blocks(message: Message) -> list[dict[str, Any]]:
@@ -318,9 +440,34 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
                 f"model={response.get('model')}, "
                 f"usage={response.get('usage')}"
             )
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        for block in content_blocks:
+            block_type = block.get("type")
+            if block_type == "tool_use":
+                # Translate to OpenAI wire format. Anthropic returns a parsed
+                # ``input`` dict; OpenAI keeps ``arguments`` as a JSON string.
+                tool_calls.append(
+                    ToolCall.model_validate(
+                        {
+                            "id": block["id"],
+                            "type": "function",
+                            "function": {
+                                "name": block["name"],
+                                "arguments": json.dumps(block.get("input", {})),
+                            },
+                        }
+                    )
+                )
+            elif block_type == "text" or "text" in block:
+                # Real Anthropic responses always set type="text"; tolerate
+                # fixtures that omit type when only `text` is present.
+                text_parts.append(block.get("text", ""))
+        text_content = "".join(text_parts)
         new_message = Message(
-            content=content_blocks[0]["text"],
+            content=text_content if text_content else None,
             role=Role.ASSISTANT,
+            tool_calls=tool_calls or None,
         )
         metadata = dict(original_conversation.metadata)
         usage = self._extract_usage_from_response(response)
@@ -333,6 +480,7 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             messages=[*original_conversation.messages, new_message],
             metadata=metadata,
             conversation_id=original_conversation.conversation_id,
+            tools=original_conversation.tools,
         )
 
     @override
@@ -351,6 +499,7 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             "max_new_tokens",
             "stop_strings",
             "temperature",
+            "tool_choice",
             "top_p",
         }
 

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import itertools
 import json
 from typing import Any
 
@@ -52,9 +53,12 @@ from oumi.utils.logging import logger
 
 _CONTENT_KEY: str = "content"
 
+# We are only constraining to ToolChoiceOptions in OpenAI
+# https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(method)%20create%20%3E%20(params)%200.non_streaming%20%3E%20(param)%20tool_choice%20%3E%20(schema)
 _OPENAI_TO_ANTHROPIC_TOOL_CHOICE: dict[str, dict[str, str]] = {
     "auto": {"type": "auto"},
     "required": {"type": "any"},
+    "none": {"type": "none"},
 }
 
 # Anthropic accepts image/jpeg, image/png, image/gif, image/webp for `image`
@@ -196,18 +200,9 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
 
         tool_choice = generation_params.tool_choice
         if conversation.tools:
-            anthropic_tools = self._openai_tools_to_anthropic(conversation.tools)
-            if tool_choice == "none":
-                # Anthropic has no `none` tool_choice — omitting the tools
-                # field entirely is the equivalent.
-                logger.info(
-                    "tool_choice='none' is not directly supported by the "
-                    "Anthropic API; dropping the tools field instead."
-                )
-            else:
-                body["tools"] = anthropic_tools
-                if tool_choice is not None:
-                    body["tool_choice"] = self._translate_tool_choice(tool_choice)
+            body["tools"] = self._openai_tools_to_anthropic(conversation.tools)
+            if tool_choice is not None:
+                body["tool_choice"] = self._translate_tool_choice(tool_choice)
 
         return body
 
@@ -218,11 +213,8 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         """Translates OpenAI-format tool definitions to Anthropic shape.
 
         Anthropic uses ``input_schema`` instead of ``parameters`` and lifts
-        ``name`` / ``description`` to the top level (no ``function`` wrapper).
-        Marks the last tool with ``cache_control: {"type": "ephemeral"}`` so
-        Anthropic caches the tools section across turns — tools are typically
-        large static JSON Schema and identical from turn to turn, making them
-        the highest-ROI cache marker.
+        ``name``, ``description`` and ``input_schema`` to the top level (no
+        ``function`` wrapper).
         """
         anthropic_tools: list[dict[str, Any]] = [
             {
@@ -234,13 +226,11 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
                 "input_schema": (
                     tool.function.parameters.model_dump(mode="json", exclude_none=True)
                     if tool.function.parameters is not None
-                    else {"type": "object"}
+                    else {"type": "object", "properties": {}}
                 ),
             }
             for tool in tools
         ]
-        if anthropic_tools:
-            anthropic_tools[-1]["cache_control"] = {"type": "ephemeral"}
         return anthropic_tools
 
     @staticmethod
@@ -263,7 +253,6 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
                     f"tool_choice dict missing function.name: {tool_choice}"
                 )
             return {"type": "tool", "name": name}
-        raise ValueError(f"Unsupported tool_choice type: {type(tool_choice).__name__}")
 
     @staticmethod
     def _messages_to_anthropic_blocks(
@@ -273,34 +262,33 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
 
         Translates each message into a list of content blocks (text, image,
         tool_use, tool_result) and merges adjacent same-role messages into a
-        single turn — Anthropic requires alternating user/assistant turns, and
-        ``Role.TOOL`` collapses to user. For pure-text turns originating from a
-        single ``content: str`` message, the wire shape is collapsed back to
-        ``content: "string"`` to keep the payload tidy; both forms are valid.
+        single turn (Anthropic requires alternating user/assistant turns).
+        ``Role.TOOL`` collapses to user.
+
+        For pure-text turns originating from a single ``content: str`` message,
+        the wire shape is collapsed back to ``content: "string"`` to keep the
+        payload tidy; both forms are valid.
         """
         result: list[dict[str, Any]] = []
-        idx = 0
-        while idx < len(messages):
-            role = AnthropicInferenceEngine._effective_anthropic_role(messages[idx])
+        for role, group_iter in itertools.groupby(
+            messages, key=AnthropicInferenceEngine._effective_anthropic_role
+        ):
+            group = list(group_iter)
             blocks: list[dict[str, Any]] = []
-            group_start = idx
-            while (
-                idx < len(messages)
-                and AnthropicInferenceEngine._effective_anthropic_role(messages[idx])
-                == role
-            ):
+            for msg in group:
                 blocks.extend(
-                    AnthropicInferenceEngine._message_to_anthropic_blocks(messages[idx])
+                    AnthropicInferenceEngine._message_to_anthropic_blocks(msg)
                 )
-                idx += 1
-            single_msg = messages[group_start]
+            # Collapse a solo single-text-block turn back to bare-string content.
+            # The type check matters — a Role.TOOL message with str content
+            # produces a tool_result block, which must stay in the list form.
             if (
-                idx - group_start == 1
+                len(group) == 1
                 and len(blocks) == 1
                 and blocks[0].get("type") == "text"
-                and isinstance(single_msg.content, str)
+                and isinstance(group[0].content, str)
             ):
-                result.append({"role": role, "content": single_msg.content})
+                result.append({"role": role, "content": group[0].content})
             else:
                 result.append({"role": role, "content": blocks})
         return result
@@ -314,38 +302,51 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
     def _message_to_anthropic_blocks(message: Message) -> list[dict[str, Any]]:
         """Translates one Oumi ``Message`` into a list of Anthropic content blocks."""
         if message.role == Role.TOOL:
-            tool_result: dict[str, Any] = {
-                "type": "tool_result",
-                "tool_use_id": message.tool_call_id or "",
-            }
-            if isinstance(message.content, str):
-                tool_result["content"] = message.content
-            elif isinstance(message.content, list):
-                tool_result["content"] = [
-                    AnthropicInferenceEngine._content_item_to_anthropic_block(item)
-                    for item in message.content
-                ]
-            else:
-                tool_result["content"] = ""
-            return [tool_result]
-        blocks: list[dict[str, Any]] = []
-        if message.content is not None:
-            blocks.extend(
-                AnthropicInferenceEngine._content_to_anthropic_blocks(message)
-            )
+            return [AnthropicInferenceEngine._tool_result_block(message)]
+        blocks = AnthropicInferenceEngine._content_to_anthropic_blocks(message)
         if message.role == Role.ASSISTANT and message.tool_calls:
-            for tc in message.tool_calls:
-                blocks.append(
-                    {
-                        "type": "tool_use",
-                        "id": tc.id,
-                        "name": tc.function.name,
-                        "input": json.loads(tc.function.arguments)
-                        if tc.function.arguments
-                        else {},
-                    }
-                )
+            blocks.extend(
+                AnthropicInferenceEngine._tool_use_block(tc)
+                for tc in message.tool_calls
+            )
         return blocks
+
+    @staticmethod
+    def _tool_result_block(message: Message) -> dict[str, Any]:
+        """Builds an Anthropic ``tool_result`` block from a ``Role.TOOL`` message.
+
+        Anthropic accepts either a plain string or a list of content blocks for
+        ``content``; the string form is preserved when the source was a plain
+        ``str`` to keep the wire payload tidy.
+        """
+        if not message.tool_call_id:
+            raise ValueError("Role.TOOL message is missing tool_call_id")
+        if message.content is None:
+            content: str | list[dict[str, Any]] = ""
+        elif isinstance(message.content, str):
+            content = message.content
+        else:
+            content = AnthropicInferenceEngine._content_to_anthropic_blocks(message)
+        return {
+            "type": "tool_result",
+            "tool_use_id": message.tool_call_id,
+            "content": content,
+        }
+
+    @staticmethod
+    def _tool_use_block(tool_call: ToolCall) -> dict[str, Any]:
+        """Builds an Anthropic ``tool_use`` block from an OpenAI-shaped ``ToolCall``.
+
+        Anthropic expects a parsed ``input`` dict; OpenAI keeps ``arguments`` as
+        a JSON string, so it is decoded here.
+        """
+        args = tool_call.function.arguments
+        return {
+            "type": "tool_use",
+            "id": tool_call.id,
+            "name": tool_call.function.name,
+            "input": json.loads(args) if args else {},
+        }
 
     @staticmethod
     def _content_to_anthropic_blocks(message: Message) -> list[dict[str, Any]]:

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -5,11 +6,14 @@ import pytest
 
 from oumi.core.configs import GenerationParams, ModelParams, RemoteParams
 from oumi.core.types.conversation import (
+    ContentItem,
     Conversation,
     FinishReason,
     Message,
     Role,
+    Type,
 )
+from oumi.core.types.tool_call import ToolCall, ToolDefinition
 from oumi.inference.anthropic_inference_engine import AnthropicInferenceEngine
 from oumi.inference.remote_inference_engine import BatchInfo, BatchStatus
 
@@ -454,11 +458,338 @@ def test_convert_api_output_to_conversation_with_usage_and_finish_reason(
     assert result.metadata["usage"]["completion_tokens"] == 5
 
 
+#
+# Tool-calling tests
+#
+_WEATHER_TOOL = ToolDefinition.model_validate(
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+)
+
+_CALENDAR_TOOL = ToolDefinition.model_validate(
+    {
+        "type": "function",
+        "function": {
+            "name": "create_event",
+            "description": "Create a calendar event.",
+            "parameters": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+            },
+        },
+    }
+)
+
+
 def _build_body(engine, conversation, **gen_overrides):
     generation_params = GenerationParams(max_new_tokens=100, **gen_overrides)
     return engine._convert_conversation_to_api_input(
         conversation, generation_params, engine._model_params
     )
+
+
+def test_openai_tools_translated_to_anthropic_schema(anthropic_engine):
+    """``parameters`` becomes ``input_schema``; the ``function`` wrapper drops."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL, _CALENDAR_TOOL],
+        messages=[Message(role=Role.USER, content="hi")],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    assert "tools" in body
+    assert body["tools"][0]["name"] == "get_weather"
+    assert body["tools"][0]["description"] == "Get current weather for a city."
+    assert body["tools"][0]["input_schema"] == {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+    assert "function" not in body["tools"][0]
+    assert "parameters" not in body["tools"][0]
+
+
+def test_last_tool_has_cache_control_marker(anthropic_engine):
+    """Cache marker stamps only the last tool entry; nothing on the others."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL, _CALENDAR_TOOL],
+        messages=[Message(role=Role.USER, content="hi")],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    assert "cache_control" not in body["tools"][0]
+    assert body["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_assistant_tool_calls_emit_tool_use_blocks(anthropic_engine):
+    """Assistant ``tool_calls`` become ``tool_use`` blocks with parsed input."""
+    tool_call_dict = {
+        "id": "call_abc",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+    }
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="weather?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[ToolCall.model_validate(tool_call_dict)],
+            ),
+            Message(role=Role.TOOL, content="22C", tool_call_id="call_abc"),
+        ],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    assistant_msg = body["messages"][1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] == [
+        {
+            "type": "tool_use",
+            "id": "call_abc",
+            "name": "get_weather",
+            # Anthropic expects parsed input, not the JSON-string OpenAI sends.
+            "input": {"city": "Tokyo"},
+        }
+    ]
+
+
+def test_tool_role_string_emits_user_tool_result(anthropic_engine):
+    """Role.TOOL with a string body emits a user/tool_result with string content."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="weather?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall.model_validate(
+                        {
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Tokyo"}',
+                            },
+                        }
+                    )
+                ],
+            ),
+            Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_abc"),
+        ],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    tool_msg = body["messages"][2]
+    assert tool_msg["role"] == "user"
+    assert tool_msg["content"] == [
+        {
+            "type": "tool_result",
+            "tool_use_id": "call_abc",
+            "content": "22C, sunny",
+        }
+    ]
+
+
+def test_tool_role_multimodal_emits_blocks_in_tool_result(anthropic_engine):
+    """Multimodal Role.TOOL content emits a list of text/image blocks."""
+    png_bytes = b"\x89PNG\r\n\x1a\nfakeimg"
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="map?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall.model_validate(
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": "{}",
+                            },
+                        }
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                tool_call_id="call_xyz",
+                content=[
+                    ContentItem(type=Type.TEXT, content="See attached:"),
+                    ContentItem(type=Type.IMAGE_BINARY, binary=png_bytes),
+                ],
+            ),
+        ],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    tool_msg = body["messages"][2]
+    assert tool_msg["role"] == "user"
+    blocks = tool_msg["content"][0]["content"]
+    assert blocks[0] == {"type": "text", "text": "See attached:"}
+    assert blocks[1]["type"] == "image"
+    assert blocks[1]["source"] == {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": base64.b64encode(png_bytes).decode("ascii"),
+    }
+
+
+@pytest.mark.parametrize(
+    "magic_bytes,expected_media_type",
+    [
+        (b"\x89PNG\r\n\x1a\n", "image/png"),
+        (b"\xff\xd8\xff\xe0\x00\x10JFIF", "image/jpeg"),
+        (b"GIF89a", "image/gif"),
+        (b"RIFF\x00\x00\x00\x00WEBPVP8 ", "image/webp"),
+    ],
+)
+def test_image_media_type_sniffed_from_magic_bytes(
+    anthropic_engine, magic_bytes, expected_media_type
+):
+    """media_type reflects the actual image format, not a hardcoded image/png."""
+    image_bytes = magic_bytes + b"...rest of payload..."
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="map?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall.model_validate(
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                tool_call_id="call_1",
+                content=[ContentItem(type=Type.IMAGE_BINARY, binary=image_bytes)],
+            ),
+        ],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    image_block = body["messages"][2]["content"][0]["content"][0]
+    assert image_block["type"] == "image"
+    assert image_block["source"]["media_type"] == expected_media_type
+    assert image_block["source"]["data"] == base64.b64encode(image_bytes).decode(
+        "ascii"
+    )
+
+
+def test_unrecognized_image_bytes_fall_back_to_png(anthropic_engine, caplog):
+    """Unknown formats default to image/png and emit a warning."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="map?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall.model_validate(
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                tool_call_id="call_1",
+                content=[
+                    ContentItem(type=Type.IMAGE_BINARY, binary=b"unknown-format-bytes")
+                ],
+            ),
+        ],
+    )
+    with caplog.at_level("WARNING"):
+        body = _build_body(anthropic_engine, conversation)
+    image_block = body["messages"][2]["content"][0]["content"][0]
+    assert image_block["source"]["media_type"] == "image/png"
+    assert any("Unrecognized image format" in rec.message for rec in caplog.records)
+
+
+def test_response_tool_use_blocks_populate_tool_calls(anthropic_engine):
+    """tool_use blocks in the response become OpenAI-format Message.tool_calls."""
+    api_response = {
+        "content": [
+            {"type": "text", "text": "Looking up weather."},
+            {
+                "type": "tool_use",
+                "id": "toolu_01",
+                "name": "get_weather",
+                "input": {"city": "Tokyo"},
+            },
+        ],
+        "stop_reason": "tool_use",
+    }
+    original = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="weather?")],
+    )
+    result = anthropic_engine._convert_api_output_to_conversation(
+        api_response, original
+    )
+    assistant = result.messages[-1]
+    assert assistant.role == Role.ASSISTANT
+    assert assistant.content == "Looking up weather."
+    assert assistant.tool_calls is not None
+    assert [tc.model_dump(mode="json") for tc in assistant.tool_calls] == [
+        {
+            "id": "toolu_01",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                # OpenAI keeps arguments as a JSON-encoded string.
+                "arguments": json.dumps({"city": "Tokyo"}),
+            },
+        }
+    ]
+    assert result.metadata["finish_reason"] == "tool_calls"
+    assert result.tools == [_WEATHER_TOOL]
+
+
+def test_tool_choice_translation(anthropic_engine):
+    """tool_choice translates: auto/required/by-name; 'none' drops tools."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="hi")],
+    )
+
+    body_auto = _build_body(anthropic_engine, conversation, tool_choice="auto")
+    assert body_auto["tool_choice"] == {"type": "auto"}
+
+    body_required = _build_body(anthropic_engine, conversation, tool_choice="required")
+    assert body_required["tool_choice"] == {"type": "any"}
+
+    body_named = _build_body(
+        anthropic_engine,
+        conversation,
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    assert body_named["tool_choice"] == {"type": "tool", "name": "get_weather"}
+
+    body_none = _build_body(anthropic_engine, conversation, tool_choice="none")
+    assert "tools" not in body_none
+    assert "tool_choice" not in body_none
 
 
 def test_pure_text_conversation_emits_string_content(anthropic_engine):
@@ -498,3 +829,40 @@ def test_adjacent_same_role_messages_are_merged(anthropic_engine):
         {"type": "text", "text": "Second user line."},
     ]
     assert body["messages"][1] == {"role": "assistant", "content": "Reply."}
+
+
+def test_tool_role_merges_into_adjacent_user_turn(anthropic_engine):
+    """Role.TOOL collapses to a user turn and merges with adjacent user content."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[
+            Message(role=Role.USER, content="weather?"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall.model_validate(
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Tokyo"}',
+                            },
+                        }
+                    )
+                ],
+            ),
+            Message(role=Role.TOOL, content="22C, sunny", tool_call_id="call_1"),
+            Message(role=Role.USER, content="And tomorrow?"),
+        ],
+    )
+    body = _build_body(anthropic_engine, conversation)
+    assert [m["role"] for m in body["messages"]] == ["user", "assistant", "user"]
+    merged_user_turn = body["messages"][2]["content"]
+    assert merged_user_turn[0] == {
+        "type": "tool_result",
+        "tool_use_id": "call_1",
+        "content": "22C, sunny",
+    }
+    assert merged_user_turn[1] == {"type": "text", "text": "And tomorrow?"}

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -518,17 +518,6 @@ def test_openai_tools_translated_to_anthropic_schema(anthropic_engine):
     assert "parameters" not in body["tools"][0]
 
 
-def test_last_tool_has_cache_control_marker(anthropic_engine):
-    """Cache marker stamps only the last tool entry; nothing on the others."""
-    conversation = Conversation(
-        tools=[_WEATHER_TOOL, _CALENDAR_TOOL],
-        messages=[Message(role=Role.USER, content="hi")],
-    )
-    body = _build_body(anthropic_engine, conversation)
-    assert "cache_control" not in body["tools"][0]
-    assert body["tools"][-1]["cache_control"] == {"type": "ephemeral"}
-
-
 def test_assistant_tool_calls_emit_tool_use_blocks(anthropic_engine):
     """Assistant ``tool_calls`` become ``tool_use`` blocks with parsed input."""
     tool_call_dict = {
@@ -788,8 +777,7 @@ def test_tool_choice_translation(anthropic_engine):
     assert body_named["tool_choice"] == {"type": "tool", "name": "get_weather"}
 
     body_none = _build_body(anthropic_engine, conversation, tool_choice="none")
-    assert "tools" not in body_none
-    assert "tool_choice" not in body_none
+    assert body_none["tool_choice"] == {"type": "none"}
 
 
 def test_pure_text_conversation_emits_string_content(anthropic_engine):


### PR DESCRIPTION
# Description

Anthropic's wire format differs from OpenAI's (tool definitions, assistant tool calls, and tool results)  and translation happens at the engine boundary.

## What changed

Reuses the block-builder structure introduced in the multimodal image-shape fix PR and extends it for tool calls.

- **Tool definitions** (`_openai_tools_to_anthropic`): `parameters` becomes `input_schema`, `name` and `description` are lifted out of the `function` wrapper, and the last tool entry gets `cache_control: {"type": "ephemeral"}`. `JSONSchema.parameters` is dumped via `model_dump(mode="json", exclude_none=True)` so Anthropic's `input_schema` is a plain dict.
- **Assistant `tool_calls`**: rendered as `tool_use` blocks. Anthropic expects `input` as a parsed dict, while OpenAI keeps `arguments` as a JSON string, so the engine parses on the way out.
- **`Role.TOOL` messages**: rewritten to `user` turns carrying a `tool_result` block (`_effective_anthropic_role` collapses `Role.TOOL` to `"user"`). 
- **`tool_choice` mapping** (`_translate_tool_choice`)
- **Response side**: iterates `content` blocks, collecting `text` blocks into a single string and `tool_use` blocks into typed `Message.tool_calls` (re-stringifying `input` as JSON so the wire format stays uniform across engines). `Conversation.tools` propagates onto the result.

## Out of scope

- Tool streaming
- batch-API tool-calling tests (the Anthropic batch path inherits the new request shape via `_convert_conversation_to_api_input`)
- broader Anthropic prompt-caching cleanup beyond the tools section.

## Related issues


## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.