### PR TITLE
[Det Env v2] Phase 2: Planner guided JSON decoding

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -12,19 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import random
 
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
     MultiTurnAttribute,
 )
 from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.synthesis.attribute_formatter import AttributeFormatter
-from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.conversation import (
+    PLANNER_JSON_SCHEMA,
+    Conversation,
+    Message,
+    Role,
+)
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
 
@@ -221,10 +228,11 @@ class ConversationSynthesizer:
         return augmented_samples
 
     def _parse_plan(self, plan: str, target_turns: int) -> list[str] | None:
-        """Parse a JSON-formatted conversation plan.
+        """Parse a guided-decoded planner output into per-turn instructions.
 
-        Extracts turn instructions from JSON array. Expects format:
-        [{"turn": 1, "instruction": "..."}, ...]
+        Expects the ``{"turns": [{"turn": 1, "instruction": "..."}, ...]}``
+        shape enforced by ``PLANNER_JSON_SCHEMA``. Anything else returns
+        ``None`` so ``_plan_samples``'s retry loop can re-prompt.
 
         Args:
             plan: The full plan text from the planner.
@@ -236,13 +244,10 @@ class ConversationSynthesizer:
         if not plan:
             return None
 
-        turns = extract_json(plan, expected_type=list)
-        if turns is None:
-            single = extract_json(plan, expected_type=dict)
-            if single is not None:
-                turns = [single]
-            else:
-                return None
+        wrapped = extract_json(plan, expected_type=dict)
+        if not isinstance(wrapped, dict) or not isinstance(wrapped.get("turns"), list):
+            return None
+        turns = wrapped["turns"]
 
         result = [""] * target_turns
         for turn in turns:
@@ -364,7 +369,8 @@ class ConversationSynthesizer:
         """Create the planner prompt template with role context and turn order.
 
         Returns a Conversation with a one-shot example for consistent formatting.
-        The prompt instructs the model to output JSON wrapped in code fences.
+        Pairs with :meth:`_planner_inference_config` to drive guided JSON
+        decoding against ``PLANNER_JSON_SCHEMA``.
         """
         role_context = self._build_role_context(sample, multiturn_attribute)
         turn_order = self._default_turn_order
@@ -374,8 +380,10 @@ class ConversationSynthesizer:
         system_prompt = (
             "You are a conversation planner. Create conversation outlines "
             "that flow logically from start to finish.\n\n"
-            "IMPORTANT: Output your plan as a JSON array wrapped in ```json code "
-            "fences. Each element must have: turn (number) and instruction (string).\n"
+            "IMPORTANT: Output your plan as a raw JSON object with a `turns` "
+            "array. Do not use markdown or code fences. "
+            "Each element of `turns` must have: turn (number) and instruction "
+            "(string).\n"
             "Your instructions MUST be specific to the role context provided. "
             "Each turn's instruction should reflect what that specific role "
             "would do at that point in the conversation."
@@ -393,14 +401,18 @@ class ConversationSynthesizer:
             "Additional instructions: Focus on resolving the order issue "
             "efficiently while maintaining a polite and helpful tone."
         )
-        example_response = """```json
-[
-  {"turn": 1, "instruction": "Greet support and explain the issue with the order"},
-  {"turn": 2, "instruction": "Acknowledge the issue and ask for order details"},
-  {"turn": 3, "instruction": "Provide order number and describe the problem further"},
-  {"turn": 4, "instruction": "Confirm the issue and offer a resolution"}
-]
-```"""
+        example_response = (
+            '{"turns": [\n'
+            '  {"turn": 1, "instruction": "Greet support and explain the '
+            'issue with the order"},\n'
+            '  {"turn": 2, "instruction": "Acknowledge the issue and ask '
+            'for order details"},\n'
+            '  {"turn": 3, "instruction": "Provide order number and describe '
+            'the problem further"},\n'
+            '  {"turn": 4, "instruction": "Confirm the issue and offer a '
+            'resolution"}\n'
+            "]}"
+        )
 
         base_prompt = (
             f"Plan a {target_turns}-turn conversation.\n"
@@ -423,10 +435,7 @@ class ConversationSynthesizer:
             )
             base_prompt += f"\nAdditional instructions: {formatted_planner}\n"
 
-        base_prompt += (
-            "\nOutput ONLY the JSON array wrapped in ```json code fences. "
-            "No other text."
-        )
+        base_prompt += "\nOutput ONLY the JSON object. No markdown. No other text."
 
         return Conversation(
             messages=[
@@ -448,10 +457,26 @@ class ConversationSynthesizer:
         """
         inference_results = self._inference_engine.infer(
             planners,
-            inference_config=self._inference_config,
+            inference_config=self._planner_inference_config(),
         )
 
         return self._extract_response(inference_results)
+
+    def _planner_inference_config(self) -> InferenceConfig:
+        """Create an inference config for planner calls with JSON guided decoding.
+
+        Returns a copy of ``self._inference_config`` whose ``generation`` block
+        carries ``GuidedDecodingParams(json=PLANNER_JSON_SCHEMA)``. The base
+        config is left untouched so per-turn (non-planner) inference is not
+        constrained.
+        """
+        return dataclasses.replace(
+            self._inference_config,
+            generation=dataclasses.replace(
+                self._inference_config.generation,
+                guided_decoding=GuidedDecodingParams(json=PLANNER_JSON_SCHEMA),
+            ),
+        )
 
     def _synthesize_all_samples(
         self,

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -618,3 +618,23 @@ class TemplatedMessage(pydantic.BaseModel):
         """Returns the message in oumi format."""
         content = str(self.content)
         return Message(content=content, role=self.role)
+
+
+class PlannedTurn(pydantic.BaseModel):
+    """A single turn in a planned multi-turn conversation."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    turn: int = pydantic.Field(ge=1, description="1-indexed turn number.")
+    instruction: str = pydantic.Field(description="What should happen on this turn.")
+
+
+class PlannerOutput(pydantic.BaseModel):
+    """Top-level planner output: a list of planned turns wrapped in an object."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    turns: list[PlannedTurn]
+
+
+PLANNER_JSON_SCHEMA: dict = PlannerOutput.model_json_schema()

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -20,6 +20,7 @@ import pytest
 
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.configs.params.remote_params import RemoteParams
 from oumi.core.configs.params.synthesis_params import (
@@ -29,17 +30,27 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttributeValue,
 )
 from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
-from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.conversation import (
+    PLANNER_JSON_SCHEMA,
+    Conversation,
+    Message,
+    Role,
+)
 
 
 @pytest.fixture
 def mock_inference_config():
-    """Create a mock inference config."""
-    mock = Mock(spec=InferenceConfig)
-    mock.engine = InferenceEngineType.NATIVE
-    mock.model = Mock(spec=ModelParams)
-    mock.remote_params = Mock(spec=RemoteParams)
-    return mock
+    """Create a real InferenceConfig.
+
+    Uses a real config rather than ``Mock(spec=InferenceConfig)`` so that
+    ``dataclasses.replace`` works in ``_planner_inference_config``.
+    """
+    return InferenceConfig(
+        engine=InferenceEngineType.NATIVE,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
 
 
 @pytest.fixture
@@ -395,7 +406,9 @@ def test_planner_prompt_includes_role_context(
 
     example_response = planner.messages[2].content
     assert isinstance(example_response, str)
-    assert "```json" in example_response
+    # Wrapped object form, no markdown fences (matches PLANNER_JSON_SCHEMA).
+    assert example_response.startswith('{"turns":')
+    assert "```" not in example_response
     assert '"turn": 1' in example_response
     assert '"instruction"' in example_response
 
@@ -413,14 +426,14 @@ def test_parse_plan_extracts_turn_instructions(
         mock_inference_config,
     )
 
-    plan = """```json
-[
-  {"turn": 1, "instruction": "Greet support and explain the issue."},
-  {"turn": 2, "instruction": "Acknowledge and ask for details."},
-  {"turn": 3, "instruction": "Provide order number."},
-  {"turn": 4, "instruction": "Offer a resolution."}
-]
-```"""
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "Greet support and explain the issue."},'
+        '{"turn": 2, "instruction": "Acknowledge and ask for details."},'
+        '{"turn": 3, "instruction": "Provide order number."},'
+        '{"turn": 4, "instruction": "Offer a resolution."}'
+        "]}"
+    )
 
     result = synthesizer._parse_plan(plan, target_turns=4)
 
@@ -430,6 +443,100 @@ def test_parse_plan_extracts_turn_instructions(
     assert result[1] == "Acknowledge and ask for details."
     assert result[2] == "Provide order number."
     assert result[3] == "Offer a resolution."
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_parse_plan_unwraps_object_form(
+    mock_build_inference_engine,
+    mock_inference_config,
+):
+    """``_parse_plan`` extracts turns from the ``{"turns": [...]}`` object form.
+
+    This is the primary shape enforced by ``PLANNER_JSON_SCHEMA`` for guided
+    decoding, so the happy path must be covered directly.
+    """
+    mock_build_inference_engine.return_value = Mock()
+
+    synthesizer = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+    )
+
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "Greet"},'
+        '{"turn": 2, "instruction": "Answer"}'
+        "]}"
+    )
+    result = synthesizer._parse_plan(plan, target_turns=2)
+    assert result == ["Greet", "Answer"]
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_generate_plan_uses_planner_only_guided_decoding(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_inference_config,
+):
+    """Planner calls get JSON guided decoding without affecting turn generation."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    planner_result = Conversation(
+        messages=[
+            Message(
+                role=Role.ASSISTANT,
+                content=(
+                    '{"turns": ['
+                    '{"turn": 1, "instruction": "Ask"},'
+                    '{"turn": 2, "instruction": "Answer"}'
+                    "]}"
+                ),
+            )
+        ]
+    )
+    turn_result = Conversation(messages=[Message(role=Role.ASSISTANT, content="Turn")])
+    mock_inference_engine.infer.side_effect = [
+        [planner_result],
+        [turn_result],
+        [turn_result],
+    ]
+
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    result = synthesizer.synthesize(
+        [{"customer_type": "friendly", "issue": "product question"}],
+        MultiTurnAttribute(
+            id="test_conversation",
+            min_turns=2,
+            max_turns=2,
+            role_instruction_messages={
+                Role.USER: "You are a {customer_type} customer with issue: {issue}.",
+                Role.ASSISTANT: "You are a helpful support agent.",
+            },
+            conversation_planner="Plan a conversation about {issue}.",
+        ),
+    )
+
+    assert result[0] is not None
+    planner_call = mock_inference_engine.infer.call_args_list[0].kwargs[
+        "inference_config"
+    ]
+    turn_call = mock_inference_engine.infer.call_args_list[1].kwargs["inference_config"]
+
+    # Planner config is a fresh copy with guided decoding set.
+    assert planner_call is not mock_inference_config
+    assert planner_call.generation is not mock_inference_config.generation
+    assert planner_call.generation.guided_decoding is not None
+    assert planner_call.generation.guided_decoding.json == PLANNER_JSON_SCHEMA
+    # Turn calls use the original config — no guided decoding.
+    assert turn_call is mock_inference_config
+    assert turn_call.generation.guided_decoding is None
+    # Original config is left untouched.
+    assert mock_inference_config.generation.guided_decoding is None
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
@@ -463,12 +570,12 @@ def test_parse_plan_handles_missing_turns(
         mock_inference_config,
     )
 
-    plan = """```json
-[
-  {"turn": 1, "instruction": "First message."},
-  {"turn": 3, "instruction": "Third message."}
-]
-```"""
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "First message."},'
+        '{"turn": 3, "instruction": "Third message."}'
+        "]}"
+    )
 
     result = synthesizer._parse_plan(plan, target_turns=3)
 
@@ -492,10 +599,12 @@ def test_parse_plan_handles_raw_json(
         mock_inference_config,
     )
 
-    plan = """[
-  {"turn": 1, "instruction": "First instruction"},
-  {"turn": 2, "instruction": "Second instruction"}
-]"""
+    plan = (
+        '{"turns": ['
+        '{"turn": 1, "instruction": "First instruction"},'
+        '{"turn": 2, "instruction": "Second instruction"}'
+        "]}"
+    )
 
     result = synthesizer._parse_plan(plan, target_turns=2)
 
@@ -537,12 +646,12 @@ def test_parse_plan_handles_string_turn_numbers(
         GeneralSynthesisParams(),
         mock_inference_config,
     )
-    plan = """```json
-[
-  {"turn": "1", "instruction": "First instruction"},
-  {"turn": "2", "instruction": "Second instruction"}
-]
-```"""
+    plan = (
+        '{"turns": ['
+        '{"turn": "1", "instruction": "First instruction"},'
+        '{"turn": "2", "instruction": "Second instruction"}'
+        "]}"
+    )
 
     result = synthesizer._parse_plan(plan, target_turns=2)
 
@@ -614,63 +723,23 @@ def test_parse_plan_extracts_json_with_surrounding_prose(
     mock_build_inference_engine,
     mock_inference_config,
 ):
-    """Test that _parse_plan extracts JSON when LLM wraps it in prose."""
+    """Tolerate stray prose around the wrapped object — `extract_json` finds it."""
     mock_build_inference_engine.return_value = Mock()
     synthesizer = ConversationSynthesizer(
         GeneralSynthesisParams(), mock_inference_config
     )
     plan = (
         "Sure! Here is a conversation plan:\n"
-        "```json\n"
-        "[\n"
-        '  {"turn": 1, "instruction": "Ask about the product"},\n'
-        '  {"turn": 2, "instruction": "Provide product details"}\n'
-        "]\n"
-        "```\n"
+        '{"turns": ['
+        '{"turn": 1, "instruction": "Ask about the product"},'
+        '{"turn": 2, "instruction": "Provide product details"}'
+        "]}\n"
         "Let me know if you need any changes."
     )
     result = synthesizer._parse_plan(plan, target_turns=2)
     assert result is not None
     assert result[0] == "Ask about the product"
     assert result[1] == "Provide product details"
-
-
-@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_parse_plan_extracts_raw_json_without_fences(
-    mock_build_inference_engine,
-    mock_inference_config,
-):
-    """Test that _parse_plan extracts raw JSON without code fences."""
-    mock_build_inference_engine.return_value = Mock()
-    synthesizer = ConversationSynthesizer(
-        GeneralSynthesisParams(), mock_inference_config
-    )
-    plan = (
-        "Here is the plan:\n"
-        '[{"turn": 1, "instruction": "Greet"}, '
-        '{"turn": 2, "instruction": "Respond"}]\n'
-        "That should work."
-    )
-    result = synthesizer._parse_plan(plan, target_turns=2)
-    assert result is not None
-    assert result[0] == "Greet"
-    assert result[1] == "Respond"
-
-
-@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_parse_plan_handles_single_dict_json(
-    mock_build_inference_engine,
-    mock_inference_config,
-):
-    """Test that _parse_plan handles LLM returning a single dict instead of a list."""
-    mock_build_inference_engine.return_value = Mock()
-    synthesizer = ConversationSynthesizer(
-        GeneralSynthesisParams(), mock_inference_config
-    )
-    plan = '```json\n{"turn": 1, "instruction": "Only turn"}\n```'
-    result = synthesizer._parse_plan(plan, target_turns=1)
-    assert result is not None
-    assert result[0] == "Only turn"
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")


### PR DESCRIPTION
# Description

Part of the **Det Env v2** PR series — **Phase 2 of 7**.

**What changed**: Switch the planner to JSON guided decoding against a Pydantic-derived `PLANNER_JSON_SCHEMA`. Planner output now arrives as a structured `{"turns": [...]}` object instead of markdown-fenced JSON.

**Why**: Markdown-fenced output is brittle — truncated fences and trailing prose force a re-parse loop and add latency. Guided decoding lets the inference engine constrain the output directly so the planner returns valid JSON on the first attempt.

## What's in scope

- **`PlannerOutput` / `PlannedTurn`** Pydantic models in `core.types.conversation`, with a derived `PLANNER_JSON_SCHEMA: dict` constant. The schema enforces a `{"turns": [{"turn": int, "instruction": str}, ...]}` shape.
- **`ConversationSynthesizer._planner_inference_config()`** — returns a copy of the user's inference config with `GuidedDecodingParams(json=PLANNER_JSON_SCHEMA)` set on the planner call only. The original config is never mutated, so per-turn (non-planner) inference stays unconstrained.
- **`_create_planner_prompt`** updated to emit the wrapped object form with no markdown fences, matching the schema.
- **`_parse_plan`** reads the wrapped object form first and falls back to a bare list for backward compatibility.
- **`_generate_plan`** calls `_planner_inference_config()` instead of passing the raw config.
- **Test fixture** `mock_inference_config` switched from `Mock(spec=InferenceConfig)` to a real `InferenceConfig` so `dataclasses.replace` works in the new helper.
- New tests: `test_parse_plan_unwraps_object_form`, `test_generate_plan_uses_planner_only_guided_decoding` (verifies planner gets guided decoding, turn calls don't, and the original config is left untouched).

## Notes

- 447 tests pass across `tests/unit/core/synthesis/`, `tests/unit/core/configs/params/`, `tests/unit/utils/test_str_utils.py`.
- `_planner_inference_config` is a 4-line `dataclasses.replace` chain — both `InferenceConfig.generation` and `GenerationParams` are guaranteed to be present (non-optional fields with defaults), so no `getattr` / isinstance defensive code.

## Series context

This is PR 2 of a 7-PR series (rebooted from the original 8-PR chain #2386–#2411). Each PR targets `main` directly, opened one at a time as predecessors land.

1. ~~Tool schema unification & validation infrastructure~~ → **#2421 (merged)**
2. **Planner: guided JSON decoding** ← this PR
3. Grounding system: types + environment integration
4. Grounding in the synthesis pipeline
5. Agentic tool-call loop in synthesizer
6. Structured tool-message projection on output
7. Library tool-use synthesis example + end-to-end test

## Related issues

None.

## Before submitting
- [x] Tests added (`test_parse_plan_unwraps_object_form`, `test_generate_plan_uses_planner_only_guided_decoding`).
