### PR TITLE
feat(launcher): add provider-agnostic ClusterNotFoundError

### DIFF
--- a/src/oumi/core/launcher/__init__.py
+++ b/src/oumi/core/launcher/__init__.py
@@ -23,10 +23,13 @@ launchers for running machine learning jobs.
 
 from oumi.core.launcher.base_cloud import BaseCloud
 from oumi.core.launcher.base_cluster import BaseCluster, JobState, JobStatus
+from oumi.core.launcher.exceptions import ClusterNotFoundError, LauncherError
 
 __all__ = [
     "BaseCloud",
     "BaseCluster",
+    "ClusterNotFoundError",
     "JobState",
     "JobStatus",
+    "LauncherError",
 ]

--- a/src/oumi/core/launcher/exceptions.py
+++ b/src/oumi/core/launcher/exceptions.py
@@ -1,0 +1,28 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-agnostic exceptions for the Oumi launcher.
+
+Callers should depend on these exceptions rather than provider-specific ones
+(e.g. ``sky.exceptions.ClusterDoesNotExist``) so that swapping providers does
+not require touching call sites.
+"""
+
+
+class LauncherError(Exception):
+    """Base class for all launcher-level errors."""
+
+
+class ClusterNotFoundError(LauncherError):
+    """Raised when the requested cluster does not exist on the cloud."""


### PR DESCRIPTION
# Description

Lifts SkyPilot's `sky.exceptions.ClusterDoesNotExist` into a generic `oumi.core.launcher.ClusterNotFoundError` so call sites depending on the launcher abstraction don't have to import provider-specific exceptions.

## How

- New `oumi/core/launcher/exceptions.py` with `LauncherError` (base) and `ClusterNotFoundError`
- Re-exports through `oumi.core.launcher` package

## Why

Foundational for the upcoming Modal launcher (next PR), and for any future provider surfacing missing-cluster lookups. Today downstream code does `from sky.exceptions import ClusterDoesNotExist` to handle a launcher-abstract failure mode — that leaks SkyPilot into provider-agnostic call sites.

## Related

Part of LOU-1827 (oumi-side, exception-only split).