### PR TITLE
[db-executable-env] Phase 1: ExecutableEnvironment + ExecutableTool skeleton

### DIFF
--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -37,6 +37,8 @@ from oumi.environments.deterministic_environment import (
     DeterministicEnvironmentKwargs,
     ToolLookupEntry,
 )
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
 from oumi.environments.synthetic_environment import (
     SyntheticEnvironment,
     SyntheticEnvironmentKwargs,
@@ -47,6 +49,8 @@ __all__ = [
     "BaseEnvironment",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
+    "ExecutableEnvironment",
+    "ExecutableTool",
     "GroundingConfig",
     "GroundingFact",
     "JSONSchema",

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -1,0 +1,79 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstract base for envs backed by user-supplied dotted-path executors.
+
+This module ships the skeleton: class shape, batch ``step`` dispatch, and
+abstract ``_build_execution_context`` hook. Per-call execution (executor
+resolution, ``ToolResult`` validation, ``output_schema`` validation,
+``_absorb_result``) arrives in a later phase.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from typing import Any, ClassVar
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class ExecutableEnvironment(BaseEnvironment):
+    """Abstract base for envs that run user-supplied dotted-path executors.
+
+    Subclasses supply the per-call execution context (DB connection, HTTP
+    client, FS root, ...) by implementing ``_build_execution_context`` as a
+    context manager. The base class will own executor resolution, result
+    validation, schema validation, the ``_absorb_result`` post-hook, and the
+    ``close`` lifecycle — those land in later phases.
+    """
+
+    tool_params_cls: type[ToolParams] = ExecutableTool
+
+    #: Keyword name under which subclasses pass the execution context to
+    #: user executors. Defaults to ``"context"``; concrete subclasses such
+    #: as ``DatabaseExecutableEnvironment`` override this (e.g. to ``"db"``).
+    _executor_context_kwarg: ClassVar[str] = "context"
+
+    _params: EnvironmentParams
+    _executors: dict[str, Callable[..., Any]]
+
+    @abstractmethod
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> AbstractContextManager[Any]:
+        """Yield the per-call execution context (DB conn, HTTP client, ...)."""
+
+    def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
+        """Post-hook called after a successful executor call. Default no-op."""
+        return None
+
+    def close(self) -> None:
+        """Release any resources owned by this env. Default no-op."""
+        return None
+
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch of tool calls; results are returned in input order."""
+        return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
+
+    def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        """Execute a single tool call. Implemented in a later phase."""
+        raise NotImplementedError(
+            "ExecutableEnvironment._step_one is not yet implemented (skeleton)."
+        )

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Abstract base for envs backed by user-supplied dotted-path executors.
-
-This module ships the skeleton: class shape, batch ``step`` dispatch, and
-abstract ``_build_execution_context`` hook. Per-call execution (executor
-resolution, ``ToolResult`` validation, ``output_schema`` validation,
-``_absorb_result``) arrives in a later phase.
-"""
+"""Abstract base for envs backed by user-supplied dotted-path executors."""
 
 from __future__ import annotations
 
@@ -39,9 +33,9 @@ class ExecutableEnvironment(BaseEnvironment):
 
     Subclasses supply the per-call execution context (DB connection, HTTP
     client, FS root, ...) by implementing ``_build_execution_context`` as a
-    context manager. The base class will own executor resolution, result
-    validation, schema validation, the ``_absorb_result`` post-hook, and the
-    ``close`` lifecycle — those land in later phases.
+    context manager. The base owns executor resolution, result validation,
+    schema validation, the ``_absorb_result`` post-hook, and the ``close``
+    lifecycle.
     """
 
     tool_params_cls: type[ToolParams] = ExecutableTool
@@ -73,7 +67,5 @@ class ExecutableEnvironment(BaseEnvironment):
         return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
 
     def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Execute a single tool call. Implemented in a later phase."""
-        raise NotImplementedError(
-            "ExecutableEnvironment._step_one is not yet implemented (skeleton)."
-        )
+        """Execute a single tool call."""
+        raise NotImplementedError

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -1,0 +1,41 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared base class for tools that resolve a dotted-path Python executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oumi.core.configs.params.tool_params import ToolParams
+
+
+@dataclass
+class ExecutableTool(ToolParams):
+    """`ToolParams` variant for envs that take user-supplied dotted-path executors.
+
+    Subclasses (``DatabaseExecutableTool``, future ``HTTPExecutableTool``, etc.)
+    inherit this and may add transport-specific per-tool overrides.
+    """
+
+    executor: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate inherited fields and enforce non-empty executor."""
+        super().__post_init__()
+        if not self.executor:
+            raise ValueError(
+                f"{type(self).__name__} '{self.id}' must declare a non-empty "
+                f"executor (dotted import path)."
+            )

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -25,8 +25,7 @@ from oumi.core.configs.params.tool_params import ToolParams
 class ExecutableTool(ToolParams):
     """`ToolParams` variant for envs that take user-supplied dotted-path executors.
 
-    Subclasses (``DatabaseExecutableTool``, future ``HTTPExecutableTool``, etc.)
-    inherit this and may add transport-specific per-tool overrides.
+    Subclasses inherit this and may add transport-specific per-tool overrides.
     """
 
     executor: str = ""

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -74,12 +74,12 @@ def test_absorb_result_is_noop():
 def test_step_batch_dispatches_to_step_one():
     """Batch step() iterates the call list and dispatches each to _step_one."""
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError, match="_step_one"):
+    with pytest.raises(NotImplementedError):
         env.step([("tool_a", {})])
 
 
-def test_step_one_is_skeleton():
-    """_step_one is the per-call dispatch hook; the skeleton phase raises."""
+def test_step_one_raises_not_implemented():
+    """_step_one is the per-call dispatch hook; the base implementation raises."""
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError, match="skeleton"):
+    with pytest.raises(NotImplementedError):
         env._step_one("tool_a", {})

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -1,0 +1,85 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableEnvironment."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class _MinimalExecEnv(ExecutableEnvironment):
+    """Smallest concrete subclass that satisfies the abstract surface."""
+
+    def __init__(self) -> None:
+        self._params = EnvironmentParams(id="test", env_type="executable")
+        self._executors = {}
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield None
+
+
+def test_cannot_instantiate_abstract_base():
+    """ExecutableEnvironment is abstract — _build_execution_context must be supplied."""
+    with pytest.raises(TypeError, match="abstract"):
+        ExecutableEnvironment()  # type: ignore[abstract]
+
+
+def test_default_executor_context_kwarg_is_context():
+    """Subclasses (e.g. database) override this; the default is ``"context"``."""
+    assert ExecutableEnvironment._executor_context_kwarg == "context"
+
+
+def test_default_tool_params_cls_is_executable_tool():
+    """ExecutableEnvironment binds to ExecutableTool by default."""
+    assert ExecutableEnvironment.tool_params_cls is ExecutableTool
+
+
+def test_close_is_noop():
+    """Default close() returns None without raising."""
+    env = _MinimalExecEnv()
+    assert env.close() is None
+
+
+def test_absorb_result_is_noop():
+    """Default _absorb_result returns None for any ToolResult."""
+    env = _MinimalExecEnv()
+    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
+    assert env._absorb_result(tool, ToolResult(output={"ok": True})) is None
+
+
+def test_step_batch_dispatches_to_step_one():
+    """Batch step() iterates the call list and dispatches each to _step_one."""
+    env = _MinimalExecEnv()
+    with pytest.raises(NotImplementedError, match="_step_one"):
+        env.step([("tool_a", {})])
+
+
+def test_step_one_is_skeleton():
+    """_step_one is the per-call dispatch hook; the skeleton phase raises."""
+    env = _MinimalExecEnv()
+    with pytest.raises(NotImplementedError, match="skeleton"):
+        env._step_one("tool_a", {})

--- a/tests/unit/environments/test_executable_tool.py
+++ b/tests/unit/environments/test_executable_tool.py
@@ -1,0 +1,35 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableTool."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.environments.executable_tool import ExecutableTool
+
+
+def test_rejects_empty_executor():
+    """An ExecutableTool with no executor dotted path is invalid at construction."""
+    with pytest.raises(ValueError, match="executor"):
+        ExecutableTool(id="t", name="t", description="d")
+
+
+def test_accepts_dotted_path():
+    """Dotted-path executor is stored as-is."""
+    tool = ExecutableTool(
+        id="t", name="t", description="d", executor="oumi.examples.foo.bar"
+    )
+    assert tool.executor == "oumi.examples.foo.bar"


### PR DESCRIPTION
# Description

Phase **1** of the **db-executable-env** phase chain, target branch: `aniruddh-alt/db-executable-env-trunk`.

**What changed**: Adds the abstract `ExecutableEnvironment` base class and `ExecutableTool` — the middle layer that future executable transports (database, HTTP, filesystem, MCP) will subclass.

**Why**: We need a shared executor-resolution / lifecycle layer before adding concrete transports. Mirrors Oumi's inference engine hierarchy (`BaseInferenceEngine → RemoteInferenceEngine → AnthropicInferenceEngine`). Replaces the monolithic PR #2441 with phase-sized units that each leave the trunk in a buildable, testable state.

## Phase chain context

- **Feature trunk**: `aniruddh-alt/db-executable-env-trunk` (will become integration PR to `main` once all phases land)
- **Phases merged into trunk**: (none yet)
- **This phase**: 1 (Executable base skeleton)
- **Next phase**: 2 (Database executable skeleton) — open in parallel, branched off this phase's branch so the imports resolve; will rebase onto trunk once this PR merges.
- **Phases remaining**: 3+ TBD (ExecutableEnvironment `_step_one` implementation, DB env engine + dialect guards, error wrapping + audit, example, postgres integration tests)

## What's in this PR (244 lines)

| File | Purpose |
|---|---|
| `src/oumi/environments/executable_environment.py` | Abstract base — class shape, batch `step()` → `_step_one` dispatch, `_build_execution_context` abstract hook, `_absorb_result` and `close` default no-ops. `_step_one` raises `NotImplementedError` (skeleton). |
| `src/oumi/environments/executable_tool.py` | `ToolParams` subclass that enforces a non-empty `executor` dotted path. |
| `src/oumi/environments/__init__.py` | Exports `ExecutableEnvironment` and `ExecutableTool`. |
| `tests/unit/environments/test_executable_environment.py` | Skeleton-shape tests: abstract instantiation rejected, class vars correct, batch dispatch reaches `_step_one`, defaults are no-ops. |
| `tests/unit/environments/test_executable_tool.py` | Skeleton-shape tests: rejects empty executor; accepts dotted path. |

## Why a skeleton phase

Each phase in this chain leaves the trunk buildable. The skeleton ships the shape (subclasses can be written against the abstract surface) but raises `NotImplementedError` from `_step_one` so no caller is misled into thinking execution is wired. Implementation lands in a follow-on phase.

The batch `step(calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]` signature matches `BaseEnvironment.step` exactly — fixing the signature mismatch flagged on PR #2441.

## Related issues

(No associated issue — direct continuation of the work that lived in PR #2441.)

## Before submitting

- [x] Did you add / update tests where needed?
- [x] Did you run the local test suite? `pytest tests/unit/environments/` — 67/67 passing on this branch.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
