### PR TITLE
feat/launcher-config-overrides-passthrough

### DIFF
--- a/src/oumi/core/configs/job_config.py
+++ b/src/oumi/core/configs/job_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from omegaconf import MISSING
 from typing_extensions import override
@@ -137,6 +138,19 @@ class JobResources:
     multiple region support.
 
     Overridden by image_id if both are specified.
+    """
+
+    config_overrides: dict[str, Any] | None = None
+    """Cloud-specific config overrides (optional).
+
+    Passed through to SkyPilot as `experimental.config_overrides`. For Kubernetes,
+    the shape is typically::
+
+        {"kubernetes": {"pod_config": {"spec": {"affinity": {...},
+                                                "tolerations": [...]}}}}
+
+    Other clouds support keys like `{"docker": {"run_options": [...]}}`. See the
+    SkyPilot docs for the supported schema per cloud.
     """
 
 

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -17,7 +17,7 @@ import os
 import re
 from collections.abc import Iterator
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from oumi.core.configs import JobConfig
 from oumi.core.launcher import JobState, JobStatus
@@ -129,7 +129,7 @@ def _convert_job_to_task(job: JobConfig) -> "sky.Task":
     elif job.resources.image_id_map is not None:
         image_id = job.resources.image_id_map  # type: ignore[assignment]
 
-    resources = sky.Resources(
+    resources_kwargs: dict[str, Any] = dict(
         cloud=sky_cloud,
         instance_type=job.resources.instance_type,
         cpus=job.resources.cpus,
@@ -142,6 +142,10 @@ def _convert_job_to_task(job: JobConfig) -> "sky.Task":
         disk_tier=job.resources.disk_tier,
         image_id=image_id,
     )
+    if job.resources.config_overrides is not None:
+        # Maps to SkyPilot's `experimental.config_overrides` (see sky/task.py).
+        resources_kwargs["_cluster_config_overrides"] = job.resources.config_overrides
+    resources = sky.Resources(**resources_kwargs)
     sky_task = sky.Task(
         name=job.name,
         setup=job.setup,

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -260,6 +260,76 @@ def test_convert_job_to_task_with_populated_image_and_dict(
                     mock_task.set_resources.assert_called_once()
 
 
+def test_convert_job_to_task_without_config_overrides(
+    mock_sky_data_storage,
+):
+    with patch.dict(os.environ, {"OUMI_USE_SPOT_VM": "nonspot"}, clear=True):
+        with patch("sky.Resources") as mock_resources:
+            with patch("sky.clouds.GCP") as mock_cloud:
+                mock_gcp = Mock()
+                mock_cloud.return_value = mock_gcp
+                with patch("sky.Task"):
+                    job = _get_default_job("gcp")
+                    assert job.resources.config_overrides is None
+
+                    _ = _convert_job_to_task(job)
+
+                    mock_resources.assert_called_once()
+                    _, kwargs = mock_resources.call_args
+                    assert "_cluster_config_overrides" not in kwargs
+
+
+def test_convert_job_to_task_with_config_overrides(
+    mock_sky_data_storage,
+):
+    with patch.dict(os.environ, {"OUMI_USE_SPOT_VM": "nonspot"}, clear=True):
+        with patch("sky.Resources") as mock_resources:
+            with patch("sky.clouds.Kubernetes") as mock_cloud:
+                mock_k8s = Mock()
+                mock_cloud.return_value = mock_k8s
+                with patch("sky.Task") as mock_task_cls:
+                    mock_task = Mock()
+                    mock_task_cls.return_value = mock_task
+                    job = _get_default_job("k8s")
+                    overrides = {
+                        "kubernetes": {
+                            "pod_config": {
+                                "spec": {
+                                    "tolerations": [
+                                        {
+                                            "key": "nvidia.com/gpu",
+                                            "operator": "Exists",
+                                            "effect": "NoSchedule",
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                    job.resources.config_overrides = overrides
+
+                    _ = _convert_job_to_task(job)
+
+                    mock_resources.assert_has_calls(
+                        [
+                            call(
+                                cloud=mock_k8s,
+                                instance_type=job.resources.instance_type,
+                                cpus=job.resources.cpus,
+                                memory=job.resources.memory,
+                                accelerators=job.resources.accelerators,
+                                use_spot=False,
+                                region=job.resources.region,
+                                zone=job.resources.zone,
+                                disk_size=job.resources.disk_size,
+                                disk_tier=job.resources.disk_tier,
+                                image_id=job.resources.image_id,
+                                _cluster_config_overrides=overrides,
+                            )
+                        ]
+                    )
+
+
 @pytest.mark.parametrize(
     "env_var_use_spot_vm,expected_use_spot_vm",
     [

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -604,3 +604,19 @@ def test_sky_client_stop():
         client = SkyClient()
         client.stop("mycluster")
         mock_stop.assert_called_once_with("mycluster")
+
+
+def test_convert_job_to_task_config_overrides_reaches_real_sky_resources(
+    mock_sky_data_storage,
+):
+    # Guards SkyPilot's private `_cluster_config_overrides` kwarg from silent
+    # signature drift across minor-version bumps.
+    overrides = {"docker": {"run_options": ["--shm-size=2g"]}}
+    job = _get_default_job("gcp")
+    job.resources.config_overrides = overrides
+
+    with patch.dict(os.environ, {"OUMI_USE_SPOT_VM": "nonspot"}, clear=True):
+        task = _convert_job_to_task(job)
+
+    resources = next(iter(task.resources))
+    assert resources.cluster_config_overrides == overrides


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Description:

  Adds an optional config_overrides field to JobResources that flows through to SkyPilot's experimental.config_overrides mechanism, letting callers pass cloud-specific overrides (most commonly Kubernetes pod_config) through the
  oumi launcher without bypassing it.

  Motivation

Today there's no way to pass Kubernetes pod customization (nodeAffinity, nodeSelector, tolerations, custom labels, resource limits, etc.) through oumi.launcher.up(). Users who need these have to skip the launcher and call
sky.launch directly, losing the JobConfig abstraction. SkyPilot already supports this via experimental.config_overrides in the task YAML — this PR just plumbs it through.

  Changes

  - JobResources.config_overrides: dict[str, Any] | None = None — new optional field on the public dataclass. Defaults to None, fully backwards compatible.
  - _convert_job_to_task — when set, passes the dict to sky.Resources as _cluster_config_overrides (the kwarg SkyPilot's YAML loader uses for experimental.config_overrides, see sky/task.py).

  Testing

  - Existing tests/unit/launcher/clients/test_sky_client.py continues to pass (the field defaults to None, so existing call sites are unaffected).
  -Verified end-to-end: JobConfig → YAML → JobConfig → _convert_job_to_task → sky.Resources._cluster_config_overrides round-trip preserves the override dict.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
