### PR TITLE
fix(trainer): preserve _name_or_path in saved config.json

### DIFF
--- a/src/oumi/core/trainers/hf_trainer.py
+++ b/src/oumi/core/trainers/hf_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import pathlib
 from typing import cast
 
@@ -24,6 +25,26 @@ from oumi.core.distributed import is_world_process_zero
 from oumi.core.processors.base_processor import BaseProcessor
 from oumi.core.trainers.base_trainer import BaseTrainer
 from oumi.utils.logging import logger
+
+
+def _patch_name_or_path_in_config(output_dir: str, model_name: str) -> None:
+    """Set ``_name_or_path`` in the saved ``config.json`` if null/missing.
+
+    ``build_huggingface_model`` loads with a pre-instantiated ``hf_config``,
+    which overrides HF's default behavior of populating this field.
+    """
+    config_path = pathlib.Path(output_dir) / "config.json"
+    if not config_path.exists():
+        return
+    try:
+        cfg = json.loads(config_path.read_text())
+    except json.JSONDecodeError:
+        logger.warning(f"Failed to parse {config_path}; skipping _name_or_path patch.")
+        return
+    if cfg.get("_name_or_path"):
+        return
+    cfg["_name_or_path"] = model_name
+    config_path.write_text(json.dumps(cfg, indent=2))
 
 
 class HuggingFaceTrainer(BaseTrainer):
@@ -130,6 +151,8 @@ class HuggingFaceTrainer(BaseTrainer):
             self._processor.save_config(output_dir)
             logger.info(f"Processor config has been saved at {output_dir}")
 
+        _patch_name_or_path_in_config(output_dir, config.model.model_name)
+
     def _save_fsdp_model(self, config: TrainingConfig, final: bool = True) -> None:
         """Saves the model's weights to the specified output directory.
 
@@ -154,6 +177,10 @@ class HuggingFaceTrainer(BaseTrainer):
         if self._processor is not None:
             self._processor.save_config(output_dir)
             logger.info(f"Processor config has been saved at {output_dir}")
+
+        # FSDP path: all ranks call in, but only rank 0 should touch config.json.
+        if is_world_process_zero():
+            _patch_name_or_path_in_config(output_dir, config.model.model_name)
 
     def get_last_eval_metrics(self) -> dict:
         """Gets the last evaluation metrics from the trainer.

--- a/tests/unit/core/trainers/test_hf_trainer.py
+++ b/tests/unit/core/trainers/test_hf_trainer.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``oumi.core.trainers.hf_trainer`` helpers."""
+
+import json
+import pathlib
+
+from oumi.core.trainers.hf_trainer import _patch_name_or_path_in_config
+
+
+def test_patches_null_name_or_path(tmp_path: pathlib.Path) -> None:
+    """Null ``_name_or_path`` is replaced with ``model_name``."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"_name_or_path": None, "architectures": ["Qwen3ForCausalLM"]})
+    )
+
+    _patch_name_or_path_in_config(str(tmp_path), "Qwen/Qwen3-0.6B")
+
+    result = json.loads(config_path.read_text())
+    assert result["_name_or_path"] == "Qwen/Qwen3-0.6B"
+    assert result["architectures"] == ["Qwen3ForCausalLM"]
+
+
+def test_patches_missing_name_or_path(tmp_path: pathlib.Path) -> None:
+    """``_name_or_path`` is added when the key is absent entirely."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"architectures": ["Qwen3ForCausalLM"]}))
+
+    _patch_name_or_path_in_config(str(tmp_path), "Qwen/Qwen3-0.6B")
+
+    result = json.loads(config_path.read_text())
+    assert result["_name_or_path"] == "Qwen/Qwen3-0.6B"
+
+
+def test_preserves_existing_name_or_path(tmp_path: pathlib.Path) -> None:
+    """A non-empty ``_name_or_path`` is left alone."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"_name_or_path": "user/preserved"}))
+
+    _patch_name_or_path_in_config(str(tmp_path), "Qwen/Qwen3-0.6B")
+
+    result = json.loads(config_path.read_text())
+    assert result["_name_or_path"] == "user/preserved"
+
+
+def test_noop_when_config_missing(tmp_path: pathlib.Path) -> None:
+    """Adapter-only save dirs (no ``config.json``) are silently skipped."""
+    _patch_name_or_path_in_config(str(tmp_path), "Qwen/Qwen3-0.6B")
+    assert not (tmp_path / "config.json").exists()
+
+
+def test_noop_on_malformed_config(tmp_path: pathlib.Path) -> None:
+    """A corrupt ``config.json`` is left untouched."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{not valid json")
+
+    _patch_name_or_path_in_config(str(tmp_path), "Qwen/Qwen3-0.6B")
+
+    assert config_path.read_text() == "{not valid json"


### PR DESCRIPTION
## Summary

`save_pretrained` was writing `config.json` with `_name_or_path: null` for Oumi-trained models. Patch the field back after save so downstream consumers can identify the base model.

## Changes

- New `_patch_name_or_path_in_config(output_dir, model_name)` helper in `hf_trainer.py` reads the saved `config.json` and sets `_name_or_path` from `config.model.model_name` when null / missing.
- Called at the end of both `_save_model` and `_save_fsdp_model`. No-ops on adapter-only saves (no `config.json`) and malformed configs.
- Unit tests cover: null value, missing key, existing value preserved, missing file, malformed JSON.

## Root cause

`oumi/builders/models.py:318-328` loads with `from_pretrained(config=hf_config, pretrained_model_name_or_path=..., ...)`. Passing a pre-instantiated `hf_config` overrides HF's default behavior of populating `_name_or_path` from `pretrained_model_name_or_path`.