### PR TITLE
feat(deploy): forward idle-window kwargs on Fireworks create_endpoint

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -45,6 +45,7 @@ from oumi.deploy.fireworks_api import (
     BaseModelDetailsCheckpointFormat,
     DeploymentPrecision,
     GatewayAcceleratorType,
+    GatewayAutoscalingPolicy,
     GatewayBaseModelDetails,
     GatewayCreateModelBody,
     GatewayDeployment,
@@ -67,6 +68,32 @@ from oumi.deploy.utils import raise_api_error
 logger = logging.getLogger(__name__)
 
 _MB = 1024 * 1024
+
+
+def _build_autoscaling_policy(
+    scale_down_window_seconds: int | None,
+    scale_to_zero_window_seconds: int | None,
+) -> GatewayAutoscalingPolicy | None:
+    """Builds a ``GatewayAutoscalingPolicy`` when idle-window kwargs are set.
+
+    Returns ``None`` when neither window is set so the request omits
+    ``autoscalingPolicy`` entirely and Fireworks applies its provider default
+    (10min scale-down, 1h scale-to-zero, 5min minimum).
+    """
+    if scale_down_window_seconds is None and scale_to_zero_window_seconds is None:
+        return None
+    return GatewayAutoscalingPolicy(
+        scaleDownWindow=(
+            f"{scale_down_window_seconds}s"
+            if scale_down_window_seconds is not None
+            else None
+        ),
+        scaleToZeroWindow=(
+            f"{scale_to_zero_window_seconds}s"
+            if scale_to_zero_window_seconds is not None
+            else None
+        ),
+    )
 
 
 # Mapping from Oumi-standard accelerator names (lowercase) to Fireworks REST API
@@ -1315,6 +1342,8 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         autoscaling: AutoscalingConfig,
         display_name: str | None = None,
         endpoint_id: str | None = None,
+        scale_down_window_seconds: int | None = None,
+        scale_to_zero_window_seconds: int | None = None,
     ) -> Endpoint:
         """Creates an inference endpoint (deployment) for a model.
 
@@ -1329,6 +1358,11 @@ class FireworksDeploymentClient(BaseDeploymentClient):
                 ``accounts/{account_id}/deployments/{endpoint_id}``. When
                 omitted, Fireworks generates a random ID (the default
                 behavior).
+            scale_down_window_seconds: Idle seconds before removing a replica.
+                ``None`` → Fireworks default (10min).
+            scale_to_zero_window_seconds: Idle seconds before scaling to zero
+                replicas. ``None`` → Fireworks default (1h, 5min minimum).
+                Only meaningful when ``autoscaling.min_replicas == 0``.
 
         Returns:
             Created Endpoint
@@ -1341,6 +1375,9 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             acceleratorCount=hardware.count,
             minReplicaCount=autoscaling.min_replicas,
             maxReplicaCount=autoscaling.max_replicas,
+            autoscalingPolicy=_build_autoscaling_policy(
+                scale_down_window_seconds, scale_to_zero_window_seconds
+            ),
             displayName=display_name,
         )
 

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -296,6 +296,95 @@ class TestFireworksDeploymentClient:
             assert payload["baseModel"] == "model-456"
 
     @pytest.mark.asyncio
+    async def test_create_endpoint_omits_autoscaling_policy_without_idle_fields(
+        self,
+    ):
+        """Idle windows unset → request omits autoscalingPolicy entirely."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "name": "accounts/test-account/deployments/deploy-123",
+            "baseModel": "model-456",
+            "state": "CREATING",
+            "acceleratorType": "NVIDIA_A100_80GB",
+            "acceleratorCount": 1,
+        }
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            await client.create_endpoint(
+                model_id="model-456",
+                hardware=HardwareConfig(accelerator="nvidia_a100_80gb", count=1),
+                autoscaling=AutoscalingConfig(min_replicas=1, max_replicas=1),
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert "autoscalingPolicy" not in payload
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint_sends_idle_windows(self):
+        """Idle-window kwargs serialize as ``"{n}s"`` under autoscalingPolicy."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "name": "accounts/test-account/deployments/deploy-123",
+            "baseModel": "model-456",
+            "state": "CREATING",
+            "acceleratorType": "NVIDIA_A100_80GB",
+            "acceleratorCount": 1,
+        }
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            await client.create_endpoint(
+                model_id="model-456",
+                hardware=HardwareConfig(accelerator="nvidia_a100_80gb", count=1),
+                autoscaling=AutoscalingConfig(min_replicas=0, max_replicas=1),
+                scale_down_window_seconds=600,
+                scale_to_zero_window_seconds=900,
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert payload["autoscalingPolicy"] == {
+                "scaleDownWindow": "600s",
+                "scaleToZeroWindow": "900s",
+            }
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint_sends_only_scale_down_window(self):
+        """Only one idle window set → only that key appears in the payload."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "name": "accounts/test-account/deployments/deploy-123",
+            "baseModel": "model-456",
+            "state": "CREATING",
+            "acceleratorType": "NVIDIA_A100_80GB",
+            "acceleratorCount": 1,
+        }
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            await client.create_endpoint(
+                model_id="model-456",
+                hardware=HardwareConfig(accelerator="nvidia_a100_80gb", count=1),
+                autoscaling=AutoscalingConfig(min_replicas=1, max_replicas=1),
+                scale_down_window_seconds=600,
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert payload["autoscalingPolicy"] == {"scaleDownWindow": "600s"}
+
+    @pytest.mark.asyncio
     async def test_get_endpoint(self):
         """Test get_endpoint fetches and parses correctly."""
         client = FireworksDeploymentClient(api_key="test", account_id="test-account")


### PR DESCRIPTION
## Description

Adds optional `scale_down_window_seconds` and `scale_to_zero_window_seconds` kwargs on `FireworksDeploymentClient.create_endpoint`.

Mirrors Parasail's existing pattern of provider-specific autoscaling kwargs (`scale_down_policy` + `scale_down_threshold_ms`); the shared `AutoscalingConfig` stays minimal (`min_replicas` + `max_replicas`), which is the genuinely common shape.

Fireworks defaults applied when kwargs are omitted: 10min scale-down, 1h scale-to-zero, 5min minimum.

## Related issues

LOU-2152

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
