### PR TITLE
[Synth Env] Phase 2 (core): Stateful tool execution in SyntheticEnvironment

### DIFF
--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -32,6 +32,12 @@ environment_config:
       name: library
       description: A small library catalog with book lookup tools.
       env_type: deterministic
+      grounding:
+        sample_size: 2
+        seed: 13
+        tools:
+          lookup_book_status:
+            fields: [book_id, title, status]
       tools:
         - id: list_book_catalog
           name: list_book_catalog

--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -80,7 +80,6 @@ class EnvironmentParams(BaseParams):
 
         self._validate_unique_tool_ids()
         self._validate_env_type_registered()
-        self._validate_grounding_has_tools()
         self._warn_on_stale_grounding_tool_ids()
 
     def _validate_unique_tool_ids(self) -> None:
@@ -100,17 +99,6 @@ class EnvironmentParams(BaseParams):
             known = sorted(REGISTRY.get_all(RegistryType.ENVIRONMENT))
             raise ValueError(
                 f"Unknown env_type '{self.env_type}'. Known types: {known}"
-            )
-
-    def _validate_grounding_has_tools(self) -> None:
-        """If env-level grounding is set, ``grounding.tools`` must be non-empty."""
-        if self.grounding is None:
-            return
-        if not self.grounding.tools:
-            raise ValueError(
-                f"{type(self).__name__} '{self.id}' declares grounding but "
-                f"grounding.tools is empty. Add at least one tool entry, or "
-                f"remove env-level grounding."
             )
 
     def _warn_on_stale_grounding_tool_ids(self) -> None:

--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -80,6 +80,7 @@ class EnvironmentParams(BaseParams):
 
         self._validate_unique_tool_ids()
         self._validate_env_type_registered()
+        self._validate_grounding_has_source()
         self._warn_on_stale_grounding_tool_ids()
 
     def _validate_unique_tool_ids(self) -> None:
@@ -99,6 +100,22 @@ class EnvironmentParams(BaseParams):
             known = sorted(REGISTRY.get_all(RegistryType.ENVIRONMENT))
             raise ValueError(
                 f"Unknown env_type '{self.env_type}'. Known types: {known}"
+            )
+
+    def _validate_grounding_has_source(self) -> None:
+        """Reject a grounding config that declares no projection sources.
+
+        Without at least one entry in ``tools`` or ``state``, ``sample_grounding``
+        produces an empty pool and every planner prompt silently loses the
+        grounding placeholder.
+        """
+        if self.grounding is None:
+            return
+        if not self.grounding.tools and not self.grounding.state:
+            raise ValueError(
+                f"Environment '{self.id}': grounding is configured but neither "
+                f"grounding.tools nor grounding.state has any entries; one must "
+                f"be populated for grounding to produce any facts."
             )
 
     def _warn_on_stale_grounding_tool_ids(self) -> None:

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -43,16 +43,14 @@ class ToolGroundingConfig(BaseParams):
 class StateGroundingConfig(BaseParams):
     """Per-state-pool grounding for stateful synthetic environments.
 
-    Projects rows from ``initial_state[state_path]`` through ``fields``;
-    ``key`` names the primary-key field and must appear in ``fields``.
+    Projects rows from ``initial_state[state_path]`` through ``fields``.
     """
 
     state_path: str
     fields: list[str]
-    key: str
 
     def __post_init__(self) -> None:
-        """Validate ``state_path``, ``fields``, and ``key`` invariants."""
+        """Validate ``state_path`` and ``fields`` invariants."""
         if not self.state_path:
             raise ValueError(f"{type(self).__name__}.state_path must be non-empty.")
         if not self.fields:
@@ -61,13 +59,6 @@ class StateGroundingConfig(BaseParams):
             raise ValueError(
                 f"{type(self).__name__}.fields contains duplicate entries: "
                 f"{self.fields!r}."
-            )
-        if not self.key:
-            raise ValueError(f"{type(self).__name__}.key must be non-empty.")
-        if self.key not in self.fields:
-            raise ValueError(
-                f"{type(self).__name__}.fields must include 'key' "
-                f"({self.key!r}); got {self.fields!r}."
             )
 
 

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -111,6 +111,12 @@ class GroundingConfig(BaseParams):
             else StateGroundingConfig(**cfg)
             for cfg in self.state
         ]
+        state_paths = [cfg.state_path for cfg in self.state]
+        if len(set(state_paths)) != len(state_paths):
+            raise ValueError(
+                f"{type(self).__name__}.state contains duplicate state_path "
+                f"entries: {state_paths!r}."
+            )
 
 
 @dataclass

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -73,7 +73,12 @@ class StateGroundingConfig(BaseParams):
 
 @dataclass
 class GroundingConfig(BaseParams):
-    """Per-environment grounding configuration."""
+    """Per-environment grounding configuration.
+
+    Both sub-blocks are optional; envs read whichever applies. Deterministic
+    envs project from ``tools`` (per-tool lookup-table entries); stateful
+    synthetic envs project from ``state`` (per-pool ``initial_state`` rows).
+    """
 
     sample_size: int = 3
     """Number of grounding facts sampled per conversation."""
@@ -84,8 +89,11 @@ class GroundingConfig(BaseParams):
     tools: dict[str, ToolGroundingConfig] = field(default_factory=dict)
     """Per-tool field whitelists, keyed by tool id."""
 
+    state: list[StateGroundingConfig] = field(default_factory=list)
+    """Per-state-pool projections for stateful synthetic envs."""
+
     def __post_init__(self) -> None:
-        """Validate ``sample_size`` and coerce ``tools`` entries."""
+        """Validate ``sample_size`` and coerce ``tools``/``state`` entries."""
         if self.sample_size < 1:
             raise ValueError(
                 f"{type(self).__name__}.sample_size must be >= 1, "
@@ -97,6 +105,12 @@ class GroundingConfig(BaseParams):
             else ToolGroundingConfig(**cfg)
             for tool_id, cfg in self.tools.items()
         }
+        self.state = [
+            cfg
+            if isinstance(cfg, StateGroundingConfig)
+            else StateGroundingConfig(**cfg)
+            for cfg in self.state
+        ]
 
 
 @dataclass

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -24,23 +24,50 @@ from oumi.core.configs.params.base_params import BaseParams
 
 @dataclass
 class ToolGroundingConfig(BaseParams):
-    """Per-tool field whitelist for grounding projection.
-
-    Tools listed in ``GroundingConfig.tools`` are projected through
-    ``fields`` when the env samples grounding facts. Tools not listed
-    contribute nothing.
-    """
+    """Per-tool field whitelist for deterministic-env grounding projection."""
 
     fields: list[str]
 
     def __post_init__(self) -> None:
-        """Validate ``fields`` invariants."""
+        """Validate ``fields`` is non-empty and de-duplicated."""
         if not self.fields:
             raise ValueError(f"{type(self).__name__}.fields must be non-empty.")
         if len(set(self.fields)) != len(self.fields):
             raise ValueError(
                 f"{type(self).__name__}.fields contains duplicate entries: "
                 f"{self.fields!r}."
+            )
+
+
+@dataclass
+class StateGroundingConfig(BaseParams):
+    """Per-state-pool grounding for stateful synthetic environments.
+
+    Projects rows from ``initial_state[state_path]`` through ``fields``;
+    ``key`` names the primary-key field and must appear in ``fields``.
+    """
+
+    state_path: str
+    fields: list[str]
+    key: str
+
+    def __post_init__(self) -> None:
+        """Validate ``state_path``, ``fields``, and ``key`` invariants."""
+        if not self.state_path:
+            raise ValueError(f"{type(self).__name__}.state_path must be non-empty.")
+        if not self.fields:
+            raise ValueError(f"{type(self).__name__}.fields must be non-empty.")
+        if len(set(self.fields)) != len(self.fields):
+            raise ValueError(
+                f"{type(self).__name__}.fields contains duplicate entries: "
+                f"{self.fields!r}."
+            )
+        if not self.key:
+            raise ValueError(f"{type(self).__name__}.key must be non-empty.")
+        if self.key not in self.fields:
+            raise ValueError(
+                f"{type(self).__name__}.fields must include 'key' "
+                f"({self.key!r}); got {self.fields!r}."
             )
 
 

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -23,7 +23,6 @@ from typing import Any
 import jsonschema
 
 from oumi.core.configs.params.base_params import BaseParams
-from oumi.core.configs.params.grounding_params import ToolGroundingConfig
 from oumi.core.types.tool_call import (
     FunctionDefinition,
     JSONSchema,
@@ -68,7 +67,6 @@ class ToolParams(BaseParams):
     parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
     output_schema: dict[str, Any] | None = None
     read_only: bool = True
-    grounding: ToolGroundingConfig | None = None
     executor: str = ""
     """Optional dotted import path to a callable that executes this tool.
 
@@ -86,7 +84,6 @@ class ToolParams(BaseParams):
             raise TypeError(
                 f"Tool definitions must be tool objects or mappings, got {type(raw)}"
             )
-        grounding_raw = raw.get("grounding")
         return cls(
             id=raw["id"],
             name=raw["name"],
@@ -98,12 +95,6 @@ class ToolParams(BaseParams):
                 else None
             ),
             read_only=raw.get("read_only", True),
-            grounding=(
-                grounding_raw
-                if grounding_raw is None
-                or isinstance(grounding_raw, ToolGroundingConfig)
-                else ToolGroundingConfig(**grounding_raw)
-            ),
             executor=raw.get("executor", ""),
         )
 
@@ -126,10 +117,6 @@ class ToolParams(BaseParams):
             self.output_schema = self.output_schema.model_dump(
                 mode="json", exclude_none=True
             )
-        if self.grounding is not None and not isinstance(
-            self.grounding, ToolGroundingConfig
-        ):
-            self.grounding = ToolGroundingConfig(**self.grounding)
 
     def to_llm_schema(self) -> dict[str, Any]:
         """Export a provider-agnostic schema for LLM tool registration."""

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -23,6 +23,7 @@ from typing import Any
 import jsonschema
 
 from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.configs.params.grounding_params import ToolGroundingConfig
 from oumi.core.types.tool_call import (
     FunctionDefinition,
     JSONSchema,
@@ -67,6 +68,14 @@ class ToolParams(BaseParams):
     parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
     output_schema: dict[str, Any] | None = None
     read_only: bool = True
+    grounding: ToolGroundingConfig | None = None
+    executor: str = ""
+    """Optional dotted import path to a callable that executes this tool.
+
+    When set, the host env dispatches calls to it instead of LLM-simulating.
+    ``SyntheticEnvironment`` passes ``(arguments, state)`` when
+    ``state_params`` is set, else ``(arguments,)``.
+    """
 
     @classmethod
     def create(cls, raw: Any) -> ToolParams:
@@ -77,6 +86,7 @@ class ToolParams(BaseParams):
             raise TypeError(
                 f"Tool definitions must be tool objects or mappings, got {type(raw)}"
             )
+        grounding_raw = raw.get("grounding")
         return cls(
             id=raw["id"],
             name=raw["name"],
@@ -88,6 +98,13 @@ class ToolParams(BaseParams):
                 else None
             ),
             read_only=raw.get("read_only", True),
+            grounding=(
+                grounding_raw
+                if grounding_raw is None
+                or isinstance(grounding_raw, ToolGroundingConfig)
+                else ToolGroundingConfig(**grounding_raw)
+            ),
+            executor=raw.get("executor", ""),
         )
 
     def __post_init__(self):
@@ -109,6 +126,10 @@ class ToolParams(BaseParams):
             self.output_schema = self.output_schema.model_dump(
                 mode="json", exclude_none=True
             )
+        if self.grounding is not None and not isinstance(
+            self.grounding, ToolGroundingConfig
+        ):
+            self.grounding = ToolGroundingConfig(**self.grounding)
 
     def to_llm_schema(self) -> dict[str, Any]:
         """Export a provider-agnostic schema for LLM tool registration."""

--- a/src/oumi/core/configs/synthesis_config.py
+++ b/src/oumi/core/configs/synthesis_config.py
@@ -106,7 +106,15 @@ class SynthesisConfig(BaseConfig):
             )
 
         if self.environment_config is not None:
-            return self.environment_config
+            if isinstance(self.environment_config, EnvironmentConfig):
+                return self.environment_config
+            if isinstance(self.environment_config, dict):
+                return EnvironmentConfig(**self.environment_config)
+            raise ValueError(
+                "SynthesisConfig.environment_config must be an "
+                "EnvironmentConfig instance or a dict; got "
+                f"{type(self.environment_config).__name__}."
+            )
 
         if self.environment_config_path is not None:
             if self.environment_config_path == "":

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -278,9 +278,7 @@ class ConversationSynthesizer:
             self._warn_on_grounding_placeholder(multiturn_attributes)
             self._attach_grounding_facts(samples, multiturn_attributes)
             samples = self._plan_samples(samples, multiturn_attributes)
-            conversations = self._synthesize_all_samples(
-                samples, multiturn_attributes
-            )
+            conversations = self._synthesize_all_samples(samples, multiturn_attributes)
         finally:
             self._sample_routers = []
 

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -106,14 +106,11 @@ class ConversationSynthesizer:
         self._sample_routers: list[ToolRouter | None] = []
 
     def _prepare_sample_routers(self, n_samples: int) -> None:
-        """Build per-sample router clones for one ``synthesize()`` batch.
+        """Replace ``self._sample_routers`` with one router clone per sample.
 
-        Replaces ``self._sample_routers`` with a fresh list of length
-        ``n_samples`` so every sample's tool dispatch and grounding read
-        hit an env instance with state independent of every other sample.
-        ``synthesize()`` calls this at batch entry and clears the list in
-        ``finally``; tests that exercise ``_dispatch_tool_calls`` or
-        ``_attach_grounding_facts`` directly call it themselves.
+        Each sample's tool dispatch and grounding read hit an env with state
+        independent of every other sample's. ``synthesize()`` calls this at
+        batch entry and clears the list in ``finally``.
         """
         self._sample_routers = (
             [self._router.for_sample() for _ in range(n_samples)]
@@ -1011,15 +1008,9 @@ class ConversationSynthesizer:
         across all envs in scope that declare a ``GroundingConfig``. No-op
         when ``environment_config`` is absent or no env in scope declares
         grounding. Emits one ``logger.warning`` per env when truncation
-        occurs (sample_size > pool_size).
-
-        Grounding reads each sample's env from ``self._sample_routers`` so
-        sample ``i``'s grounding pool comes from the same env instance that
-        will later receive sample ``i``'s tool calls. Today grounding runs
-        before any tool fires, so this is observationally identical to a
-        shared-instance read of ``initial_state``; the per-sample wiring
-        keeps the two phases consistent if grounding ever moves into the
-        per-turn loop.
+        occurs (sample_size > pool_size). Each sample reads its grounding
+        pool from the same per-sample router that will later receive its
+        tool calls.
         """
         if self._environment_config is None:
             return

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -17,13 +17,10 @@ import json
 import random
 from typing import Any
 
-from oumi.builders.environments import build_environment
 from oumi.builders.inference_engines import build_inference_engine
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.inference_engine_type import InferenceEngineType
-from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.grounding_params import GroundingConfig
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
@@ -106,6 +103,24 @@ class ConversationSynthesizer:
                 on_env_built=self._wire_inference,
             )
 
+        self._sample_routers: list[ToolRouter | None] = []
+
+    def _prepare_sample_routers(self, n_samples: int) -> None:
+        """Build per-sample router clones for one ``synthesize()`` batch.
+
+        Replaces ``self._sample_routers`` with a fresh list of length
+        ``n_samples`` so every sample's tool dispatch and grounding read
+        hit an env instance with state independent of every other sample.
+        ``synthesize()`` calls this at batch entry and clears the list in
+        ``finally``; tests that exercise ``_dispatch_tool_calls`` or
+        ``_attach_grounding_facts`` directly call it themselves.
+        """
+        self._sample_routers = (
+            [self._router.for_sample() for _ in range(n_samples)]
+            if self._router is not None
+            else [None] * n_samples
+        )
+
     def _wire_inference(self, env: BaseEnvironment) -> None:
         """Inject the synthesizer's engine + base config into synthetic envs."""
         if isinstance(env, SyntheticEnvironment):
@@ -149,32 +164,39 @@ class ConversationSynthesizer:
             content=content,
         )
 
-    def _dispatch_tool_calls(self, tool_calls: list[ToolCall]) -> list[Message]:
+    def _dispatch_tool_calls(
+        self, tool_calls: list[ToolCall], sample_idx: int
+    ) -> list[Message]:
         """Dispatch a batch of tool calls; returns one TOOL message per call.
 
         Validates each call via the router, then groups surviving calls by env
         and routes each group in one batched ``env.step()``. If the batched
         route raises, falls back to per-call routing so individual errors stay
         attributed.
+
+        ``sample_idx`` selects the per-sample router clone built at
+        ``synthesize()`` entry; routing through it keeps state mutations
+        scoped to one sample's env instances.
         """
-        assert self._router is not None, "tool calls require an environment_config"
+        router = self._sample_routers[sample_idx]
+        assert router is not None, "tool calls require an environment_config"
         results: list[Message | None] = [None] * len(tool_calls)
         groups: dict[int, list[tuple[int, ToolCall, dict[str, Any]]]] = {}
         for idx, tc in enumerate(tool_calls):
             try:
-                arguments = self._router.parse_and_validate_arguments(
+                arguments = router.parse_and_validate_arguments(
                     tc.function.name, tc.function.arguments
                 )
             except (ToolArgumentError, ToolLookupError) as exc:
                 results[idx] = self._tool_error(tc, str(exc))
                 continue
-            env = self._router.tool_to_env[tc.function.name]
+            env = router.tool_to_env[tc.function.name]
             groups.setdefault(id(env), []).append((idx, tc, arguments))
 
         for group in groups.values():
             calls = [(tc.function.name, args) for _, tc, args in group]
             try:
-                outputs = self._router.route_batch(calls)
+                outputs = router.route_batch(calls)
             except Exception:
                 # On batch failure, re-route each call individually so per-call
                 # errors stay attributed. SyntheticEnvironment's in-batch cache
@@ -183,7 +205,7 @@ class ConversationSynthesizer:
                 # Phase 2's corrective-retry should replace this fallback.
                 for idx, tc, args in group:
                     try:
-                        [single] = self._router.route_batch([(tc.function.name, args)])
+                        [single] = router.route_batch([(tc.function.name, args)])
                     except Exception as exc:
                         results[idx] = self._tool_error(
                             tc, f"Tool '{tc.function.name}' raised: {exc}"
@@ -251,10 +273,16 @@ class ConversationSynthesizer:
                 [tool.id for tool in available_tools],
             )
 
-        self._warn_on_grounding_placeholder(multiturn_attributes)
-        self._attach_grounding_facts(samples, multiturn_attributes)
-        samples = self._plan_samples(samples, multiturn_attributes)
-        conversations = self._synthesize_all_samples(samples, multiturn_attributes)
+        self._prepare_sample_routers(len(samples))
+        try:
+            self._warn_on_grounding_placeholder(multiturn_attributes)
+            self._attach_grounding_facts(samples, multiturn_attributes)
+            samples = self._plan_samples(samples, multiturn_attributes)
+            conversations = self._synthesize_all_samples(
+                samples, multiturn_attributes
+            )
+        finally:
+            self._sample_routers = []
 
         records: list[dict[str, dict | str] | None] = []
         plan_key = f"{multiturn_attributes.id}_plan"
@@ -795,7 +823,9 @@ class ConversationSynthesizer:
                         tool_calls=assistant_msg.tool_calls,
                     )
                 )
-                staging[idx].extend(self._dispatch_tool_calls(assistant_msg.tool_calls))
+                staging[idx].extend(
+                    self._dispatch_tool_calls(assistant_msg.tool_calls, idx)
+                )
                 round_count[idx] += 1
             else:
                 staging[idx].append(
@@ -984,6 +1014,14 @@ class ConversationSynthesizer:
         when ``environment_config`` is absent or no env in scope declares
         grounding. Emits one ``logger.warning`` per env when truncation
         occurs (sample_size > pool_size).
+
+        Grounding reads each sample's env from ``self._sample_routers`` so
+        sample ``i``'s grounding pool comes from the same env instance that
+        will later receive sample ``i``'s tool calls. Today grounding runs
+        before any tool fires, so this is observationally identical to a
+        shared-instance read of ``initial_state``; the per-sample wiring
+        keeps the two phases consistent if grounding ever moves into the
+        per-turn loop.
         """
         if self._environment_config is None:
             return
@@ -993,14 +1031,12 @@ class ConversationSynthesizer:
             if multiturn_attribute.available_environments
             else {env.id for env in self._environment_config.environments}
         )
-        grounding_envs: list[
-            tuple[EnvironmentParams, GroundingConfig, BaseEnvironment]
-        ] = [
-            (env_params, env_params.grounding, build_environment(env_params))
+        grounding_env_params = [
+            env_params
             for env_params in self._environment_config.environments
             if env_params.id in scoped_env_ids and env_params.grounding is not None
         ]
-        if not grounding_envs:
+        if not grounding_env_params:
             return
 
         warned_envs: set[str] = set()
@@ -1010,8 +1046,13 @@ class ConversationSynthesizer:
             else None
         )
         for sample_index, sample in enumerate(samples):
+            router = self._sample_routers[sample_index]
+            assert router is not None, "grounding requires an environment_config"
             facts: list[GroundingFact] = []
-            for env_params, grounding, env_runtime in grounding_envs:
+            for env_params in grounding_env_params:
+                grounding = env_params.grounding
+                assert grounding is not None
+                env_runtime = router.env_by_id[env_params.id]
                 rng = self._make_grounding_rng(grounding.seed, sample_index)
                 sampled = env_runtime.sample_grounding(
                     n=grounding.sample_size,

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -58,12 +58,16 @@ class ToolRouter:
     ) -> ToolRouter:
         """Build a router from an env config."""
         tool_env_map = env_config.tool_environment_map
-        reachable_env_ids = set(tool_env_map.values())
+        included_env_ids = set(tool_env_map.values()) | {
+            env_params.id
+            for env_params in env_config.environments
+            if env_params.grounding is not None
+        }
 
         env_params_by_id: dict[str, EnvironmentParams] = {}
         env_by_id: dict[str, BaseEnvironment] = {}
         for env_params in env_config.environments:
-            if env_params.id not in reachable_env_ids:
+            if env_params.id not in included_env_ids:
                 continue
             env_params_by_id[env_params.id] = env_params
             env = build_environment(env_params)

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from oumi.builders.environments import build_environment
 from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.tool_params import (
     ToolArgumentError,
     ToolLookupError,
@@ -34,12 +35,20 @@ from oumi.environments.base_environment import BaseEnvironment
 
 @dataclass
 class ToolRouter:
-    """Routes LLM tool calls to environment-owned tools."""
+    """Routes LLM tool calls to environment-owned tools.
+
+    Use :meth:`for_sample` to obtain a per-sample clone whose envs have
+    independent state; the synthesizer builds one clone per sample at
+    batch entry so tool mutations don't leak across samples.
+    """
 
     tool_specs: list[ToolDefinition]
     tools_by_id: dict[str, ToolParams]
     env_by_id: dict[str, BaseEnvironment]
     tool_to_env: dict[str, BaseEnvironment]
+    env_params_by_id: dict[str, EnvironmentParams]
+    tool_env_map: dict[str, str]
+    on_env_built: Callable[[BaseEnvironment], None] | None
 
     @classmethod
     def from_environment_config(
@@ -51,10 +60,12 @@ class ToolRouter:
         tool_env_map = env_config.tool_environment_map
         reachable_env_ids = set(tool_env_map.values())
 
+        env_params_by_id: dict[str, EnvironmentParams] = {}
         env_by_id: dict[str, BaseEnvironment] = {}
         for env_params in env_config.environments:
             if env_params.id not in reachable_env_ids:
                 continue
+            env_params_by_id[env_params.id] = env_params
             env = build_environment(env_params)
             if on_env_built is not None:
                 on_env_built(env)
@@ -71,6 +82,38 @@ class ToolRouter:
             tools_by_id=tools_by_id,
             env_by_id=env_by_id,
             tool_to_env=tool_to_env,
+            env_params_by_id=env_params_by_id,
+            tool_env_map=tool_env_map,
+            on_env_built=on_env_built,
+        )
+
+    def for_sample(self) -> ToolRouter:
+        """Return a router with fresh env instances for one sample.
+
+        Each ``BaseEnvironment`` is rebuilt via ``build_environment`` so its
+        mutable state (e.g. ``SyntheticEnvironment._state``) is independent
+        from the parent router and from any sibling ``for_sample`` clone.
+        ``on_env_built`` is re-invoked on every fresh env so synthetic envs
+        get their inference engine re-attached.
+        """
+        env_by_id_new: dict[str, BaseEnvironment] = {}
+        for env_id, env_params in self.env_params_by_id.items():
+            fresh = build_environment(env_params)
+            if self.on_env_built is not None:
+                self.on_env_built(fresh)
+            env_by_id_new[env_id] = fresh
+
+        return ToolRouter(
+            tool_specs=self.tool_specs,
+            tools_by_id=self.tools_by_id,
+            env_by_id=env_by_id_new,
+            tool_to_env={
+                tool_id: env_by_id_new[env_id]
+                for tool_id, env_id in self.tool_env_map.items()
+            },
+            env_params_by_id=self.env_params_by_id,
+            tool_env_map=self.tool_env_map,
+            on_env_built=self.on_env_built,
         )
 
     def parse_and_validate_arguments(

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -90,11 +90,9 @@ class ToolRouter:
     def for_sample(self) -> ToolRouter:
         """Return a router with fresh env instances for one sample.
 
-        Each ``BaseEnvironment`` is rebuilt via ``build_environment`` so its
-        mutable state (e.g. ``SyntheticEnvironment._state``) is independent
-        from the parent router and from any sibling ``for_sample`` clone.
-        ``on_env_built`` is re-invoked on every fresh env so synthetic envs
-        get their inference engine re-attached.
+        Each env is rebuilt via ``build_environment`` so its mutable state
+        is independent from the parent and from any sibling clone.
+        ``on_env_built`` re-runs on every fresh env.
         """
         env_by_id_new: dict[str, BaseEnvironment] = {}
         for env_id, env_params in self.env_params_by_id.items():

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -92,15 +92,21 @@ class ToolRouter:
         )
 
     def for_sample(self) -> ToolRouter:
-        """Return a router with fresh env instances for one sample.
+        """Return a router safe to use for one sample.
 
-        Each env is rebuilt via ``build_environment`` so its mutable state
-        is independent from the parent and from any sibling clone.
-        ``on_env_built`` re-runs on every fresh env.
+        Envs whose ``requires_isolation()`` returns ``True`` are rebuilt via
+        ``build_environment`` so their mutable state stays independent across
+        samples; ``on_env_built`` re-runs on those fresh instances. Envs that
+        don't require isolation (e.g. ``DeterministicEnvironment`` and
+        stateless ``SyntheticEnvironment``) are shared with the parent
+        router to avoid the per-sample build + inference-engine attach cost.
         """
         env_by_id_new: dict[str, BaseEnvironment] = {}
-        for env_id, env_params in self.env_params_by_id.items():
-            fresh = build_environment(env_params)
+        for env_id, parent_env in self.env_by_id.items():
+            if not parent_env.requires_isolation():
+                env_by_id_new[env_id] = parent_env
+                continue
+            fresh = build_environment(self.env_params_by_id[env_id])
             if self.on_env_built is not None:
                 self.on_env_built(fresh)
             env_by_id_new[env_id] = fresh

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -21,6 +21,7 @@ concrete environment's `@register_environment(...)` decorator.
 from oumi.core.configs.params.grounding_params import (
     GroundingConfig,
     GroundingFact,
+    StateGroundingConfig,
     ToolGroundingConfig,
 )
 from oumi.core.configs.params.tool_params import (
@@ -49,13 +50,14 @@ __all__ = [
     "GroundingConfig",
     "GroundingFact",
     "JSONSchema",
-    "ToolLookupEntry",
+    "StateGroundingConfig",
     "SyntheticEnvironment",
     "SyntheticEnvironmentKwargs",
     "SyntheticStateParams",
     "ToolArgumentError",
     "ToolError",
     "ToolGroundingConfig",
+    "ToolLookupEntry",
     "ToolLookupError",
     "ToolParams",
     "ToolResult",

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -35,6 +35,15 @@ class BaseEnvironment(ABC):
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
         """Execute a batch of tool calls; returns results in the same order."""
 
+    def requires_isolation(self) -> bool:
+        """Whether this env must be rebuilt per sample to avoid cross-sample leakage.
+
+        Default ``False`` — the env is safe to share across samples.
+        Override and return ``True`` for envs carrying mutable per-sample
+        state (e.g. stateful synthetic tool execution).
+        """
+        return False
+
     def sample_grounding(
         self,
         n: int,

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -91,13 +91,7 @@ class DeterministicEnvironment(BaseEnvironment):
         self._validate_lookup_table()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
-        """Resolve a batch of deterministic tool calls to their outputs.
-
-        Raises:
-            ValueError: If any ``tool_id`` is not declared in this env's tools list.
-            ToolLookupError: If no entry in the env's lookup table matches
-                the provided arguments for any call.
-        """
+        """Resolve a batch of deterministic tool calls to their outputs."""
         return [self._resolve_one(tool_id, args) for tool_id, args in calls]
 
     def _resolve_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -15,9 +15,11 @@
 """Synthetic environment backed by LLM-simulated or Python-executed tools.
 
 Stateless mode (``state_params=None``) batches LLM-simulated tool outputs
-per tool id, cached by ``(tool_id, args)``. Stateful mode runs the per-tool
-``executor`` callables sequentially so state mutations thread through the
-batch. Tools without an ``executor`` always fall back to LLM simulation.
+per tool id, cached by ``(tool_id, args)``. Individual tools may still
+opt into Python execution by setting ``executor`` -- LLM simulation is
+the fallback for tools without one. Stateful mode (``state_params`` is
+set) requires every tool to define ``executor``; the env runs them
+sequentially so state mutations thread through the batch.
 """
 
 from __future__ import annotations
@@ -167,6 +169,14 @@ class SyntheticEnvironment(BaseEnvironment):
             for tool in params.tools
             if tool.executor
         }
+        if kwargs.state_params is not None:
+            missing = [t.id for t in params.tools if not t.executor]
+            if missing:
+                raise ValueError(
+                    "SyntheticEnvironment in stateful mode (state_params set) "
+                    "requires every tool to define an executor; LLM-simulated "
+                    f"tools cannot mutate state. Missing executor: {missing}"
+                )
         if self._state is not None:
             self._validate_state_grounding()
         self._engine: BaseInferenceEngine | None = None

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -165,13 +165,14 @@ class SyntheticEnvironment(BaseEnvironment):
             for tool in params.tools
             if tool.executor
         }
-        if kwargs.state_params is not None:
+        if self._state is not None:
             missing = [t.id for t in params.tools if not t.executor]
             if missing:
                 raise ValueError(
-                    "SyntheticEnvironment in stateful mode (state_params set) "
-                    "requires every tool to define an executor; LLM-simulated "
-                    f"tools cannot mutate state. Missing executor: {missing}"
+                    "SyntheticEnvironment in stateful mode (state_params with "
+                    "initial_state set) requires every tool to define an executor; "
+                    "LLM-simulated tools cannot mutate state. Missing executor: "
+                    f"{missing}"
                 )
         if self._state is not None:
             self._validate_state_grounding()
@@ -320,8 +321,11 @@ class SyntheticEnvironment(BaseEnvironment):
     def _step_stateful_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
         """Dispatch a stateful tool and commit ``updated_state`` after validation.
 
-        ``state_in`` is a deep copy so in-place mutation by the executor
-        doesn't bleed through if validation later rejects the result.
+        ``state_in`` is a deep copy so the executor's reference to ``state``
+        can't reach back into ``self._state``: executors that mutate ``state``
+        in place (or hand the same dict back as ``updated_state``) end up
+        touching the copy, and ``self._state`` is only reassigned via the
+        explicit deepcopy of ``result.updated_state`` below.
         """
         assert self._state is not None
         tool = self._lookup_tool(tool_id)

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -58,24 +58,16 @@ if TYPE_CHECKING:
 class SyntheticStateParams(BaseParams):
     """Optional state configuration for a synthetic environment.
 
-    ``grounding`` declares one or more state pools (``state_path``) to
-    project ``GroundingFact``s from. Each entry's ``state_path`` must
-    resolve to a ``list[dict]`` in ``initial_state``.
+    State grounding for these pools is declared at the env level
+    via ``EnvironmentParams.grounding.state`` — each entry's
+    ``state_path`` must resolve to a ``list[dict]`` in ``initial_state``.
     """
 
     state_schema: dict[str, Any] | None = None
     initial_state: dict[str, Any] | None = None
-    grounding: list[StateGroundingConfig] | None = None
 
     def __post_init__(self):
         """Validate state config consistency."""
-        if self.grounding is not None:
-            self.grounding = [
-                cfg
-                if isinstance(cfg, StateGroundingConfig)
-                else StateGroundingConfig(**cfg)
-                for cfg in self.grounding
-            ]
         if self.state_schema is not None and self.initial_state is not None:
             jsonschema.validate(self.initial_state, self.state_schema)
 
@@ -160,10 +152,14 @@ class SyntheticEnvironment(BaseEnvironment):
             else None
         )
         self._state_grounding: list[StateGroundingConfig] = (
-            kwargs.state_params.grounding or []
-            if kwargs.state_params is not None
-            else []
+            list(params.grounding.state) if params.grounding is not None else []
         )
+        if self._state is None and self._state_grounding:
+            raise ValueError(
+                f"SyntheticEnvironment '{params.id}': grounding.state is "
+                f"configured but the env has no state (state_params with "
+                f"initial_state is required)."
+            )
         self._executors: dict[str, Callable[..., Any]] = {
             tool.id: _import_executor(tool.executor, tool.id)
             for tool in params.tools
@@ -372,9 +368,9 @@ class SyntheticEnvironment(BaseEnvironment):
         rng: random.Random,
         tool_ids: set[str] | None = None,
     ) -> list[GroundingFact]:
-        """Project grounding facts from ``state_params.grounding`` pools.
+        """Project grounding facts from ``grounding.state`` pools.
 
-        No-op for stateless envs or envs without ``state_params.grounding``.
+        No-op for stateless envs or envs without ``grounding.state`` entries.
         ``tool_ids`` is accepted for ``BaseEnvironment`` signature compatibility
         but ignored — state grounding is pool-scoped, not tool-scoped.
 
@@ -395,7 +391,7 @@ class SyntheticEnvironment(BaseEnvironment):
         return rng.sample(pool, min(n, len(pool)))
 
     def _validate_state_grounding(self) -> None:
-        """Validate each ``state_params.grounding`` entry against state."""
+        """Validate each ``grounding.state`` entry against current state."""
         assert self._state is not None
         for cfg in self._state_grounding:
             if cfg.state_path not in self._state:

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -188,6 +188,10 @@ class SyntheticEnvironment(BaseEnvironment):
         self._engine = engine
         self._base_inference_config = base_config
 
+    def requires_isolation(self) -> bool:
+        """Stateful synth envs need per-sample isolation; stateless do not."""
+        return self._state is not None
+
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> SyntheticEnvironment:
         """Build a SyntheticEnvironment from its params object."""

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Synthetic environment backed by LLM-simulated tool execution."""
+"""Synthetic environment backed by LLM-simulated or Python-executed tools.
+
+Stateless mode (``state_params=None``) batches LLM-simulated tool outputs
+per tool id, cached by ``(tool_id, args)``. Stateful mode runs the per-tool
+``executor`` callables sequentially so state mutations thread through the
+batch. Tools without an ``executor`` always fall back to LLM simulation.
+"""
 
 from __future__ import annotations
 
 import copy
 import dataclasses
+import importlib
 import json
+import random
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -27,6 +36,10 @@ import jsonschema
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.grounding_params import (
+    GroundingFact,
+    StateGroundingConfig,
+)
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.registry import register_environment
@@ -41,13 +54,26 @@ if TYPE_CHECKING:
 
 @dataclass
 class SyntheticStateParams(BaseParams):
-    """Optional state configuration for a synthetic environment."""
+    """Optional state configuration for a synthetic environment.
+
+    ``grounding`` declares one or more state pools (``state_path``) to
+    project ``GroundingFact``s from. Each entry's ``state_path`` must
+    resolve to a ``list[dict]`` in ``initial_state``.
+    """
 
     state_schema: dict[str, Any] | None = None
     initial_state: dict[str, Any] | None = None
+    grounding: list[StateGroundingConfig] | None = None
 
     def __post_init__(self):
         """Validate state config consistency."""
+        if self.grounding is not None:
+            self.grounding = [
+                cfg
+                if isinstance(cfg, StateGroundingConfig)
+                else StateGroundingConfig(**cfg)
+                for cfg in self.grounding
+            ]
         if self.state_schema is not None and self.initial_state is not None:
             jsonschema.validate(self.initial_state, self.state_schema)
 
@@ -78,9 +104,38 @@ class SyntheticEnvironmentKwargs(BaseParams):
             )
 
 
+def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
+    """Resolve a dotted import path to a callable. Raises ValueError on failure."""
+    module_path, _, attr = dotted.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' must be a dotted import "
+            f"path (e.g. 'pkg.module.fn')."
+        )
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise ValueError(
+            f"Tool '{tool_id}': cannot import executor module '{module_path}': {e}"
+        ) from e
+    executor = getattr(module, attr, None)
+    if executor is None:
+        raise ValueError(
+            f"Tool '{tool_id}': module '{module_path}' has no attribute '{attr}'."
+        )
+    if not callable(executor):
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' resolved to a non-callable."
+        )
+    return executor
+
+
 @register_environment("synthetic")
 class SyntheticEnvironment(BaseEnvironment):
-    """LLM-simulated environment with optional mutable state."""
+    """LLM-simulated environment with optional mutable state.
+
+    See the module docstring for the stateless vs stateful contract.
+    """
 
     def __init__(
         self,
@@ -97,6 +152,23 @@ class SyntheticEnvironment(BaseEnvironment):
             and kwargs.state_params.initial_state is not None
             else None
         )
+        self._state_schema: dict[str, Any] | None = (
+            kwargs.state_params.state_schema
+            if kwargs.state_params is not None
+            else None
+        )
+        self._state_grounding: list[StateGroundingConfig] = (
+            kwargs.state_params.grounding or []
+            if kwargs.state_params is not None
+            else []
+        )
+        self._executors: dict[str, Callable[..., Any]] = {
+            tool.id: _import_executor(tool.executor, tool.id)
+            for tool in params.tools
+            if tool.executor
+        }
+        if self._state is not None:
+            self._validate_state_grounding()
         self._engine: BaseInferenceEngine | None = None
         self._base_inference_config: InferenceConfig | None = None
 
@@ -163,56 +235,173 @@ class SyntheticEnvironment(BaseEnvironment):
         )
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
-        """Execute synthetic tool calls. Cache-misses batched per tool_id.
+        """Execute tool calls. See module docstring for routing rules.
 
         Raises:
-            RuntimeError: If ``attach_inference`` was not called.
             ValueError: If any tool id is unknown.
-            ToolError: On simulator parse failure or output_schema mismatch.
+            RuntimeError: If an LLM-simulated tool is invoked before
+                ``attach_inference`` was called.
+            ToolError: On simulator parse failure or schema mismatch.
         """
         if not calls:
             return []
         for tool_id, _ in calls:
             self._lookup_tool(tool_id)
-        if self._engine is None or self._base_inference_config is None:
-            raise RuntimeError(
-                "SyntheticEnvironment.step called before attach_inference(). "
-                "Wire the synthesizer's engine via attach_inference(engine, "
-                "base_config) before invoking step()."
-            )
 
+        stateful = self._state is not None
         results: list[ToolResult | None] = [None] * len(calls)
-        misses: list[tuple[int, str, dict[str, Any]]] = []
+        sim_misses: list[tuple[int, str, dict[str, Any]]] = []
         for i, (tool_id, args) in enumerate(calls):
+            if tool_id in self._executors:
+                if stateful:
+                    results[i] = self._step_stateful_one(tool_id, args)
+                else:
+                    results[i] = self._step_executor_one(tool_id, args)
+                continue
             cached = self._resolve_cached(tool_id, args)
             if cached is not None:
                 results[i] = cached
             else:
-                misses.append((i, tool_id, args))
+                sim_misses.append((i, tool_id, args))
 
-        groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
-        for i, tool_id, args in misses:
-            groups.setdefault(tool_id, []).append((i, args))
-
-        for tool_id, group in groups.items():
-            tool = self._lookup_tool(tool_id)
-            convs = [self._build_call_conv(tool, args) for _, args in group]
-            inferred = self._engine.infer(convs, self._simulator_inference_config(tool))
-            if len(inferred) != len(group):
+        if sim_misses:
+            if self._engine is None or self._base_inference_config is None:
                 raise RuntimeError(
-                    f"Simulator returned {len(inferred)} responses for "
-                    f"{len(group)} calls to '{tool_id}'."
+                    "SyntheticEnvironment.step called before "
+                    "attach_inference(). Wire the synthesizer's engine via "
+                    "attach_inference(engine, base_config) before invoking "
+                    "step()."
                 )
-            for (idx, args), conv in zip(group, inferred):
-                raw = self._extract_text(conv)
-                result = self._parse_and_validate(raw, tool)
-                self._cache_result(tool_id, args, result)
-                results[idx] = result
+            groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+            for i, tool_id, args in sim_misses:
+                groups.setdefault(tool_id, []).append((i, args))
+
+            for tool_id, group in groups.items():
+                tool = self._lookup_tool(tool_id)
+                convs = [self._build_call_conv(tool, args) for _, args in group]
+                inferred = self._engine.infer(
+                    convs, self._simulator_inference_config(tool)
+                )
+                if len(inferred) != len(group):
+                    raise RuntimeError(
+                        f"Simulator returned {len(inferred)} responses for "
+                        f"{len(group)} calls to '{tool_id}'."
+                    )
+                for (idx, args), conv in zip(group, inferred):
+                    raw = self._extract_text(conv)
+                    result = self._parse_and_validate(raw, tool)
+                    self._cache_result(tool_id, args, result)
+                    results[idx] = result
 
         assert all(r is not None for r in results), (
             "every call must produce a ToolResult"
         )
         return results  # type: ignore[return-value]
+
+    def _step_executor_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        """Execute a stateless tool via its executor callable."""
+        tool = self._lookup_tool(tool_id)
+        tool.validate_arguments(arguments)
+        result = self._executors[tool_id](arguments=arguments)
+        self._validate_executor_output(tool, result)
+        if result.updated_state is not None:
+            raise ToolError(
+                f"Tool '{tool.id}' executor returned updated_state but the "
+                f"environment is stateless."
+            )
+        return result
+
+    def _step_stateful_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        """Dispatch a stateful tool and commit ``updated_state`` after validation.
+
+        ``state_in`` is a deep copy so in-place mutation by the executor
+        doesn't bleed through if validation later rejects the result.
+        """
+        assert self._state is not None
+        tool = self._lookup_tool(tool_id)
+        tool.validate_arguments(arguments)
+        state_in = copy.deepcopy(self._state)
+        result = self._executors[tool_id](arguments=arguments, state=state_in)
+        self._validate_executor_output(tool, result)
+        if result.updated_state is not None:
+            if tool.read_only:
+                raise ToolError(
+                    f"Tool '{tool_id}' is read_only but executor returned "
+                    f"updated_state. Read-only tools must not mutate state."
+                )
+            if self._state_schema is not None:
+                try:
+                    jsonschema.validate(result.updated_state, self._state_schema)
+                except jsonschema.ValidationError as e:
+                    raise ToolError(
+                        f"Tool '{tool_id}' updated_state failed state_schema "
+                        f"validation: {e}"
+                    ) from e
+            self._state = copy.deepcopy(result.updated_state)
+        return result
+
+    def _validate_executor_output(self, tool: ToolParams, result: Any) -> None:
+        """Validate executor return type + ``output_schema`` conformance."""
+        if not isinstance(result, ToolResult):
+            raise ToolError(
+                f"Tool '{tool.id}' executor must return ToolResult, got "
+                f"{type(result).__name__}."
+            )
+        if tool.output_schema is not None:
+            try:
+                jsonschema.validate(result.output, tool.output_schema)
+            except jsonschema.ValidationError as e:
+                raise ToolError(
+                    f"Tool '{tool.id}' executor output failed schema validation: {e}"
+                ) from e
+
+    def sample_grounding(
+        self,
+        n: int,
+        *,
+        rng: random.Random,
+        tool_ids: set[str] | None = None,
+    ) -> list[GroundingFact]:
+        """Project grounding facts from ``state_params.grounding`` pools.
+
+        No-op for stateless envs or envs without ``state_params.grounding``.
+        ``tool_ids`` is accepted for ``BaseEnvironment`` signature compatibility
+        but ignored — state grounding is pool-scoped, not tool-scoped.
+
+        ``_validate_state_grounding`` at init guarantees each ``state_path``
+        resolves to a list in ``self._state``, and ``state_schema`` validation
+        on every commit keeps it that way, so the projection loop trusts the
+        shape.
+        """
+        del tool_ids
+        if self._state is None or not self._state_grounding:
+            return []
+        pool: list[GroundingFact] = []
+        for cfg in self._state_grounding:
+            whitelist = set(cfg.fields)
+            for row in self._state[cfg.state_path]:
+                projected = {k: v for k, v in row.items() if k in whitelist}
+                pool.append(GroundingFact(data=projected))
+        return rng.sample(pool, min(n, len(pool)))
+
+    def _validate_state_grounding(self) -> None:
+        """Validate each ``state_params.grounding`` entry against state."""
+        assert self._state is not None
+        for cfg in self._state_grounding:
+            if cfg.state_path not in self._state:
+                raise ValueError(
+                    f"SyntheticEnvironment '{self._params.id}': grounding "
+                    f"state_path '{cfg.state_path}' is not present in "
+                    f"initial_state. Top-level keys: "
+                    f"{sorted(self._state.keys())}."
+                )
+            rows = self._state[cfg.state_path]
+            if not isinstance(rows, list):
+                raise ValueError(
+                    f"SyntheticEnvironment '{self._params.id}': grounding "
+                    f"state_path '{cfg.state_path}' must resolve to a list, "
+                    f"got {type(rows).__name__}."
+                )
 
     def _build_simulator_system_prompt(self, tool: ToolParams) -> str:
         """Compose the simulator system prompt: env persona + tool schema."""
@@ -257,14 +446,11 @@ class SyntheticEnvironment(BaseEnvironment):
 
     @staticmethod
     def _extract_text(conv: Conversation) -> str:
-        """Pull the simulator's text response from an inferred conversation.
+        """Return the assistant's text response, or ``""`` to trigger a ToolError.
 
-        Returns ``""`` (which forces the ``ToolError`` path in
-        ``_parse_and_validate``) when the last message is not an assistant
-        turn — guards against a passthrough/partial-failure path where the
-        engine returns ``convs`` unchanged and ``messages[-1]`` is still the
-        user payload (itself valid JSON of the form
-        ``{"tool": ..., "arguments": ...}``).
+        Engines that passthrough on partial failure can leave the user payload
+        (itself valid JSON) as ``messages[-1]``; the role guard forces the
+        ToolError path so we don't echo arguments back as a tool result.
         """
         if not conv.messages:
             return ""

--- a/tests/unit/core/configs/params/test_environment_params.py
+++ b/tests/unit/core/configs/params/test_environment_params.py
@@ -142,19 +142,6 @@ def test_grounding_post_init_coerces_dict_to_grounding_config():
     assert isinstance(p.grounding.tools["t"], ToolGroundingConfig)
 
 
-def test_grounding_validate_rejects_empty_tools_dict():
-    p = EnvironmentParams(
-        id="e1",
-        name="E1",
-        description="d",
-        env_type="deterministic",
-        tools=[_make_tool()],
-        grounding=GroundingConfig(sample_size=3, tools={}),
-    )
-    with pytest.raises(ValueError, match="grounding.tools is empty"):
-        p.finalize_and_validate()
-
-
 def test_grounding_validate_passes_with_at_least_one_tool():
     p = EnvironmentParams(
         id="e1",

--- a/tests/unit/core/configs/params/test_grounding_params.py
+++ b/tests/unit/core/configs/params/test_grounding_params.py
@@ -74,17 +74,16 @@ def test_grounding_config_coerces_state_entries():
     """Raw state entries are coerced to StateGroundingConfig instances."""
     cfg = GroundingConfig(
         state=[  # type: ignore[list-item]
-            {"state_path": "books", "key": "book_id", "fields": ["book_id", "title"]},
+            {"state_path": "books", "fields": ["book_id", "title"]},
         ],
     )
     assert isinstance(cfg.state[0], StateGroundingConfig)
     assert cfg.state[0].state_path == "books"
-    assert cfg.state[0].key == "book_id"
     assert cfg.state[0].fields == ["book_id", "title"]
 
 
 def test_grounding_config_passthrough_for_typed_state_entries():
-    sg = StateGroundingConfig(state_path="books", key="id", fields=["id", "title"])
+    sg = StateGroundingConfig(state_path="books", fields=["id", "title"])
     cfg = GroundingConfig(state=[sg])
     assert cfg.state[0] is sg
 

--- a/tests/unit/core/configs/params/test_grounding_params.py
+++ b/tests/unit/core/configs/params/test_grounding_params.py
@@ -17,6 +17,7 @@ import pytest
 from oumi.core.configs.params.grounding_params import (
     GroundingConfig,
     GroundingFact,
+    StateGroundingConfig,
     ToolGroundingConfig,
 )
 
@@ -46,6 +47,7 @@ def test_grounding_config_defaults():
     assert cfg.sample_size == 3
     assert cfg.seed is None
     assert cfg.tools == {}
+    assert cfg.state == []
 
 
 def test_grounding_config_rejects_zero_sample_size():
@@ -66,6 +68,25 @@ def test_grounding_config_passthrough_for_already_typed_entries():
     tg = ToolGroundingConfig(fields=["a", "b"])
     cfg = GroundingConfig(tools={"t": tg})
     assert cfg.tools["t"] is tg
+
+
+def test_grounding_config_coerces_state_entries():
+    """Raw state entries are coerced to StateGroundingConfig instances."""
+    cfg = GroundingConfig(
+        state=[  # type: ignore[list-item]
+            {"state_path": "books", "key": "book_id", "fields": ["book_id", "title"]},
+        ],
+    )
+    assert isinstance(cfg.state[0], StateGroundingConfig)
+    assert cfg.state[0].state_path == "books"
+    assert cfg.state[0].key == "book_id"
+    assert cfg.state[0].fields == ["book_id", "title"]
+
+
+def test_grounding_config_passthrough_for_typed_state_entries():
+    sg = StateGroundingConfig(state_path="books", key="id", fields=["id", "title"])
+    cfg = GroundingConfig(state=[sg])
+    assert cfg.state[0] is sg
 
 
 # --- GroundingFact ---

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2339,7 +2339,11 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
 def test_prepare_sample_routers_builds_one_router_per_sample(
     mock_inference_config,
 ):
-    """_prepare_sample_routers materializes a router clone per sample."""
+    """_prepare_sample_routers materializes a router clone per sample.
+
+    The deterministic env carries no mutable state so it is shared across
+    routers; only the router wrappers themselves are per-sample.
+    """
     env_config = _grounded_env_config(n_entries=5, sample_size=2, seed=1)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     synth._prepare_sample_routers(3)
@@ -2351,8 +2355,7 @@ def test_prepare_sample_routers_builds_one_router_per_sample(
     envs_0 = routers[0].env_by_id["env1"]
     envs_1 = routers[1].env_by_id["env1"]
     envs_2 = routers[2].env_by_id["env1"]
-    assert envs_0 is not envs_1
-    assert envs_1 is not envs_2
+    assert envs_0 is envs_1 is envs_2
 
 
 def test_prepare_sample_routers_without_env_config_yields_none_slots(

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1079,7 +1079,6 @@ def _grounding_attr(
 
 
 def test_make_grounding_rng_unseeded_returns_fresh_random(mock_inference_config):
-
     synth = _make_synthesizer(mock_inference_config)
     rng = synth._make_grounding_rng(seed=None, sample_index=0)
     assert isinstance(rng, random.Random)
@@ -1277,7 +1276,6 @@ def test_attach_grounding_facts_concatenates_across_multiple_envs(
 def test_attach_grounding_facts_truncation_emits_logger_warning(
     mock_inference_config, caplog
 ):
-
     env_config = _grounded_env_config(n_entries=2, sample_size=5, seed=1)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
@@ -1459,7 +1457,6 @@ def test_synthesize_invokes_attach_grounding_facts(
 def test_warn_on_grounding_placeholder_warns_in_user_persona(
     mock_inference_config, caplog
 ):
-
     synth = _make_synthesizer(mock_inference_config)
     attr = MultiTurnAttribute(
         id="t",
@@ -1480,7 +1477,6 @@ def test_warn_on_grounding_placeholder_warns_in_user_persona(
 def test_warn_on_grounding_placeholder_warns_in_assistant_persona(
     mock_inference_config, caplog
 ):
-
     synth = _make_synthesizer(mock_inference_config)
     attr = MultiTurnAttribute(
         id="t",
@@ -1501,7 +1497,6 @@ def test_warn_on_grounding_placeholder_warns_in_assistant_persona(
 def test_warn_on_grounding_placeholder_no_warning_when_placeholder_absent(
     mock_inference_config, caplog
 ):
-
     synth = _make_synthesizer(mock_inference_config)
     attr = MultiTurnAttribute(
         id="t",

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2379,7 +2379,7 @@ def test_dispatch_tool_calls_uses_distinct_envs_across_samples(
     """Two samples' dispatches land on different env instances."""
     mock_build_inference_engine.return_value = Mock()
 
-    built_envs: list[BaseEnvironment] = []
+    built_envs: list[Mock] = []
 
     def _fresh_env(_params):
         env = Mock(spec=BaseEnvironment)
@@ -2407,10 +2407,9 @@ def test_dispatch_tool_calls_uses_distinct_envs_across_samples(
     synth._dispatch_tool_calls([tc], 0)
     synth._dispatch_tool_calls([tc], 1)
 
-    router_0, router_1 = synth._sample_routers
-    assert router_0 is not None and router_1 is not None
-    env_sample_0 = router_0.env_by_id["e"]
-    env_sample_1 = router_1.env_by_id["e"]
+    # __init__ builds the parent env; _prepare_sample_routers(2) builds 2 more.
+    assert len(built_envs) == 3
+    env_sample_0, env_sample_1 = built_envs[1], built_envs[2]
     assert env_sample_0 is not env_sample_1
     assert env_sample_0.step.call_count == 1
     assert env_sample_1.step.call_count == 1
@@ -2472,9 +2471,7 @@ def test_synthesize_clears_sample_routers_on_exception(
         environment_config=env_config,
     )
 
-    with patch.object(
-        synth, "_plan_samples", side_effect=RuntimeError("plan boom")
-    ):
+    with patch.object(synth, "_plan_samples", side_effect=RuntimeError("plan boom")):
         with pytest.raises(RuntimeError, match="plan boom"):
             synth.synthesize([{"x": 1}], mock_multiturn_attribute)
     assert synth._sample_routers == []

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1128,6 +1128,7 @@ def test_attach_grounding_facts_populates_samples(mock_inference_config):
     env_config = _grounded_env_config(n_entries=10, sample_size=3, seed=42)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}, {}]
+    synth._prepare_sample_routers(len(samples))
     synth._attach_grounding_facts(
         samples,
         _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
@@ -1151,6 +1152,8 @@ def test_attach_grounding_facts_seeded_is_reproducible(mock_inference_config):
     samples_a = [{}, {}, {}]
     samples_b = [{}, {}, {}]
     attr = _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    synth_a._prepare_sample_routers(len(samples_a))
+    synth_b._prepare_sample_routers(len(samples_b))
     synth_a._attach_grounding_facts(samples_a, attr)
     synth_b._attach_grounding_facts(samples_b, attr)
     for a, b in zip(samples_a, samples_b):
@@ -1163,6 +1166,7 @@ def test_attach_grounding_facts_seeded_different_samples_differ(mock_inference_c
     env_config = _grounded_env_config(n_entries=50, sample_size=3, seed=7)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
+    synth._prepare_sample_routers(len(samples))
     synth._attach_grounding_facts(
         samples,
         _grounding_attr(available_envs=["env1"], available_tools=["lookup"]),
@@ -1186,6 +1190,7 @@ def test_attach_grounding_facts_respects_available_environments_scoping(
     env_config = EnvironmentConfig(environments=[env_a, env_b])
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}]
+    synth._prepare_sample_routers(len(samples))
     synth._attach_grounding_facts(
         samples,
         _grounding_attr(available_envs=["env_a"], available_tools=["tool_a"]),
@@ -1240,6 +1245,7 @@ def test_attach_grounding_facts_filters_by_available_tools(mock_inference_config
     )
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
+    synth._prepare_sample_routers(len(samples))
     synth._attach_grounding_facts(samples, multiturn)
     for sample in samples:
         facts = sample["grounding_facts"]
@@ -1261,6 +1267,7 @@ def test_attach_grounding_facts_concatenates_across_multiple_envs(
     env_config = EnvironmentConfig(environments=[env_a, env_b])
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}]
+    synth._prepare_sample_routers(len(samples))
     synth._attach_grounding_facts(
         samples, _grounding_attr(available_tools=["tool_a", "tool_b"])
     )
@@ -1274,6 +1281,7 @@ def test_attach_grounding_facts_truncation_emits_logger_warning(
     env_config = _grounded_env_config(n_entries=2, sample_size=5, seed=1)
     synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
     samples = [{}, {}]
+    synth._prepare_sample_routers(len(samples))
     with caplog.at_level(logging.WARNING, logger="oumi"):
         synth._attach_grounding_facts(
             samples,
@@ -1769,7 +1777,8 @@ def test_dispatch_tool_calls_routes_through_env(
         id="call_1",
         function=FunctionCall(name="get_weather", arguments='{"city": "Paris"}'),
     )
-    [msg] = synth._dispatch_tool_calls([tc])
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
 
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "call_1"
@@ -1812,7 +1821,8 @@ def test_dispatch_tool_calls_folds_same_env_calls_into_one_step(
         ToolCall(id=f"c{i}", function=FunctionCall(name="t", arguments=f'{{"i": {i}}}'))
         for i in range(3)
     ]
-    msgs = synth._dispatch_tool_calls(tcs)
+    synth._prepare_sample_routers(1)
+    msgs = synth._dispatch_tool_calls(tcs, 0)
     assert [m.tool_call_id for m in msgs] == ["c0", "c1", "c2"]
     assert [m.content for m in msgs] == ['{"i": 0}', '{"i": 1}', '{"i": 2}']
     fake_env.step.assert_called_once_with(
@@ -1849,7 +1859,8 @@ def test_dispatch_tool_calls_handles_malformed_arguments(
         id="call_x",
         function=FunctionCall(name="t", arguments="{not valid json"),
     )
-    [msg] = synth._dispatch_tool_calls([tc])
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "call_x"
     assert "arguments are not valid JSON" in str(msg.content)
@@ -1884,7 +1895,8 @@ def test_dispatch_tool_calls_handles_non_dict_arguments(
     )
 
     tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="[1, 2, 3]"))
-    [msg] = synth._dispatch_tool_calls([tc])
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
     assert msg.role == Role.TOOL
     assert msg.tool_call_id == "c"
     assert "must be a JSON object" in str(msg.content)
@@ -1920,7 +1932,8 @@ def test_dispatch_tool_calls_handles_unknown_tool(
         id="c",
         function=FunctionCall(name="ghost_tool", arguments="{}"),
     )
-    [msg] = synth._dispatch_tool_calls([tc])
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
     assert msg.role == Role.TOOL
     assert "Unknown tool 'ghost_tool'" in str(msg.content)
     fake_env.step.assert_not_called()
@@ -1953,7 +1966,8 @@ def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
     )
 
     tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="{}"))
-    [msg] = synth._dispatch_tool_calls([tc])
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
     assert msg.role == Role.TOOL
     assert "Tool 't' raised: boom" in str(msg.content)
 
@@ -2322,3 +2336,145 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
     assert isinstance(env, SyntheticEnvironment)
     assert env._engine is mock_engine
     assert env._base_inference_config is inference_config
+
+
+# ---------- per-sample router isolation ----------
+
+
+def test_prepare_sample_routers_builds_one_router_per_sample(
+    mock_inference_config,
+):
+    """_prepare_sample_routers materializes a router clone per sample."""
+    env_config = _grounded_env_config(n_entries=5, sample_size=2, seed=1)
+    synth = _make_synthesizer(mock_inference_config, environment_config=env_config)
+    synth._prepare_sample_routers(3)
+    assert len(synth._sample_routers) == 3
+    routers = synth._sample_routers
+    assert routers[0] is not None and routers[1] is not None and routers[2] is not None
+    assert routers[0] is not routers[1]
+    assert routers[1] is not routers[2]
+    envs_0 = routers[0].env_by_id["env1"]
+    envs_1 = routers[1].env_by_id["env1"]
+    envs_2 = routers[2].env_by_id["env1"]
+    assert envs_0 is not envs_1
+    assert envs_1 is not envs_2
+
+
+def test_prepare_sample_routers_without_env_config_yields_none_slots(
+    mock_inference_config,
+):
+    """Synthesizers without an env config still get a per-sample slot list."""
+    synth = _make_synthesizer(mock_inference_config)
+    synth._prepare_sample_routers(2)
+    assert synth._sample_routers == [None, None]
+
+
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_dispatch_tool_calls_uses_distinct_envs_across_samples(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+):
+    """Two samples' dispatches land on different env instances."""
+    mock_build_inference_engine.return_value = Mock()
+
+    built_envs: list[BaseEnvironment] = []
+
+    def _fresh_env(_params):
+        env = Mock(spec=BaseEnvironment)
+        env.step.return_value = [ToolResult(output={"ok": True})]
+        built_envs.append(env)
+        return env
+
+    mock_build_environment.side_effect = _fresh_env
+
+    env_config = _make_env_config("e", "t")
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+    synth._prepare_sample_routers(2)
+
+    tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="{}"))
+    synth._dispatch_tool_calls([tc], 0)
+    synth._dispatch_tool_calls([tc], 1)
+
+    router_0, router_1 = synth._sample_routers
+    assert router_0 is not None and router_1 is not None
+    env_sample_0 = router_0.env_by_id["e"]
+    env_sample_1 = router_1.env_by_id["e"]
+    assert env_sample_0 is not env_sample_1
+    assert env_sample_0.step.call_count == 1
+    assert env_sample_1.step.call_count == 1
+
+
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_clears_sample_routers_on_normal_exit(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+):
+    """sample_routers is reset to [] after a successful synthesize() call."""
+    mock_engine = Mock()
+    mock_engine.infer.return_value = []
+    mock_build_inference_engine.return_value = mock_engine
+    mock_build_environment.return_value = Mock(spec=BaseEnvironment)
+
+    env_config = _make_env_config("e", "t")
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+
+    synth.synthesize([], mock_multiturn_attribute)
+    assert synth._sample_routers == []
+
+
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_clears_sample_routers_on_exception(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+):
+    """sample_routers is reset to [] even if a downstream stage raises."""
+    mock_build_inference_engine.return_value = Mock()
+    mock_build_environment.return_value = Mock(spec=BaseEnvironment)
+
+    env_config = _make_env_config("e", "t")
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+
+    with patch.object(
+        synth, "_plan_samples", side_effect=RuntimeError("plan boom")
+    ):
+        with pytest.raises(RuntimeError, match="plan boom"):
+            synth.synthesize([{"x": 1}], mock_multiturn_attribute)
+    assert synth._sample_routers == []

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2437,7 +2437,11 @@ def test_synthesize_clears_sample_routers_on_normal_exit(
         environment_config=env_config,
     )
 
-    synth.synthesize([], mock_multiturn_attribute)
+    with (
+        patch.object(synth, "_plan_samples", side_effect=lambda samples, _: samples),
+        patch.object(synth, "_synthesize_all_samples", return_value=[]),
+    ):
+        synth.synthesize([{"x": 1}], mock_multiturn_attribute)
     assert synth._sample_routers == []
 
 

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -128,7 +128,7 @@ def test_from_environment_config_includes_grounding_only_envs():
         },
         grounding=GroundingConfig(
             sample_size=1,
-            state=[StateGroundingConfig(state_path="rows", fields=["id"], key="id")],
+            state=[StateGroundingConfig(state_path="rows", fields=["id"])],
         ),
     )
     env_config = EnvironmentConfig(environments=[state_env])

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -169,11 +169,17 @@ def test_parse_and_validate_arguments_empty_string_defaults_to_empty_dict():
 def _mock_router(tool_to_env: dict[str, BaseEnvironment]) -> ToolRouter:
     """Build a ToolRouter directly with mocked envs (skip from_environment_config)."""
     env_by_id = {f"env_{i}": env for i, env in enumerate(set(tool_to_env.values()))}
+    inv_env_by_id = {id(env): env_id for env_id, env in env_by_id.items()}
     return ToolRouter(
         tool_specs=[],
         tools_by_id={},
         env_by_id=env_by_id,
         tool_to_env=tool_to_env,
+        env_params_by_id={},
+        tool_env_map={
+            tool_id: inv_env_by_id[id(env)] for tool_id, env in tool_to_env.items()
+        },
+        on_env_built=None,
     )
 
 
@@ -261,3 +267,101 @@ def test_route_batch_env_exception_propagates():
     router = _mock_router({"t1": fake_env})
     with pytest.raises(RuntimeError, match="boom"):
         router.route_batch([("t1", {})])
+
+
+# ---------- for_sample ----------
+
+
+def test_for_sample_returns_router_with_fresh_env_instances():
+    """Each for_sample() build_environment-s a new env per env_id."""
+    env_config = EnvironmentConfig(
+        environments=[
+            _det_env_params("env1", [_tool("t1")]),
+            _det_env_params("env2", [_tool("t2")]),
+        ]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+
+    clone = router.for_sample()
+
+    assert set(clone.env_by_id) == {"env1", "env2"}
+    assert clone.env_by_id["env1"] is not router.env_by_id["env1"]
+    assert clone.env_by_id["env2"] is not router.env_by_id["env2"]
+
+
+def test_for_sample_two_clones_have_independent_envs():
+    """Sibling clones don't share env instances either."""
+    env_config = EnvironmentConfig(
+        environments=[_det_env_params("env1", [_tool("t1")])]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+
+    clone_a = router.for_sample()
+    clone_b = router.for_sample()
+
+    assert clone_a.env_by_id["env1"] is not clone_b.env_by_id["env1"]
+
+
+def test_for_sample_invokes_on_env_built_for_each_clone():
+    """on_env_built is re-run for each fresh env in each clone."""
+    env_config = EnvironmentConfig(
+        environments=[
+            _det_env_params("env1", [_tool("t1")]),
+            _det_env_params("env2", [_tool("t2")]),
+        ]
+    )
+    seen: list[BaseEnvironment] = []
+    router = ToolRouter.from_environment_config(env_config, on_env_built=seen.append)
+
+    seen.clear()
+    router.for_sample()
+    router.for_sample()
+
+    assert len(seen) == 4
+    assert all(isinstance(env, DeterministicEnvironment) for env in seen)
+
+
+def test_for_sample_preserves_tool_routing_topology():
+    """Cloned tool_to_env points at the cloned env_by_id entries."""
+    env_config = EnvironmentConfig(
+        environments=[
+            _det_env_params("env1", [_tool("t1"), _tool("t2")]),
+            _det_env_params("env2", [_tool("t3")]),
+        ]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+
+    clone = router.for_sample()
+
+    assert clone.tool_to_env["t1"] is clone.env_by_id["env1"]
+    assert clone.tool_to_env["t2"] is clone.env_by_id["env1"]
+    assert clone.tool_to_env["t3"] is clone.env_by_id["env2"]
+
+
+def test_for_sample_shares_immutable_metadata_with_parent():
+    """Specs/params dicts are reference-shared (immutable across samples)."""
+    env_config = EnvironmentConfig(
+        environments=[_det_env_params("env1", [_tool("t1")])]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+
+    clone = router.for_sample()
+
+    assert clone.tool_specs is router.tool_specs
+    assert clone.tools_by_id is router.tools_by_id
+    assert clone.env_params_by_id is router.env_params_by_id
+    assert clone.tool_env_map is router.tool_env_map
+
+
+def test_for_sample_mutation_does_not_bleed_back_to_parent():
+    """A clone's env_by_id is a fresh dict; reassigning it doesn't touch parent."""
+    env_config = EnvironmentConfig(
+        environments=[_det_env_params("env1", [_tool("t1")])]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+    parent_env = router.env_by_id["env1"]
+
+    clone = router.for_sample()
+    clone.env_by_id["env1"] = Mock(spec=BaseEnvironment)
+
+    assert router.env_by_id["env1"] is parent_env

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -58,6 +58,31 @@ def _det_env_params(
     )
 
 
+def _stateful_synth_env_params(env_id: str) -> EnvironmentParams:
+    """Build a stateful synth params block; grounding pins router enrollment."""
+    from oumi.core.configs.params.grounding_params import (
+        GroundingConfig,
+        StateGroundingConfig,
+    )
+
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"Env {env_id}",
+        env_type="synthetic",
+        tools=[],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": {"initial_state": {"rows": [{"id": "1"}]}},
+            "cache_by_input": False,
+        },
+        grounding=GroundingConfig(
+            sample_size=1,
+            state=[StateGroundingConfig(state_path="rows", fields=["id"])],
+        ),
+    )
+
+
 # ---------- from_environment_config ----------
 
 
@@ -303,42 +328,53 @@ def test_route_batch_env_exception_propagates():
 # ---------- for_sample ----------
 
 
-def test_for_sample_returns_router_with_fresh_env_instances():
-    """Each for_sample() build_environment-s a new env per env_id."""
+def test_for_sample_clones_envs_that_require_isolation():
+    """Stateful synth envs are rebuilt per sample so state can't bleed across."""
+    env_config = EnvironmentConfig(
+        environments=[_stateful_synth_env_params("stateful")]
+    )
+    router = ToolRouter.from_environment_config(env_config)
+
+    clone = router.for_sample()
+
+    assert clone.env_by_id["stateful"] is not router.env_by_id["stateful"]
+
+
+def test_for_sample_shares_envs_that_do_not_require_isolation():
+    """Deterministic envs carry no mutable state, so they are shared with parent."""
     env_config = EnvironmentConfig(
         environments=[
-            _det_env_params("env1", [_tool("t1")]),
-            _det_env_params("env2", [_tool("t2")]),
+            _det_env_params("det1", [_tool("t1")]),
+            _det_env_params("det2", [_tool("t2")]),
         ]
     )
     router = ToolRouter.from_environment_config(env_config)
 
     clone = router.for_sample()
 
-    assert set(clone.env_by_id) == {"env1", "env2"}
-    assert clone.env_by_id["env1"] is not router.env_by_id["env1"]
-    assert clone.env_by_id["env2"] is not router.env_by_id["env2"]
+    assert clone.env_by_id["det1"] is router.env_by_id["det1"]
+    assert clone.env_by_id["det2"] is router.env_by_id["det2"]
 
 
-def test_for_sample_two_clones_have_independent_envs():
-    """Sibling clones don't share env instances either."""
+def test_for_sample_two_clones_have_independent_stateful_envs():
+    """Sibling clones get distinct stateful env instances."""
     env_config = EnvironmentConfig(
-        environments=[_det_env_params("env1", [_tool("t1")])]
+        environments=[_stateful_synth_env_params("stateful")]
     )
     router = ToolRouter.from_environment_config(env_config)
 
     clone_a = router.for_sample()
     clone_b = router.for_sample()
 
-    assert clone_a.env_by_id["env1"] is not clone_b.env_by_id["env1"]
+    assert clone_a.env_by_id["stateful"] is not clone_b.env_by_id["stateful"]
 
 
-def test_for_sample_invokes_on_env_built_for_each_clone():
-    """on_env_built is re-run for each fresh env in each clone."""
+def test_for_sample_invokes_on_env_built_only_for_isolated_envs():
+    """on_env_built re-runs on per-sample clones but not on shared envs."""
     env_config = EnvironmentConfig(
         environments=[
-            _det_env_params("env1", [_tool("t1")]),
-            _det_env_params("env2", [_tool("t2")]),
+            _det_env_params("det", [_tool("t1")]),
+            _stateful_synth_env_params("stateful"),
         ]
     )
     seen: list[BaseEnvironment] = []
@@ -348,12 +384,13 @@ def test_for_sample_invokes_on_env_built_for_each_clone():
     router.for_sample()
     router.for_sample()
 
-    assert len(seen) == 4
-    assert all(isinstance(env, DeterministicEnvironment) for env in seen)
+    # Only the stateful env is rebuilt per for_sample() call (2 calls -> 2 envs).
+    assert len(seen) == 2
+    assert all(env is not router.env_by_id["det"] for env in seen)
 
 
 def test_for_sample_preserves_tool_routing_topology():
-    """Cloned tool_to_env points at the cloned env_by_id entries."""
+    """Cloned tool_to_env points at the right env_by_id entries (shared or fresh)."""
     env_config = EnvironmentConfig(
         environments=[
             _det_env_params("env1", [_tool("t1"), _tool("t2")]),

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -108,6 +108,37 @@ def test_from_environment_config_routes_tools_across_envs():
     assert {spec.function.name for spec in router.tool_specs} == {"t1", "t2", "t3"}
 
 
+def test_from_environment_config_includes_grounding_only_envs():
+    """Envs with grounding but no tools are still built by from_environment_config."""
+    from oumi.core.configs.params.grounding_params import (
+        GroundingConfig,
+        StateGroundingConfig,
+    )
+
+    state_env = EnvironmentParams(
+        id="state_only",
+        name="state_only",
+        description="grounding-only env",
+        env_type="synthetic",
+        tools=[],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": {"initial_state": {"rows": [{"id": "1"}]}},
+            "cache_by_input": False,
+        },
+        grounding=GroundingConfig(
+            sample_size=1,
+            state=[StateGroundingConfig(state_path="rows", fields=["id"], key="id")],
+        ),
+    )
+    env_config = EnvironmentConfig(environments=[state_env])
+
+    router = ToolRouter.from_environment_config(env_config)
+
+    assert "state_only" in router.env_by_id
+    assert "state_only" in router.env_params_by_id
+
+
 # ---------- parse_and_validate_arguments ----------
 
 

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -76,6 +76,7 @@ def test_from_params_constructs_stateless():
 
 def test_from_params_constructs_stateful():
     params = _make_params(
+        tools=[_make_tool(executor=f"{__name__}._state_increment")],
         env_kwargs={
             "system_prompt": "You manage a filesystem.",
             "state_params": SyntheticStateParams(
@@ -87,6 +88,22 @@ def test_from_params_constructs_stateful():
     )
     env = SyntheticEnvironment.from_params(params)
     assert env.current_state == {"files": {"count": 1}}
+
+
+def test_stateful_mode_requires_executor_on_every_tool():
+    params = _make_params(
+        tools=[
+            _make_tool(id="with_exec", executor=f"{__name__}._state_increment"),
+            _make_tool(id="without_exec"),
+        ],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(),
+            "cache_by_input": False,
+        }
+    )
+    with pytest.raises(ValueError, match=r"requires every tool to define an executor.*without_exec"):
+        SyntheticEnvironment.from_params(params)
 
 
 def test_empty_system_prompt_raises():

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -21,6 +21,7 @@ from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.generation_params import GenerationParams
 from oumi.core.configs.params.grounding_params import (
+    GroundingConfig,
     StateGroundingConfig,
 )
 from oumi.core.configs.params.model_params import ModelParams
@@ -513,16 +514,18 @@ def test_state_grounding_projects_from_state_path():
                         {"book_id": "B3", "title": "C"},
                     ]
                 },
-                grounding=[
-                    StateGroundingConfig(
-                        state_path="books",
-                        key="book_id",
-                        fields=["book_id", "title"],
-                    )
-                ],
             ),
             "cache_by_input": False,
         },
+        grounding=GroundingConfig(
+            state=[
+                StateGroundingConfig(
+                    state_path="books",
+                    key="book_id",
+                    fields=["book_id", "title"],
+                )
+            ],
+        ),
     )
     env = SyntheticEnvironment.from_params(params)
     facts = env.sample_grounding(n=10, rng=random.Random(0))
@@ -545,16 +548,33 @@ def test_state_grounding_state_path_missing_raises_at_init():
             "state_params": SyntheticStateParams(
                 state_schema={"type": "object"},
                 initial_state={"files": {"count": 0}},
-                grounding=[
-                    StateGroundingConfig(
-                        state_path="books",
-                        key="book_id",
-                        fields=["book_id"],
-                    )
-                ],
             ),
             "cache_by_input": False,
         },
+        grounding=GroundingConfig(
+            state=[
+                StateGroundingConfig(
+                    state_path="books",
+                    key="book_id",
+                    fields=["book_id"],
+                )
+            ],
+        ),
     )
     with pytest.raises(ValueError, match="state_path"):
+        SyntheticEnvironment.from_params(params)
+
+
+def test_state_grounding_without_state_raises():
+    """grounding.state on a stateless synthetic env is a config error."""
+    params = _make_params(
+        grounding=GroundingConfig(
+            state=[
+                StateGroundingConfig(
+                    state_path="books", key="book_id", fields=["book_id"]
+                )
+            ],
+        ),
+    )
+    with pytest.raises(ValueError, match="grounding.state is configured"):
         SyntheticEnvironment.from_params(params)

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 from unittest.mock import Mock
 
 import pytest
@@ -19,6 +20,9 @@ import pytest
 from oumi.core.configs.inference_config import InferenceConfig
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.generation_params import GenerationParams
+from oumi.core.configs.params.grounding_params import (
+    StateGroundingConfig,
+)
 from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.types.conversation import Conversation, Message, Role
@@ -320,3 +324,218 @@ def test_build_call_conv_has_system_and_user_messages():
     assert "answer" in str(conv.messages[0].content)
     user_payload = str(conv.messages[1].content)
     assert '"tool"' in user_payload and '"answer"' in user_payload
+
+
+def _ok_stateless_exec(arguments):
+    return ToolResult(output={"echo": arguments})
+
+
+def _state_increment(arguments, state):
+    new_state = {"files": {"count": state["files"]["count"] + 1}}
+    return ToolResult(
+        output={"new_count": new_state["files"]["count"]},
+        updated_state=new_state,
+    )
+
+
+def _bad_returns_non_toolresult(arguments, state):
+    return {"not": "a tool result"}
+
+
+def _bad_invalid_state(arguments, state):
+    return ToolResult(output={}, updated_state={"files": {"count": "not-an-int"}})
+
+
+def _stateless_returns_state(arguments):
+    return ToolResult(output={}, updated_state={"oops": True})
+
+
+def test_stateless_executor_dispatches_callable_no_state():
+    tool = ToolParams(
+        id="echo",
+        name="Echo",
+        description="Echo",
+        executor=f"{__name__}._ok_stateless_exec",
+    )
+    params = _make_params(tools=[tool])
+    env = SyntheticEnvironment.from_params(params)
+    results = env.step([("echo", {"x": 1})])
+    assert results == [ToolResult(output={"echo": {"x": 1}})]
+
+
+def test_stateful_executor_threads_state_and_mutates():
+    tool = ToolParams(
+        id="bump",
+        name="Bump",
+        description="Bump count",
+        read_only=False,
+        executor=f"{__name__}._state_increment",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema=_make_state_schema(),
+                initial_state={"files": {"count": 1}},
+            ),
+            "cache_by_input": False,
+        },
+    )
+    env = SyntheticEnvironment.from_params(params)
+    out = env.step([("bump", {}), ("bump", {})])
+    assert out[0].output == {"new_count": 2}
+    assert out[1].output == {"new_count": 3}
+    assert env.current_state == {"files": {"count": 3}}
+
+
+def test_read_only_tool_rejected_when_executor_returns_state():
+    tool = ToolParams(
+        id="bump",
+        name="Bump",
+        description="Bump",
+        read_only=True,
+        executor=f"{__name__}._state_increment",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema=_make_state_schema(),
+                initial_state={"files": {"count": 1}},
+            ),
+            "cache_by_input": False,
+        },
+    )
+    env = SyntheticEnvironment.from_params(params)
+    with pytest.raises(ToolError, match="read_only"):
+        env.step([("bump", {})])
+
+
+def test_updated_state_validated_against_schema():
+    tool = ToolParams(
+        id="bad",
+        name="Bad",
+        description="Returns bad state",
+        read_only=False,
+        executor=f"{__name__}._bad_invalid_state",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema=_make_state_schema(),
+                initial_state={"files": {"count": 1}},
+            ),
+            "cache_by_input": False,
+        },
+    )
+    env = SyntheticEnvironment.from_params(params)
+    with pytest.raises(ToolError, match="state_schema"):
+        env.step([("bad", {})])
+
+
+def test_stateless_executor_rejecting_state_return():
+    tool = ToolParams(
+        id="oops",
+        name="Oops",
+        description="Stateless tool returning updated_state",
+        executor=f"{__name__}._stateless_returns_state",
+    )
+    params = _make_params(tools=[tool])
+    env = SyntheticEnvironment.from_params(params)
+    with pytest.raises(ToolError, match="stateless"):
+        env.step([("oops", {})])
+
+
+def test_executor_returning_non_toolresult_raises():
+    tool = ToolParams(
+        id="x",
+        name="X",
+        description="X",
+        executor=f"{__name__}._bad_returns_non_toolresult",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema=_make_state_schema(),
+                initial_state={"files": {"count": 1}},
+            ),
+            "cache_by_input": False,
+        },
+    )
+    env = SyntheticEnvironment.from_params(params)
+    with pytest.raises(ToolError, match="must return ToolResult"):
+        env.step([("x", {})])
+
+
+def test_state_grounding_projects_from_state_path():
+    tool = ToolParams(
+        id="bump",
+        name="Bump",
+        description="Bump",
+        read_only=False,
+        executor=f"{__name__}._state_increment",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema={"type": "object"},
+                initial_state={
+                    "books": [
+                        {"book_id": "B1", "title": "A"},
+                        {"book_id": "B2", "title": "B"},
+                        {"book_id": "B3", "title": "C"},
+                    ]
+                },
+                grounding=[
+                    StateGroundingConfig(
+                        state_path="books",
+                        key="book_id",
+                        fields=["book_id", "title"],
+                    )
+                ],
+            ),
+            "cache_by_input": False,
+        },
+    )
+    env = SyntheticEnvironment.from_params(params)
+    facts = env.sample_grounding(n=10, rng=random.Random(0))
+    assert len(facts) == 3
+    assert {f.data["book_id"] for f in facts} == {"B1", "B2", "B3"}
+
+
+def test_state_grounding_state_path_missing_raises_at_init():
+    tool = ToolParams(
+        id="bump",
+        name="Bump",
+        description="Bump",
+        read_only=False,
+        executor=f"{__name__}._state_increment",
+    )
+    params = _make_params(
+        tools=[tool],
+        env_kwargs={
+            "system_prompt": "p",
+            "state_params": SyntheticStateParams(
+                state_schema={"type": "object"},
+                initial_state={"files": {"count": 0}},
+                grounding=[
+                    StateGroundingConfig(
+                        state_path="books",
+                        key="book_id",
+                        fields=["book_id"],
+                    )
+                ],
+            ),
+            "cache_by_input": False,
+        },
+    )
+    with pytest.raises(ValueError, match="state_path"):
+        SyntheticEnvironment.from_params(params)

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -84,7 +84,7 @@ def test_from_params_constructs_stateful():
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
-        }
+        },
     )
     env = SyntheticEnvironment.from_params(params)
     assert env.current_state == {"files": {"count": 1}}
@@ -100,9 +100,11 @@ def test_stateful_mode_requires_executor_on_every_tool():
             "system_prompt": "p",
             "state_params": SyntheticStateParams(),
             "cache_by_input": False,
-        }
+        },
     )
-    with pytest.raises(ValueError, match=r"requires every tool to define an executor.*without_exec"):
+    with pytest.raises(
+        ValueError, match=r"requires every tool to define an executor.*without_exec"
+    ):
         SyntheticEnvironment.from_params(params)
 
 

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -521,7 +521,6 @@ def test_state_grounding_projects_from_state_path():
             state=[
                 StateGroundingConfig(
                     state_path="books",
-                    key="book_id",
                     fields=["book_id", "title"],
                 )
             ],
@@ -555,7 +554,6 @@ def test_state_grounding_state_path_missing_raises_at_init():
             state=[
                 StateGroundingConfig(
                     state_path="books",
-                    key="book_id",
                     fields=["book_id"],
                 )
             ],
@@ -569,11 +567,7 @@ def test_state_grounding_without_state_raises():
     """grounding.state on a stateless synthetic env is a config error."""
     params = _make_params(
         grounding=GroundingConfig(
-            state=[
-                StateGroundingConfig(
-                    state_path="books", key="book_id", fields=["book_id"]
-                )
-            ],
+            state=[StateGroundingConfig(state_path="books", fields=["book_id"])],
         ),
     )
     with pytest.raises(ValueError, match="grounding.state is configured"):

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -99,7 +99,7 @@ def test_stateful_mode_requires_executor_on_every_tool():
         ],
         env_kwargs={
             "system_prompt": "p",
-            "state_params": SyntheticStateParams(),
+            "state_params": SyntheticStateParams(initial_state={"counter": 0}),
             "cache_by_input": False,
         },
     )


### PR DESCRIPTION
## Description

Part of the **Stateful Tool Execution** PR chain (Wave 1 of 2) — core implementation.

Extends `SyntheticEnvironment` so the same class handles both stateless
LLM-simulated tools and stateful tools whose outputs are produced by
user-supplied Python executors. Selecting between the two modes is now
a config decision: pass `state_params` in `env_kwargs` to opt into
stateful behavior; omit it for the existing batched-LLM behavior from
Phase 1.

### What changes

- `ToolParams.executor` (new, optional): dotted import path to a
  Python callable. `SyntheticEnvironment` dispatches calls to it
  instead of LLM-simulating. Tools without an executor stay LLM-simulated.
- `SyntheticEnvironment.step()` routes per-call: stateful executor
  receives `(arguments, state)` with state threaded sequentially across
  the batch; stateless executor receives `(arguments,)`; everything
  else falls back to the existing batched simulator path.
- `ToolGroundingConfig` gets optional `key` + `state_path`. When
  `state_path` is set, the env projects grounding facts from
  `initial_state[state_path]` instead of a deterministic lookup table.
- Removes the standalone `StatefulEnvironment`, `StatefulTool`, and
  `EnvironmentStateParams` introduced earlier on this branch — their
  capabilities now live on `SyntheticEnvironment` / `ToolParams` /
  `SyntheticStateParams`. The env_type `stateful` no longer resolves;
  configs that used it should switch to `synthetic` with `state_params`.

### Validation

- `read_only=True` tools may not return `updated_state` (raises `ToolError`).
- `updated_state` is validated against `state_schema` before commit.
- Stateless executors returning `updated_state` are rejected.
- Grounding `state_path` is checked against `initial_state` at env
  construction time.

### Example usage

A worked example (EHR workflow + executors) lands in the follow-up PR — see the chain navigation below.

## PR Chain Navigation

- **Next PR**: #2458 (Examples: EHR stateful synthesis config + executors)

## Related issues

<!-- link any Linear or GitHub issues here -->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
