### PR TITLE
test(launcher): align modal get_logs_stream test with batch-read impl

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -1130,7 +1130,12 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         automatically via ``seek``/``tell``.
         """
         with open(file_path, "rb") as f:
-            response = _requests.put(signed_url, data=f, headers=headers, timeout=600)
+            response = _requests.put(
+                signed_url,
+                data=f,
+                headers=cast(dict[str, str | bytes], headers),
+                timeout=600,
+            )
         if not response.ok:
             logger.error(
                 "GCS upload failed (HTTP %d, %s %s): %s",

--- a/tests/unit/launcher/clients/test_modal_client.py
+++ b/tests/unit/launcher/clients/test_modal_client.py
@@ -270,8 +270,10 @@ def test_get_status_failed_when_sandbox_exits_nonzero(fake_modal):
 
 def test_get_logs_stream_returns_concatenated_stdout_and_stderr(fake_modal):
     sandbox = MagicMock()
-    sandbox.stdout = iter(["hello\n", "world\n"])
-    sandbox.stderr = iter([])
+    sandbox.stdout = MagicMock()
+    sandbox.stdout.read.return_value = "hello\nworld\n"
+    sandbox.stderr = MagicMock()
+    sandbox.stderr.read.return_value = ""
     fake_modal.Sandbox.from_id.return_value = sandbox
     with patch(
         "oumi.launcher.clients.modal_client._import_modal", return_value=fake_modal


### PR DESCRIPTION
## Summary

Two small, independent fixes bundled so static-checks (CPU Tests) can go green on a branch cut from main:

1. **`test(launcher)`** — `ModalClient.get_logs_stream()` was switched to call `stream.read()` on `sandbox.stdout` / `sandbox.stderr` in #2455 so post-mortem retrieval works after a sandbox has terminated. The corresponding unit test was left mocking the streams as plain iterators (`iter([...])`). The new impl skips streams without a `.read()` attribute, so the test currently asserts `'' == 'hello\n'` and fails on every CI run that picks up main. Swap the mocks to `MagicMock` objects whose `.read()` returns the expected text so the test exercises the new batch-read path.
2. **`fix(deploy)`** — `requests.put()` expects `HeadersType` (`MutableMapping[str, str | bytes]`), but the local `headers` dict in `FireworksClient._sync_put_file` is `dict[str, str]`. Pyright's invariant treatment of `MutableMapping` makes the call site fail static-checks. Cast at the call to broaden the value type — runtime behavior is unchanged. (Cherry-picked from #2410 so this branch's CI also goes green; either PR landing first resolves it on main.)

## Test plan

- [x] `pytest tests/unit/launcher/clients/test_modal_client.py` — all 18 pass locally
- [x] `pyright src/oumi/deploy/fireworks_client.py` — 0 errors
- [ ] CPU Tests CI on this PR passes

cc @minoring (PR #2455 author) for sanity check on the modal test mock change.