### PR TITLE
fix: guard against empty choices and message=None in vLLM inference

### DIFF
--- a/scripts/polaris/jobs/python/vllm_inference.py
+++ b/scripts/polaris/jobs/python/vllm_inference.py
@@ -75,6 +75,8 @@ def main() -> None:
             model=MODEL,
         )
 
+        if not chat_completion.choices or chat_completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         messages.append(
             {"role": "assistant", "content": chat_completion.choices[0].message.content}
         )


### PR DESCRIPTION
## Problem

In `scripts/polaris/jobs/python/vllm_inference.py`, the vLLM completion response is accessed without checking:

```python
{"role": "assistant", "content": chat_completion.choices[0].message.content}
```

This raises `IndexError` (empty choices) or `AttributeError` (message=None on filtered content), silently aborting the inference worker.

## Fix

```python
if not chat_completion.choices or chat_completion.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

**2 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
