### PR TITLE
feat(gemma4): add Gemma 4 31B LoRA recipe

### DIFF
--- a/configs/recipes/gemma4/README.md
+++ b/configs/recipes/gemma4/README.md
@@ -69,5 +69,5 @@ oumi launch up -c oumi://configs/recipes/gemma4/sft/e4b_lora/gcp_job.yaml --clus
 To launch Gemma 4 31B LoRA training on a remote GCP 8x A100 cluster:
 
 ```shell
-oumi launch up -c configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
+oumi launch up -c oumi://configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
 ```

--- a/configs/recipes/gemma4/README.md
+++ b/configs/recipes/gemma4/README.md
@@ -41,12 +41,13 @@ oumi launch up -c oumi://configs/recipes/gemma4/sft/e4b_full/gcp_job.yaml --clus
 
 ### LoRA Training
 
-LoRA is scoped to the language-model layers only. Gemma 4's vision/audio towers
-use `Gemma4ClippableLinear` wrappers that PEFT cannot adapt, and they share
-projection names (`q_proj`, `v_proj`, ...) with the text model. The recipes target
-the plain projection names and set `lora_exclude_modules: [".*vision_tower.*",
-".*audio_tower.*"]`, which oumi passes to PEFT's `exclude_modules` to keep LoRA off
-the towers.
+LoRA is scoped to the language-model layers only. Gemma 4's non-text towers use
+`Gemma4ClippableLinear` wrappers that PEFT cannot adapt, and they share projection
+names (`q_proj`, `v_proj`, ...) with the text model. The recipes target the plain
+projection names and set `lora_exclude_modules` to keep LoRA off the towers: the
+Efficient (text+image+audio) models exclude `[".*vision_tower.*", ".*audio_tower.*"]`,
+and the Larger (image+text) models exclude `[".*vision_tower.*", ".*multi_modal_projector.*"]`.
+oumi passes this list to PEFT's `exclude_modules`.
 
 To launch Gemma 4 E4B LoRA training locally (fits a single A100/H100):
 

--- a/configs/recipes/gemma4/README.md
+++ b/configs/recipes/gemma4/README.md
@@ -9,7 +9,7 @@ Configs for Google's Gemma 4 model family. See the [Hugging Face announcement](h
   - [google/gemma-4-E4B-it](https://huggingface.co/google/gemma-4-E4B-it) (~8B) — **FFT + LoRA configs available**
 - Larger (image + text, 256K context)
   - [google/gemma-4-26B-A4B-it](https://huggingface.co/google/gemma-4-26B-A4B-it) (MoE, 27B)
-  - [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it) (dense, 31B)
+  - [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it) (dense, 31B) — **LoRA config available**
 
 Gemma 4 requires accepting the model license on Hugging Face before downloading.
 Training requires `transformers >= 5.5.4`, which oumi installs automatically.
@@ -64,4 +64,10 @@ To launch Gemma 4 E4B LoRA training on a remote GCP A100 cluster:
 
 ```shell
 oumi launch up -c oumi://configs/recipes/gemma4/sft/e4b_lora/gcp_job.yaml --cluster gemma4-e4b-lora
+```
+
+To launch Gemma 4 31B LoRA training on a remote GCP 8x A100 cluster:
+
+```shell
+oumi launch up -c configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
 ```

--- a/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
@@ -1,0 +1,53 @@
+# Job config to LoRA tune Gemma 4 31B (dense).
+#
+# NOTE: This recipe installs Oumi in EDITABLE mode from the synced working dir
+# (`-e '.[gpu]'`) and runs the LOCAL config path (no `oumi://` prefix). This is
+# required while the Gemma 4 31B recipe and the `lora_exclude_modules` feature
+# are pre-release and not yet on `main`.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: gemma4-31b-lora
+
+resources:
+  cloud: gcp
+  accelerators: "A100:8"
+  use_spot: true
+  region: europe-west4  # 40GB A100s available here with abundant spot quota.
+  disk_size: 500  # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: gemma4-31b.lora
+
+setup: |
+  set -e
+  pip install uv && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OUMI=0.0.0.dev0 uv pip install --system -e '.[gpu]' hf_transfer
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi distributed torchrun -m oumi train \
+      -c configs/recipes/gemma4/sft/31b_lora/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
@@ -1,17 +1,12 @@
 # Job config to LoRA tune Gemma 4 31B (dense).
 #
-# NOTE: This recipe installs Oumi in EDITABLE mode from the synced working dir
-# (`-e '.[gpu]'`) and runs the LOCAL config path (no `oumi://` prefix). This is
-# required while the Gemma 4 31B recipe and the `lora_exclude_modules` feature
-# are pre-release and not yet on `main`.
-#
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
 #   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:
-#   oumi launch up -c configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
+#   oumi launch up -c oumi://configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml --cluster gemma4-31b-lora
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
@@ -24,8 +19,7 @@ name: gemma4-31b-lora
 resources:
   cloud: gcp
   accelerators: "A100:8"
-  use_spot: true
-  region: europe-west4  # 40GB A100s available here with abundant spot quota.
+  use_spot: false
   disk_size: 500  # Disk size in GBs
 
 working_dir: .
@@ -39,7 +33,7 @@ envs:
 
 setup: |
   set -e
-  pip install uv && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OUMI=0.0.0.dev0 uv pip install --system -e '.[gpu]' hf_transfer
+  pip install uv && uv pip install --system oumi[gpu] hf_transfer
 
 run: |
   set -e  # Exit if any command failed.
@@ -47,7 +41,7 @@ run: |
 
   set -x
   oumi distributed torchrun -m oumi train \
-      -c configs/recipes/gemma4/sft/31b_lora/train.yaml \
+      -c oumi://configs/recipes/gemma4/sft/31b_lora/train.yaml \
       --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
 
   echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml
@@ -2,7 +2,7 @@
 #
 # Requirements:
 #   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
-#   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-31B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:

--- a/configs/recipes/gemma4/sft/31b_lora/train.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/train.yaml
@@ -4,8 +4,9 @@
 #   - 32.7B parameter dense multimodal model from Google (Gemma 4 Larger series)
 #   - 256K context length; image + text inputs
 #   - LoRA is scoped to the text transformer only. The vision tower and the
-#     multimodal projector are excluded via `lora_exclude_modules` below; they
-#     share projection-like names with the text model but PEFT cannot adapt them.
+#     multimodal projector use `Gemma4ClippableLinear` wrappers that PEFT cannot
+#     adapt, and share projection names with the text model — so they are excluded
+#     via `lora_exclude_modules` below.
 #
 # Requirements:
 #   - transformers >= 5.5.4
@@ -51,7 +52,6 @@ training:
   enable_gradient_checkpointing: true
   gradient_checkpointing_kwargs:
     use_reentrant: false
-  ddp_find_unused_parameters: true  # LoRA leaves the vision tower frozen.
   compile: false
 
   optimizer: "adamw_torch_fused"

--- a/configs/recipes/gemma4/sft/31b_lora/train.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/train.yaml
@@ -8,7 +8,7 @@
 #     share projection-like names with the text model but PEFT cannot adapt them.
 #
 # Requirements:
-#   - transformers >= 5.10.0
+#   - transformers >= 5.5.4
 #   - peft (installed automatically with oumi)
 #   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
@@ -41,6 +41,10 @@ training:
   save_final_model: true
   num_train_epochs: 1
   per_device_train_batch_size: 1
+  # NOTE: gradient accumulation inflates reported loss for Gemma 4 (~4x) due
+  # to a missing `accepts_loss_kwargs = False` on Gemma4ForConditionalGeneration.
+  # Fixed on transformers main but not yet released as of 5.5.4. See
+  # huggingface/transformers#40564 (same bug existed in Gemma 3).
   gradient_accumulation_steps: 8
   max_grad_norm: 1.0
 

--- a/configs/recipes/gemma4/sft/31b_lora/train.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/train.yaml
@@ -11,7 +11,7 @@
 # Requirements:
 #   - transformers >= 5.5.4
 #   - peft (installed automatically with oumi)
-#   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-31B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:

--- a/configs/recipes/gemma4/sft/31b_lora/train.yaml
+++ b/configs/recipes/gemma4/sft/31b_lora/train.yaml
@@ -1,0 +1,90 @@
+# LoRA SFT config for Gemma 4 31B Instruct (dense).
+#
+# Model highlights:
+#   - 32.7B parameter dense multimodal model from Google (Gemma 4 Larger series)
+#   - 256K context length; image + text inputs
+#   - LoRA is scoped to the text transformer only. The vision tower and the
+#     multimodal projector are excluded via `lora_exclude_modules` below; they
+#     share projection-like names with the text model but PEFT cannot adapt them.
+#
+# Requirements:
+#   - transformers >= 5.10.0
+#   - peft (installed automatically with oumi)
+#   - apache-2.0 license, no gating: https://huggingface.co/google/gemma-4-31B-it
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/31b_lora/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/*train.yaml
+
+model:
+  model_name: "google/gemma-4-31B-it"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: false
+  enable_liger_kernel: false  # Disabled (may conflict with Gemma output format).
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"  # 51,760 examples
+
+training:
+  use_peft: true
+  trainer_type: "TRL_SFT"
+  save_final_model: true
+  num_train_epochs: 1
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8
+  max_grad_norm: 1.0
+
+  enable_gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: false
+  ddp_find_unused_parameters: true  # LoRA leaves the vision tower frozen.
+  compile: false
+
+  optimizer: "adamw_torch_fused"
+  learning_rate: 2.0e-04
+  lr_scheduler_type: "cosine"
+  warmup_ratio: 0.05
+  weight_decay: 0.01
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 8
+  logging_steps: 5
+  empty_device_cache_steps: 50
+  output_dir: "output/gemma4_31b.lora"
+  include_performance_metrics: true
+  enable_wandb: true
+
+peft:
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - "q_proj"
+    - "k_proj"
+    - "v_proj"
+    - "o_proj"
+    - "gate_proj"
+    - "up_proj"
+    - "down_proj"
+  # Keep LoRA on the text transformer only; exclude the vision tower and the
+  # multimodal projector (image+text model, no audio tower).
+  lora_exclude_modules:
+    - ".*vision_tower.*"
+    - ".*multi_modal_projector.*"
+
+fsdp:
+  enable_fsdp: true
+  sharding_strategy: "FULL_SHARD"
+  forward_prefetch: true
+  auto_wrap_policy: "TRANSFORMER_BASED_WRAP"
+  transformer_layer_cls: "Gemma4TextDecoderLayer"


### PR DESCRIPTION
# Add Gemma 4 31B LoRA recipe

Adds a ready-to-run **LoRA SFT recipe for Gemma 4 31B** (`google/gemma-4-31B-it` — dense, 32.7B, image+text) under `configs/recipes/gemma4/sft/31b_lora/`. Builds on #2479 (now merged), which added the `lora_exclude_modules` support these recipes rely on.

## What's in this PR

- `configs/recipes/gemma4/sft/31b_lora/train.yaml` — FSDP (FULL_SHARD) LoRA SFT on `alpaca-cleaned`. LoRA is scoped to the text transformer via `lora_exclude_modules` (`.*vision_tower.*`, `.*multi_modal_projector.*`); `transformer_layer_cls: Gemma4TextDecoderLayer`.
- `configs/recipes/gemma4/sft/31b_lora/gcp_job.yaml` — SkyPilot GCP job (A100:8, FSDP via `oumi distributed torchrun`).
- `configs/recipes/gemma4/README.md` — mark 31B as "LoRA config available" + launch example.

Mirrors the existing `e4b_lora` (model/training/peft fields) and `e4b_full` (FSDP block) recipes.

## Validation

Beyond the GCP smoke test, this recipe's LoRA setup was validated end-to-end in oumi's OSS environment (`torch 2.10.0+cu128`, `transformers 5.7.0`, `peft 0.19.1`, `trl 1.4.0`) on 4× H100 with FSDP `FULL_SHARD`. PEFT applies LoRA scoped to the text transformer — **61,214,720 trainable params (~0.19%)**; the vision tower is excluded via `lora_exclude_modules`, so there is no `Gemma4ClippableLinear` crash.

Pointing the recipe's LoRA configuration at a downstream task's training split (in place of the shipped `alpaca-cleaned` default) produces real accuracy gains over the base model, evaluated with oumi's `NATIVE` engine:

| Task | Base | + LoRA |
|---|---|---|
| banking77 (n=1000) | 82.0% | **90.2%** |
| pubmedqa (n=100) | 73.0% | **80.0%** |

Training converges cleanly (loss → <0.3, token-accuracy > 0.98). This was a real fine-tune per task, not a smoke run. (Long free-form generation tasks were not included here — `NATIVE` generation on the device_map-sharded 31B is throughput-bound for long outputs, an eval-infra limitation rather than a recipe issue.)

## Related issues

N/A — config-only addition. Builds on #2479 (merged).

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
