### PR TITLE
feat(launcher): Add SkyPilot-routed Slurm support as sky-slurm

### DIFF
--- a/docs/user_guides/launch/launch.md
+++ b/docs/user_guides/launch/launch.md
@@ -286,6 +286,39 @@ run: |
 Nebius support is provided through SkyPilot. Enable it the same way as other providers: run `sky check` and follow the instructions for the "Nebius" row (see the [SkyPilot Nebius docs](https://docs.skypilot.co/en/latest/reference/cloud-setup/cloud-permissions/nebius.html)).
 :::
 
+:::{tab-item} Slurm (via SkyPilot)
+````{dropdown} sample-sky-slurm-job.yaml
+```yaml
+name: sample-sky-slurm-job
+
+resources:
+  cloud: sky-slurm
+  region: my-slurm-cluster  # Matches a `Host` entry in ~/.slurm/config
+  zone: gpu                 # Optional Slurm partition (queue)
+  accelerators: "H100:8"
+
+num_nodes: 1
+
+working_dir: .
+
+envs:
+  OUMI_RUN_NAME: sample.sky-slurm.job
+
+setup: |
+  set -e
+  pip install uv && uv pip install --system 'oumi[gpu]'
+
+run: |
+  set -e
+  oumi train -c ./path/to/your/config
+```
+````
+
+`sky-slurm` routes jobs to an existing Slurm cluster via SkyPilot 0.12's Slurm integration. Configure SSH access to the login node in `~/.slurm/config`, then reference the `Host` entry via `region` (and optionally a partition via `zone`). See the [SkyPilot Slurm docs](https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html) for cluster setup.
+
+This is distinct from oumi's native `cloud: slurm`, which talks to Slurm directly via SSH+`sbatch` (see [custom_cluster.md](custom_cluster.md)). Use `sky-slurm` when you want unified handling with other SkyPilot clouds (dashboard, status, log streaming).
+:::
+
 :::{tab-item} Lambda
 ````{dropdown} sample-lambda-job.yaml
 ```yaml

--- a/docs/user_guides/launch/launch.md
+++ b/docs/user_guides/launch/launch.md
@@ -314,9 +314,7 @@ run: |
 ```
 ````
 
-`sky-slurm` routes jobs to an existing Slurm cluster via SkyPilot 0.12's Slurm integration. Configure SSH access to the login node in `~/.slurm/config`, then reference the `Host` entry via `region` (and optionally a partition via `zone`). See the [SkyPilot Slurm docs](https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html) for cluster setup.
-
-This is distinct from oumi's native `cloud: slurm`, which talks to Slurm directly via SSH+`sbatch` (see [custom_cluster.md](custom_cluster.md)). Use `sky-slurm` when you want unified handling with other SkyPilot clouds (dashboard, status, log streaming).
+`sky-slurm` routes jobs to an existing Slurm cluster via SkyPilot. Configure SSH access to the login node in `~/.slurm/config`, then reference the `Host` entry via `region` (and an optional partition via `zone`). See the [SkyPilot Slurm docs](https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html) for cluster setup. Distinct from the native `cloud: slurm` (SSH+`sbatch`); use `sky-slurm` for unified handling with other SkyPilot clouds.
 :::
 
 :::{tab-item} Lambda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "requests>=2.31,<3.0",        # Used by deploy module (GCS upload)
     "responses>=0.25,<0.27",
     "safetensors>=0.6,<0.8",
-    "skypilot>=0.11.1,<0.13", # 0.11.1 includes db locking fix
+    "skypilot>=0.12,<0.13", # 0.12 adds Slurm cloud support
     "tensorboard>=2.20,<2.21", # Optional, for monitoring training
     "tiktoken>=0.7,<1.0",
     "torch>=2.6,<2.13.0",      # vllm only supports up to torch==2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ lambda = ["skypilot[lambda]"]
 modal = ["modal>=0.64,<2"]
 runpod = ["skypilot[runpod]"]
 nebius = ["skypilot[nebius]"]
+slurm = ["skypilot[slurm]"]
 
 synthesis = [
     "pdftext>=0.6.3; python_version >= '3.10'", # Document ingestion for synthesis

--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -48,6 +48,8 @@ def _get_sky_cloud_from_job(job: JobConfig) -> "sky.clouds.Cloud":
         return sky.clouds.Kubernetes()
     elif job.resources.cloud == SkyClient.SupportedClouds.NEBIUS.value:
         return sky.clouds.Nebius()
+    elif job.resources.cloud == SkyClient.SupportedClouds.SLURM.value:
+        return sky.clouds.Slurm()
     raise ValueError(f"Unsupported cloud: {job.resources.cloud}")
 
 
@@ -173,6 +175,7 @@ class SkyClient:
         LAMBDA = "lambda"
         K8S = "k8s"
         NEBIUS = "nebius"
+        SLURM = "sky-slurm"
 
     def __init__(self):
         """Initializes a new instance of the SkyClient class."""

--- a/src/oumi/launcher/clouds/sky_cloud.py
+++ b/src/oumi/launcher/clouds/sky_cloud.py
@@ -94,6 +94,8 @@ class SkyCloud(BaseCloud):
             return self._get_clusters_by_class(sky.clouds.Kubernetes)
         elif self._cloud_name == SkyClient.SupportedClouds.NEBIUS.value:
             return self._get_clusters_by_class(sky.clouds.Nebius)
+        elif self._cloud_name == SkyClient.SupportedClouds.SLURM.value:
+            return self._get_clusters_by_class(sky.clouds.Slurm)
         raise ValueError(f"Unsupported cloud: {self._cloud_name}")
 
 
@@ -137,3 +139,9 @@ def k8s_cloud_builder() -> SkyCloud:
 def nebius_cloud_builder() -> SkyCloud:
     """Builds a SkyCloud instance for Nebius."""
     return SkyCloud(SkyClient.SupportedClouds.NEBIUS.value)
+
+
+@register_cloud_builder("sky-slurm")
+def sky_slurm_cloud_builder() -> SkyCloud:
+    """Builds a SkyCloud instance for SkyPilot-managed Slurm."""
+    return SkyCloud(SkyClient.SupportedClouds.SLURM.value)

--- a/tests/unit/launcher/clients/test_sky_client.py
+++ b/tests/unit/launcher/clients/test_sky_client.py
@@ -91,6 +91,11 @@ def test_sky_client_nebius_name():
     assert client.SupportedClouds.NEBIUS.value == "nebius"
 
 
+def test_sky_client_slurm_name():
+    client = SkyClient()
+    assert client.SupportedClouds.SLURM.value == "sky-slurm"
+
+
 def test_convert_job_to_task(
     mock_sky_data_storage,
 ):

--- a/tests/unit/launcher/clouds/test_sky_cloud.py
+++ b/tests/unit/launcher/clouds/test_sky_cloud.py
@@ -779,3 +779,7 @@ def test_k8s_cloud_builder_registered():
 
 def test_nebius_cloud_builder_registered():
     assert REGISTRY.contains("nebius", RegistryType.CLOUD)
+
+
+def test_sky_slurm_cloud_builder_registered():
+    assert REGISTRY.contains("sky-slurm", RegistryType.CLOUD)


### PR DESCRIPTION
## Description

SkyPilot 0.12 ships native Slurm support via `~/.slurm/config`. This PR wires it into oumi's `SkyCloud` dispatch under a new cloud name `sky-slurm`.

The name avoids a registry collision: oumi already binds `"slurm"` to its native `SlurmCloud` (SSH+`sbatch`), and `register_cloud_builder` rejects duplicates. Using `"sky-slurm"` lets the two coexist — pick the SkyPilot variant when you want unified status/logs/dashboard with the other Sky-based clouds, or the native one for direct `sbatch` against an existing cluster.

Bumps the `skypilot` lower bound to `>=0.12` since `sky.clouds.Slurm` was added in that release.

Used downstream by:
- [oumi-ai/api#4405](https://github.com/oumi-ai/api/pull/4405) — foundation
- [oumi-ai/api#4406](https://github.com/oumi-ai/api/pull/4406) — training dispatch
- [oumi-ai/api#4407](https://github.com/oumi-ai/api/pull/4407) — inference dispatch

## Related issues

N/A — internal request from oumi-ai/api (RunPod Slurm Instant Cluster onboarding).

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?