### PR TITLE
fix(evals): adapt lm_harness to lm_eval 0.4.12 EvalResults TypedDict

### DIFF
--- a/src/oumi/core/evaluation/backends/lm_harness.py
+++ b/src/oumi/core/evaluation/backends/lm_harness.py
@@ -18,7 +18,7 @@ import os
 import random
 from collections.abc import Callable
 from pprint import pformat
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import torch
@@ -192,7 +192,7 @@ def _get_task_dict(
         assert len(task_dict) == 1
         task_name = next(iter(task_dict))
         if isinstance(task_name, ConfigurableGroup):
-            task_name: str = task_name.group_name
+            task_name = task_name.group_name
         if task_name != task_params.task_name:
             raise ValueError(
                 f"Inconsistent task naming. Task `{task_params.task_name}` was "
@@ -334,8 +334,11 @@ def evaluate(
         return EvaluationResult()
 
     assert lm_eval_output is not None
+    # `evaluate()` returns a tight TypedDict; downstream code treats it as an
+    # open config dict (adds `config`, `git_hash`, env+tokenizer info, etc.).
+    lm_eval_output = cast(dict[str, Any], lm_eval_output)
     task_name = task_params.task_name
-    metric_dict = lm_eval_output["results"][task_name]  # type: ignore
+    metric_dict = lm_eval_output["results"][task_name]
     logger.info(f"{task_name}'s metric dict is {pformat(metric_dict)}")
 
     if config.enable_wandb:


### PR DESCRIPTION
## Summary

Unblock CI: pyright has been failing on `main` (and every PR) since **2026-05-11 ~17:00 UTC** with 12 type errors in `src/oumi/core/evaluation/backends/lm_harness.py`. Nothing in the codebase changed to cause this — `lm_eval` released `0.4.12` between two CI runs on `main`, which narrowed the return type of `evaluate()` / `simple_evaluate()` to the newly-introduced `EvalResults` TypedDict (see `lm_eval/result_schema.py`, [v0.4.11...v0.4.12](https://github.com/EleutherAI/lm-evaluation-harness/compare/v0.4.11...v0.4.12)). Our `pyproject.toml` constraint is `lm_eval[wandb]>=0.4,<0.5.0`, so CI picked it up on the next fresh install.

Downstream code in `lm_harness.py` treats the eval result as an open config dict — it adds `config`, `git_hash`, env / tokenizer info, `task_params`, `task_dict`, etc. None of those fit the new TypedDict surface, surfacing 12 latent type errors.

## Evidence chain

| When | Commit on `main` | `lm-eval` resolved | pyright result |
|---|---|---|---|
| 2026-05-11 09:22 UTC | `4d8cd627` | `0.4.11` | ✅ Passed |
| 2026-05-11 17:02 UTC | `6edcaff6` | `0.4.12` | ❌ 12 errors in `lm_harness.py` |

The only intervening source change was `#2442` (launcher feature), unrelated to evals.

## Fix

Boundary cast — `lm_eval_output` continues to be used as an open dict (matching the existing code's intent); we re-bind it to `dict[str, Any]` once right after the not-None assertion so the rest of the function type-checks without per-line workarounds. Also dropped the bad `task_name: str = task_name.group_name` annotation (since `group_name` is `str | None`).

```diff
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 ...
         if isinstance(task_name, ConfigurableGroup):
-            task_name: str = task_name.group_name
+            task_name = task_name.group_name
 ...
     assert lm_eval_output is not None
+    # `evaluate()` returns a tight TypedDict; downstream code treats it as an
+    # open config dict (adds `config`, `git_hash`, env+tokenizer info, etc.).
+    lm_eval_output = cast(dict[str, Any], lm_eval_output)
     task_name = task_params.task_name
-    metric_dict = lm_eval_output["results"][task_name]  # type: ignore
+    metric_dict = lm_eval_output["results"][task_name]
```

## Validation

Ran `pyright==1.1.409` (same version CI uses) locally against this file with `lm_eval[wandb]==0.4.12` installed:

| State | Result |
|---|---|
| `origin/main` (current code) | 12 errors — exact same set CI reports (lines 195, 352, 374, 375, 380×2, 381×2, 384, 385, 386, 391) |
| This branch | **0 errors, 0 warnings, 0 informations** ✅ |

## Test plan

- [ ] Static-checks CI passes on this PR.
- [ ] Static-checks CI starts passing on `main` once this lands.
- [ ] No runtime behavior change: `cast` is a no-op at runtime; the dropped `: str` annotation was already wrong at runtime since `group_name` can be `None`.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
