### PR TITLE
fix(launcher): guarantee SlurmLogStream tail-subprocess termination

### DIFF
--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -413,12 +413,33 @@ class SlurmLogStream(io.TextIOBase):
             finally:
                 # Always terminate the tail on thread exit so a long-blocking
                 # ``tail -F`` against a no-longer-growing log file doesn't
-                # outlive the stream consumer.
+                # outlive the stream consumer. The subprocess was started with
+                # ``shell=True`` + ``start_new_session=True``, so ``proc.pid``
+                # is the ``/bin/sh`` wrapper's pid and ``proc.terminate()``
+                # alone wouldn't reach the ``ssh`` child if the shell didn't
+                # ``exec`` into it. Signal the whole process group instead —
+                # same pattern as ``close()`` above.
                 try:
-                    proc.terminate()
+                    os.killpg(proc.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass  # process already gone — race with self.close()
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to terminate log tail (pgid={proc.pid}): {e}"
+                    )
+                try:
                     proc.wait(timeout=5)
                 except Exception:
-                    pass
+                    # If SIGTERM didn't take, escalate. SIGKILL is unhandleable
+                    # so the process group is guaranteed to be reaped after.
+                    try:
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to SIGKILL log tail (pgid={proc.pid}): {e}"
+                        )
 
         self._job_check_thread = threading.Thread(target=check_job_status, daemon=True)
         self._job_check_thread.start()

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -395,16 +395,30 @@ class SlurmLogStream(io.TextIOBase):
         """Start background thread to check job status."""
 
         def check_job_status():
-            while True:
-                try:
-                    job = self._client.get_job(self.job_id)
+            try:
+                while True:
+                    try:
+                        job = self._client.get_job(self.job_id)
+                    except Exception as e:
+                        # A transient ``get_job`` failure shouldn't strand
+                        # the tail subprocess waiting on a static file.
+                        logger.warning(
+                            f"Job-status check for {self.job_id} failed: {e}; "
+                            "terminating log tail."
+                        )
+                        return
                     if job is None or job.done:
-                        proc.terminate()
-                        proc.wait()
-                        break
+                        return
                     time.sleep(2)
+            finally:
+                # Always terminate the tail on thread exit so a long-blocking
+                # ``tail -F`` against a no-longer-growing log file doesn't
+                # outlive the stream consumer.
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=5)
                 except Exception:
-                    break
+                    pass
 
         self._job_check_thread = threading.Thread(target=check_job_status, daemon=True)
         self._job_check_thread.start()

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -1,3 +1,4 @@
+import signal
 import subprocess
 import tempfile
 from datetime import datetime, timedelta
@@ -1118,34 +1119,62 @@ def _build_log_stream(mock_proc, mock_client):
 
 
 def test_slurm_log_stream_terminates_tail_when_job_done():
-    """Happy path: job completes, watcher terminates the ``tail`` proc."""
+    """Happy path: job completes, watcher signals the ``tail`` process
+    group so the SSH child gets the signal too (not just the ``sh`` wrapper).
+    """
     mock_proc = Mock()
-    mock_job = Mock()
-    mock_job.done = True
+    mock_proc.pid = 12345
+    mock_job = Mock(done=True)
     mock_client = Mock()
     mock_client.get_job.return_value = mock_job
 
-    stream = _build_log_stream(mock_proc, mock_client)
-    assert stream._job_check_thread is not None
-    stream._job_check_thread.join(timeout=2)
-
-    assert not stream._job_check_thread.is_alive()
-    mock_proc.terminate.assert_called_once()
+    with patch("oumi.launcher.clients.slurm_client.os.killpg") as mock_killpg:
+        stream = _build_log_stream(mock_proc, mock_client)
+        assert stream._job_check_thread is not None
+        stream._job_check_thread.join(timeout=2)
+        assert not stream._job_check_thread.is_alive()
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
 
 
 def test_slurm_log_stream_terminates_tail_when_get_job_raises():
     """Regression: a transient ``get_job`` exception used to ``break`` out
     of the watcher loop without calling ``proc.terminate()``, leaving the
     ``tail -F`` running against a static log file. The ``finally``-block
-    must always terminate the proc.
+    must always signal the proc.
     """
     mock_proc = Mock()
+    mock_proc.pid = 12345
     mock_client = Mock()
     mock_client.get_job.side_effect = RuntimeError("ssh wedged")
 
-    stream = _build_log_stream(mock_proc, mock_client)
-    assert stream._job_check_thread is not None
-    stream._job_check_thread.join(timeout=2)
+    with patch("oumi.launcher.clients.slurm_client.os.killpg") as mock_killpg:
+        stream = _build_log_stream(mock_proc, mock_client)
+        assert stream._job_check_thread is not None
+        stream._job_check_thread.join(timeout=2)
+        assert not stream._job_check_thread.is_alive()
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
 
-    assert not stream._job_check_thread.is_alive()
-    mock_proc.terminate.assert_called_once()
+
+def test_slurm_log_stream_escalates_to_sigkill_when_wait_times_out():
+    """If ``proc.wait`` times out after SIGTERM, the watcher must escalate
+    to SIGKILL on the process group so the consumer always sees EOF.
+    """
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="tail", timeout=5)
+    mock_job = Mock(done=True)
+    mock_client = Mock()
+    mock_client.get_job.return_value = mock_job
+
+    with patch("oumi.launcher.clients.slurm_client.os.killpg") as mock_killpg:
+        stream = _build_log_stream(mock_proc, mock_client)
+        assert stream._job_check_thread is not None
+        stream._job_check_thread.join(timeout=2)
+        sigterm = [
+            c for c in mock_killpg.call_args_list if c == call(12345, signal.SIGTERM)
+        ]
+        sigkill = [
+            c for c in mock_killpg.call_args_list if c == call(12345, signal.SIGKILL)
+        ]
+        assert sigterm, "SIGTERM should be sent first"
+        assert sigkill, "SIGKILL should escalate after wait timeout"

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -1097,3 +1097,55 @@ def test_slurm_client_get_active_users_failure(mock_subprocess):
         capture_output=True,
     )
     assert active_users == []
+
+
+#
+# SlurmLogStream — tail-subprocess termination
+#
+def _build_log_stream(mock_proc, mock_client):
+    """Construct a SlurmLogStream that bypasses the live SSH preflight.
+
+    ``__init__`` normally calls ``_start_job_checking`` inside
+    ``_start_tail_process`` — patching the latter skips it, so we invoke
+    the watcher explicitly here.
+    """
+    from oumi.launcher.clients.slurm_client import SlurmLogStream
+
+    with patch.object(SlurmLogStream, "_start_tail_process", return_value=mock_proc):
+        stream = SlurmLogStream("test-cluster", "job-123", mock_client)
+    stream._start_job_checking(mock_proc)
+    return stream
+
+
+def test_slurm_log_stream_terminates_tail_when_job_done():
+    """Happy path: job completes, watcher terminates the ``tail`` proc."""
+    mock_proc = Mock()
+    mock_job = Mock()
+    mock_job.done = True
+    mock_client = Mock()
+    mock_client.get_job.return_value = mock_job
+
+    stream = _build_log_stream(mock_proc, mock_client)
+    assert stream._job_check_thread is not None
+    stream._job_check_thread.join(timeout=2)
+
+    assert not stream._job_check_thread.is_alive()
+    mock_proc.terminate.assert_called_once()
+
+
+def test_slurm_log_stream_terminates_tail_when_get_job_raises():
+    """Regression: a transient ``get_job`` exception used to ``break`` out
+    of the watcher loop without calling ``proc.terminate()``, leaving the
+    ``tail -F`` running against a static log file. The ``finally``-block
+    must always terminate the proc.
+    """
+    mock_proc = Mock()
+    mock_client = Mock()
+    mock_client.get_job.side_effect = RuntimeError("ssh wedged")
+
+    stream = _build_log_stream(mock_proc, mock_client)
+    assert stream._job_check_thread is not None
+    stream._job_check_thread.join(timeout=2)
+
+    assert not stream._job_check_thread.is_alive()
+    mock_proc.terminate.assert_called_once()


### PR DESCRIPTION
## Summary

`SlurmLogStream._start_job_checking`'s watcher loop has a silent-leak path: any exception from `self._client.get_job(...)` `break`s out of the loop without terminating the `tail -F` subprocess it was responsible for cleaning up. The orphaned tail blocks indefinitely on a now-static log file, and stream consumers (anyone iterating `SlurmLogStream`) block on `proc.stdout.readline()` forever.

## Reproduction

Any consumer doing:

```python
log_stream = cluster.get_logs_stream(cluster_name, job_id)
for line in log_stream:
    ...
```

…will hang if the watcher exits via the `except Exception: break` branch (e.g. a transient SSH wedge, a `sacct`/`squeue` parse miss, or any other `get_job` failure). `tail -F` follows the file with retry semantics and does not exit on its own, so `proc.stdout.readline()` never returns EOF.

## Root cause

Pre-existing watcher (`src/oumi/launcher/clients/slurm_client.py:394`):

```python
def check_job_status():
    while True:
        try:
            job = self._client.get_job(self.job_id)
            if job is None or job.done:
                proc.terminate()
                proc.wait()
                break
            time.sleep(2)
        except Exception:
            break   # ← exits without calling proc.terminate()
```

`break` on exception exits the loop without running the termination path. `tail -F` survives the daemon thread because the subprocess is started in a new session.

## Fix

Restructure with `try`/`finally` so termination always runs on any exit path:

```python
def check_job_status():
    try:
        while True:
            try:
                job = self._client.get_job(self.job_id)
            except Exception as e:
                logger.warning(
                    f"Job-status check for {self.job_id} failed: {e}; "
                    "terminating log tail."
                )
                return
            if job is None or job.done:
                return
            time.sleep(2)
    finally:
        try:
            proc.terminate()
            proc.wait(timeout=5)
        except Exception:
            pass
```

Side effects:
- `get_job` failure now surfaces as `logger.warning` instead of being swallowed.
- `proc.wait(timeout=5)` bounds shutdown so a wedged subprocess can't keep the watcher thread alive.

No public API change. Behavior on the happy path (`job.done == True`) is identical.

## Tests

Two unit tests in `tests/unit/launcher/clients/test_slurm_client.py`:

| Test | Asserts |
|---|---|
| `test_slurm_log_stream_terminates_tail_when_job_done` | happy path — `proc.terminate()` called when `get_job` returns `done=True` |
| `test_slurm_log_stream_terminates_tail_when_get_job_raises` | regression — `proc.terminate()` still called when `get_job` raises |

`37 passed` locally (35 existing + 2 new).

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
