### PR TITLE
docs: add v0.8 release to news section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 ## 🔥 News
 
+- [2026/05] [Oumi v0.8 released](https://github.com/oumi-ai/oumi/releases/tag/v0.8) with `oumi deploy` CLI for dedicated inference endpoints, an `oumi-mcp` MCP server for Claude/Cursor integration, batch API support across Anthropic/Fireworks/Together, and Transformers v5 / TRL / vLLM dependency upgrades
 - [2026/03] Upgraded to Transformers v5, TRL v0.30, vLLM v0.19, and veRL v0.7 compatibility
 - [2026/03] [MCP Integration Phase 1](https://github.com/oumi-ai/oumi/pull/2234): package scaffold and dependencies for MCP server support
 - [2026/03] New: `oumi deploy` command for deploying oumi models dedicated inference endpoints on fireworks.ai and parasail
@@ -34,12 +35,12 @@
 - [2025/12] [WeMakeDevs AI Agents Assemble Hackathon: Oumi webinar on Finetuning for Text-to-SQL](https://www.youtube.com/watch?v=6wPikqRZ7bQ&t=3203s)
 - [2025/12] [Oumi co-sponsors WeMakeDevs AI Agents Assemble Hackathon with over 2000 project submissions](https://www.wemakedevs.org/hackathons/assemblehack25)
 - [2025/11] [Oumi v0.5.0 released](https://github.com/oumi-ai/oumi/releases/tag/v0.5) with advanced data synthesis, hyperparameter tuning automation, support for OpenEnv, and more
-- [2025/11] [Example notebook to perform RLVF fine-tuning with OpenEnv](https://github.com/oumi-ai/oumi/blob/main/notebooks/Oumi%20-%20OpenEnv%20GRPO%20with%20trl.ipynb), an open source library from the Meta PyTorch team for creating, deploying, and distributing agentic RL environments
-- [2025/10] [Oumi v0.4.1](https://github.com/oumi-ai/oumi/releases/tag/v0.4.1) and [v0.4.2](https://github.com/oumi-ai/oumi/releases/tag/v0.4.2) released] with support for Qwen3-VL and Transformers v4.56, data synthesis documentation and examples, and many bug fixes
 
 <details>
 <summary>Older updates</summary>
 
+- [2025/11] [Example notebook to perform RLVF fine-tuning with OpenEnv](https://github.com/oumi-ai/oumi/blob/main/notebooks/Oumi%20-%20OpenEnv%20GRPO%20with%20trl.ipynb), an open source library from the Meta PyTorch team for creating, deploying, and distributing agentic RL environments
+- [2025/10] [Oumi v0.4.1](https://github.com/oumi-ai/oumi/releases/tag/v0.4.1) and [v0.4.2](https://github.com/oumi-ai/oumi/releases/tag/v0.4.2) released] with support for Qwen3-VL and Transformers v4.56, data synthesis documentation and examples, and many bug fixes
 - [2025/09] [Oumi v0.4.0 released](https://github.com/oumi-ai/oumi/releases/tag/v0.4.0) with DeepSpeed support, a Hugging Face Hub cache management tool, KTO/Vision DPO trainer support
 - [2025/08] Training and inference support for OpenAI's `gpt-oss-20b` and `gpt-oss-120b`: [recipes here](https://github.com/oumi-ai/oumi/tree/main/configs/recipes/gpt_oss)
 - [2025/08] Aug 14 Webinar - [OpenAI's gpt-oss: Separating the Substance from the Hype](https://youtu.be/g1PkAV7fXn0).


### PR DESCRIPTION
Adds a news entry for the [v0.8 release](https://github.com/oumi-ai/oumi/releases/tag/v0.8). Entry synthesized from release notes.