### PR TITLE
[Inference] Parse reasoning_content from remote inference responses

### DIFF
--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -265,6 +265,17 @@ class Message(pydantic.BaseModel):
     prior assistant ``tool_calls`` entry.
     """
 
+    reasoning_content: str | None = None
+    """Model-emitted reasoning / chain-of-thought content.
+
+    Populated by inference engines that surface a separate reasoning field
+    in the API response (e.g., Fireworks ``reasoning_content``, Together
+    ``reasoning``). Distinct from ``content``: this is the model's
+    internal deliberation, not the final answer.
+
+    Only set on assistant messages.
+    """
+
     def model_post_init(self, __context) -> None:
         """Post-initialization method for the Message model.
 

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -513,6 +513,9 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         # accepts; only fall back to "" when there are no tool_calls either.
         if content is None and not tool_calls:
             content = ""
+        # Reasoning content: providers expose it under different keys.
+        # Together uses ``reasoning``; Fireworks uses ``reasoning_content``.
+        reasoning_content = message.get("reasoning") or message.get("reasoning_content")
         metadata = dict(original_conversation.metadata)
         usage = self._extract_usage_from_response(response)
         if usage is not None:
@@ -527,6 +530,7 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                     content=content,
                     role=Role(message["role"]),
                     tool_calls=tool_calls,
+                    reasoning_content=reasoning_content,
                 ),
             ],
             metadata=metadata,

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -340,12 +340,20 @@ def remove_excessive_images(
         if len(filtered_items) == 1 and isinstance(filtered_items[0].content, str):
             result.append(
                 Message(
-                    id=message.id, content=filtered_items[0].content, role=message.role
+                    id=message.id,
+                    content=filtered_items[0].content,
+                    role=message.role,
+                    reasoning_content=message.reasoning_content,
                 )
             )
         else:
             result.append(
-                Message(id=message.id, content=filtered_items, role=message.role)
+                Message(
+                    id=message.id,
+                    content=filtered_items,
+                    role=message.role,
+                    reasoning_content=message.reasoning_content,
+                )
             )
 
     return result
@@ -457,11 +465,17 @@ def truncate_text_in_content_items(
             ):
                 assert isinstance(items[0].content, str)
                 result[msg_idx] = Message(
-                    id=message.id, content=items[0].content, role=message.role
+                    id=message.id,
+                    content=items[0].content,
+                    role=message.role,
+                    reasoning_content=message.reasoning_content,
                 )
             else:
                 result[msg_idx] = Message(
-                    id=message.id, content=items, role=message.role
+                    id=message.id,
+                    content=items,
+                    role=message.role,
+                    reasoning_content=message.reasoning_content,
                 )
 
     return result

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -338,23 +338,10 @@ def remove_excessive_images(
                 images_to_keep -= 1
             filtered_items.append(item)
         if len(filtered_items) == 1 and isinstance(filtered_items[0].content, str):
-            result.append(
-                Message(
-                    id=message.id,
-                    content=filtered_items[0].content,
-                    role=message.role,
-                    reasoning_content=message.reasoning_content,
-                )
-            )
+            new_content: str | list[ContentItem] = filtered_items[0].content
         else:
-            result.append(
-                Message(
-                    id=message.id,
-                    content=filtered_items,
-                    role=message.role,
-                    reasoning_content=message.reasoning_content,
-                )
-            )
+            new_content = filtered_items
+        result.append(message.model_copy(update={"content": new_content}))
 
     return result
 
@@ -464,18 +451,9 @@ def truncate_text_in_content_items(
                 and isinstance(messages[msg_idx].content, str)
             ):
                 assert isinstance(items[0].content, str)
-                result[msg_idx] = Message(
-                    id=message.id,
-                    content=items[0].content,
-                    role=message.role,
-                    reasoning_content=message.reasoning_content,
-                )
+                new_content: str | list[ContentItem] = items[0].content
             else:
-                result[msg_idx] = Message(
-                    id=message.id,
-                    content=items,
-                    role=message.role,
-                    reasoning_content=message.reasoning_content,
-                )
+                new_content = items
+            result[msg_idx] = message.model_copy(update={"content": new_content})
 
     return result

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -1350,3 +1350,56 @@ def test_typed_field_access_on_message_tool_calls():
     assert msg.tool_calls[0].id == "call_abc"
     assert msg.tool_calls[0].function.name == "get_weather"
     assert msg.tool_calls[0].function.arguments == '{"city": "SF"}'
+
+
+# -----------------------------------------------------------------------------
+# reasoning_content (Fireworks/Together separate-field format)
+# -----------------------------------------------------------------------------
+
+
+def test_message_reasoning_content_field():
+    """reasoning_content is preserved alongside content."""
+    msg = Message(role=Role.ASSISTANT, content="answer", reasoning_content="thought")
+    assert msg.reasoning_content == "thought"
+    assert msg.content == "answer"
+
+
+def test_message_reasoning_content_defaults_to_none():
+    """reasoning_content defaults to None when unset."""
+    msg = Message(role=Role.ASSISTANT, content="answer")
+    assert msg.reasoning_content is None
+
+
+def test_message_reasoning_content_round_trips_through_dict():
+    """reasoning_content survives a model_dump / re-construct cycle."""
+    msg = Message(role=Role.ASSISTANT, content="answer", reasoning_content="thought")
+    restored = Message(**msg.model_dump(mode="json", exclude_none=True))
+    assert restored.reasoning_content == "thought"
+
+
+def test_message_with_only_reasoning_content_is_invalid():
+    """Validator still requires content or tool_calls; reasoning alone isn't enough."""
+    with pytest.raises(ValueError, match="at least one of `content`"):
+        Message(role=Role.ASSISTANT, reasoning_content="thought")
+
+
+def test_conversation_to_dict_excludes_none_reasoning_content():
+    """to_dict() omits reasoning_content when None (exclude_none semantics)."""
+    conv = Conversation(messages=[Message(role=Role.USER, content="hi")])
+    d = conv.to_dict()
+    assert "reasoning_content" not in d["messages"][0]
+
+
+def test_conversation_to_dict_includes_set_reasoning_content():
+    """to_dict() includes reasoning_content when present."""
+    conv = Conversation(
+        messages=[
+            Message(
+                role=Role.ASSISTANT,
+                content="answer",
+                reasoning_content="thought",
+            )
+        ]
+    )
+    d = conv.to_dict()
+    assert d["messages"][0]["reasoning_content"] == "thought"

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -4022,3 +4022,131 @@ def test_response_populates_tool_calls():
     assert results[0].metadata["finish_reason"] == "tool_calls"
     # Tools propagate through to the result so downstream callers can inspect.
     assert results[0].tools == [_WEATHER_TOOL]
+
+
+# -----------------------------------------------------------------------------
+# reasoning_content parsing (Fireworks / Together)
+# -----------------------------------------------------------------------------
+
+
+def _reasoning_engine_and_original() -> tuple[RemoteInferenceEngine, Conversation]:
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(),
+        remote_params=RemoteParams(api_url=_TARGET_SERVER),
+    )
+    original = Conversation(messages=[Message(role=Role.USER, content="Hi")])
+    return engine, original
+
+
+def test_response_populates_reasoning_content_fireworks_style():
+    """Fireworks exposes reasoning as `reasoning_content`."""
+    engine, original = _reasoning_engine_and_original()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "final answer",
+                    "reasoning_content": "let me think...",
+                }
+            }
+        ]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assert result.messages[-1].content == "final answer"
+    assert result.messages[-1].reasoning_content == "let me think..."
+
+
+def test_response_populates_reasoning_content_together_style():
+    """Together exposes reasoning as `reasoning`."""
+    engine, original = _reasoning_engine_and_original()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "final answer",
+                    "reasoning": "let me think...",
+                }
+            }
+        ]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assert result.messages[-1].content == "final answer"
+    assert result.messages[-1].reasoning_content == "let me think..."
+
+
+def test_response_reasoning_field_takes_precedence_over_reasoning_content():
+    """When both keys are present, `reasoning` wins (Together-style first)."""
+    engine, original = _reasoning_engine_and_original()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "final answer",
+                    "reasoning": "from reasoning",
+                    "reasoning_content": "from reasoning_content",
+                }
+            }
+        ]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assert result.messages[-1].reasoning_content == "from reasoning"
+
+
+def test_response_leaves_think_tags_in_content_untouched():
+    """`<think>` tags are not auto-extracted; content is preserved verbatim."""
+    engine, original = _reasoning_engine_and_original()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>let me think...</think>final answer",
+                }
+            }
+        ]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assert result.messages[-1].content == "<think>let me think...</think>final answer"
+    assert result.messages[-1].reasoning_content is None
+
+
+def test_response_no_reasoning_leaves_field_none():
+    """Plain responses (no reasoning anywhere) have reasoning_content=None."""
+    engine, original = _reasoning_engine_and_original()
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "final answer"}}]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assert result.messages[-1].content == "final answer"
+    assert result.messages[-1].reasoning_content is None
+
+
+def test_response_combines_reasoning_with_tool_calls():
+    """Reasoning + tool_calls coexist on the same assistant message."""
+    engine, original = _reasoning_engine_and_original()
+    tool_call_payload = {
+        "id": "call_xyz",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+    }
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "i should call the tool",
+                    "tool_calls": [tool_call_payload],
+                }
+            }
+        ]
+    }
+    result = engine._convert_api_output_to_conversation(response, original)
+    assistant = result.messages[-1]
+    assert assistant.content is None
+    assert assistant.reasoning_content == "i should call the tool"
+    assert assistant.tool_calls is not None
+    assert assistant.tool_calls[0].function.name == "get_weather"

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -913,3 +913,56 @@ def test_truncate_text_in_content_items_preserves_reasoning_content():
     result = truncate_text_in_content_items([msg], tokenizer=tokenizer, max_tokens=3)
     assert len(result) == 1
     assert result[0].reasoning_content == "thinking"
+
+
+#
+# Other Message fields (id, tool_calls, tool_call_id) are also preserved by the
+# reconstructions in remove_excessive_images / truncate_text_in_content_items.
+# Previously these utilities dropped any field not explicitly threaded through;
+# switching to ``model_copy(update=...)`` keeps the model schema-additive.
+#
+_TOOL_CALL_DICT_FOR_PRESERVATION = {
+    "id": "call_xyz",
+    "type": "function",
+    "function": {"name": "get_weather", "arguments": "{}"},
+}
+
+
+def test_remove_excessive_images_preserves_id():
+    """Message.id survives image-dropping reconstruction."""
+    img = ContentItem(
+        type=Type.IMAGE_BINARY,
+        binary=create_png_bytes_from_image(PIL.Image.new("RGB", (2, 2))),
+    )
+    msg = Message(
+        id="msg-1",
+        role=Role.USER,
+        content=[ContentItem(type=Type.TEXT, content="hi"), img],
+    )
+    [out] = remove_excessive_images([msg], max_images=0)
+    assert out.id == "msg-1"
+
+
+def test_truncate_text_preserves_tool_calls():
+    """Assistant tool-call messages preserve tool_calls through truncation."""
+    tokenizer = build_tokenizer(ModelParams(model_name="gpt2"))
+    msg = Message(
+        role=Role.ASSISTANT,
+        content="i should call a tool to answer this question precisely",
+        tool_calls=[ToolCall.model_validate(_TOOL_CALL_DICT_FOR_PRESERVATION)],
+    )
+    [out] = truncate_text_in_content_items([msg], tokenizer=tokenizer, max_tokens=3)
+    assert out.tool_calls is not None
+    assert out.tool_calls[0].id == "call_xyz"
+
+
+def test_truncate_text_preserves_tool_call_id():
+    """Tool response messages preserve tool_call_id through truncation."""
+    tokenizer = build_tokenizer(ModelParams(model_name="gpt2"))
+    msg = Message(
+        role=Role.TOOL,
+        content="the weather is great here today and the sky is very blue",
+        tool_call_id="call_xyz",
+    )
+    [out] = truncate_text_in_content_items([msg], tokenizer=tokenizer, max_tokens=3)
+    assert out.tool_call_id == "call_xyz"

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -19,6 +19,7 @@ from oumi.utils.conversation_utils import (
     create_list_of_message_json_dicts,
     load_image_bytes_to_content_item,
     load_pil_image_from_content_item,
+    remove_excessive_images,
     remove_excessive_images_from_conversation,
     truncate_text_in_content_items,
 )
@@ -880,3 +881,35 @@ def test_create_list_of_message_json_dicts_no_tool_keys_when_unset():
     for d in result:
         assert "tool_calls" not in d
         assert "tool_call_id" not in d
+
+
+#
+# reasoning_content preservation through utility reconstructions
+#
+def test_remove_excessive_images_preserves_reasoning_content():
+    """reasoning_content survives image-dropping reconstruction."""
+    img = ContentItem(
+        type=Type.IMAGE_BINARY,
+        binary=create_png_bytes_from_image(PIL.Image.new("RGB", (2, 2))),
+    )
+    msg = Message(
+        role=Role.ASSISTANT,
+        content=[ContentItem(type=Type.TEXT, content="answer"), img],
+        reasoning_content="thinking",
+    )
+    result = remove_excessive_images([msg], max_images=0)
+    assert len(result) == 1
+    assert result[0].reasoning_content == "thinking"
+
+
+def test_truncate_text_in_content_items_preserves_reasoning_content():
+    """reasoning_content survives text-truncation reconstruction."""
+    tokenizer = build_tokenizer(ModelParams(model_name="gpt2"))
+    msg = Message(
+        role=Role.ASSISTANT,
+        content="the quick brown fox jumps over the lazy dog",
+        reasoning_content="thinking",
+    )
+    result = truncate_text_in_content_items([msg], tokenizer=tokenizer, max_tokens=3)
+    assert len(result) == 1
+    assert result[0].reasoning_content == "thinking"


### PR DESCRIPTION
# Description

Adds a `reasoning_content` field to `Message` and populates it from the chat-completions response in `RemoteInferenceEngine._convert_api_output_to_conversation`. Several providers (Fireworks, Together, OpenRouter, and OpenAI-compatible APIs for thinking models like Kimi K2.6, GLM-5.1, GPT-OSS-120B, DeepSeek-R1, etc.) expose model reasoning under a separate response field. Previously, our engine silently dropped that field; this PR surfaces it on the `Message` so downstream evaluators, judges, and storage layers can preserve it.

Providers expose reasoning content under different keys:
- Fireworks responses use `message.reasoning_content`.
- Together / OpenRouter responses use `message.reasoning`.
- Both are parsed into a single `Message.reasoning_content` field. Lookup prefers `reasoning` first.

Considerations:
- Some models like DeepSeek R1 place reasoning content in `<think>...</think>` tags located in `content` param. We leave it verbatim and do not autoparse for the user to avoid any surprise behavior

## Verification

Real `oumi infer` calls against Fireworks, Together, and OpenRouter across multiple reasoning models. All populated `reasoning_content` correctly:

| Provider | Model | Result | `reasoning_content` populated |
|---|---|---|---|
| Fireworks | GLM-5.1 (`accounts/fireworks/models/glm-5p1`) | ✅ | ✅ both prompts |
| Fireworks | Kimi-K2.6 (`accounts/fireworks/models/kimi-k2p6`) | ✅ | ✅ both prompts |
| Fireworks | GPT-OSS-120B (`accounts/fireworks/models/gpt-oss-120b`) | ✅ | ✅ both prompts |
| Together | GLM-5.1 (`zai-org/GLM-5.1`) | ✅ | ✅ both prompts |
| Together | Kimi-K2.6 (`moonshotai/Kimi-K2.6`) | ✅ | ✅ both prompts |
| Together | GPT-OSS-120B (`openai/gpt-oss-120b`) | ✅ | ✅ both prompts |
| Together | DeepSeek-R1 (`deepseek-ai/DeepSeek-R1`) | ✅ | ✅ both prompts |
| Together | Qwen3.6-Plus (`Qwen/Qwen3.6-Plus`) | ❌ | streaming-only model — out of scope |
| OpenRouter | GLM-5.1 (`z-ai/glm-5.1`) | ✅ | ✅ both prompts |
| OpenRouter | Kimi-K2.6 (`moonshotai/kimi-k2.6`) | ✅ | ✅ both prompts |
| OpenRouter | Qwen3.6-Plus (`qwen/qwen3.6-plus`) | ✅ | ✅ both prompts (streaming handled server-side) |
| OpenRouter | GPT-OSS-120B (`openai/gpt-oss-120b`) | ✅ | ✅ both prompts |

Also confirmed the production failure mode: when a thinking model exhausts its token budget on reasoning, Together returns `content: ""` (string) or `null` and the reasoning is preserved via `reasoning_content` instead of being lost.

Resources:
https://docs.fireworks.ai/guides/reasoning 
https://docs.together.ai/docs/inference/chat/reasoning#supported-models
https://openrouter.ai/docs/guides/features/tool-calling

## Related issues

Fixes # (issue)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
