### PR TITLE
feat(launcher): Forward JobResources.accelerators/cpus/memory to sbatch

### DIFF
--- a/src/oumi/launcher/clusters/slurm_cluster.py
+++ b/src/oumi/launcher/clusters/slurm_cluster.py
@@ -22,8 +22,7 @@ from functools import reduce
 from pathlib import Path
 from typing import Any
 
-from oumi.core.configs import JobConfig
-from oumi.core.configs.job_config import JobResources
+from oumi.core.configs import JobConfig, JobResources
 from oumi.core.launcher import BaseCluster, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient, SlurmLogStream
 from oumi.utils.logging import logger
@@ -107,6 +106,13 @@ def _parse_accelerators_to_gres(accelerators: str | None) -> str | None:
     cluster only has untyped GRES configured, the user can pass ``":8"``
     or ``"8"`` to skip the type.
 
+    Args:
+        accelerators: The oumi accelerator string, e.g. ``"H100:8"``.
+
+    Returns:
+        The ``--gres`` value (e.g. ``"gpu:H100:8"``, ``"gpu:8"``), or
+        ``None`` if ``accelerators`` is unset.
+
     Examples:
         ``"H100:8"``      -> ``"gpu:H100:8"``
         ``"H100"``        -> ``"gpu:H100:1"``
@@ -130,7 +136,15 @@ def _parse_accelerators_to_gres(accelerators: str | None) -> str | None:
 
 
 def _strip_modifier(value: str | None) -> str | None:
-    """Strips the SkyPilot ``+`` modifier from a numeric resource string."""
+    """Strips the SkyPilot ``+`` modifier from a numeric resource string.
+
+    Args:
+        value: A string like ``"4"``, ``"4+"``, or ``None``.
+
+    Returns:
+        The numeric string with any trailing ``+`` removed, or ``None``
+        if the input was ``None`` or empty after stripping.
+    """
     if value is None:
         return None
     stripped = value.rstrip("+").strip()
@@ -145,9 +159,15 @@ def _resources_to_sbatch_kwargs(resources: JobResources) -> dict[str, Any]:
     (e.g. ``cpus_per_task``); :meth:`SlurmClient.submit_job` converts
     them to ``--cpus-per-task`` automatically.
 
-    Return type is ``dict[str, Any]`` because :meth:`SlurmClient.submit_job`
+    The return type is ``dict[str, Any]`` because :meth:`SlurmClient.submit_job`
     has typed kwargs (e.g. ``ntasks: int``) that ``**``-unpacking could
     collide with; ``Any`` lets the call type-check.
+
+    Args:
+        resources: The job's resource request.
+
+    Returns:
+        Kwargs to pass to :meth:`SlurmClient.submit_job`.
     """
     kwargs: dict[str, Any] = {}
     gres = _parse_accelerators_to_gres(resources.accelerators)

--- a/src/oumi/launcher/clusters/slurm_cluster.py
+++ b/src/oumi/launcher/clusters/slurm_cluster.py
@@ -120,13 +120,15 @@ def _parse_accelerators_to_gres(accelerators: str | None) -> str | None:
         ``":8"``          -> ``"gpu:8"`` (untyped count)
         ``"8"``           -> ``"gpu:8"`` (untyped count)
     """
-    if not accelerators:
+    spec = _strip_modifier(accelerators)
+    if not spec:
         return None
-    spec = accelerators.strip()
     if ":" in spec:
         gpu_type, _, count = spec.partition(":")
         gpu_type = gpu_type.strip()
-        count = count.strip() or "1"
+        # Count may still carry a SkyPilot ``+`` if it came after the colon
+        # (e.g. ``"H100:8+"``). Strip it before formatting.
+        count = _strip_modifier(count) or "1"
         if gpu_type:
             return f"gpu:{gpu_type}:{count}"
         return f"gpu:{count}"
@@ -147,7 +149,7 @@ def _strip_modifier(value: str | None) -> str | None:
     """
     if value is None:
         return None
-    stripped = value.rstrip("+").strip()
+    stripped = value.strip().rstrip("+").strip()
     return stripped or None
 
 

--- a/src/oumi/launcher/clusters/slurm_cluster.py
+++ b/src/oumi/launcher/clusters/slurm_cluster.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from oumi.core.configs import JobConfig
+from oumi.core.configs.job_config import JobResources
 from oumi.core.launcher import BaseCluster, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient, SlurmLogStream
 from oumi.utils.logging import logger
@@ -98,6 +99,71 @@ def _create_job_script(job: JobConfig) -> str:
     return "\n".join(output_lines) + "\n"
 
 
+def _parse_accelerators_to_gres(accelerators: str | None) -> str | None:
+    """Translates an oumi accelerator string into a Slurm ``--gres`` value.
+
+    Slurm's typed-GRES requires the type string to match an entry in the
+    cluster's ``gres.conf``. If the user gave a type, we emit it; if the
+    cluster only has untyped GRES configured, the user can pass ``":8"``
+    or ``"8"`` to skip the type.
+
+    Examples:
+        ``"H100:8"``      -> ``"gpu:H100:8"``
+        ``"H100"``        -> ``"gpu:H100:1"``
+        ``"A100-80GB:4"`` -> ``"gpu:A100-80GB:4"``
+        ``":8"``          -> ``"gpu:8"`` (untyped count)
+        ``"8"``           -> ``"gpu:8"`` (untyped count)
+    """
+    if not accelerators:
+        return None
+    spec = accelerators.strip()
+    if ":" in spec:
+        gpu_type, _, count = spec.partition(":")
+        gpu_type = gpu_type.strip()
+        count = count.strip() or "1"
+        if gpu_type:
+            return f"gpu:{gpu_type}:{count}"
+        return f"gpu:{count}"
+    if spec.isdigit():
+        return f"gpu:{spec}"
+    return f"gpu:{spec}:1"
+
+
+def _strip_modifier(value: str | None) -> str | None:
+    """Strips the SkyPilot ``+`` modifier from a numeric resource string."""
+    if value is None:
+        return None
+    stripped = value.rstrip("+").strip()
+    return stripped or None
+
+
+def _resources_to_sbatch_kwargs(resources: JobResources) -> dict[str, Any]:
+    """Translates :class:`JobResources` fields into ``sbatch`` kwargs.
+
+    Anything left unset on ``resources`` is omitted so the cluster
+    defaults take effect. Returned keys use Python underscore form
+    (e.g. ``cpus_per_task``); :meth:`SlurmClient.submit_job` converts
+    them to ``--cpus-per-task`` automatically.
+
+    Return type is ``dict[str, Any]`` because :meth:`SlurmClient.submit_job`
+    has typed kwargs (e.g. ``ntasks: int``) that ``**``-unpacking could
+    collide with; ``Any`` lets the call type-check.
+    """
+    kwargs: dict[str, Any] = {}
+    gres = _parse_accelerators_to_gres(resources.accelerators)
+    if gres:
+        kwargs["gres"] = gres
+    cpus = _strip_modifier(resources.cpus)
+    if cpus:
+        kwargs["cpus_per_task"] = cpus
+    memory = _strip_modifier(resources.memory)
+    if memory:
+        # JobResources.memory is GiB. sbatch --mem accepts a unit suffix
+        # (K|M|G|T); preserve an explicit one if the caller provided it.
+        kwargs["mem"] = memory if memory[-1] in "KMGTkmgt" else f"{memory}G"
+    return kwargs
+
+
 def _validate_job_config(job: JobConfig) -> None:
     """Validates the provided job configuration.
 
@@ -115,26 +181,19 @@ def _validate_job_config(job: JobConfig) -> None:
             f"`Resources.cloud` must be `slurm`. "
             f"Unsupported cloud: {job.resources.cloud}"
         )
-    # Warn that other resource parameters are unused for Slurm.
     if not job.working_dir:
         logger.warning("Working directory is not set. This is not recommended.")
+    # Resource fields that don't map to sbatch flags — warn so users know
+    # they're inert. ``accelerators``, ``cpus``, ``memory`` are forwarded
+    # via ``_resources_to_sbatch_kwargs`` and are NOT warned here.
     if job.resources.region:
         logger.warning("Region is unused for Slurm jobs.")
     if job.resources.zone:
         logger.warning("Zone is unused for Slurm jobs.")
-    if job.resources.accelerators:
-        logger.warning("Accelerators are unused for Slurm jobs.")
-    if job.resources.cpus:
-        logger.warning("CPUs are unused for Slurm jobs.")
-    if job.resources.memory:
-        logger.warning("Memory is unused for Slurm jobs.")
     if job.resources.instance_type:
         logger.warning("Instance type is unused for Slurm jobs.")
     if job.resources.disk_size:
         logger.warning("Disk size is unused for Slurm jobs.")
-    if job.resources.instance_type:
-        logger.warning("Instance type is unused for Slurm jobs.")
-    # Warn that storage mounts are currently unsupported.
     if len(job.storage_mounts.items()) > 0:
         logger.warning("Storage mounts are currently unsupported for Slurm jobs.")
 
@@ -262,11 +321,13 @@ class SlurmCluster(BaseCluster):
         # Set the proper CHMOD permissions.
         self._client.run_commands([f"chmod +x {script_path}"])
         # Submit the job.
+        sbatch_kwargs = _resources_to_sbatch_kwargs(job.resources)
         job_id = self._client.submit_job(
             str(script_path),
             str(remote_working_dir),
             job.num_nodes,
             name=job_name,
+            **sbatch_kwargs,
         )
         max_retries = 3
         wait_time = 5

--- a/tests/unit/launcher/clusters/test_slurm_cluster.py
+++ b/tests/unit/launcher/clusters/test_slurm_cluster.py
@@ -7,7 +7,11 @@ import pytest
 from oumi.core.configs import JobConfig, JobResources, StorageMount
 from oumi.core.launcher import JobState, JobStatus
 from oumi.launcher.clients.slurm_client import SlurmClient
-from oumi.launcher.clusters.slurm_cluster import SlurmCluster
+from oumi.launcher.clusters.slurm_cluster import (
+    SlurmCluster,
+    _parse_accelerators_to_gres,
+    _resources_to_sbatch_kwargs,
+)
 
 
 #
@@ -382,6 +386,9 @@ def test_slurm_cluster_run_job(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -435,6 +442,9 @@ def test_slurm_cluster_run_job_no_working_dir(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -513,6 +523,9 @@ def test_slurm_cluster_run_job_with_polling_succeeds(
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_has_calls(
         [call("1234"), call("1234"), call("1234")]
@@ -586,6 +599,9 @@ def test_slurm_cluster_run_job_no_name(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="1-2-3",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -644,6 +660,9 @@ def test_slurm_cluster_run_job_no_mounts(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -700,6 +719,9 @@ def test_slurm_cluster_run_job_no_pbs(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -756,6 +778,9 @@ def test_slurm_cluster_run_job_no_setup(mock_datetime, mock_slurm_client):
         "~/oumi_launcher/20241009_130424513094",
         2,
         name="myjob",
+        gres="gpu:A100-80GB:1",
+        cpus_per_task="4",
+        mem="64G",
     )
     mock_slurm_client.get_job.assert_called_with("1234")
     assert job_status == expected_status
@@ -780,3 +805,90 @@ def test_slurm_cluster_stop(mock_datetime, mock_slurm_client):
     cluster = SlurmCluster("debug-scaling@host", mock_slurm_client)
     cluster.stop()
     # Nothing to assert, this method is a no-op.
+
+
+#
+# Resource → sbatch translation
+#
+@pytest.mark.parametrize(
+    "accelerators, expected_gres",
+    [
+        ("H100:8", "gpu:H100:8"),
+        ("H100", "gpu:H100:1"),
+        ("A100-80GB:4", "gpu:A100-80GB:4"),
+        (":8", "gpu:8"),
+        ("8", "gpu:8"),
+        ("  H100:2  ", "gpu:H100:2"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_parse_accelerators_to_gres(accelerators, expected_gres):
+    assert _parse_accelerators_to_gres(accelerators) == expected_gres
+
+
+def test_resources_to_sbatch_kwargs_all_fields():
+    kwargs = _resources_to_sbatch_kwargs(
+        JobResources(
+            cloud="slurm",
+            accelerators="H100:8",
+            cpus="16",
+            memory="128",
+        )
+    )
+    assert kwargs == {"gres": "gpu:H100:8", "cpus_per_task": "16", "mem": "128G"}
+
+
+def test_resources_to_sbatch_kwargs_strips_skypilot_modifier():
+    kwargs = _resources_to_sbatch_kwargs(
+        JobResources(cloud="slurm", cpus="8+", memory="256+")
+    )
+    assert kwargs == {"cpus_per_task": "8", "mem": "256G"}
+
+
+def test_resources_to_sbatch_kwargs_keeps_explicit_memory_unit():
+    kwargs = _resources_to_sbatch_kwargs(JobResources(cloud="slurm", memory="32G"))
+    assert kwargs == {"mem": "32G"}
+
+    kwargs = _resources_to_sbatch_kwargs(JobResources(cloud="slurm", memory="2T"))
+    assert kwargs == {"mem": "2T"}
+
+
+def test_resources_to_sbatch_kwargs_empty():
+    assert _resources_to_sbatch_kwargs(JobResources(cloud="slurm")) == {}
+
+
+def test_slurm_cluster_run_job_skips_sbatch_resource_flags_when_unset(
+    mock_datetime, mock_slurm_client
+):
+    """Cluster defaults take effect when ``JobResources`` doesn't pin GPU/CPU/mem."""
+    cluster = SlurmCluster("debug@host", mock_slurm_client)
+    mock_successful_cmd = Mock()
+    mock_successful_cmd.exit_code = 0
+    mock_slurm_client.run_commands.return_value = mock_successful_cmd
+    mock_slurm_client.submit_job.return_value = "1234"
+    mock_slurm_client.get_job.return_value = JobStatus(
+        id="1234",
+        name="x",
+        status="RUNNING",
+        metadata="",
+        cluster="debug@host",
+        done=False,
+        state=JobState.PENDING,
+    )
+    job = JobConfig(
+        name="bare",
+        user="user",
+        working_dir="./",
+        num_nodes=1,
+        resources=JobResources(cloud="slurm"),  # accelerators/cpus/memory all None
+        envs={},
+        run="./go.sh",
+    )
+    cluster.run_job(job)
+    mock_slurm_client.submit_job.assert_called_once_with(
+        "~/oumi_launcher/20241009_130424513094/oumi_job.sh",
+        "~/oumi_launcher/20241009_130424513094",
+        1,
+        name="bare",
+    )

--- a/tests/unit/launcher/clusters/test_slurm_cluster.py
+++ b/tests/unit/launcher/clusters/test_slurm_cluster.py
@@ -819,8 +819,14 @@ def test_slurm_cluster_stop(mock_datetime, mock_slurm_client):
         (":8", "gpu:8"),
         ("8", "gpu:8"),
         ("  H100:2  ", "gpu:H100:2"),
+        # SkyPilot "at least" modifier — accelerators behaves like cpus/memory.
+        ("H100:8+", "gpu:H100:8"),
+        ("8+", "gpu:8"),
+        (" H100:8+ ", "gpu:H100:8"),
         (None, None),
         ("", None),
+        ("   ", None),
+        ("+", None),
     ],
 )
 def test_parse_accelerators_to_gres(accelerators, expected_gres):


### PR DESCRIPTION
## Summary

`SlurmCluster.run_job` currently logs "Accelerators are unused for Slurm jobs" and drops `JobResources.accelerators`, `cpus`, and `memory` on the floor. Any job submitted with `cloud="slurm"` and `accelerators="H100:8"` runs as CPU-only and fails on GPU-dependent code. This forwards them to `sbatch` as `--gres` / `--cpus-per-task` / `--mem`.

## Changes

- `_parse_accelerators_to_gres()` — translates oumi accelerator strings into Slurm `--gres` values

  | Input | Output |
  |---|---|
  | `"H100:8"` | `"gpu:H100:8"` |
  | `"H100"` | `"gpu:H100:1"` |
  | `"A100-80GB:4"` | `"gpu:A100-80GB:4"` |
  | `":8"` | `"gpu:8"` (untyped) |
  | `"8"` | `"gpu:8"` (untyped) |
  | `"H100:8+"` (SkyPilot "at least") | `"gpu:H100:8"` |
  | `"8+"` | `"gpu:8"` |

- `_resources_to_sbatch_kwargs()` — collects gres + cpus_per_task + mem from a `JobResources`. Strips SkyPilot's `"+"` minimum-modifier across all three fields. Preserves explicit memory unit suffixes (`32G`, `2T`); defaults to `G` for bare numbers (per `JobResources.memory` doc: "in GiB").

- `SlurmCluster.run_job` forwards the kwargs to `SlurmClient.submit_job`, which already routes unknown kwargs to `--<flag>=<value>` on the sbatch command.

- `_validate_job_config` no longer warns for fields we now forward (accelerators, cpus, memory). Region/zone/instance_type/disk_size warnings remain — those still don't have a Slurm mapping.

## Tests

- 13 new unit tests covering the helper edge cases, typed vs untyped GRES, SkyPilot modifier stripping (incl. `H100:8+` and `8+`), explicit memory units, and the bare-resources case (cluster defaults take effect when nothing's pinned).
- 7 existing `run_job` assertions updated to expect the new kwargs (the default test fixture uses `accelerators="A100-80GB" cpus="4" memory="64"` — those now propagate).
- All 82 slurm cluster/client tests pass.

Skipped local pyright (`SKIP=pyright`) — pre-existing `src/oumi/cli/analyze.py` errors on `origin/main` unrelated to this change.

## E2E verification

### Direct `oumi.launcher.up` (standalone)

```python
oumi.launcher.up(
    JobConfig(
        cloud="slurm",
        resources=JobResources(cloud="slurm", accelerators="H100:1"),
        run="echo CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES; nvidia-smi -L",
    ),
    cluster_name="root@<controller>",
)
```

Job 214 on RunPod cluster: `JobState=COMPLETED ExitCode=0:0`, `TresPerNode=gres:gpu:H100:1`, stdout shows `CUDA_VISIBLE_DEVICES=6` + `nvidia-smi -L` listing the H100s.

### Full worker stack (curl → API → workflow → run_job_activity → oumi → sbatch)

Submitted a training request via the local API (`POST /v1/projects/{id}/models:train`, `cloud_provider="slurm"`, `accelerator="H100:1"` via `TRAINING_ACCELERATOR_TIERS` override). Worker dispatched Slurm job 219:

```
JobId=219 JobName=job-172-1317
   JobState=FAILED Reason=NonZeroExitCode ExitCode=127:0   ← script needed `sudo apt-get`, unrelated
   BatchHost=node-1
   TRES=cpu=2,node=1,billing=2
   TresPerNode=gres:gpu:H100:1                              ← --gres correctly forwarded
```

Confirmed via a temporary `logger.info` (now removed) that the worker's call into oumi was:
```
_resources_to_sbatch_kwargs: accelerators='H100:1' cpus=None memory=None -> kwargs={'gres': 'gpu:H100:1'}
```

So the resource forwarding correctly traverses: API request → worker JobConfig → oumi `SlurmCluster.run_job` → `SlurmClient.submit_job` → `sbatch --gres=gpu:H100:1`.

Before this PR: the same path produced `TresPerNode=` empty (the warning fired, accelerators dropped).

## Caveat for cluster operators

Typed-GRES requires the type string to match an entry in the cluster's `gres.conf`. If the user passes `"H100:8"` and the cluster only has untyped GRES (`gres.conf` doesn't define `Type=H100`), sbatch will reject the request. Workaround: pass `":8"` or `"8"` to skip the type, or fix `gres.conf` upstream.