### PR TITLE
fix(inference/fireworks): map EXPIRED job state to BatchStatus.EXPIRED

### DIFF
--- a/src/oumi/inference/fireworks_inference_engine.py
+++ b/src/oumi/inference/fireworks_inference_engine.py
@@ -56,6 +56,7 @@ class FireworksInferenceEngine(RemoteInferenceEngine):
         "RUNNING": BatchStatus.IN_PROGRESS,
         "COMPLETED": BatchStatus.COMPLETED,
         "FAILED": BatchStatus.FAILED,
+        "EXPIRED": BatchStatus.EXPIRED,
         "CANCELLING": BatchStatus.CANCELLED,
         "CANCELLED": BatchStatus.CANCELLED,
         "DELETING": BatchStatus.CANCELLED,


### PR DESCRIPTION
# Description

Fireworks batch jobs can enter the `EXPIRED` state, but it was missing from `_FIREWORKS_STATE_MAPPING` in `FireworksInferenceEngine`. Unmapped states fall through to `BatchStatus.IN_PROGRESS`, so an expired (terminal) job looked like it was still running and callers would poll indefinitely. This adds the `EXPIRED -> BatchStatus.EXPIRED` mapping so the engine reports the terminal state correctly.

## Related issues

N/A — minor bug fix surfaced while reviewing Fireworks batch state handling.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
