### PR TITLE
feat(deploy): expose replica_count + raw accelerator_type on Endpoint

### DIFF
--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -105,6 +105,14 @@ class Endpoint:
     inference_model_name: str | None = None  # Model name to use for inference calls
     status_code: str | None = None  # Provider status code, e.g. "RESOURCE_EXHAUSTED"
     status_message: str | None = None  # Raw provider status message (operator-only)
+    # Live replica count reported by the provider at fetch time. Distinct from
+    # autoscaling.min/max_replicas — this is the actual currently-running count,
+    # used for billing GPU-hours against the real footprint.
+    replica_count: int | None = None
+    # Raw upstream accelerator type (e.g. ``"NVIDIA_A100_80GB"``). Preserved
+    # alongside the normalized ``hardware.accelerator`` so billing can map to
+    # SkyPilot-canonical names without re-deriving from the lower-cased form.
+    accelerator_type: str | None = None
 
 
 # Async callback for upload/deploy progress updates.

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -311,6 +311,12 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             inference_model_name=name or None,
             status_code=status_code,
             status_message=status_message,
+            replica_count=deployment.replica_count,
+            accelerator_type=(
+                deployment.accelerator_type.value
+                if deployment.accelerator_type
+                else None
+            ),
         )
 
     @staticmethod


### PR DESCRIPTION
# Description

Adds two optional fields to the `Endpoint` dataclass populated from `GatewayDeployment`:

- `replica_count: int | None` — live replica count (distinct from `autoscaling.min/max_replicas`).
- `accelerator_type: str | None` — raw upstream `GatewayAcceleratorType` enum value (e.g. `"NVIDIA_A100_80GB"`).

## Related issues

LOU-1167

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

`oumi-ai/oumi-staff`