### PR TITLE
feat(deploy): deploy Fireworks endpoints by validated deployment shape

### DIFF
--- a/src/oumi/deploy/base_client.py
+++ b/src/oumi/deploy/base_client.py
@@ -59,10 +59,9 @@ class HardwareConfig:
 
 @dataclass
 class DeploymentShape:
-    """Provider-validated ``(base_model, accelerator_type, accelerator_count)``.
+    """A provider-validated hardware option for a base model.
 
-    ``base_model`` is the provider's resource path; ``accelerator_type`` is
-    the provider's native string.
+    ``base_model`` and ``accelerator_type`` are the provider's native strings.
     """
 
     base_model: str

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -20,6 +20,7 @@ import logging
 import os
 import shutil
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -175,6 +176,31 @@ def _validate_fireworks_model_id(model_id: str) -> None:
 
 
 _raise_api_error = raise_api_error
+
+
+@dataclass
+class FireworksDeploymentShape(DeploymentShape):
+    """A ``DeploymentShape`` plus the Fireworks shape resource path.
+
+    ``resource_path`` (e.g. ``accounts/fireworks/deploymentShapes/rft-gpt-oss-20b``)
+    is what CreateDeployment uses to deploy *by shape* instead of by raw
+    hardware. Fireworks-specific; not part of the provider-agnostic shape.
+    """
+
+    resource_path: str | None = None
+
+
+def _strip_version_suffix(resource_name: str | None) -> str | None:
+    """Return the unversioned deployment-shape family path.
+
+    Shape versions are listed as
+    ``accounts/.../deploymentShapes/<family>/versions/<id>``. CreateDeployment
+    takes the family path and binds the latest validated version, so the
+    ``/versions/<id>`` suffix is dropped here. ``None`` passes through.
+    """
+    if resource_name and "/versions/" in resource_name:
+        return resource_name.split("/versions/", 1)[0]
+    return resource_name
 
 
 class FireworksDeploymentClient(BaseDeploymentClient):
@@ -1338,18 +1364,26 @@ class FireworksDeploymentClient(BaseDeploymentClient):
     async def create_endpoint(
         self,
         model_id: str,
-        hardware: HardwareConfig,
+        hardware: HardwareConfig | None,
         autoscaling: AutoscalingConfig,
         display_name: str | None = None,
         endpoint_id: str | None = None,
         scale_down_window_seconds: int | None = None,
         scale_to_zero_window_seconds: int | None = None,
+        deployment_shape: str | None = None,
     ) -> Endpoint:
         """Creates an inference endpoint (deployment) for a model.
 
+        Deploys either by raw ``hardware`` or by a validated
+        ``deployment_shape``. Exactly one must be provided — Fireworks rejects
+        a request carrying both, and passing neither (or a ``None``
+        ``resource_path`` that the caller forgot to handle) raises rather than
+        silently picking a path.
+
         Args:
             model_id: Fireworks model ID
-            hardware: Hardware configuration
+            hardware: Hardware to request. Mutually exclusive with
+                ``deployment_shape``; pass ``None`` when deploying by shape.
             autoscaling: Autoscaling configuration
             display_name: Optional display name
             endpoint_id: Optional caller-supplied deployment ID. When provided,
@@ -1363,23 +1397,41 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             scale_to_zero_window_seconds: Idle seconds before scaling to zero
                 replicas. ``None`` → Fireworks default (1h, 5min minimum).
                 Only meaningful when ``autoscaling.min_replicas == 0``.
+            deployment_shape: Validated deployment-shape resource path
+                (``accounts/fireworks/deploymentShapes/<family>``) to deploy by.
+                Mutually exclusive with ``hardware``; the shape carries its own
+                hardware.
 
         Returns:
             Created Endpoint
+
+        Raises:
+            ValueError: unless exactly one of ``hardware`` / ``deployment_shape``
+                is provided.
         """
-        deployment = GatewayDeployment(
-            baseModel=model_id,
-            acceleratorType=cast(
-                GatewayAcceleratorType, self._to_fireworks_accelerator(hardware)
-            ),
-            acceleratorCount=hardware.count,
-            minReplicaCount=autoscaling.min_replicas,
-            maxReplicaCount=autoscaling.max_replicas,
-            autoscalingPolicy=_build_autoscaling_policy(
+        if (hardware is None) == (deployment_shape is None):
+            raise ValueError(
+                "create_endpoint requires exactly one of 'hardware' or "
+                "'deployment_shape'."
+            )
+
+        deployment_kwargs: dict[str, Any] = {
+            "baseModel": model_id,
+            "minReplicaCount": autoscaling.min_replicas,
+            "maxReplicaCount": autoscaling.max_replicas,
+            "autoscalingPolicy": _build_autoscaling_policy(
                 scale_down_window_seconds, scale_to_zero_window_seconds
             ),
-            displayName=display_name,
-        )
+            "displayName": display_name,
+        }
+        if deployment_shape is not None:
+            deployment_kwargs["deploymentShape"] = deployment_shape
+        elif hardware is not None:
+            deployment_kwargs["acceleratorType"] = cast(
+                GatewayAcceleratorType, self._to_fireworks_accelerator(hardware)
+            )
+            deployment_kwargs["acceleratorCount"] = hardware.count
+        deployment = GatewayDeployment(**deployment_kwargs)
 
         params: dict[str, Any] = {}
         if endpoint_id is not None:
@@ -1517,7 +1569,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
 
     async def list_deployment_shapes(
         self, base_model: str | None = None
-    ) -> list[DeploymentShape]:
+    ) -> list[FireworksDeploymentShape]:
         """Lists ``latest_validated`` deployment shapes published by Fireworks.
 
         Paginates ``/v1/accounts/-/deploymentShapes/-/versions``, optionally
@@ -1532,7 +1584,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             "order_by": "create_time desc",
         }
 
-        shapes: list[DeploymentShape] = []
+        shapes: list[FireworksDeploymentShape] = []
         page_token: str | None = None
         while True:
             params = dict(params_base)
@@ -1559,10 +1611,11 @@ class FireworksDeploymentClient(BaseDeploymentClient):
                 ):
                     continue
                 shapes.append(
-                    DeploymentShape(
+                    FireworksDeploymentShape(
                         base_model=snapshot.base_model,
                         accelerator_type=snapshot.accelerator_type,
                         accelerator_count=snapshot.accelerator_count,
+                        resource_path=_strip_version_suffix(version.name),
                     )
                 )
 

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -40,6 +40,7 @@ from oumi.deploy.fireworks_client import (
     FIREWORKS_ACCELERATORS,
     FireworksDeploymentClient,
     FireworksInvalidModelIdError,
+    _strip_version_suffix,
     _validate_fireworks_model_id,
 )
 
@@ -259,6 +260,57 @@ class TestFireworksDeploymentClient:
             assert payload["displayName"] == "test-deployment"
             # No caller-supplied ID → no deploymentId query param.
             assert call_args[1].get("params", {}) == {}
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint_by_shape_omits_accelerator(self):
+        """deployment_shape set → sends deploymentShape, not acceleratorType/Count."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "name": "accounts/test-account/deployments/deploy-123",
+            "baseModel": "model-456",
+            "state": "CREATING",
+            "acceleratorType": "NVIDIA_H200_141GB",
+            "acceleratorCount": 1,
+        }
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            await client.create_endpoint(
+                model_id="model-456",
+                hardware=None,
+                autoscaling=AutoscalingConfig(min_replicas=1, max_replicas=2),
+                deployment_shape="accounts/fireworks/deploymentShapes/rft-qwen3-8b",
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert payload["deploymentShape"] == (
+                "accounts/fireworks/deploymentShapes/rft-qwen3-8b"
+            )
+            # Shape carries the hardware; raw accelerator fields must be absent.
+            assert "acceleratorType" not in payload
+            assert "acceleratorCount" not in payload
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint_requires_exactly_one_of_hardware_or_shape(self):
+        """Passing both, or neither, raises instead of silently picking one."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+        autoscaling = AutoscalingConfig(min_replicas=1, max_replicas=1)
+
+        with pytest.raises(ValueError, match="exactly one"):
+            await client.create_endpoint(
+                model_id="m", hardware=None, autoscaling=autoscaling
+            )
+        with pytest.raises(ValueError, match="exactly one"):
+            await client.create_endpoint(
+                model_id="m",
+                hardware=HardwareConfig(accelerator="nvidia_a100_80gb", count=1),
+                autoscaling=autoscaling,
+                deployment_shape="accounts/fireworks/deploymentShapes/rft-qwen3-8b",
+            )
 
     @pytest.mark.asyncio
     async def test_create_endpoint_with_endpoint_id(self):
@@ -566,6 +618,42 @@ class TestFireworksDeploymentClient:
         assert shapes[1].accelerator_type == "NVIDIA_H100_80GB"
 
     @pytest.mark.asyncio
+    async def test_list_deployment_shapes_populates_resource_path_stripping_version(
+        self,
+    ):
+        """``resource_path`` is the family path with the version suffix stripped."""
+        client = FireworksDeploymentClient(api_key="test", account_id="test-account")
+
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "deploymentShapeVersions": [
+                {
+                    "name": (
+                        "accounts/fireworks/deploymentShapes/rft-qwen3-8b/versions/v123"
+                    ),
+                    "latestValidated": True,
+                    "snapshot": {
+                        "baseModel": "accounts/fireworks/models/qwen3-8b",
+                        "acceleratorType": "NVIDIA_H200_141GB",
+                        "acceleratorCount": 1,
+                    },
+                },
+            ],
+            "nextPageToken": "",
+        }
+
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            shapes = await client.list_deployment_shapes()
+
+        assert len(shapes) == 1
+        assert shapes[0].resource_path == (
+            "accounts/fireworks/deploymentShapes/rft-qwen3-8b"
+        )
+
+    @pytest.mark.asyncio
     async def test_list_deployment_shapes_scopes_filter_to_base_model(self):
         """A base_model argument is added as a snapshot.base_model AND clause."""
         client = FireworksDeploymentClient(api_key="test", account_id="test-account")
@@ -608,6 +696,30 @@ class TestFireworksDeploymentClient:
         client = FireworksDeploymentClient(api_key="test", account_id="test-account")
         headers = client._get_inference_auth_headers()
         assert headers == {"Authorization": "Bearer test"}
+
+
+class TestStripVersionSuffix:
+    """Tests for _strip_version_suffix."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            # Versioned path -> family path.
+            (
+                "accounts/fireworks/deploymentShapes/rft-qwen3-8b/versions/v123",
+                "accounts/fireworks/deploymentShapes/rft-qwen3-8b",
+            ),
+            # Already a family path -> unchanged.
+            (
+                "accounts/fireworks/deploymentShapes/rft-qwen3-8b",
+                "accounts/fireworks/deploymentShapes/rft-qwen3-8b",
+            ),
+            # Missing name -> None.
+            (None, None),
+        ],
+    )
+    def test_strip_version_suffix(self, name, expected):
+        assert _strip_version_suffix(name) == expected
 
 
 class TestValidateFireworksModelId:


### PR DESCRIPTION
# Description

Adds `DeploymentShape.name` and a `deployment_shape` argument to `create_endpoint`, so callers can deploy a Fireworks endpoint by a validated deployment shape instead of a raw `acceleratorType` x `count`. `list_deployment_shapes` now fills `name` from the shape's family path (with the `/versions/<id>` suffix stripped).

## Related issues

Towards LOU-2245

## Before submitting

- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
