### PR TITLE
[Det Env v2] Phase 4: Grounding in the synthesis pipeline

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -15,10 +15,13 @@
 import dataclasses
 import random
 
+from oumi.builders.environments import build_environment
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.grounding_params import GroundingConfig
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
@@ -32,6 +35,9 @@ from oumi.core.types.conversation import (
     Message,
     Role,
 )
+from oumi.environments import GroundingFact
+from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.utils import describe_grounding_default
 from oumi.utils.logging import logger
 from oumi.utils.str_utils import extract_json
 
@@ -128,6 +134,8 @@ class ConversationSynthesizer:
                 [tool.id for tool in available_tools],
             )
 
+        self._warn_on_grounding_placeholder(multiturn_attributes)
+        self._attach_grounding_facts(samples, multiturn_attributes)
         samples = self._plan_samples(samples, multiturn_attributes)
         conversations = self._synthesize_all_samples(samples, multiturn_attributes)
 
@@ -427,6 +435,39 @@ class ConversationSynthesizer:
         if role_context:
             base_prompt += f"\nRole context:\n{role_context}\n"
 
+        grounding_facts = sample.get("grounding_facts") or []
+        if grounding_facts:
+            block = describe_grounding_default(grounding_facts)
+            base_prompt += (
+                "\nGround this plan in these specific entities:\n"
+                f"{block}\n"
+                "Grounding rules (role-aware):\n"
+                "- USER turn instructions MAY inline concrete identifiers "
+                "from the list above (e.g. 'order ORD-4421 is late', "
+                "'book B007'). The user persona cannot see this list, so "
+                "identifiers the user should mention must be written into "
+                "their turn instruction.\n"
+                "- Treat each entity's non-identifier fields (e.g. status, "
+                "due_date, return_date) as preconditions. If a field's value "
+                "contradicts the conversation intent -- for example trying "
+                "to borrow a book whose status is 'borrowed' or 'overdue', "
+                "or trying to return one that is 'available' -- plan a "
+                "recovery flow that handles the conflict (offer an "
+                "alternative entity from the list, explain the conflict, ask "
+                "a clarifying question) instead of a happy-path that the "
+                "tool will reject.\n"
+                "- ASSISTANT turn instructions MUST NOT pre-resolve or "
+                "pre-state any tool output — no identifiers, statuses, "
+                "borrower names, due dates, or other facts the assistant "
+                "would normally look up. Reference entities by what the "
+                "user said (e.g. the title) and describe which TOOL the "
+                "assistant should call to resolve or verify. Example — "
+                "write 'call lookup_book_status with the book_id from the "
+                "catalog', not 'tell the user book B007 is checked out'.\n"
+                "- The planner's job for assistant turns is to probe the "
+                "right tool usage, not to do the tool's work.\n"
+            )
+
         if multiturn_attribute.conversation_planner:
             formatted_planner = self._formatter.format(
                 sample,
@@ -614,3 +655,100 @@ class ConversationSynthesizer:
             system_message,
         )
         return Message(role=Role.SYSTEM, content=formatted_content.strip())
+
+    def _make_grounding_rng(self, seed: int | None, sample_index: int) -> random.Random:
+        """Build the per-sample RNG for grounding.
+
+        Seeded mode makes facts deterministic from ``(seed + sample_index)``;
+        unseeded uses OS entropy.
+        """
+        if seed is None:
+            return random.Random()
+        return random.Random(seed + sample_index)
+
+    def _warn_on_grounding_placeholder(
+        self, multiturn_attribute: MultiTurnAttribute
+    ) -> None:
+        """Warn if ``{grounding_facts}`` appears in user/assistant personas.
+
+        Grounding facts are planner-only — placing the placeholder in a
+        user or assistant persona template defeats its purpose and may
+        leak env state to roles that should not see it.
+        """
+        for role, persona in multiturn_attribute.role_instruction_messages.items():
+            if not isinstance(persona, str):
+                continue
+            if "{grounding_facts}" in persona and role in (
+                Role.USER,
+                Role.ASSISTANT,
+            ):
+                logger.warning(
+                    "MultiTurnAttribute '%s' references {grounding_facts} in "
+                    "the %s persona template. grounding is planner-only; "
+                    "placing {grounding_facts} in user/assistant templates "
+                    "defeats its purpose and may leak env state to roles "
+                    "that should not see it.",
+                    multiturn_attribute.id,
+                    role.value,
+                )
+
+    def _attach_grounding_facts(
+        self,
+        samples: list[dict],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> None:
+        """Attach per-sample grounding facts drawn from grounded envs in scope.
+
+        Writes ``sample["grounding_facts"]`` as a flat list concatenated
+        across all envs in scope that declare a ``GroundingConfig``. No-op
+        when ``environment_config`` is absent or no env in scope declares
+        grounding. Emits one ``logger.warning`` per env when truncation
+        occurs (sample_size > pool_size).
+        """
+        if self._environment_config is None:
+            return
+
+        scoped_env_ids = (
+            set(multiturn_attribute.available_environments)
+            if multiturn_attribute.available_environments
+            else {env.id for env in self._environment_config.environments}
+        )
+        grounding_envs: list[
+            tuple[EnvironmentParams, GroundingConfig, BaseEnvironment]
+        ] = [
+            (env_params, env_params.grounding, build_environment(env_params))
+            for env_params in self._environment_config.environments
+            if env_params.id in scoped_env_ids and env_params.grounding is not None
+        ]
+        if not grounding_envs:
+            return
+
+        warned_envs: set[str] = set()
+        tool_scope = (
+            set(multiturn_attribute.available_tools)
+            if multiturn_attribute.available_tools
+            else None
+        )
+        for sample_index, sample in enumerate(samples):
+            facts: list[GroundingFact] = []
+            for env_params, grounding, env_runtime in grounding_envs:
+                rng = self._make_grounding_rng(grounding.seed, sample_index)
+                sampled = env_runtime.sample_grounding(
+                    n=grounding.sample_size,
+                    rng=rng,
+                    tool_ids=tool_scope,
+                )
+                if (
+                    len(sampled) < grounding.sample_size
+                    and env_params.id not in warned_envs
+                ):
+                    logger.warning(
+                        "Grounding sample_size=%d exceeds pool size for "
+                        "environment '%s'; truncating to %d facts.",
+                        grounding.sample_size,
+                        env_params.id,
+                        len(sampled),
+                    )
+                    warned_envs.add(env_params.id)
+                facts.extend(sampled)
+            sample["grounding_facts"] = facts

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -14,6 +14,8 @@
 
 """Tests for ConversationSynthesizer."""
 
+import logging
+import random
 from unittest.mock import Mock, patch
 
 import pytest
@@ -935,3 +937,535 @@ def test_synthesize_filters_all_conversations_returns_empty(
         result = synthesizer.synthesize(samples, multiturn_attr)
 
     assert result == [None, None]
+
+
+# --- Grounding helpers ---
+
+
+def _make_synthesizer(mock_inference_config, environment_config=None):
+    """Build a synthesizer with the inference engine builder patched out."""
+    with patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine"):
+        return ConversationSynthesizer(
+            GeneralSynthesisParams(),
+            mock_inference_config,
+            environment_config=environment_config,
+        )
+
+
+def _grounded_env_params(
+    env_id: str = "env1",
+    tool_id: str = "lookup",
+    n_entries: int = 10,
+    sample_size: int = 3,
+    seed: int | None = None,
+):
+    from oumi.core.configs.params.environment_params import EnvironmentParams
+    from oumi.core.configs.params.grounding_params import (
+        GroundingConfig,
+        ToolGroundingConfig,
+    )
+    from oumi.core.configs.params.tool_params import ToolParams
+
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"env {env_id}",
+        env_type="deterministic",
+        tools=[ToolParams(id=tool_id, name=tool_id, description="Look up an id.")],
+        env_kwargs={
+            "lookup_table": {
+                tool_id: [
+                    {"input": {"id": str(i)}, "output": {"title": f"title-{i}"}}
+                    for i in range(n_entries)
+                ]
+            }
+        },
+        grounding=GroundingConfig(
+            sample_size=sample_size,
+            seed=seed,
+            tools={tool_id: ToolGroundingConfig(fields=["id", "title"])},
+        ),
+    )
+
+
+def _grounded_env_config(**env_kwargs):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    return EnvironmentConfig(environments=[_grounded_env_params(**env_kwargs)])
+
+
+def _ungrounded_env_config():
+    from oumi.core.configs.environment_config import EnvironmentConfig
+    from oumi.core.configs.params.environment_params import EnvironmentParams
+    from oumi.core.configs.params.tool_params import ToolParams
+
+    return EnvironmentConfig(
+        environments=[
+            EnvironmentParams(
+                id="env1",
+                name="env1",
+                description="ungrounded env",
+                env_type="deterministic",
+                tools=[ToolParams(id="lookup", name="lookup", description="Look up.")],
+                env_kwargs={
+                    "lookup_table": {
+                        "lookup": [{"input": {"id": "1"}, "output": {"title": "t"}}]
+                    }
+                },
+            )
+        ]
+    )
+
+
+def _grounding_attr(
+    available_envs: list[str] | None = None,
+    available_tools: list[str] | None = None,
+):
+    return MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "u",
+            Role.ASSISTANT: "a",
+        },
+        available_environments=available_envs or [],
+        available_tools=available_tools or [],
+    )
+
+
+# --- _make_grounding_rng ---
+
+
+def test_make_grounding_rng_unseeded_returns_fresh_random(mock_inference_config):
+
+    synth = _make_synthesizer(mock_inference_config)
+    rng = synth._make_grounding_rng(seed=None, sample_index=0)
+    assert isinstance(rng, random.Random)
+
+
+def test_make_grounding_rng_seeded_is_reproducible(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    rng_a = synth._make_grounding_rng(seed=42, sample_index=3)
+    rng_b = synth._make_grounding_rng(seed=42, sample_index=3)
+    assert [rng_a.random() for _ in range(5)] == [rng_b.random() for _ in range(5)]
+
+
+def test_make_grounding_rng_seeded_varies_across_sample_indices(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    rng_0 = synth._make_grounding_rng(seed=42, sample_index=0)
+    rng_1 = synth._make_grounding_rng(seed=42, sample_index=1)
+    assert [rng_0.random() for _ in range(5)] != [rng_1.random() for _ in range(5)]
+
+
+# --- _attach_grounding_facts ---
+
+
+def test_attach_grounding_facts_noop_without_env_config(mock_inference_config):
+    synth = _make_synthesizer(mock_inference_config)
+    samples = [{"a": 1}, {"b": 2}]
+    synth._attach_grounding_facts(samples, _grounding_attr())
+    assert "grounding_facts" not in samples[0]
+    assert "grounding_facts" not in samples[1]
+
+
+def test_attach_grounding_facts_noop_when_no_env_has_grounding(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    samples = [{}, {}]
+    synth._attach_grounding_facts(
+        samples, _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    )
+    assert "grounding_facts" not in samples[0]
+    assert "grounding_facts" not in samples[1]
+
+
+def test_attach_grounding_facts_populates_samples(mock_inference_config):
+    from oumi.core.configs.params.grounding_params import GroundingFact
+
+    env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}, {}, {}]
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+    )
+    for sample in samples:
+        assert "grounding_facts" in sample
+        assert len(sample["grounding_facts"]) == 3
+        for fact in sample["grounding_facts"]:
+            assert isinstance(fact, GroundingFact)
+
+
+def test_attach_grounding_facts_seeded_is_reproducible(mock_inference_config):
+    synth_a = _make_synthesizer(
+        mock_inference_config,
+        environment_config=_grounded_env_config(n_entries=20, sample_size=4, seed=7),
+    )
+    synth_b = _make_synthesizer(
+        mock_inference_config,
+        environment_config=_grounded_env_config(n_entries=20, sample_size=4, seed=7),
+    )
+    samples_a = [{}, {}, {}]
+    samples_b = [{}, {}, {}]
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    synth_a._attach_grounding_facts(samples_a, attr)
+    synth_b._attach_grounding_facts(samples_b, attr)
+    for a, b in zip(samples_a, samples_b):
+        assert [f.data["id"] for f in a["grounding_facts"]] == [
+            f.data["id"] for f in b["grounding_facts"]
+        ]
+
+
+def test_attach_grounding_facts_seeded_different_samples_differ(mock_inference_config):
+    env_config = _grounded_env_config(n_entries=50, sample_size=3, seed=7)
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}, {}]
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+    )
+    ids_0 = sorted(f.data["id"] for f in samples[0]["grounding_facts"])
+    ids_1 = sorted(f.data["id"] for f in samples[1]["grounding_facts"])
+    assert ids_0 != ids_1
+
+
+def test_attach_grounding_facts_respects_available_environments_scoping(
+    mock_inference_config,
+):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    env_a = _grounded_env_params(
+        env_id="env_a", tool_id="tool_a", n_entries=5, sample_size=2, seed=1
+    )
+    env_b = _grounded_env_params(
+        env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=2, seed=2
+    )
+    env_config = EnvironmentConfig(environments=[env_a, env_b])
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}]
+    synth._attach_grounding_facts(
+        samples,
+        _grounding_attr(available_envs=["env_a"], available_tools=["tool_a"]),
+    )
+    assert len(samples[0]["grounding_facts"]) == 2
+
+
+def test_attach_grounding_facts_filters_by_available_tools(mock_inference_config):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+    from oumi.core.configs.params.environment_params import EnvironmentParams
+    from oumi.core.configs.params.grounding_params import (
+        GroundingConfig,
+        ToolGroundingConfig,
+    )
+    from oumi.core.configs.params.tool_params import ToolParams
+
+    env_params = EnvironmentParams(
+        id="env",
+        name="Env",
+        description="d",
+        env_type="deterministic",
+        tools=[
+            ToolParams(id="lookup_a", name="A", description="d"),
+            ToolParams(id="lookup_b", name="B", description="d"),
+        ],
+        env_kwargs={
+            "lookup_table": {
+                "lookup_a": [{"input": {"id": "A1"}, "output": {"v": "from_a"}}],
+                "lookup_b": [{"input": {"id": "B1"}, "output": {"v": "from_b"}}],
+            }
+        },
+        grounding=GroundingConfig(
+            sample_size=10,
+            seed=0,
+            tools={
+                "lookup_a": ToolGroundingConfig(fields=["id", "v"]),
+                "lookup_b": ToolGroundingConfig(fields=["id", "v"]),
+            },
+        ),
+    )
+    env_config = EnvironmentConfig(environments=[env_params])
+    multiturn = MultiTurnAttribute(
+        id="mt",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "user persona",
+            Role.ASSISTANT: "assistant persona",
+        },
+        available_environments=["env"],
+        available_tools=["lookup_a"],
+    )
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}, {}]
+    synth._attach_grounding_facts(samples, multiturn)
+    for sample in samples:
+        facts = sample["grounding_facts"]
+        assert len(facts) == 1
+        assert facts[0].data == {"id": "A1", "v": "from_a"}
+
+
+def test_attach_grounding_facts_concatenates_across_multiple_envs(
+    mock_inference_config,
+):
+    from oumi.core.configs.environment_config import EnvironmentConfig
+
+    env_a = _grounded_env_params(
+        env_id="env_a", tool_id="tool_a", n_entries=5, sample_size=2, seed=1
+    )
+    env_b = _grounded_env_params(
+        env_id="env_b", tool_id="tool_b", n_entries=5, sample_size=3, seed=2
+    )
+    env_config = EnvironmentConfig(environments=[env_a, env_b])
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}]
+    synth._attach_grounding_facts(
+        samples, _grounding_attr(available_tools=["tool_a", "tool_b"])
+    )
+    assert len(samples[0]["grounding_facts"]) == 5
+
+
+def test_attach_grounding_facts_truncation_emits_logger_warning(
+    mock_inference_config, caplog
+):
+
+    env_config = _grounded_env_config(n_entries=2, sample_size=5, seed=1)
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    samples = [{}, {}]
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._attach_grounding_facts(
+            samples,
+            _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
+        )
+    truncation_records = [
+        rec for rec in caplog.records if "sample_size" in rec.getMessage()
+    ]
+    assert len(truncation_records) == 1
+    assert "env1" in truncation_records[0].getMessage()
+
+
+# --- Planner prompt grounding injection ---
+
+
+def test_create_planner_prompt_injects_grounding_block_when_facts_present(
+    mock_inference_config,
+):
+    from oumi.core.configs.params.grounding_params import GroundingFact
+
+    env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=1)
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+        "grounding_facts": [
+            GroundingFact(data={"id": "42", "title": "Dune"}),
+            GroundingFact(data={"id": "7", "title": "LotR"}),
+        ],
+    }
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan in these specific entities" in planner_user_msg
+    assert '- id="42", title="Dune"' in planner_user_msg
+    assert '- id="7", title="LotR"' in planner_user_msg
+    assert "Grounding rules (role-aware)" in planner_user_msg
+
+
+def test_create_planner_prompt_includes_state_aware_branching_nudge(
+    mock_inference_config,
+):
+    from oumi.core.configs.params.grounding_params import GroundingFact
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=4,
+        max_turns=4,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+    )
+    sample = {
+        "target_turns": 4,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 4,
+        "grounding_facts": [
+            GroundingFact(data={"book_id": "B001", "status": "borrowed"}),
+        ],
+    }
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "preconditions" in planner_user_msg
+    assert "recovery flow" in planner_user_msg
+    assert "happy-path" in planner_user_msg
+
+
+def test_create_planner_prompt_no_grounding_block_when_facts_absent(
+    mock_inference_config,
+):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+    }
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan" not in planner_user_msg
+
+
+def test_create_planner_prompt_empty_grounding_facts_omits_block(mock_inference_config):
+    synth = _make_synthesizer(
+        mock_inference_config, environment_config=_ungrounded_env_config()
+    )
+    attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    sample = {
+        "target_turns": 2,
+        "conversation_plan": "",
+        "parsed_turn_plans": [""] * 2,
+        "grounding_facts": [],
+    }
+    conversation = synth._create_planner_prompt(attr, sample)
+    planner_user_msg = conversation.messages[-1].content
+    assert isinstance(planner_user_msg, str)
+    assert "Ground this plan" not in planner_user_msg
+
+
+# --- synthesize integration ---
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_invokes_attach_grounding_facts(
+    mock_build_inference_engine, mock_inference_config
+):
+    """End-to-end: synthesize() calls _attach_grounding_facts before planning."""
+    plan_json = (
+        "```json\n"
+        '[{"turn": 1, "instruction": "a"}, {"turn": 2, "instruction": "b"}]\n'
+        "```"
+    )
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    call_count = {"n": 0}
+
+    def infer_side_effect(conversations, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [
+                Conversation(messages=[Message(role=Role.ASSISTANT, content=plan_json)])
+                for _ in conversations
+            ]
+        return [
+            Conversation(messages=[Message(role=Role.ASSISTANT, content="response")])
+            for _ in conversations
+        ]
+
+    mock_inference_engine.infer.side_effect = infer_side_effect
+    env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=5)
+    synth = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+        environment_config=env_config,
+    )
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        available_environments=["env1"],
+        available_tools=["lookup"],
+    )
+    samples = [{}]
+    result = synth.synthesize(samples, attr)
+    assert "grounding_facts" in samples[0]
+    assert len(samples[0]["grounding_facts"]) == 2
+    assert len(result) == 1
+
+
+# --- {grounding_facts} placeholder misuse warning ---
+
+
+def test_warn_on_grounding_placeholder_warns_in_user_persona(
+    mock_inference_config, caplog
+):
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user interested in {grounding_facts}.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+    warnings = [rec for rec in caplog.records if "grounding_facts" in rec.getMessage()]
+    assert len(warnings) >= 1
+    assert "user" in warnings[0].getMessage().lower()
+
+
+def test_warn_on_grounding_placeholder_warns_in_assistant_persona(
+    mock_inference_config, caplog
+):
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You know these entities: {grounding_facts}.",
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+    warnings = [rec for rec in caplog.records if "grounding_facts" in rec.getMessage()]
+    assert len(warnings) >= 1
+    assert "assistant" in warnings[0].getMessage().lower()
+
+
+def test_warn_on_grounding_placeholder_no_warning_when_placeholder_absent(
+    mock_inference_config, caplog
+):
+
+    synth = _make_synthesizer(mock_inference_config)
+    attr = MultiTurnAttribute(
+        id="t",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        synth._warn_on_grounding_placeholder(attr)
+    grounding_warnings = [
+        rec for rec in caplog.records if "grounding_facts" in rec.getMessage()
+    ]
+    assert grounding_warnings == []


### PR DESCRIPTION
# Description

Phase 4 of 7 in the Det Env v2 series. **Stacked on #2424** — the base of this branch is `aniruddh-alt/det-env-v2-03-grounding`. Once #2424 merges, this PR's base auto-rebases to `main`.

This PR is the synthesizer-side consumer of the grounding hooks introduced in #2424. The flow:

1. Env owns the data (lookup tables, state).
2. `ConversationSynthesizer` queries the env via `env.sample_grounding(...)` per conversation.
3. Sampled facts get rendered and injected into the planner prompt.

Without this PR, the grounding hooks in #2424 are unused infrastructure. This is what closes the loop.

## What's new on `ConversationSynthesizer`

- **`_make_grounding_rng(seed, sample_index)`** — per-sample deterministic `Random` when `GroundingConfig.seed` is set; unseeded `Random()` otherwise. The `(seed, sample_index)` pair gives stable but distinct RNGs across samples in the same run.
- **`_attach_grounding_facts(samples, attribute)`** — walks every env in scope (honoring `available_environments` and `available_tools` filters), calls `env.sample_grounding(...)` per env, writes the concatenated facts to `sample["grounding_facts"]`. Logs one warning per env per `synthesize()` call when `sample_size > pool_size`.
- **Planner prompt grounding injection** — when `sample["grounding_facts"]` is non-empty, `_create_planner_prompt` appends:
  - The bulleted fact list via `describe_grounding_default(...)`.
  - A "Grounding rules (role-aware)" block: identifiers belong in user turns, status fields are preconditions (plan a recovery flow when a fact contradicts the conversation intent), assistant turns must NOT pre-resolve tool output.
- **`_warn_on_grounding_placeholder`** — warns once if a user/assistant persona template inlines `{grounding_facts}`. Grounding is planner-only; leaking the fact list to user/assistant personas defeats its purpose.

## Tests

20 new tests in `test_conversation_synthesizer.py`:
- `_make_grounding_rng` reproducibility (seeded/unseeded, varies-across-samples).
- `_attach_grounding_facts` no-op paths (no env config, no grounded env), scoping by environments and tools, multi-env concatenation, truncation warnings.
- Planner prompt injection: block present when facts exist, omitted when absent or empty, state-aware branching nudge included.
- Integration through `synthesize()`.
- `_warn_on_grounding_placeholder` for user/assistant personas (warns) vs no placeholder (silent).

275 tests pass across the affected directories.

## Open follow-ups (from review comments)

- The "Grounding rules (role-aware)" block has library-domain examples baked in (`book B007`, `borrowed/overdue`, `borrower_name`). Worth generalizing or parameterizing before a non-library env lands.
- The grounding rules prose is a 30-line string literal in `_create_planner_prompt`. Worth extracting to a module-level constant for testability and prompt iteration.

## Series context

1. ~~Tool schema unification & validation~~ — #2421 (merged)
2. ~~Planner: guided JSON decoding~~ — #2422 (merged)
3. Grounding system: types + env-owned lookup tables — #2424 (in review)
4. **Grounding in the synthesis pipeline** ← this PR
5. Agentic tool-call loop in synthesizer
6. Structured tool-message projection on output
7. Library tool-use synthesis example + e2e

## Before submitting

- [x] Tests for `_make_grounding_rng`, `_attach_grounding_facts` (no-op paths, scoping, multi-env, truncation), planner prompt injection (block present/absent, state-aware nudge), integration through `synthesize()`, `{grounding_facts}` placeholder warning.
