### PR TITLE
fix(launcher): trim trailing newline from modal_client.py

### DIFF
--- a/src/oumi/launcher/clients/modal_client.py
+++ b/src/oumi/launcher/clients/modal_client.py
@@ -335,4 +335,3 @@ class ModalClient:
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"Modal {stream_attr} read failed: {e!r}")
         return ModalLogStream(cast("Iterator[str]", iter(chunks)))
-


### PR DESCRIPTION
## Summary

One-byte fix: `src/oumi/launcher/clients/modal_client.py` currently ends with two trailing newlines, which makes the `end-of-file-fixer` pre-commit hook fail in CI. This PR removes the extra newline so the file ends in exactly one `\n` (matching what the hook auto-produces).

## Why it broke now

PR #2443 (Modal launcher) merged at `2026-05-12 17:33 UTC` with a red `static-checks` job. The failures were:

- `end-of-file-fixer` on this very file (the issue this PR fixes).
- `pyright` on `src/oumi/core/evaluation/backends/lm_harness.py` — a *pre-existing* failure on `main` caused by the `lm_eval==0.4.12` release (see #2450 for the fix).

Both failures appeared in the same `static-checks` job, so #2443's introduction of this new end-of-file issue was masked-by-and-bundled-with the pre-existing pyright red. This PR (plus #2450) restores green `static-checks` on `main`.

## Diff

The exact change CI's hook auto-produces when run locally:

```diff
@@ -335,4 +335,3 @@ class ModalClient:
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"Modal {stream_attr} read failed: {e!r}")
         return ModalLogStream(cast("Iterator[str]", iter(chunks)))
-
```

(a single blank line stripped from the end of the file)

## Test plan

- [ ] `static-checks` job passes on this PR (end-of-file-fixer green).
- [ ] After this and #2450 merge, `static-checks` passes on `main`.

cc @min-oumi (author of #2443) for awareness.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
