### PR TITLE
refactor(launcher): SlurmClient.get_job uses squeue + scontrol directly

### DIFF
--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -108,6 +108,47 @@ def _is_job_done(job_state: JobState) -> bool:
     )
 
 
+def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
+    """Parses one row of ``squeue --noheader --format='%i %j %u %T %R'``."""
+    parts = line.strip().split(None, 4)
+    if len(parts) < 4:
+        return None
+    job_id, name, _user, raw_state = parts[0], parts[1], parts[2], parts[3]
+    state = _get_job_state(raw_state)
+    return JobStatus(
+        id=job_id,
+        name=name,
+        status=raw_state,
+        cluster=cluster_name,
+        metadata=line,
+        done=_is_job_done(state),
+        state=state,
+    )
+
+
+def _parse_scontrol_show_job(output: str, cluster_name: str) -> JobStatus | None:
+    """Parses ``scontrol show job <id>`` output into a JobStatus."""
+    fields: dict[str, str] = {}
+    for line in output.split("\n"):
+        for kv in line.strip().split(" "):
+            if "=" in kv:
+                key, value = kv.split("=", 1)
+                fields.setdefault(key, value)
+    if "JobId" not in fields or "JobState" not in fields:
+        return None
+    raw_state = fields["JobState"]
+    state = _get_job_state(raw_state)
+    return JobStatus(
+        id=fields["JobId"],
+        name=fields.get("JobName", ""),
+        status=raw_state,
+        cluster=cluster_name,
+        metadata=output,
+        done=_is_job_done(state),
+        state=state,
+    )
+
+
 def _split_status_line(
     line: str, column_lengths: list[int], cluster_name: str, metadata: str
 ) -> JobStatus:
@@ -656,8 +697,37 @@ class SlurmClient:
             jobs.append(status)
         return jobs
 
+    def _list_active_jobs_squeue(self) -> list[JobStatus]:
+        """Lists active jobs via ``squeue``."""
+        command = f"squeue --user={self._user} --noheader --format='%i %j %u %T %R'"
+        result = self.run_commands([command])
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"Failed to list jobs via squeue. stderr: {result.stderr}"
+            )
+        jobs: list[JobStatus] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            status = _parse_squeue_line(line, self._cluster_name)
+            if status is not None:
+                jobs.append(status)
+        return jobs
+
+    def _scontrol_get_job(self, job_id: str) -> JobStatus | None:
+        """Looks up a single job via ``scontrol show job <id>``."""
+        command = f"scontrol show job {job_id}"
+        result = self.run_commands([command])
+        if result.exit_code != 0:
+            return None
+        return _parse_scontrol_show_job(result.stdout, self._cluster_name)
+
     def get_job(self, job_id: str) -> JobStatus | None:
         """Gets the specified job's status.
+
+        Queries ``squeue`` for active jobs, then falls back to
+        ``scontrol show job`` for jobs that have left the queue but
+        are still retained by ``slurmctld`` (per ``MinJobAge``).
 
         Args:
             job_id: The ID of the job to get.
@@ -665,11 +735,10 @@ class SlurmClient:
         Returns:
             The job status if found, None otherwise.
         """
-        job_list = self.list_jobs()
-        for job in job_list:
+        for job in self._list_active_jobs_squeue():
             if job.id == job_id:
                 return job
-        return None
+        return self._scontrol_get_job(job_id)
 
     def get_latest_job(self) -> JobStatus | None:
         """Gets the most recent job on this cluster."""

--- a/src/oumi/launcher/clusters/slurm_cluster.py
+++ b/src/oumi/launcher/clusters/slurm_cluster.py
@@ -206,11 +206,11 @@ class SlurmCluster(BaseCluster):
         return self._connection.name
 
     def get_job(self, job_id: str) -> JobStatus | None:
-        """Gets the jobs on this cluster if it exists, else returns None."""
-        for job in self.get_jobs():
-            if job.id == job_id:
-                return job
-        return None
+        """Gets the job's status if it exists on this cluster, else returns None."""
+        status = self._client.get_job(job_id)
+        if status is not None:
+            status.cluster = self._connection.name
+        return status
 
     def get_jobs(self) -> list[JobStatus]:
         """Lists the jobs on this cluster."""

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
-from oumi.core.launcher import JobState, JobStatus
+from oumi.core.launcher import JobState
 from oumi.launcher.clients.slurm_client import SlurmClient
 
 _CTRL_PATH: str = "-S ~/.ssh/control-%h-%p-%r"
@@ -421,197 +421,134 @@ def test_slurm_client_list_jobs_failure(mock_subprocess):
     )
 
 
-def test_slurm_client_get_job_success(mock_subprocess):
-    mock_run = Mock()
-    mock_subprocess.run.return_value = mock_run
-    mock_run.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run.stderr = b"foo"
-    mock_run.returncode = 0
-
-    client = SlurmClient("user", "host", "cluster_name")
-    job_status = client.get_job("6")
-    mock_subprocess.run.assert_called_with(
-        _run_commands_template(
-            [
-                _SACCT_CMD,
-            ]
-        ),
-        shell=True,
-        capture_output=True,
-        timeout=180,
-    )
-    expected_status = JobStatus(
-        id="6",
-        name="test",
-        status="COMPLETED",
-        cluster="cluster_name",
-        metadata=(
-            "JobID                                                 JobName                           User                          State                         Reason\n"  # noqa: E501
-            "------------------------------ ------------------------------ ------------------------------ ------------------------------ ------------------------------\n"  # noqa: E501
-            "                             6                           test                         taenin                      COMPLETED                           None"  # noqa: E501
-        ),
-        done=True,
-        state=JobState.SUCCEEDED,
-    )
-    assert job_status == expected_status
+def _mock_refresh_creds_run() -> Mock:
+    """Mock for the ``ssh -O check`` that ``@retry_auth`` runs before each command."""
+    r = Mock()
+    r.stdout = b""
+    r.stderr = b""
+    r.returncode = 0
+    return r
 
 
-def test_slurm_client_get_job_success_one_job(mock_subprocess):
-    data = _get_test_data("sacct.txt").encode("utf-8")
-    data = b"\n".join(data.split(b"\n")[:3])
-    mock_run = Mock()
-    mock_subprocess.run.return_value = mock_run
-    mock_run.stdout = data
-    mock_run.stderr = b"foo"
-    mock_run.returncode = 0
+def test_slurm_client_get_job_returns_active_job_from_squeue(mock_subprocess):
+    squeue_ok = Mock()
+    squeue_ok.stdout = b"100 myjob user RUNNING node-1\n"
+    squeue_ok.stderr = b""
+    squeue_ok.returncode = 0
 
-    client = SlurmClient("user", "host", "cluster_name")
-    job_status = client.get_job("6")
-    mock_subprocess.run.assert_called_with(
-        _run_commands_template(
-            [
-                _SACCT_CMD,
-            ]
-        ),
-        shell=True,
-        capture_output=True,
-        timeout=180,
-    )
-    expected_status = JobStatus(
-        id="6",
-        name="test",
-        status="COMPLETED",
-        cluster="cluster_name",
-        metadata=(
-            "JobID                                                 JobName                           User                          State                         Reason\n"  # noqa: E501
-            "------------------------------ ------------------------------ ------------------------------ ------------------------------ ------------------------------\n"  # noqa: E501
-            "                             6                           test                         taenin                      COMPLETED                           None"  # noqa: E501
-        ),
-        done=True,
-        state=JobState.SUCCEEDED,
-    )
-    assert job_status == expected_status
-
-
-def test_slurm_client_get_job_not_found(mock_subprocess):
-    mock_run = Mock()
-    mock_subprocess.run.return_value = mock_run
-    mock_run.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run.stderr = b"foo"
-    mock_run.returncode = 0
-    client = SlurmClient("user", "host", "cluster_name")
-    job_status = client.get_job("2017652")
-    mock_subprocess.run.assert_called_with(
-        _run_commands_template([_SACCT_CMD]),
-        shell=True,
-        capture_output=True,
-        timeout=180,
-    )
-    assert job_status is None
-
-
-def test_slurm_client_get_job_not_found_empty(mock_subprocess):
-    data = _get_test_data("sacct.txt").encode("utf-8")
-    data = b"\n".join(data.split(b"\n")[:2])
-    mock_run = Mock()
-    mock_subprocess.run.return_value = mock_run
-    mock_run.stdout = data
-    mock_run.stderr = b"foo"
-    mock_run.returncode = 0
-
-    client = SlurmClient("user", "host", "cluster_name")
-    job_status = client.get_job("6")
-    mock_subprocess.run.assert_called_with(
-        _run_commands_template([_SACCT_CMD]),
-        shell=True,
-        capture_output=True,
-        timeout=180,
-    )
-    assert job_status is None
-
-
-def test_slurm_client_get_job_failure(mock_subprocess):
-    mock_success_run = Mock()
-    mock_success_run.stdout = b"out"
-    mock_success_run.stderr = b"err"
-    mock_success_run.returncode = 0
-    mock_run = Mock()
     mock_subprocess.run.side_effect = [
-        mock_success_run,
-        mock_success_run,
-        mock_run,
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_ok,
     ]
-    mock_run.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run.stderr = b"foo"
-    mock_run.returncode = 1
+
     client = SlurmClient("user", "host", "cluster_name")
-    with pytest.raises(RuntimeError, match="Failed to list jobs. stderr: foo"):
-        _ = client.get_job("2017652")
-    mock_subprocess.run.assert_called_with(
-        _run_commands_template([_SACCT_CMD]),
-        shell=True,
-        capture_output=True,
-        timeout=180,
+    job_status = client.get_job("100")
+
+    assert job_status is not None
+    assert job_status.id == "100"
+    assert job_status.state == JobState.RUNNING
+
+
+def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
+    mock_subprocess,
+):
+    squeue_empty = Mock()
+    squeue_empty.stdout = b""
+    squeue_empty.stderr = b""
+    squeue_empty.returncode = 0
+
+    scontrol_ok = Mock()
+    scontrol_ok.stdout = (
+        b"JobId=100 JobName=myjob\n"
+        b"   UserId=user(1000) GroupId=user(1000) MCS_label=N/A\n"
+        b"   JobState=COMPLETED Reason=None Dependency=(null)\n"
     )
+    scontrol_ok.stderr = b""
+    scontrol_ok.returncode = 0
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_empty,
+        _mock_refresh_creds_run(),
+        scontrol_ok,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    job_status = client.get_job("100")
+
+    assert job_status is not None
+    assert job_status.id == "100"
+    assert job_status.state == JobState.SUCCEEDED
+    assert job_status.done is True
+
+
+def test_slurm_client_get_job_returns_none_when_purged(mock_subprocess):
+    squeue_empty = Mock()
+    squeue_empty.stdout = b""
+    squeue_empty.stderr = b""
+    squeue_empty.returncode = 0
+
+    scontrol_fail = Mock()
+    scontrol_fail.stdout = b""
+    scontrol_fail.stderr = b"slurm_load_jobs error: Invalid job id specified\n"
+    scontrol_fail.returncode = 1
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_empty,
+        _mock_refresh_creds_run(),
+        scontrol_fail,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    assert client.get_job("999") is None
+
+
+def test_slurm_client_get_job_squeue_failure_raises(mock_subprocess):
+    squeue_fail = Mock()
+    squeue_fail.stdout = b""
+    squeue_fail.stderr = b"squeue: error: connection refused\n"
+    squeue_fail.returncode = 1
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_fail,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    with pytest.raises(RuntimeError, match="Failed to list jobs via squeue"):
+        _ = client.get_job("100")
 
 
 def test_slurm_client_cancel_success(mock_subprocess):
-    mock_run2 = Mock()
-    mock_run2.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run2.stderr = b"foo"
-    mock_run2.returncode = 0
-    mock_subprocess.run.return_value = mock_run2
+    scancel_ok = Mock()
+    scancel_ok.stdout = b""
+    scancel_ok.stderr = b""
+    scancel_ok.returncode = 0
+
+    squeue_ok = Mock()
+    squeue_ok.stdout = b"7.batch batch user RUNNING node-1\n"
+    squeue_ok.stderr = b""
+    squeue_ok.returncode = 0
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        scancel_ok,
+        _mock_refresh_creds_run(),
+        squeue_ok,
+    ]
 
     client = SlurmClient("user", "host", "cluster_name")
     job_status = client.cancel("7.batch")
-    mock_subprocess.run.assert_has_calls(
-        [
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template(["scancel 7.batch"]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template([_SACCT_CMD]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-        ]
-    )
-    expected_status = JobStatus(
-        id="7.batch",
-        name="batch",
-        status="RUNNING",
-        cluster="cluster_name",
-        metadata=(
-            "JobID                                                 JobName                           User                          State                         Reason\n"  # noqa: E501
-            "------------------------------ ------------------------------ ------------------------------ ------------------------------ ------------------------------\n"  # noqa: E501
-            "                       7.batch                          batch                                                       RUNNING"  # noqa: E501
-        ),
-        done=False,
-        state=JobState.RUNNING,
-    )
-    assert job_status == expected_status
+
+    assert job_status is not None
+    assert job_status.id == "7.batch"
+    assert job_status.state == JobState.RUNNING
 
 
 def test_slurm_client_cancel_scancel_failure(mock_subprocess):
@@ -643,104 +580,58 @@ def test_slurm_client_cancel_scancel_failure(mock_subprocess):
     )
 
 
-def test_slurm_client_cancel_sacct_failure(mock_subprocess):
-    mock_run1 = Mock()
-    mock_run1.stdout = b""
-    mock_run1.stderr = b""
-    mock_run1.returncode = 0
-    mock_run2 = Mock()
-    mock_run2.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run2.stderr = b"foo"
-    mock_run2.returncode = 1
+def test_slurm_client_cancel_squeue_failure(mock_subprocess):
+    scancel_ok = Mock()
+    scancel_ok.stdout = b""
+    scancel_ok.stderr = b""
+    scancel_ok.returncode = 0
+
+    squeue_fail = Mock()
+    squeue_fail.stdout = b""
+    squeue_fail.stderr = b"foo"
+    squeue_fail.returncode = 1
+
     mock_subprocess.run.side_effect = [
-        mock_run1,
-        mock_run1,
-        mock_run1,
-        mock_run1,
-        mock_run2,
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        scancel_ok,
+        _mock_refresh_creds_run(),
+        squeue_fail,
     ]
-    with pytest.raises(RuntimeError, match="Failed to list jobs. stderr: foo"):
+
+    with pytest.raises(RuntimeError, match="Failed to list jobs via squeue"):
         client = SlurmClient("user", "host", "cluster_name")
         _ = client.cancel("2017652")
-    mock_subprocess.run.assert_has_calls(
-        [
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template(["scancel 2017652"]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template([_SACCT_CMD]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-        ]
-    )
 
 
 def test_slurm_client_cancel_job_not_found_success(mock_subprocess):
-    mock_run2 = Mock()
-    mock_run2.stdout = _get_test_data("sacct.txt").encode("utf-8")
-    mock_run2.stderr = b"foo"
-    mock_run2.returncode = 0
-    mock_subprocess.run.return_value = mock_run2
+    scancel_ok = Mock()
+    scancel_ok.stdout = b""
+    scancel_ok.stderr = b""
+    scancel_ok.returncode = 0
+
+    squeue_empty = Mock()
+    squeue_empty.stdout = b""
+    squeue_empty.stderr = b""
+    squeue_empty.returncode = 0
+
+    scontrol_fail = Mock()
+    scontrol_fail.stdout = b""
+    scontrol_fail.stderr = b"slurm_load_jobs error: Invalid job id specified\n"
+    scontrol_fail.returncode = 1
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        scancel_ok,
+        _mock_refresh_creds_run(),
+        squeue_empty,
+        _mock_refresh_creds_run(),
+        scontrol_fail,
+    ]
+
     client = SlurmClient("user", "host", "cluster_name")
-    job_status = client.cancel("2017652")
-    mock_subprocess.run.assert_has_calls(
-        [
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template(["scancel 2017652"]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-            call(
-                "ssh -S ~/.ssh/control-%h-%p-%r -O check user@host",
-                shell=True,
-                capture_output=True,
-                timeout=10,
-            ),
-            call(
-                _run_commands_template([_SACCT_CMD]),
-                shell=True,
-                capture_output=True,
-                timeout=180,
-            ),
-        ]
-    )
-    assert job_status is None
+    assert client.cancel("2017652") is None
 
 
 def test_slurm_client_run_commands_success(mock_subprocess):

--- a/tests/unit/launcher/clusters/test_slurm_cluster.py
+++ b/tests/unit/launcher/clusters/test_slurm_cluster.py
@@ -15,7 +15,9 @@ from oumi.launcher.clusters.slurm_cluster import SlurmCluster
 #
 @pytest.fixture
 def mock_slurm_client():
-    yield Mock(spec=SlurmClient)
+    client = Mock(spec=SlurmClient)
+    client.get_job.return_value = None
+    yield client
 
 
 @pytest.fixture
@@ -163,84 +165,44 @@ def test_slurm_cluster_name(mock_datetime, mock_slurm_client):
 
 def test_slurm_cluster_get_job_valid_id(mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("debug@host", mock_slurm_client)
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="myjob",
-            name="some name",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="job2",
-            name="some",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="final job",
-            name="name3",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="myjob",
+        name="some name",
+        status="running",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     job = cluster.get_job("myjob")
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_once_with("myjob")
     assert job is not None
     assert job.id == "myjob"
     assert job.cluster == "debug@host"
 
 
-def test_slurm_cluster_get_job_invalid_id_empty(mock_datetime, mock_slurm_client):
+def test_slurm_cluster_get_job_not_found(mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("debug@host", mock_slurm_client)
-    mock_slurm_client.list_jobs.return_value = []
     job = cluster.get_job("myjob")
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_once_with("myjob")
     assert job is None
 
 
-def test_slurm_cluster_get_job_invalid_id_nonempty(mock_datetime, mock_slurm_client):
+def test_slurm_cluster_get_job_found(mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("debug@host", mock_slurm_client)
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="myjob",
-            name="some name",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="job2",
-            name="some",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="final job",
-            name="name3",
-            status="running",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        ),
-    ]
-    job = cluster.get_job("wrong job")
-    mock_slurm_client.list_jobs.assert_called_once_with()
-    assert job is None
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="myjob",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="",
+        done=False,
+        state=JobState.RUNNING,
+    )
+    job = cluster.get_job("myjob")
+    assert job is not None
+    assert job.id == "myjob"
+    assert job.cluster == "debug@host"
 
 
 def test_slurm_cluster_get_jobs_nonempty(mock_datetime, mock_slurm_client):
@@ -319,35 +281,15 @@ def test_slurm_cluster_get_jobs_empty(mock_datetime, mock_slurm_client):
 
 def test_slurm_cluster_cancel_job(mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("prod@host", mock_slurm_client)
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="myjob",
-            name="some name",
-            status="running",
-            metadata="",
-            cluster="debug@host",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="job2",
-            name="some",
-            status="running",
-            metadata="",
-            cluster="debug@host",
-            done=False,
-            state=JobState.PENDING,
-        ),
-        JobStatus(
-            id="final job",
-            name="name3",
-            status="running",
-            metadata="",
-            cluster="debug@host",
-            done=False,
-            state=JobState.PENDING,
-        ),
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="job2",
+        name="some",
+        status="running",
+        metadata="",
+        cluster="debug@host",
+        done=False,
+        state=JobState.PENDING,
+    )
     job_status = cluster.cancel_job("job2")
     expected_status = JobStatus(
         id="job2",
@@ -387,17 +329,15 @@ def test_slurm_cluster_run_job(mock_datetime, mock_slurm_client):
     mock_successful_cmd.exit_code = 0
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -443,7 +383,7 @@ def test_slurm_cluster_run_job(mock_datetime, mock_slurm_client):
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
@@ -453,17 +393,15 @@ def test_slurm_cluster_run_job_no_working_dir(mock_datetime, mock_slurm_client):
     mock_successful_cmd.exit_code = 0
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -498,7 +436,7 @@ def test_slurm_cluster_run_job_no_working_dir(mock_datetime, mock_slurm_client):
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
@@ -518,30 +456,18 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
     ]
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.side_effect = [
-        [],
-        [
-            JobStatus(
-                id="1",
-                name="some name",
-                status="RUNNING",
-                metadata="",
-                cluster="mycluster",
-                done=False,
-                state=JobState.PENDING,
-            )
-        ],
-        [
-            JobStatus(
-                id="1234",
-                name="some name",
-                status="RUNNING",
-                metadata="",
-                cluster="mycluster",
-                done=False,
-                state=JobState.PENDING,
-            )
-        ],
+    mock_slurm_client.get_job.side_effect = [
+        None,
+        None,
+        JobStatus(
+            id="1234",
+            name="some name",
+            status="RUNNING",
+            metadata="",
+            cluster="mycluster",
+            done=False,
+            state=JobState.PENDING,
+        ),
     ]
     expected_status = JobStatus(
         id="1234",
@@ -588,7 +514,9 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_has_calls([call(), call(), call()])
+    mock_slurm_client.get_job.assert_has_calls(
+        [call("1234"), call("1234"), call("1234")]
+    )
     mock_time.sleep.assert_has_calls([call(5), call(5)])
     assert job_status == expected_status
 
@@ -599,17 +527,15 @@ def test_slurm_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -661,7 +587,7 @@ def test_slurm_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
         2,
         name="1-2-3",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
@@ -671,17 +597,15 @@ def test_slurm_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -721,7 +645,7 @@ def test_slurm_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
@@ -731,17 +655,15 @@ def test_slurm_cluster_run_job_no_pbs(mock_datetime, mock_slurm_client):
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -779,7 +701,7 @@ def test_slurm_cluster_run_job_no_pbs(mock_datetime, mock_slurm_client):
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
@@ -789,17 +711,15 @@ def test_slurm_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
     mock_slurm_client.run_commands.return_value = mock_successful_cmd
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "1234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="some name",
+        status="RUNNING",
+        metadata="",
+        cluster="mycluster",
+        done=False,
+        state=JobState.PENDING,
+    )
     expected_status = JobStatus(
         id="1234",
         name="some name",
@@ -837,24 +757,14 @@ def test_slurm_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
         2,
         name="myjob",
     )
-    mock_slurm_client.list_jobs.assert_called_once_with()
+    mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
 
 
 def test_slurm_cluster_run_job_fails(mock_time, mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("debug@host", mock_slurm_client)
     mock_slurm_client.submit_job.return_value = "234"
-    mock_slurm_client.list_jobs.return_value = [
-        JobStatus(
-            id="1234",
-            name="some name",
-            status="RUNNING",
-            metadata="",
-            cluster="mycluster",
-            done=False,
-            state=JobState.PENDING,
-        )
-    ]
+    # get_job returns None for the submitted id — fixture default already covers this.
     with pytest.raises(RuntimeError):
         _ = cluster.run_job(_get_default_job("slurm"))
     mock_time.sleep.assert_has_calls([call(5), call(5), call(5)])


### PR DESCRIPTION
## Summary

Refactors `SlurmClient.get_job(id)` to use `squeue` + `scontrol` directly

## What changes

- `SlurmClient.get_job(id)`:
  - **Active jobs:** `squeue --user=X --noheader --format='%i %j %u %T %R'`
  - **Recently-finished jobs:** `scontrol show job <id>` (retained by `slurmctld` for `MinJobAge` seconds — default 300, commonly raised to 86400 in production)
- `SlurmCluster.get_job(id)` now delegates directly to `SlurmClient.get_job` instead of iterating `get_jobs()`

## Why

- Works on clusters without `slurmdbd` (e.g. RunPod Instant Clusters)
- More real-time than `sacct` (which lags `slurmdbd` flush interval, typically 1-5 min) on clusters that do have it
- Smaller code surface — no `sacct`-detection branching

For terminal-state retention past `MinJobAge`, the cluster admin sets `MinJobAge` to a larger value (e.g. 86400 = 24h). No code-side fallback needed.

## Diff

Net **-130 lines** — much of the savings from removing now-redundant sacct-based test setup.

```
 src/oumi/launcher/clients/slurm_client.py          |  75 ++-
 src/oumi/launcher/clusters/slurm_cluster.py        |  10 +-
 tests/unit/launcher/clients/test_slurm_client.py   | 405 +++++++-------------
 tests/unit/launcher/clusters/test_slurm_cluster.py | 320 +++++-----------
 4 files changed, 340 insertions(+), 470 deletions(-)
```

## Tests

64 SlurmClient + SlurmCluster tests pass, including 4 new tests covering the squeue + scontrol paths.

## Compat

`list_jobs()` semantics unchanged. Users with `slurmdbd` see no behavior difference there.

`get_job(id)` is now more real-time (squeue vs. sacct's flush-interval lag) and works on clusters without `slurmdbd`. Behavioral change: previously, calling `get_job` for a job that had been purged from `slurmctld` but was still in `sacct` would return the historical record; now it returns `None`. In practice, polling loops call `get_job` frequently enough that the active job is always caught by squeue or scontrol.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
