### PR TITLE
[db-executable-env] Phase 2: DatabaseExecutableEnvironment + tool + connection-config skeleton

### DIFF
--- a/src/oumi/core/configs/params/database_connection_params.py
+++ b/src/oumi/core/configs/params/database_connection_params.py
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Connection parameters for ``DatabaseExecutableEnvironment``.
-
-Skeleton phase: declares the data shape and the structured-vs-DSN XOR
-validation. URL resolution (``resolve_url``) and the SQLAlchemy dependency
-arrive in the implementation phase.
-"""
+"""Connection parameters for ``DatabaseExecutableEnvironment``."""
 
 from __future__ import annotations
 

--- a/src/oumi/core/configs/params/database_connection_params.py
+++ b/src/oumi/core/configs/params/database_connection_params.py
@@ -1,0 +1,87 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Connection parameters for ``DatabaseExecutableEnvironment``.
+
+Skeleton phase: declares the data shape and the structured-vs-DSN XOR
+validation. URL resolution (``resolve_url``) and the SQLAlchemy dependency
+arrive in the implementation phase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oumi.core.configs.params.base_params import BaseParams
+
+
+@dataclass
+class DatabaseConnectionConfig(BaseParams):
+    """SQLAlchemy connection config for ``DatabaseExecutableEnvironment``.
+
+    Two modes (mutually exclusive):
+
+    - **Structured fields:** populate ``driver`` and ``database`` (and host /
+      port / username as needed). The password is resolved at connect time
+      from ``password_env_var`` so it never appears in YAML.
+    - **DSN env var:** populate ``dsn_env_var`` with the name of an env var
+      holding a complete SQLAlchemy URL.
+    """
+
+    # Mode 1: structured fields
+    driver: str = ""  # e.g. "postgresql+psycopg", "mysql+pymysql", "sqlite"
+    host: str = ""
+    port: int | None = None
+    database: str = ""
+    username: str = ""
+    password_env_var: str = ""  # name of env var holding the password
+
+    # Mode 2: full DSN from env (escape hatch)
+    dsn_env_var: str = ""  # mutually exclusive with structured fields
+
+    # Pool / timeouts
+    pool_size: int = 5
+    pool_max_overflow: int = 10
+    pool_pre_ping: bool = True
+    connect_timeout_s: float = 10.0
+
+    def __finalize_and_validate__(self) -> None:
+        """Validate mode XOR (structured vs DSN) and pool numeric bounds."""
+        structured = bool(self.driver and self.database)
+        dsn = bool(self.dsn_env_var)
+        if structured and dsn:
+            raise ValueError(
+                "DatabaseConnectionConfig: set EITHER (driver, database, ...) "
+                "OR dsn_env_var, not both."
+            )
+        if not structured and not dsn:
+            raise ValueError(
+                "DatabaseConnectionConfig: must set either (driver + database) "
+                "OR dsn_env_var. Got neither."
+            )
+        if self.pool_size < 1:
+            raise ValueError(
+                f"DatabaseConnectionConfig.pool_size must be >= 1, "
+                f"got {self.pool_size}."
+            )
+        if self.pool_max_overflow < 0:
+            raise ValueError(
+                f"DatabaseConnectionConfig.pool_max_overflow must be >= 0, "
+                f"got {self.pool_max_overflow}."
+            )
+        if self.connect_timeout_s <= 0:
+            raise ValueError(
+                f"DatabaseConnectionConfig.connect_timeout_s must be > 0, "
+                f"got {self.connect_timeout_s}."
+            )

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -37,6 +37,8 @@ from oumi.environments.deterministic_environment import (
     DeterministicEnvironmentKwargs,
     ToolLookupEntry,
 )
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
 from oumi.environments.synthetic_environment import (
     SyntheticEnvironment,
     SyntheticEnvironmentKwargs,
@@ -47,6 +49,8 @@ __all__ = [
     "BaseEnvironment",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
+    "ExecutableEnvironment",
+    "ExecutableTool",
     "GroundingConfig",
     "GroundingFact",
     "JSONSchema",

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -32,6 +32,11 @@ from oumi.core.configs.params.tool_params import (
 )
 from oumi.core.types.tool_call import JSONSchema, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+    DatabaseExecutableEnvironmentKwargs,
+)
+from oumi.environments.database_executable_tool import DatabaseExecutableTool
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
     DeterministicEnvironmentKwargs,
@@ -47,6 +52,9 @@ from oumi.environments.synthetic_environment import (
 
 __all__ = [
     "BaseEnvironment",
+    "DatabaseExecutableEnvironment",
+    "DatabaseExecutableEnvironmentKwargs",
+    "DatabaseExecutableTool",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
     "ExecutableEnvironment",

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SQLAlchemy-backed environment that runs user-supplied executors.
-
-Skeleton phase: declares the class shape, the env-type registration, and the
-per-env kwargs dataclass. Engine construction, dialect-aware safety guards,
-``DBAPIError`` auto-wrapping, audit logging, and the per-call connection
-checkout land in follow-on phases. ``from_params`` and
-``_build_execution_context`` therefore raise ``NotImplementedError`` here.
-"""
+"""SQLAlchemy-backed environment that runs user-supplied executors."""
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
@@ -69,14 +61,10 @@ class DatabaseExecutableEnvironmentKwargs(BaseParams):
 class DatabaseExecutableEnvironment(ExecutableEnvironment):
     """Environment that runs user-supplied executors against a real SQL database.
 
-    The DB *is* the state. Each ``_step_one`` will check out a connection
-    from the SQLAlchemy pool, run the executor in autocommit mode, and
-    return the connection. SQL errors that escape the executor will be
-    auto-wrapped as a structured ``ToolResult`` so the agent can self-correct.
-
-    This phase ships the skeleton: class registered, kwargs shape declared,
-    abstract hooks left to raise ``NotImplementedError`` until the engine
-    implementation phase.
+    The DB *is* the state. Each tool call checks out a connection from the
+    SQLAlchemy pool, runs the executor in autocommit mode, and returns the
+    connection. SQL errors that escape the executor are auto-wrapped as a
+    structured ``ToolResult`` so the agent can self-correct.
     """
 
     tool_params_cls = DatabaseExecutableTool
@@ -85,19 +73,10 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
         """Build a ``DatabaseExecutableEnvironment`` from its params object."""
-        raise NotImplementedError(
-            "DatabaseExecutableEnvironment.from_params is not yet implemented "
-            "(skeleton phase). The implementation phase wires the SQLAlchemy "
-            "engine, dialect guards, and fail-fast SELECT 1."
-        )
+        raise NotImplementedError
 
-    @contextmanager
     def _build_execution_context(
         self, tool: ExecutableTool, arguments: dict[str, Any]
-    ) -> Iterator[Any]:
-        """Yield a per-call SQLAlchemy ``Connection`` (implementation pending)."""
-        raise NotImplementedError(
-            "DatabaseExecutableEnvironment._build_execution_context is not yet "
-            "implemented (skeleton phase)."
-        )
-        yield None  # unreachable; satisfies the Iterator return type
+    ) -> AbstractContextManager[Any]:
+        """Check out a SQLAlchemy ``Connection`` for one tool call."""
+        raise NotImplementedError

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -1,0 +1,103 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SQLAlchemy-backed environment that runs user-supplied executors.
+
+Skeleton phase: declares the class shape, the env-type registration, and the
+per-env kwargs dataclass. Engine construction, dialect-aware safety guards,
+``DBAPIError`` auto-wrapping, audit logging, and the per-call connection
+checkout land in follow-on phases. ``from_params`` and
+``_build_execution_context`` therefore raise ``NotImplementedError`` here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.configs.params.database_connection_params import (
+    DatabaseConnectionConfig,
+)
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.registry import register_environment
+from oumi.environments.database_executable_tool import DatabaseExecutableTool
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+@dataclass
+class DatabaseExecutableEnvironmentKwargs(BaseParams):
+    """Type-specific kwargs for ``DatabaseExecutableEnvironment``."""
+
+    connection: DatabaseConnectionConfig | None = None
+    read_only: bool = False
+    statement_timeout_ms: int | None = None
+    audit: bool = False
+
+    def __post_init__(self) -> None:
+        """Coerce ``connection`` dict into a ``DatabaseConnectionConfig``."""
+        if isinstance(self.connection, dict):
+            self.connection = DatabaseConnectionConfig(**self.connection)
+
+    def __finalize_and_validate__(self) -> None:
+        """Validate connection presence and numeric bounds."""
+        if self.connection is None:
+            raise ValueError(
+                "DatabaseExecutableEnvironmentKwargs.connection is required."
+            )
+        if self.statement_timeout_ms is not None and self.statement_timeout_ms <= 0:
+            raise ValueError(
+                f"statement_timeout_ms must be > 0, got {self.statement_timeout_ms}."
+            )
+
+
+@register_environment("database")
+class DatabaseExecutableEnvironment(ExecutableEnvironment):
+    """Environment that runs user-supplied executors against a real SQL database.
+
+    The DB *is* the state. Each ``_step_one`` will check out a connection
+    from the SQLAlchemy pool, run the executor in autocommit mode, and
+    return the connection. SQL errors that escape the executor will be
+    auto-wrapped as a structured ``ToolResult`` so the agent can self-correct.
+
+    This phase ships the skeleton: class registered, kwargs shape declared,
+    abstract hooks left to raise ``NotImplementedError`` until the engine
+    implementation phase.
+    """
+
+    tool_params_cls = DatabaseExecutableTool
+    _executor_context_kwarg: ClassVar[str] = "db"
+
+    @classmethod
+    def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
+        """Build a ``DatabaseExecutableEnvironment`` from its params object."""
+        raise NotImplementedError(
+            "DatabaseExecutableEnvironment.from_params is not yet implemented "
+            "(skeleton phase). The implementation phase wires the SQLAlchemy "
+            "engine, dialect guards, and fail-fast SELECT 1."
+        )
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        """Yield a per-call SQLAlchemy ``Connection`` (implementation pending)."""
+        raise NotImplementedError(
+            "DatabaseExecutableEnvironment._build_execution_context is not yet "
+            "implemented (skeleton phase)."
+        )
+        yield None  # unreachable; satisfies the Iterator return type

--- a/src/oumi/environments/database_executable_tool.py
+++ b/src/oumi/environments/database_executable_tool.py
@@ -27,9 +27,9 @@ from oumi.environments.executable_tool import ExecutableTool
 class DatabaseExecutableTool(ExecutableTool):
     """``ExecutableTool`` for ``DatabaseExecutableEnvironment``.
 
-    Adds an optional per-tool ``statement_timeout_ms`` that may **only**
-    tighten the env-level timeout. Cross-validation against the env's value
-    happens in the env's ``from_params`` (implementation phase).
+    Adds an optional per-tool ``statement_timeout_ms`` that may only tighten
+    the env-level timeout. Cross-validation against the env value happens
+    in the env.
     """
 
     statement_timeout_ms: int | None = None

--- a/src/oumi/environments/database_executable_tool.py
+++ b/src/oumi/environments/database_executable_tool.py
@@ -1,0 +1,59 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database-specific ``ExecutableTool`` subclass."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from oumi.environments.executable_tool import ExecutableTool
+
+
+@dataclass
+class DatabaseExecutableTool(ExecutableTool):
+    """``ExecutableTool`` for ``DatabaseExecutableEnvironment``.
+
+    Adds an optional per-tool ``statement_timeout_ms`` that may **only**
+    tighten the env-level timeout. Cross-validation against the env's value
+    happens in the env's ``from_params`` (implementation phase).
+    """
+
+    statement_timeout_ms: int | None = None
+
+    @classmethod
+    def create(cls, raw: Any) -> DatabaseExecutableTool:
+        """Construct a ``DatabaseExecutableTool`` from raw config data."""
+        if isinstance(raw, DatabaseExecutableTool):
+            return raw
+        if not isinstance(raw, Mapping):
+            raise TypeError(
+                f"Tool definitions must be tool objects or mappings, got {type(raw)}"
+            )
+        return cls(
+            id=raw["id"],
+            name=raw["name"],
+            description=raw["description"],
+            parameters=dict(raw.get("parameters") or {"type": "object"}),
+            output_schema=(
+                dict(raw["output_schema"])
+                if raw.get("output_schema") is not None
+                else None
+            ),
+            read_only=raw.get("read_only", True),
+            executor=raw["executor"],
+            statement_timeout_ms=raw.get("statement_timeout_ms"),
+        )

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -1,0 +1,79 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstract base for envs backed by user-supplied dotted-path executors.
+
+This module ships the skeleton: class shape, batch ``step`` dispatch, and
+abstract ``_build_execution_context`` hook. Per-call execution (executor
+resolution, ``ToolResult`` validation, ``output_schema`` validation,
+``_absorb_result``) arrives in a later phase.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from typing import Any, ClassVar
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class ExecutableEnvironment(BaseEnvironment):
+    """Abstract base for envs that run user-supplied dotted-path executors.
+
+    Subclasses supply the per-call execution context (DB connection, HTTP
+    client, FS root, ...) by implementing ``_build_execution_context`` as a
+    context manager. The base class will own executor resolution, result
+    validation, schema validation, the ``_absorb_result`` post-hook, and the
+    ``close`` lifecycle — those land in later phases.
+    """
+
+    tool_params_cls: type[ToolParams] = ExecutableTool
+
+    #: Keyword name under which subclasses pass the execution context to
+    #: user executors. Defaults to ``"context"``; concrete subclasses such
+    #: as ``DatabaseExecutableEnvironment`` override this (e.g. to ``"db"``).
+    _executor_context_kwarg: ClassVar[str] = "context"
+
+    _params: EnvironmentParams
+    _executors: dict[str, Callable[..., Any]]
+
+    @abstractmethod
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> AbstractContextManager[Any]:
+        """Yield the per-call execution context (DB conn, HTTP client, ...)."""
+
+    def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
+        """Post-hook called after a successful executor call. Default no-op."""
+        return None
+
+    def close(self) -> None:
+        """Release any resources owned by this env. Default no-op."""
+        return None
+
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch of tool calls; results are returned in input order."""
+        return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
+
+    def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        """Execute a single tool call. Implemented in a later phase."""
+        raise NotImplementedError(
+            "ExecutableEnvironment._step_one is not yet implemented (skeleton)."
+        )

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Abstract base for envs backed by user-supplied dotted-path executors.
-
-This module ships the skeleton: class shape, batch ``step`` dispatch, and
-abstract ``_build_execution_context`` hook. Per-call execution (executor
-resolution, ``ToolResult`` validation, ``output_schema`` validation,
-``_absorb_result``) arrives in a later phase.
-"""
+"""Abstract base for envs backed by user-supplied dotted-path executors."""
 
 from __future__ import annotations
 
@@ -39,9 +33,9 @@ class ExecutableEnvironment(BaseEnvironment):
 
     Subclasses supply the per-call execution context (DB connection, HTTP
     client, FS root, ...) by implementing ``_build_execution_context`` as a
-    context manager. The base class will own executor resolution, result
-    validation, schema validation, the ``_absorb_result`` post-hook, and the
-    ``close`` lifecycle — those land in later phases.
+    context manager. The base owns executor resolution, result validation,
+    schema validation, the ``_absorb_result`` post-hook, and the ``close``
+    lifecycle.
     """
 
     tool_params_cls: type[ToolParams] = ExecutableTool
@@ -73,7 +67,5 @@ class ExecutableEnvironment(BaseEnvironment):
         return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
 
     def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Execute a single tool call. Implemented in a later phase."""
-        raise NotImplementedError(
-            "ExecutableEnvironment._step_one is not yet implemented (skeleton)."
-        )
+        """Execute a single tool call."""
+        raise NotImplementedError

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -1,0 +1,41 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared base class for tools that resolve a dotted-path Python executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oumi.core.configs.params.tool_params import ToolParams
+
+
+@dataclass
+class ExecutableTool(ToolParams):
+    """`ToolParams` variant for envs that take user-supplied dotted-path executors.
+
+    Subclasses (``DatabaseExecutableTool``, future ``HTTPExecutableTool``, etc.)
+    inherit this and may add transport-specific per-tool overrides.
+    """
+
+    executor: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate inherited fields and enforce non-empty executor."""
+        super().__post_init__()
+        if not self.executor:
+            raise ValueError(
+                f"{type(self).__name__} '{self.id}' must declare a non-empty "
+                f"executor (dotted import path)."
+            )

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -25,8 +25,7 @@ from oumi.core.configs.params.tool_params import ToolParams
 class ExecutableTool(ToolParams):
     """`ToolParams` variant for envs that take user-supplied dotted-path executors.
 
-    Subclasses (``DatabaseExecutableTool``, future ``HTTPExecutableTool``, etc.)
-    inherit this and may add transport-specific per-tool overrides.
+    Subclasses inherit this and may add transport-specific per-tool overrides.
     """
 
     executor: str = ""

--- a/tests/unit/core/configs/params/test_database_connection_params.py
+++ b/tests/unit/core/configs/params/test_database_connection_params.py
@@ -1,0 +1,67 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ``DatabaseConnectionConfig``."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.core.configs.params.database_connection_params import (
+    DatabaseConnectionConfig,
+)
+
+
+def test_rejects_neither_mode():
+    """Empty config rejects: structured XOR DSN must be set."""
+    config = DatabaseConnectionConfig()
+    with pytest.raises(ValueError, match="either"):
+        config.finalize_and_validate()
+
+
+def test_rejects_both_modes():
+    """Setting both structured fields and DSN env var is invalid."""
+    config = DatabaseConnectionConfig(
+        driver="sqlite", database="x.db", dsn_env_var="DB_URL"
+    )
+    with pytest.raises(ValueError, match="not both"):
+        config.finalize_and_validate()
+
+
+def test_accepts_structured_mode():
+    """Structured fields (driver + database) is a valid mode."""
+    config = DatabaseConnectionConfig(driver="sqlite", database="x.db")
+    config.finalize_and_validate()
+
+
+def test_accepts_dsn_mode():
+    """DSN env var alone is a valid mode."""
+    config = DatabaseConnectionConfig(dsn_env_var="DATABASE_URL")
+    config.finalize_and_validate()
+
+
+def test_rejects_zero_pool_size():
+    """pool_size must be >= 1."""
+    config = DatabaseConnectionConfig(driver="sqlite", database="x.db", pool_size=0)
+    with pytest.raises(ValueError, match="pool_size"):
+        config.finalize_and_validate()
+
+
+def test_rejects_non_positive_connect_timeout():
+    """connect_timeout_s must be > 0."""
+    config = DatabaseConnectionConfig(
+        driver="sqlite", database="x.db", connect_timeout_s=0
+    )
+    with pytest.raises(ValueError, match="connect_timeout_s"):
+        config.finalize_and_validate()

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -39,10 +39,10 @@ def test_tool_params_cls_is_database_executable_tool():
     assert DatabaseExecutableEnvironment.tool_params_cls is DatabaseExecutableTool
 
 
-def test_from_params_is_skeleton():
-    """``from_params`` raises NotImplementedError until the implementation phase."""
+def test_from_params_raises_not_implemented():
+    """``from_params`` raises NotImplementedError until the engine wiring lands."""
     params = EnvironmentParams(id="test", env_type="database")
-    with pytest.raises(NotImplementedError, match="skeleton"):
+    with pytest.raises(NotImplementedError):
         DatabaseExecutableEnvironment.from_params(params)
 
 

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -1,0 +1,72 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ``DatabaseExecutableEnvironment``."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.core.configs.params.database_connection_params import (
+    DatabaseConnectionConfig,
+)
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+    DatabaseExecutableEnvironmentKwargs,
+)
+from oumi.environments.database_executable_tool import DatabaseExecutableTool
+
+
+def test_executor_context_kwarg_is_db():
+    """DatabaseExecutableEnvironment passes the connection as ``db=`` to executors."""
+    assert DatabaseExecutableEnvironment._executor_context_kwarg == "db"
+
+
+def test_tool_params_cls_is_database_executable_tool():
+    """The env binds to ``DatabaseExecutableTool``."""
+    assert DatabaseExecutableEnvironment.tool_params_cls is DatabaseExecutableTool
+
+
+def test_from_params_is_skeleton():
+    """``from_params`` raises NotImplementedError until the implementation phase."""
+    params = EnvironmentParams(id="test", env_type="database")
+    with pytest.raises(NotImplementedError, match="skeleton"):
+        DatabaseExecutableEnvironment.from_params(params)
+
+
+def test_kwargs_requires_connection():
+    """Kwargs validation rejects a missing ``connection``."""
+    kwargs = DatabaseExecutableEnvironmentKwargs()
+    with pytest.raises(ValueError, match="connection"):
+        kwargs.finalize_and_validate()
+
+
+def test_kwargs_rejects_non_positive_statement_timeout():
+    """Env-level ``statement_timeout_ms`` must be > 0 when set."""
+    kwargs = DatabaseExecutableEnvironmentKwargs(
+        connection=DatabaseConnectionConfig(driver="sqlite", database="x.db"),
+        statement_timeout_ms=0,
+    )
+    with pytest.raises(ValueError, match="statement_timeout_ms"):
+        kwargs.finalize_and_validate()
+
+
+def test_kwargs_coerces_connection_dict():
+    """A raw connection dict is coerced into ``DatabaseConnectionConfig``."""
+    kwargs = DatabaseExecutableEnvironmentKwargs(
+        connection={"driver": "sqlite", "database": "x.db"},  # type: ignore[arg-type]
+    )
+    assert isinstance(kwargs.connection, DatabaseConnectionConfig)
+    assert kwargs.connection.driver == "sqlite"

--- a/tests/unit/environments/test_database_executable_tool.py
+++ b/tests/unit/environments/test_database_executable_tool.py
@@ -1,0 +1,60 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ``DatabaseExecutableTool``."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.environments.database_executable_tool import DatabaseExecutableTool
+
+
+def test_inherits_executor_requirement():
+    """DatabaseExecutableTool keeps ExecutableTool's non-empty executor check."""
+    with pytest.raises(ValueError, match="executor"):
+        DatabaseExecutableTool(id="t", name="t", description="d")
+
+
+def test_carries_optional_statement_timeout():
+    """Per-tool statement_timeout_ms is stored as-is for env-side validation."""
+    tool = DatabaseExecutableTool(
+        id="t",
+        name="t",
+        description="d",
+        executor="oumi.examples.foo.bar",
+        statement_timeout_ms=5000,
+    )
+    assert tool.statement_timeout_ms == 5000
+
+
+def test_create_from_mapping():
+    """``create`` builds an instance from a raw mapping (YAML round-trip)."""
+    tool = DatabaseExecutableTool.create(
+        {
+            "id": "t",
+            "name": "t",
+            "description": "d",
+            "executor": "x.y",
+            "statement_timeout_ms": 1000,
+        }
+    )
+    assert tool.statement_timeout_ms == 1000
+    assert tool.executor == "x.y"
+
+
+def test_create_rejects_non_mapping():
+    """Anything that isn't a mapping or a DatabaseExecutableTool is rejected."""
+    with pytest.raises(TypeError, match="mappings"):
+        DatabaseExecutableTool.create("not a mapping")  # type: ignore[arg-type]

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -74,12 +74,12 @@ def test_absorb_result_is_noop():
 def test_step_batch_dispatches_to_step_one():
     """Batch step() iterates the call list and dispatches each to _step_one."""
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError, match="_step_one"):
+    with pytest.raises(NotImplementedError):
         env.step([("tool_a", {})])
 
 
-def test_step_one_is_skeleton():
-    """_step_one is the per-call dispatch hook; the skeleton phase raises."""
+def test_step_one_raises_not_implemented():
+    """_step_one is the per-call dispatch hook; the base implementation raises."""
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError, match="skeleton"):
+    with pytest.raises(NotImplementedError):
         env._step_one("tool_a", {})

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -1,0 +1,85 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableEnvironment."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class _MinimalExecEnv(ExecutableEnvironment):
+    """Smallest concrete subclass that satisfies the abstract surface."""
+
+    def __init__(self) -> None:
+        self._params = EnvironmentParams(id="test", env_type="executable")
+        self._executors = {}
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield None
+
+
+def test_cannot_instantiate_abstract_base():
+    """ExecutableEnvironment is abstract — _build_execution_context must be supplied."""
+    with pytest.raises(TypeError, match="abstract"):
+        ExecutableEnvironment()  # type: ignore[abstract]
+
+
+def test_default_executor_context_kwarg_is_context():
+    """Subclasses (e.g. database) override this; the default is ``"context"``."""
+    assert ExecutableEnvironment._executor_context_kwarg == "context"
+
+
+def test_default_tool_params_cls_is_executable_tool():
+    """ExecutableEnvironment binds to ExecutableTool by default."""
+    assert ExecutableEnvironment.tool_params_cls is ExecutableTool
+
+
+def test_close_is_noop():
+    """Default close() returns None without raising."""
+    env = _MinimalExecEnv()
+    assert env.close() is None
+
+
+def test_absorb_result_is_noop():
+    """Default _absorb_result returns None for any ToolResult."""
+    env = _MinimalExecEnv()
+    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
+    assert env._absorb_result(tool, ToolResult(output={"ok": True})) is None
+
+
+def test_step_batch_dispatches_to_step_one():
+    """Batch step() iterates the call list and dispatches each to _step_one."""
+    env = _MinimalExecEnv()
+    with pytest.raises(NotImplementedError, match="_step_one"):
+        env.step([("tool_a", {})])
+
+
+def test_step_one_is_skeleton():
+    """_step_one is the per-call dispatch hook; the skeleton phase raises."""
+    env = _MinimalExecEnv()
+    with pytest.raises(NotImplementedError, match="skeleton"):
+        env._step_one("tool_a", {})

--- a/tests/unit/environments/test_executable_tool.py
+++ b/tests/unit/environments/test_executable_tool.py
@@ -1,0 +1,35 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableTool."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.environments.executable_tool import ExecutableTool
+
+
+def test_rejects_empty_executor():
+    """An ExecutableTool with no executor dotted path is invalid at construction."""
+    with pytest.raises(ValueError, match="executor"):
+        ExecutableTool(id="t", name="t", description="d")
+
+
+def test_accepts_dotted_path():
+    """Dotted-path executor is stored as-is."""
+    tool = ExecutableTool(
+        id="t", name="t", description="d", executor="oumi.examples.foo.bar"
+    )
+    assert tool.executor == "oumi.examples.foo.bar"


### PR DESCRIPTION
# Description

Phase **2** of the **db-executable-env** phase chain, target branch: `aniruddh-alt/db-executable-env-trunk`.

**What changed**: Adds the skeleton for the first concrete `ExecutableEnvironment` transport — `DatabaseExecutableEnvironment`, `DatabaseExecutableTool`, and `DatabaseConnectionConfig`. Registers `env_type: database` in the env registry.

**Why**: The abstract base from Phase 1 needs a first consumer to validate the shape. The database transport is the highest-value first target — it exercises the hardest concerns (pooling, dialect differences, error wrapping) and is the basis for the EHR DB example. The full implementation is large; this PR ships only the type surface so reviewers can sign off on the shape before engine wiring lands.

## Phase chain context

- **Feature trunk**: `aniruddh-alt/db-executable-env-trunk`
- **Phases merged into trunk**: (none yet)
- **Sibling open phase**: #2467 (Phase 1 — Executable base skeleton). This PR is branched off Phase 1 so the abstract-base imports resolve; will rebase onto the trunk once Phase 1 merges. ⚠️ Phase 1 should land first.
- **This phase**: 2 (Database executable skeleton)
- **Phases remaining**: 3+ TBD (engine + dialect guards + autocommit checkout, error auto-wrap + audit, postgres integration tests, EHR example + e2e)

## What's in this PR (456 lines)

| File | Purpose |
|---|---|
| `src/oumi/core/configs/params/database_connection_params.py` | `DatabaseConnectionConfig` — fields for structured mode (driver / host / port / database / username / `password_env_var`) and DSN mode (`dsn_env_var`), mutually exclusive. Pool sizing and `connect_timeout_s` validation. `resolve_url()` is deferred to the implementation phase (SQLAlchemy dep arrives then). |
| `src/oumi/environments/database_executable_tool.py` | Full small dataclass — adds optional `statement_timeout_ms`. Env-side cross-validation against env-level timeout lives on the env (next phase). |
| `src/oumi/environments/database_executable_environment.py` | Skeleton — `@register_environment("database")`, `_executor_context_kwarg = "db"`, `tool_params_cls = DatabaseExecutableTool`. `from_params` and `_build_execution_context` raise `NotImplementedError` until the engine phase. `DatabaseExecutableEnvironmentKwargs` carries `connection`, `read_only`, `statement_timeout_ms`, `audit`. |
| `src/oumi/environments/__init__.py` | Exports the new types. |
| `tests/unit/environments/test_database_executable_tool.py` | Inherits executor requirement; carries `statement_timeout_ms`; `create()` round-trip. |
| `tests/unit/environments/test_database_executable_environment.py` | `_executor_context_kwarg == "db"`; `from_params` raises `NotImplementedError`; `Kwargs` rejects missing connection and non-positive timeout; connection dict coercion works. |
| `tests/unit/core/configs/params/test_database_connection_params.py` | Structured-XOR-DSN, pool bounds, `connect_timeout_s` bounds. |

## Why a skeleton phase

This PR adds **no runtime dependencies** (no `sqlalchemy`). The skeleton declares the type surface and registers the env type so downstream config code can reference it; the actual engine wiring + dialect guards + error wrapping land in the next phase along with the SQLAlchemy dep.

Each piece has been pre-validated for issues flagged on #2441:
- `DatabaseConnectionConfig` mode XOR is enforced at `finalize_and_validate` time.
- `Kwargs.statement_timeout_ms` rejects non-positive values (one of the liberate-bot HIGH-priority findings on #2441 — a per-tool `0` silently disabling the Postgres timeout). The per-tool side of the same validation lives on `DatabaseExecutableTool` and the env's `_validate_tools` in the implementation phase.

## Related issues

(No associated issue — direct continuation of the work that lived in PR #2441.)

## Before submitting

- [x] Did you add / update tests where needed?
- [x] Did you run the local test suite? `pytest tests/unit/environments/ tests/unit/core/configs/` — 1337 passing on this branch.

