### PR TITLE
build(deps): revert torchvision upper bound to <0.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "tiktoken>=0.7,<1.0",
     "torch>=2.6,<2.13.0",      # vllm only supports up to torch==2.7
     "torchao>=0.16,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
-    "torchvision>=0.21,<0.28", # Used by some VLM-s (multimodal)
+    "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
     "transformers>=4.57,<5.10",
     "trl>=0.24,<1.5",


### PR DESCRIPTION
## Summary

Reverts [#2474](https://github.com/oumi-ai/oumi/pull/2474) — narrows torchvision back to `>=0.21,<0.26`.

## Why

torchvision `>=0.27` resolves to torch `2.11+`, whose default wheels ship the CUDA 13 runtime. That propagates to every consumer of oumi:

- Worker / inference base images currently built on CUDA 12 baseline
- SkyPilot setup scripts and Modal containers
- AWS / Nebius / Lambda GPU instance driver compatibility
- Pinned deps in downstream consumers (vllm, flash-attn, peft, torchao, transformers) — each has CUDA-version-sensitive prebuilt wheels

Keeping `<0.26` holds the ecosystem on CUDA 12 until the transition is explicitly planned and validated end-to-end.

## Test plan

- [ ] CI green on this PR
- [ ] No downstream consumer requires torchvision `>=0.26` today

When a real CUDA 13 transition is on the roadmap, bump this bound in a dedicated PR that also lands the matching wheels in the downstream training / inference images.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
