### PR TITLE
[Det Env v2] Phase 1: Tool schema unification & validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "hdrhistogram>=0.10,<0.11",
     "httpx>=0.27,<1.0",           # Used by deploy module (async HTTP client)
     "jsonlines",
+    "jsonschema>=4.0,<5.0",       # Used for tool argument validation
     "lm_eval[wandb]>=0.4,<0.5.0",
     "mlflow>=3.1",                # >=3.1.4 requires Python3.10>=
     "numpy>=1.26,<2.4",           # verl==0.5.0 depends on numpy<2.0.0

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -20,88 +20,52 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+import jsonschema
+
 from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.types.tool_call import (
+    FunctionDefinition,
+    JSONSchema,
+    ToolDefinition,
+)
 
 
-@dataclass
-class ToolSchema(BaseParams):
-    """JSON schema for tool inputs or outputs."""
+class ToolError(Exception):
+    """Base class for tool errors surfaced back to the LLM.
 
-    type: str = "object"
-    properties: dict[str, ToolSchema] = field(default_factory=dict)
-    description: str | None = None
-    required: list[str] = field(default_factory=list)
+    Subclasses of this exception are caught by the tool-call loop and
+    re-emitted as structured ``tool`` messages so the model can self-correct
+    on the next iteration.
+    """
 
-    @classmethod
-    def create(cls, raw: Any) -> ToolSchema:
-        """Create a schema from raw config data."""
-        if isinstance(raw, ToolSchema):
-            return raw
-        if not isinstance(raw, Mapping):
-            raise TypeError(
-                f"Tool schema definitions must be schema objects or mappings, got "
-                f"{type(raw)}"
-            )
-        return cls(
-            type=raw.get("type", "object"),
-            properties={
-                key: cls.create(value)
-                for key, value in raw.get("properties", {}).items()
-            },
-            description=raw.get("description"),
-            required=raw.get("required", []),
-        )
 
-    def __post_init__(self):
-        """Validate schema fields."""
-        if not self.type:
-            raise ValueError(f"{type(self).__name__}.type cannot be empty.")
-        if not isinstance(self.properties, dict):
-            raise ValueError(f"{type(self).__name__}.properties must be a dict.")
-        if not all(isinstance(value, ToolSchema) for value in self.properties.values()):
-            raise ValueError(
-                f"{type(self).__name__}.properties values must be ToolSchema."
-            )
-        if self.description is not None and not isinstance(self.description, str):
-            raise ValueError(
-                f"{type(self).__name__}.description must be a string when specified."
-            )
-        if not isinstance(self.required, list) or not all(
-            isinstance(param, str) for param in self.required
-        ):
-            raise ValueError(
-                f"{type(self).__name__}.required must be a list of strings."
-            )
-        missing_required = set(self.required) - set(self.properties)
-        if missing_required:
-            raise ValueError(
-                f"{type(self).__name__}.required contains unknown properties: "
-                f"{sorted(missing_required)}"
-            )
+class ToolArgumentError(ToolError):
+    """Raised when tool-call arguments fail schema validation."""
 
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to a JSON-schema-shaped dict."""
-        schema: dict[str, Any] = {"type": self.type}
-        if self.properties:
-            schema["properties"] = {
-                key: value.to_dict() for key, value in self.properties.items()
-            }
-        if self.description is not None:
-            schema["description"] = self.description
-        if self.required:
-            schema["required"] = list(self.required)
-        return schema
+
+class ToolLookupError(ToolError):
+    """Raised when a tool cannot resolve an output for the given arguments.
+
+    Currently used by ``DeterministicEnvironment`` when no configured
+    ``DeterministicToolOutput`` matches the provided arguments.
+    """
 
 
 @dataclass
 class ToolParams(BaseParams):
-    """Tool schema owned by an environment."""
+    """Tool schema owned by an environment.
+
+    ``parameters`` and ``output_schema`` are stored as plain JSON-Schema
+    dicts so OmegaConf can carry them through YAML round-trips. They are
+    converted to a Pydantic ``JSONSchema`` only at the wire-format boundary
+    in :meth:`to_tool_definition`.
+    """
 
     id: str
     name: str
     description: str
-    parameters: ToolSchema = field(default_factory=ToolSchema)
-    output_schema: ToolSchema | None = None
+    parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
+    output_schema: dict[str, Any] | None = None
     read_only: bool = True
 
     @classmethod
@@ -117,9 +81,9 @@ class ToolParams(BaseParams):
             id=raw["id"],
             name=raw["name"],
             description=raw["description"],
-            parameters=ToolSchema.create(raw.get("parameters", {})),
+            parameters=dict(raw.get("parameters", {"type": "object"})),
             output_schema=(
-                ToolSchema.create(raw["output_schema"])
+                dict(raw["output_schema"])
                 if raw.get("output_schema") is not None
                 else None
             ),
@@ -127,35 +91,59 @@ class ToolParams(BaseParams):
         )
 
     def __post_init__(self):
-        """Validate common tool fields."""
+        """Validate common tool fields.
+
+        Accepts ``JSONSchema`` instances on ``parameters`` / ``output_schema``
+        for callers that build a tool with Pydantic types directly; converts
+        them to dicts so the canonical in-memory shape stays JSON-Schema-shaped.
+        """
         if not self.id:
             raise ValueError(f"{type(self).__name__}.id cannot be empty.")
         if not self.name:
             raise ValueError(f"{type(self).__name__}.name cannot be empty.")
         if not self.description:
             raise ValueError(f"{type(self).__name__}.description cannot be empty.")
-        if not isinstance(self.parameters, ToolSchema):
-            self.parameters = ToolSchema.create(self.parameters)
-        if self.output_schema is not None and not isinstance(
-            self.output_schema, ToolSchema
-        ):
-            self.output_schema = ToolSchema.create(self.output_schema)
+        if isinstance(self.parameters, JSONSchema):
+            self.parameters = self.parameters.model_dump(mode="json", exclude_none=True)
+        if isinstance(self.output_schema, JSONSchema):
+            self.output_schema = self.output_schema.model_dump(
+                mode="json", exclude_none=True
+            )
 
     def to_llm_schema(self) -> dict[str, Any]:
         """Export a provider-agnostic schema for LLM tool registration."""
         schema: dict[str, Any] = {
-            "name": self.name,
+            "name": self.id,
+            "display_name": self.name,
             "description": self.description,
-            "parameters": self.parameters.to_dict(),
+            "parameters": self.parameters,
         }
         if self.output_schema is not None:
-            schema["output_schema"] = self.output_schema.to_dict()
+            schema["output_schema"] = self.output_schema
         return schema
 
+    def to_tool_definition(self) -> ToolDefinition:
+        """Project to OpenAI-wire-format ``ToolDefinition``.
 
-@dataclass
-class ToolResult(BaseParams):
-    """Result returned by an environment step."""
+        Drops chain-internal fields (``output_schema``, ``read_only``,
+        ``name`` display label) that have no slot in the OpenAI contract.
+        Coerces ``parameters`` to ``JSONSchema`` at the boundary.
+        """
+        return ToolDefinition(
+            function=FunctionDefinition(
+                name=self.id,
+                description=self.description,
+                parameters=JSONSchema.model_validate(self.parameters),
+            ),
+        )
 
-    output: str | dict[str, Any]
-    updated_state: dict[str, Any] | None = None
+    def validate_arguments(self, arguments: dict[str, Any]) -> None:
+        """Validate call-time arguments against this tool's ``parameters`` schema.
+
+        Raises:
+            ToolArgumentError: If ``arguments`` do not conform.
+        """
+        try:
+            jsonschema.validate(arguments, self.parameters)
+        except jsonschema.ValidationError as e:
+            raise ToolArgumentError(str(e)) from e

--- a/src/oumi/core/types/__init__.py
+++ b/src/oumi/core/types/__init__.py
@@ -45,8 +45,10 @@ from oumi.core.types.conversation import (
 from oumi.core.types.tool_call import (
     FunctionCall,
     FunctionDefinition,
+    JSONSchema,
     ToolCall,
     ToolDefinition,
+    ToolResult,
     ToolType,
 )
 from oumi.exceptions import HardwareException
@@ -59,11 +61,13 @@ __all__ = [
     "FunctionCall",
     "FunctionDefinition",
     "HardwareException",
+    "JSONSchema",
     "Message",
     "Role",
     "TemplatedMessage",
     "ToolCall",
     "ToolDefinition",
+    "ToolResult",
     "ToolType",
     "Type",
 ]

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -25,6 +25,7 @@ keys at validation time would silently lose information that
 downstream code relies on.
 """
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 
@@ -174,3 +175,17 @@ class ToolCall(pydantic.BaseModel):
 
     function: FunctionCall
     """The function the model called."""
+
+
+@dataclass
+class ToolResult:
+    """Result returned by an environment ``step()``.
+
+    Runtime value (not an OpenAI wire-format type) — projected by the
+    synthesizer into ``Message(role=TOOL, content=...)`` before output.
+    ``output`` may be a string or a JSON-serializable dict; the
+    synthesizer json-encodes dicts at the message boundary.
+    """
+
+    output: str | dict[str, Any]
+    updated_state: dict[str, Any] | None = None

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -19,10 +19,12 @@ concrete environment's `@register_environment(...)` decorator.
 """
 
 from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolError,
+    ToolLookupError,
     ToolParams,
-    ToolResult,
-    ToolSchema,
 )
+from oumi.core.types.tool_call import JSONSchema, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
@@ -44,10 +46,13 @@ __all__ = [
     "DeterministicEnvironmentKwargs",
     "DeterministicTool",
     "DeterministicToolOutput",
+    "JSONSchema",
     "SyntheticEnvironment",
     "SyntheticEnvironmentKwargs",
     "SyntheticStateParams",
+    "ToolArgumentError",
+    "ToolError",
+    "ToolLookupError",
     "ToolParams",
     "ToolResult",
-    "ToolSchema",
 ]

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from oumi.core.configs.params.tool_params import ToolParams, ToolResult
+from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.types.tool_call import ToolResult
 
 
 class BaseEnvironment(ABC):

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -22,8 +22,8 @@ from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolResult
 from oumi.core.registry import register_environment
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_tool import (
     DeterministicTool,

--- a/src/oumi/environments/deterministic_tool.py
+++ b/src/oumi/environments/deterministic_tool.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
-from oumi.core.configs.params.tool_params import ToolParams, ToolSchema
+from oumi.core.configs.params.tool_params import ToolParams
 
 
 @dataclass
@@ -76,9 +76,9 @@ class DeterministicTool(ToolParams):
             id=raw["id"],
             name=raw["name"],
             description=raw["description"],
-            parameters=ToolSchema.create(raw.get("parameters", {})),
+            parameters=dict(raw.get("parameters", {"type": "object"})),
             output_schema=(
-                ToolSchema.create(raw["output_schema"])
+                dict(raw["output_schema"])
                 if raw.get("output_schema") is not None
                 else None
             ),

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -21,58 +21,15 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
+import jsonschema
+
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolParams, ToolResult
+from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.registry import register_environment
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.deterministic_tool import DeterministicTool
-
-
-def _validate_json_schema_value(
-    value: Any,
-    schema: dict[str, Any],
-    path: str = "$",
-) -> None:
-    """Validate a JSON-like value against a minimal schema subset."""
-    expected_type = schema.get("type")
-    if expected_type == "object":
-        if not isinstance(value, dict):
-            raise ValueError(f"{path} must be an object.")
-        required = schema.get("required", [])
-        for key in required:
-            if key not in value:
-                raise ValueError(f"{path}.{key} is required.")
-        for key, child_value in value.items():
-            child_schema = schema.get("properties", {}).get(key)
-            if child_schema is not None:
-                _validate_json_schema_value(child_value, child_schema, f"{path}.{key}")
-    elif expected_type == "array":
-        if not isinstance(value, list):
-            raise ValueError(f"{path} must be an array.")
-        item_schema = schema.get("items")
-        if item_schema is not None:
-            for idx, item in enumerate(value):
-                _validate_json_schema_value(item, item_schema, f"{path}[{idx}]")
-    elif expected_type == "string":
-        if not isinstance(value, str):
-            raise ValueError(f"{path} must be a string.")
-    elif expected_type == "integer":
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise ValueError(f"{path} must be an integer.")
-    elif expected_type == "number":
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise ValueError(f"{path} must be a number.")
-    elif expected_type == "boolean":
-        if not isinstance(value, bool):
-            raise ValueError(f"{path} must be a boolean.")
-    elif expected_type == "null":
-        if value is not None:
-            raise ValueError(f"{path} must be null.")
-
-    enum_values = schema.get("enum")
-    if enum_values is not None and value not in enum_values:
-        raise ValueError(f"{path} must be one of {enum_values}.")
 
 
 @dataclass
@@ -85,7 +42,7 @@ class SyntheticStateParams(BaseParams):
     def __post_init__(self):
         """Validate state config consistency."""
         if self.state_schema is not None and self.initial_state is not None:
-            _validate_json_schema_value(self.initial_state, self.state_schema)
+            jsonschema.validate(self.initial_state, self.state_schema)
 
 
 @dataclass

--- a/tests/unit/builders/test_environments.py
+++ b/tests/unit/builders/test_environments.py
@@ -15,10 +15,8 @@
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import (
-    ToolParams,
-    ToolResult,
-)
+from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.deterministic_tool import (
     DeterministicTool,
     DeterministicToolOutput,

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -14,13 +14,11 @@
 
 from typing import Any
 
+import jsonschema
 import pytest
 
-from oumi.core.configs.params.tool_params import (
-    ToolParams,
-    ToolResult,
-    ToolSchema,
-)
+from oumi.core.configs.params.tool_params import ToolArgumentError, ToolParams
+from oumi.core.types.tool_call import JSONSchema, ToolDefinition, ToolResult
 from oumi.environments.synthetic_environment import SyntheticStateParams
 
 
@@ -49,14 +47,15 @@ def test_tool_params_to_llm_schema():
         id="search",
         name="Search",
         description="Search the catalog.",
-        parameters=ToolSchema(
-            type="object",
-            properties={"query": ToolSchema(type="string")},
-            required=["query"],
-        ),
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
     )
     assert tool.to_llm_schema() == {
-        "name": "Search",
+        "name": "search",
+        "display_name": "Search",
         "description": "Search the catalog.",
         "parameters": {
             "type": "object",
@@ -71,16 +70,17 @@ def test_tool_params_to_llm_schema_includes_output_schema():
         id="search",
         name="Search",
         description="Search the catalog.",
-        parameters=ToolSchema(type="object", properties={}),
-        output_schema=ToolSchema(
-            type="object",
-            properties={"result": ToolSchema(type="string")},
-        ),
+        parameters={"type": "object", "properties": {}},
+        output_schema={
+            "type": "object",
+            "properties": {"result": {"type": "string"}},
+        },
     )
     assert tool.to_llm_schema() == {
-        "name": "Search",
+        "name": "search",
+        "display_name": "Search",
         "description": "Search the catalog.",
-        "parameters": {"type": "object"},
+        "parameters": {"type": "object", "properties": {}},
         "output_schema": {
             "type": "object",
             "properties": {"result": {"type": "string"}},
@@ -104,8 +104,53 @@ def test_tool_params_create_reads_extended_fields():
             "output_schema": {"type": "object", "properties": {}},
         }
     )
-    assert tool.parameters.required == ["policy_id"]
-    assert tool.output_schema == ToolSchema(type="object", properties={})
+    assert tool.parameters["required"] == ["policy_id"]
+    assert tool.output_schema == {"type": "object", "properties": {}}
+
+
+def test_tool_params_accepts_jsonschema_pydantic_instance():
+    """Direct construction with a Pydantic JSONSchema is supported via post_init."""
+    tool = ToolParams(
+        id="search",
+        name="Search",
+        description="Search.",
+        parameters=JSONSchema(  # type: ignore[arg-type]
+            type="object",
+            properties={"q": JSONSchema(type="string")},
+            required=["q"],
+        ),
+    )
+    assert isinstance(tool.parameters, dict)
+    assert tool.parameters == {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+
+
+def test_tool_params_to_tool_definition_drops_chain_internals():
+    tool = ToolParams(
+        id="search",
+        name="Search Display",
+        description="Search the catalog.",
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        output_schema={"type": "object"},
+        read_only=False,
+    )
+    td = tool.to_tool_definition()
+    assert isinstance(td, ToolDefinition)
+    # name/description/parameters preserved; display name and output_schema dropped.
+    assert td.function.name == "search"
+    assert td.function.description == "Search the catalog."
+    assert td.function.parameters == JSONSchema(
+        type="object",
+        properties={"query": JSONSchema(type="string")},
+        required=["query"],
+    )
 
 
 def test_tool_result_round_trip():
@@ -114,70 +159,67 @@ def test_tool_result_round_trip():
     assert result.updated_state is None
 
 
-def test_tool_schema_to_dict():
-    schema = ToolSchema(
-        type="object",
-        properties={
-            "query": ToolSchema(type="string"),
-        },
-        description="Tool input schema.",
-        required=["query"],
+def test_validate_arguments_rejects_wrong_item_type():
+    tool = ToolParams(
+        id="t",
+        name="T",
+        description="d",
+        parameters={"type": "array", "items": {"type": "string"}},
     )
-    assert schema.to_dict() == {
-        "type": "object",
-        "properties": {"query": {"type": "string"}},
-        "description": "Tool input schema.",
-        "required": ["query"],
-    }
+    with pytest.raises(ToolArgumentError):
+        tool.validate_arguments(["ok", 2])  # type: ignore[arg-type]
 
 
-def test_tool_schema_create_recursively_coerces_nested_properties():
-    schema = ToolSchema.create(
-        {
+def test_validate_arguments_rejects_value_outside_enum():
+    tool = ToolParams(
+        id="t",
+        name="T",
+        description="d",
+        parameters={"type": "string", "enum": ["a", "b"]},
+    )
+    with pytest.raises(ToolArgumentError):
+        tool.validate_arguments("c")  # type: ignore[arg-type]
+
+
+def _policy_tool() -> ToolParams:
+    return ToolParams(
+        id="policy",
+        name="Policy",
+        description="Look up policy.",
+        parameters={
             "type": "object",
             "properties": {
-                "customer": {
-                    "type": "object",
-                    "properties": {
-                        "email": {"type": "string", "description": "Customer email."}
-                    },
-                    "required": ["email"],
-                }
+                "policy_id": {"type": "string"},
+                "limit": {"type": "integer"},
             },
-            "required": ["customer"],
-        }
-    )
-    assert isinstance(schema.properties["customer"], ToolSchema)
-    assert isinstance(schema.properties["customer"].properties["email"], ToolSchema)
-    assert schema.to_dict() == {
-        "type": "object",
-        "properties": {
-            "customer": {
-                "type": "object",
-                "properties": {
-                    "email": {
-                        "type": "string",
-                        "description": "Customer email.",
-                    }
-                },
-                "required": ["email"],
-            }
+            "required": ["policy_id"],
         },
-        "required": ["customer"],
-    }
+    )
 
 
-def test_tool_schema_required_must_exist_in_properties():
-    with pytest.raises(ValueError, match="required contains unknown properties"):
-        ToolSchema(
-            type="object",
-            properties={"query": ToolSchema(type="string")},
-            required=["missing"],
-        )
+def test_validate_arguments_accepts_conforming_value():
+    _policy_tool().validate_arguments({"policy_id": "abc", "limit": 5})
+
+
+def test_validate_arguments_missing_required_raises():
+    with pytest.raises(ToolArgumentError, match=r"policy_id"):
+        _policy_tool().validate_arguments({"limit": 5})
+
+
+def test_validate_arguments_wrong_type_raises():
+    with pytest.raises(ToolArgumentError, match=r"integer"):
+        _policy_tool().validate_arguments({"policy_id": "abc", "limit": "five"})
+
+
+def test_validate_arguments_empty_schema_accepts_any_object():
+    # Tools that don't declare parameters shouldn't force callers to pass {}.
+    tool = ToolParams(id="ping", name="Ping", description="No args.")
+    tool.validate_arguments({})
+    tool.validate_arguments({"extra": "ignored"})
 
 
 def test_synthetic_state_params_validates_initial_state_against_schema():
-    with pytest.raises(ValueError, match=r"\$\.files\.count must be an integer"):
+    with pytest.raises(jsonschema.ValidationError):
         SyntheticStateParams(
             state_schema=_make_state_schema(),
             initial_state={"files": {"count": "bad"}},

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -15,7 +15,7 @@
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolResult
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
     DeterministicEnvironmentKwargs,

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -15,10 +15,8 @@
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import (
-    ToolParams,
-    ToolResult,
-)
+from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.deterministic_tool import (
     DeterministicTool,
     DeterministicToolOutput,


### PR DESCRIPTION
# Description

Part of a new **Deterministic Environment v2** PR series — replacing the original 8-PR chain (#2386–#2411) with a more logical decomposition. **Phase 1 of 7.**

**What changed**: Replace the chain's `ToolSchema` dataclass with main's Pydantic `JSONSchema` (#2392), add a tool-error exception hierarchy, JSON-schema argument validation helpers, an OpenAI-wire-format projection, and relocate `ToolResult` to `core.types.tool_call` to co-locate with the rest of the tool-related types.

**Why**: The skeleton (#2358) shipped `ToolSchema` before #2392 unified tool types on main. This PR eliminates the duplicate and gives the chain a single, shared validation surface — every subsequent phase consumes these types, so doing this first keeps later PRs focused.

## What's in scope

- **Type unification**: `ToolSchema` deleted; `ToolParams.parameters` / `output_schema` are typed as `Any` so OmegaConf carries them as plain dicts through YAML, then `__post_init__` coerces to `JSONSchema`.
- **`_coerce_json_schema(raw)`** helper — handles `None | JSONSchema | Mapping`; replaces `ToolSchema.create()`.
- **`ToolError` / `ToolArgumentError` / `ToolLookupError`** exception hierarchy.
- **`_validate_json_schema_value`** moved from `synthetic_environment.py` to `tool_params.py` so other modules can share it without crossing the environments-package boundary.
- **`validate_arguments_against_schema(arguments, schema)`** helper, with `ToolParams.validate_arguments()` delegating to it.
- **`ToolParams.to_tool_definition()`** — projects to OpenAI-wire-format `ToolDefinition` (drops chain-internal fields like `output_schema`, `read_only`, display name).
- **`ToolResult` relocated** from `tool_params.py` to `core/types/tool_call.py` (co-located with `ToolDefinition` / `ToolCall` / `FunctionCall`); drops unused `BaseParams` inheritance.

## Notes

- The skeleton's `required ⊆ properties` check on `ToolSchema` is dropped — JSON Schema spec doesn't require this and standard validators don't enforce it.
- 398 tests pass across `tests/unit/core/configs/params/`, `tests/unit/core/synthesis/`, `tests/unit/environments/`, `tests/unit/builders/test_environments.py`.

## Series context

This is PR 1 of a 7-PR series replacing the original chain:

1. **Tool schema unification & validation infrastructure** ← this PR
2. Planner: guided JSON decoding + brace repair
3. Grounding system: types + environment integration
4. Grounding in the synthesis pipeline
5. Agentic tool-call loop in synthesizer
6. Structured tool-message projection on output
7. Library tool-use synthesis example + end-to-end test

## Related issues

None.

## Before submitting
- [x] Tests added/migrated to `JSONSchema`.
