### PR TITLE
fix(deploy/fireworks): demote per-retry upload log to WARNING

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -1139,11 +1139,8 @@ class FireworksDeploymentClient(BaseDeploymentClient):
                 timeout=600,
             )
         if not response.ok:
-            # WARNING, not ERROR: the caller (``_upload_single_file``)
-            # retries up to ``UPLOAD_MAX_RETRIES`` and only the final
-            # exhaustion log is ERROR. A WARNING per intermediate retry
-            # keeps Sentry from fingerprinting each failed PUT into its
-            # own issue.
+            # WARNING per attempt; ``_upload_single_file`` retries and
+            # only the final exhaustion is logged at ERROR.
             logger.warning(
                 "GCS upload failed (HTTP %d, %s %s): %s",
                 response.status_code,
@@ -1217,9 +1214,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
 
             # Failure handling
             error_body = response.text
-            # WARNING per attempt — the loop retries up to ``max_retries``;
-            # the final ERROR below (and the raised exception) signal the
-            # actual failure. See _sync_put_file for the same pattern.
+            # WARNING per attempt; only the final exhaustion below is ERROR.
             logger.warning(
                 "Validation attempt %d/%d failed (HTTP %d): %s",
                 attempt + 1,

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -1139,7 +1139,12 @@ class FireworksDeploymentClient(BaseDeploymentClient):
                 timeout=600,
             )
         if not response.ok:
-            logger.error(
+            # WARNING, not ERROR: the caller (``_upload_single_file``)
+            # retries up to ``UPLOAD_MAX_RETRIES`` and only the final
+            # exhaustion log is ERROR. A WARNING per intermediate retry
+            # keeps Sentry from fingerprinting each failed PUT into its
+            # own issue.
+            logger.warning(
                 "GCS upload failed (HTTP %d, %s %s): %s",
                 response.status_code,
                 response.request.method,
@@ -1212,7 +1217,10 @@ class FireworksDeploymentClient(BaseDeploymentClient):
 
             # Failure handling
             error_body = response.text
-            logger.error(
+            # WARNING per attempt — the loop retries up to ``max_retries``;
+            # the final ERROR below (and the raised exception) signal the
+            # actual failure. See _sync_put_file for the same pattern.
+            logger.warning(
                 "Validation attempt %d/%d failed (HTTP %d): %s",
                 attempt + 1,
                 max_retries,


### PR DESCRIPTION
`_sync_put_file` and `_wait_and_validate` logged each failed attempt at ERROR, but the surrounding loops retry up to `UPLOAD_MAX_RETRIES` / `VALIDATION_MAX_RETRIES` times and only the final exhaustion warrants ERROR. Per-retry ERRORs fan one transient failure into many duplicate log entries — in one case a persistent GCS 403 produced 20 ERRORs per file before the caller gave up.

Intermediate retries are now WARNING. The "All N attempts ... exhausted" log stays ERROR. No behavioral change.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
