### PR TITLE
feat(synthesis): accumulate token usage in ConversationSynthesizer

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -83,6 +83,9 @@ class ConversationSynthesizer:
         )
         self._inference_config = inference_config
         self._default_turn_order = [Role.USER, Role.ASSISTANT]
+        self._total_input_tokens: int = 0
+        self._total_output_tokens: int = 0
+        self._total_cached_tokens: int = 0
 
         if (
             self._environment_config is not None
@@ -414,6 +417,29 @@ class ConversationSynthesizer:
 
         return result
 
+    @property
+    def total_input_tokens(self) -> int:
+        """Total input/prompt tokens accumulated across all synthesize() calls."""
+        return self._total_input_tokens
+
+    @property
+    def total_output_tokens(self) -> int:
+        """Total output/completion tokens accumulated across all synthesize() calls."""
+        return self._total_output_tokens
+
+    @property
+    def total_cached_tokens(self) -> int:
+        """Total cached tokens accumulated across all synthesize() calls."""
+        return self._total_cached_tokens
+
+    def _accumulate_token_usage(self, inference_results: list[Conversation]) -> None:
+        """Accumulate token usage from inference response metadata."""
+        for result in inference_results:
+            usage = result.metadata.get("usage", {})
+            self._total_input_tokens += usage.get("prompt_tokens", 0)
+            self._total_output_tokens += usage.get("completion_tokens", 0)
+            self._total_cached_tokens += usage.get("cached_tokens", 0)
+
     def _extract_response(
         self,
         inference_conversations: list[Conversation],
@@ -636,6 +662,7 @@ class ConversationSynthesizer:
             planners,
             inference_config=self._planner_inference_config(),
         )
+        self._accumulate_token_usage(inference_results)
 
         return self._extract_response(inference_results)
 
@@ -749,6 +776,7 @@ class ConversationSynthesizer:
                 prompts,
                 inference_config=self._inference_config,
             )
+            self._accumulate_token_usage(inference_results)
 
             generated_texts = self._extract_response(inference_results)
 
@@ -803,6 +831,7 @@ class ConversationSynthesizer:
             active_prompts,
             inference_config=self._inference_config,
         )
+        self._accumulate_token_usage(results)
         if len(results) != len(active):
             raise RuntimeError(
                 f"Inference engine returned {len(results)} results for "
@@ -848,6 +877,7 @@ class ConversationSynthesizer:
             nudged_prompts,
             inference_config=self._inference_config,
         )
+        self._accumulate_token_usage(results)
         if len(results) != len(stragglers):
             raise RuntimeError(
                 f"Inference engine returned {len(results)} results for "

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2477,3 +2477,65 @@ def test_synthesize_clears_sample_routers_on_exception(
         with pytest.raises(RuntimeError, match="plan boom"):
             synth.synthesize([{"x": 1}], mock_multiturn_attribute)
     assert synth._sample_routers == []
+
+
+# ---------------------------------------------------------------------------
+# Token usage accounting
+# ---------------------------------------------------------------------------
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_token_usage_accumulates_from_inference_metadata(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+    mock_inference_config,
+):
+    """Token counts accumulate from inference response usage metadata.
+
+    Mirrors AttributeSynthesizer's token accounting: every infer() result
+    carries usage metadata, and the synthesizer must sum it across the
+    planner and per-turn calls so downstream consumers can bill multi-turn
+    conversations.
+    """
+    mock_engine = Mock()
+    mock_build_inference_engine.return_value = mock_engine
+
+    def infer_side_effect(conversations, **kwargs):
+        return [
+            Conversation(
+                messages=[Message(role=Role.ASSISTANT, content="Response")],
+                metadata={
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 4,
+                        "cached_tokens": 1,
+                    }
+                },
+            )
+            for _ in conversations
+        ]
+
+    mock_engine.infer.side_effect = infer_side_effect
+
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    assert synth.total_input_tokens == 0
+    assert synth.total_output_tokens == 0
+    assert synth.total_cached_tokens == 0
+
+    synth.synthesize(
+        [{"customer_type": "frustrated", "issue": "billing"}],
+        mock_multiturn_attribute,
+    )
+
+    assert synth.total_input_tokens > 0
+    assert synth.total_output_tokens > 0
+    assert synth.total_cached_tokens > 0
+    # Counts are consistent: cached <= input, and the ratios match the per-call
+    # metadata (10 prompt : 4 completion : 1 cached).
+    assert synth.total_output_tokens * 10 == synth.total_input_tokens * 4
+    assert synth.total_cached_tokens * 10 == synth.total_input_tokens * 1

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2532,10 +2532,84 @@ def test_token_usage_accumulates_from_inference_metadata(
         mock_multiturn_attribute,
     )
 
-    assert synth.total_input_tokens > 0
-    assert synth.total_output_tokens > 0
-    assert synth.total_cached_tokens > 0
-    # Counts are consistent: cached <= input, and the ratios match the per-call
-    # metadata (10 prompt : 4 completion : 1 cached).
-    assert synth.total_output_tokens * 10 == synth.total_input_tokens * 4
-    assert synth.total_cached_tokens * 10 == synth.total_input_tokens * 1
+    # Assert exact totals, not just ratios. With a single sample every infer()
+    # returns exactly one result, and each accumulate site adds the same usage,
+    # so the totals must equal the number of infer() calls times the per-call
+    # usage. A ratio-only check is scale-invariant — it would still pass if some
+    # accumulate sites were deleted (totals shrink but ratios hold); tying the
+    # totals to infer.call_count catches a missing site.
+    calls = mock_engine.infer.call_count
+    assert calls > 0
+    assert synth.total_input_tokens == calls * 10
+    assert synth.total_output_tokens == calls * 4
+    assert synth.total_cached_tokens == calls * 1
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_token_usage_accumulates_in_straggler_finalization(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_inference_config,
+):
+    """Straggler-finalization inference is also counted.
+
+    With ``max_consecutive_tool_turns=0`` the assistant agentic loop never runs
+    a tool round, so the assistant turn is forced down the
+    ``_finalize_stragglers`` path — the fourth accumulate site, which the
+    happy-path test above does not reach (no stragglers there). The exact-total
+    check fails if that site does not accumulate.
+    """
+    mock_engine = Mock()
+    mock_build_inference_engine.return_value = mock_engine
+
+    def infer_side_effect(conversations, **kwargs):
+        return [
+            Conversation(
+                messages=[Message(role=Role.ASSISTANT, content="Response")],
+                metadata={
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 4,
+                        "cached_tokens": 1,
+                    }
+                },
+            )
+            for _ in conversations
+        ]
+
+    mock_engine.infer.side_effect = infer_side_effect
+
+    # min == max == 2 makes the turn order deterministic (USER then ASSISTANT);
+    # max_consecutive_tool_turns=0 routes the ASSISTANT turn through
+    # _finalize_stragglers instead of a tool round.
+    multiturn_attr = MultiTurnAttribute(
+        id="straggler_conversation",
+        min_turns=2,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        max_consecutive_tool_turns=0,
+    )
+
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    result = synth.synthesize([{}], multiturn_attr)
+
+    # The straggler turn produced a (non-filtered) assistant message...
+    record = result[0]
+    assert record is not None
+    conversation = record[multiturn_attr.id]
+    assert isinstance(conversation, dict)
+    roles = [message["role"] for message in conversation["messages"]]
+    assert "assistant" in roles
+    # ...and its inference tokens were counted along with every other call.
+    calls = mock_engine.infer.call_count
+    assert calls > 0
+    assert synth.total_input_tokens == calls * 10
+    assert synth.total_output_tokens == calls * 4
+    assert synth.total_cached_tokens == calls * 1


### PR DESCRIPTION
Mirrors `AttributeSynthesizer`'s token accounting so multi-turn synthesis is symmetric with single-turn.

## What changed
- Adds `_total_input_tokens` / `_total_output_tokens` / `_total_cached_tokens` counters in `__init__`.
- Adds `total_input_tokens` / `total_output_tokens` / `total_cached_tokens` properties and an `_accumulate_token_usage()` helper (copied verbatim from `AttributeSynthesizer` so the two synthesizers match).
- Calls `_accumulate_token_usage()` after all **four** `infer()` call sites: the planner (`_generate_plan`), per-turn user generation (`_synthesize_all_samples`), the assistant tool-loop round (`_run_assistant_tool_round`), and straggler finalization (`_finalize_stragglers`).

## Why
`ConversationSynthesizer` previously did not count inference tokens, so downstream consumers (enterprise worker, CLI, anyone reading these synthesizers) saw zero tokens for multi-turn conversations — causing silent under-billing.

## Tests
TDD: added `test_token_usage_accumulates_from_inference_metadata` (failed before, passes after). Full file: 68 passed.