### PR TITLE
feat(deploy): list Fireworks deployment shapes

### DIFF
--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -58,6 +58,19 @@ class HardwareConfig:
 
 
 @dataclass
+class DeploymentShape:
+    """Provider-validated ``(base_model, accelerator_type, accelerator_count)``.
+
+    ``base_model`` is the provider's resource path; ``accelerator_type`` is
+    the provider's native string.
+    """
+
+    base_model: str
+    accelerator_type: str
+    accelerator_count: int
+
+
+@dataclass
 class AutoscalingConfig:
     """Autoscaling configuration for deployment."""
 

--- a/src/oumi/deploy/fireworks_api.py
+++ b/src/oumi/deploy/fireworks_api.py
@@ -451,6 +451,38 @@ class GatewayListDeploymentsResponse(_FWBaseModel):
     total_size: int | None = Field(default=None, alias="totalSize")
 
 
+class GatewayDeploymentShapeSnapshot(_FWBaseModel):
+    """gatewayDeploymentShapeSnapshot — hardware spec captured by a shape."""
+
+    # ``accelerator_type`` and ``precision`` are ``str`` so that values
+    # Fireworks adds before we bump the enum don't fail response parsing.
+    base_model: str | None = Field(default=None, alias="baseModel")
+    accelerator_type: str | None = Field(default=None, alias="acceleratorType")
+    accelerator_count: int | None = Field(default=None, alias="acceleratorCount")
+    precision: str | None = None
+    preset_type: str | None = Field(default=None, alias="presetType")
+
+
+class GatewayDeploymentShapeVersion(_FWBaseModel):
+    """gatewayDeploymentShapeVersion — one validated version of a shape."""
+
+    name: str | None = None
+    snapshot: GatewayDeploymentShapeSnapshot | None = None
+    validated: bool | None = None
+    public: bool | None = None
+    latest_validated: bool | None = Field(default=None, alias="latestValidated")
+
+
+class GatewayListDeploymentShapeVersionsResponse(_FWBaseModel):
+    """gatewayListDeploymentShapeVersionsResponse — paginated list of shapes."""
+
+    deployment_shape_versions: list[GatewayDeploymentShapeVersion] | None = Field(
+        default=None, alias="deploymentShapeVersions"
+    )
+    next_page_token: str | None = Field(default=None, alias="nextPageToken")
+    total_size: int | None = Field(default=None, alias="totalSize")
+
+
 # ---------------------------------------------------------------------------
 # Mapping from GatewayDeploymentState → EndpointState
 # ---------------------------------------------------------------------------

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -30,6 +30,7 @@ from oumi.deploy.base_client import (
     AutoscalingConfig,
     BaseDeploymentClient,
     DeploymentProvider,
+    DeploymentShape,
     Endpoint,
     EndpointState,
     FileResolver,
@@ -49,6 +50,7 @@ from oumi.deploy.fireworks_api import (
     GatewayDeployment,
     GatewayGetModelUploadEndpointBody,
     GatewayGetModelUploadEndpointResponse,
+    GatewayListDeploymentShapeVersionsResponse,
     GatewayListDeploymentsResponse,
     GatewayListModelsResponse,
     GatewayModel,
@@ -1467,6 +1469,63 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         return [
             HardwareConfig(accelerator=name, count=1) for name in FIREWORKS_ACCELERATORS
         ]
+
+    async def list_deployment_shapes(
+        self, base_model: str | None = None
+    ) -> list[DeploymentShape]:
+        """Lists ``latest_validated`` deployment shapes published by Fireworks.
+
+        Paginates ``/v1/accounts/-/deploymentShapes/-/versions``, optionally
+        scoped to one base-model resource path. Shapes missing any of the
+        three load-bearing fields are dropped.
+        """
+        filter_clauses = ["latest_validated=true"]
+        if base_model:
+            filter_clauses.insert(0, f'snapshot.base_model="{base_model}"')
+        params_base = {
+            "filter": " AND ".join(filter_clauses),
+            "order_by": "create_time desc",
+        }
+
+        shapes: list[DeploymentShape] = []
+        page_token: str | None = None
+        while True:
+            params = dict(params_base)
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._client.get(
+                "/v1/accounts/-/deploymentShapes/-/versions",
+                params=params,
+            )
+            self._check_response(response, "list deployment shapes")
+            resp = GatewayListDeploymentShapeVersionsResponse.model_validate(
+                response.json()
+            )
+
+            for version in resp.deployment_shape_versions or []:
+                snapshot = version.snapshot
+                if snapshot is None:
+                    continue
+                if (
+                    snapshot.base_model is None
+                    or snapshot.accelerator_type is None
+                    or snapshot.accelerator_count is None
+                ):
+                    continue
+                shapes.append(
+                    DeploymentShape(
+                        base_model=snapshot.base_model,
+                        accelerator_type=snapshot.accelerator_type,
+                        accelerator_count=snapshot.accelerator_count,
+                    )
+                )
+
+            page_token = resp.next_page_token
+            if not page_token:
+                break
+
+        return shapes
 
     async def list_models(
         self, include_public: bool = False, organization: str | None = None

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -408,7 +408,7 @@ class TestFireworksDeploymentClient:
 
     @pytest.mark.asyncio
     async def test_list_deployment_shapes_filters_invalid_and_paginates(self):
-        """list_deployment_shapes drops shapes missing required fields and walks pages."""
+        """Shapes missing required fields are dropped; pages walk to completion."""
         client = FireworksDeploymentClient(api_key="test", account_id="test-account")
 
         page_one = MagicMock()
@@ -416,21 +416,15 @@ class TestFireworksDeploymentClient:
         page_one.json.return_value = {
             "deploymentShapeVersions": [
                 {
-                    "name": "accounts/fireworks/deploymentShapes/qwen3-8b-minimal/versions/v1",
                     "latestValidated": True,
-                    "public": True,
-                    "validated": True,
                     "snapshot": {
                         "baseModel": "accounts/fireworks/models/qwen3-8b",
                         "acceleratorType": "NVIDIA_H200_141GB",
                         "acceleratorCount": 1,
-                        "precision": "FP8",
-                        "presetType": "MINIMAL",
                     },
                 },
                 # Skipped: snapshot missing accelerator fields.
                 {
-                    "name": "accounts/fireworks/deploymentShapes/incomplete/versions/v2",
                     "latestValidated": True,
                     "snapshot": {
                         "baseModel": "accounts/fireworks/models/qwen3-8b",
@@ -445,14 +439,13 @@ class TestFireworksDeploymentClient:
         page_two.json.return_value = {
             "deploymentShapeVersions": [
                 {
-                    "name": "accounts/fireworks/deploymentShapes/llama-v3p1-8b/versions/v3",
                     "latestValidated": True,
                     "snapshot": {
-                        "baseModel": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+                        "baseModel": (
+                            "accounts/fireworks/models/llama-v3p1-8b-instruct"
+                        ),
                         "acceleratorType": "NVIDIA_H100_80GB",
                         "acceleratorCount": 1,
-                        "precision": "FP8_MM",
-                        "presetType": "THROUGHPUT",
                     },
                 },
             ],

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -407,6 +407,107 @@ class TestFireworksDeploymentClient:
             assert hw.count == 1
 
     @pytest.mark.asyncio
+    async def test_list_deployment_shapes_filters_invalid_and_paginates(self):
+        """list_deployment_shapes drops shapes missing required fields and walks pages."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        page_one = MagicMock()
+        page_one.is_success = True
+        page_one.json.return_value = {
+            "deploymentShapeVersions": [
+                {
+                    "name": "accounts/fireworks/deploymentShapes/qwen3-8b-minimal/versions/v1",
+                    "latestValidated": True,
+                    "public": True,
+                    "validated": True,
+                    "snapshot": {
+                        "baseModel": "accounts/fireworks/models/qwen3-8b",
+                        "acceleratorType": "NVIDIA_H200_141GB",
+                        "acceleratorCount": 1,
+                        "precision": "FP8",
+                        "presetType": "MINIMAL",
+                    },
+                },
+                # Skipped: snapshot missing accelerator fields.
+                {
+                    "name": "accounts/fireworks/deploymentShapes/incomplete/versions/v2",
+                    "latestValidated": True,
+                    "snapshot": {
+                        "baseModel": "accounts/fireworks/models/qwen3-8b",
+                    },
+                },
+            ],
+            "nextPageToken": "next",
+            "totalSize": 3,
+        }
+        page_two = MagicMock()
+        page_two.is_success = True
+        page_two.json.return_value = {
+            "deploymentShapeVersions": [
+                {
+                    "name": "accounts/fireworks/deploymentShapes/llama-v3p1-8b/versions/v3",
+                    "latestValidated": True,
+                    "snapshot": {
+                        "baseModel": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+                        "acceleratorType": "NVIDIA_H100_80GB",
+                        "acceleratorCount": 1,
+                        "precision": "FP8_MM",
+                        "presetType": "THROUGHPUT",
+                    },
+                },
+            ],
+            "nextPageToken": "",
+        }
+
+        with patch.object(
+            client._client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=[page_one, page_two],
+        ) as mock_get:
+            shapes = await client.list_deployment_shapes()
+
+            assert mock_get.call_count == 2
+            # Second call carries the page token from the first response.
+            assert mock_get.call_args_list[1].kwargs["params"]["pageToken"] == "next"
+            assert mock_get.call_args_list[0].kwargs["params"]["filter"] == (
+                "latest_validated=true"
+            )
+
+        assert len(shapes) == 2
+        assert shapes[0].base_model == "accounts/fireworks/models/qwen3-8b"
+        assert shapes[0].accelerator_type == "NVIDIA_H200_141GB"
+        assert shapes[0].accelerator_count == 1
+        assert shapes[1].base_model == (
+            "accounts/fireworks/models/llama-v3p1-8b-instruct"
+        )
+        assert shapes[1].accelerator_type == "NVIDIA_H100_80GB"
+
+    @pytest.mark.asyncio
+    async def test_list_deployment_shapes_scopes_filter_to_base_model(self):
+        """A base_model argument is added as a snapshot.base_model AND clause."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "deploymentShapeVersions": [],
+            "nextPageToken": "",
+        }
+
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_get:
+            await client.list_deployment_shapes(
+                base_model="accounts/fireworks/models/qwen3-8b"
+            )
+
+            assert mock_get.call_args.kwargs["params"]["filter"] == (
+                'snapshot.base_model="accounts/fireworks/models/qwen3-8b" AND '
+                "latest_validated=true"
+            )
+
+    @pytest.mark.asyncio
     async def test_start_endpoint_not_supported(self):
         """Fireworks does not support start_endpoint; raises NotImplementedError."""
         client = FireworksDeploymentClient(api_key="test", account_id="test-account")


### PR DESCRIPTION
# Description

Adds `FireworksDeploymentClient.list_deployment_shapes()` and the `DeploymentShape` dataclass so downstream callers can read Fireworks's published `(base_model, accelerator_type, accelerator_count)` catalog from `/v1/accounts/-/deploymentShapes/-/versions` instead of hand-maintained tables.

Consumed by `oumi-ai/api#4273` (the apiserver-side live catalog + fast-fail). `accelerator_type` and `precision` on the snapshot model are plain `str` so values Fireworks adds before we bump the SDK enum (e.g. `B300_288GB`) don't fail response parsing.

## Related issues

n/a — enabling change for oumi-ai/api LOU-1934.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.