### PR TITLE
feat(gemma4): add 12B FFT recipe

### DIFF
--- a/configs/recipes/gemma4/README.md
+++ b/configs/recipes/gemma4/README.md
@@ -8,7 +8,7 @@ Configs for Google's Gemma 4 model family. See the [Hugging Face announcement](h
   - [google/gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it) (~5B) — **LoRA config available**
   - [google/gemma-4-E4B-it](https://huggingface.co/google/gemma-4-E4B-it) (~8B) — **FFT + LoRA configs available**
 - Unified (encoder-free, multimodal: text + image + audio)
-  - [google/gemma-4-12B-it](https://huggingface.co/google/gemma-4-12B-it) (12B) — **LoRA config available**
+  - [google/gemma-4-12B-it](https://huggingface.co/google/gemma-4-12B-it) (12B) — **FFT + LoRA configs available**
 - Larger (image + text, 256K context)
   - [google/gemma-4-26B-A4B-it](https://huggingface.co/google/gemma-4-26B-A4B-it) (MoE, 27B)
   - [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it) (dense, 31B) — **LoRA config available**
@@ -42,6 +42,18 @@ To launch Gemma 4 E4B FFT training on a remote GCP 4x A100 cluster:
 
 ```shell
 oumi launch up -c oumi://configs/recipes/gemma4/sft/e4b_full/gcp_job.yaml --cluster gemma4-e4b-full
+```
+
+To launch Gemma 4 12B FFT training locally with FSDP (needs a multi-GPU node):
+
+```shell
+oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/12b_full/train.yaml
+```
+
+To launch Gemma 4 12B FFT training on a remote GCP 8x A100 cluster:
+
+```shell
+oumi launch up -c oumi://configs/recipes/gemma4/sft/12b_full/gcp_job.yaml --cluster gemma4-12b-full
 ```
 
 ### LoRA Training

--- a/configs/recipes/gemma4/sft/12b_full/gcp_job.yaml
+++ b/configs/recipes/gemma4/sft/12b_full/gcp_job.yaml
@@ -1,0 +1,50 @@
+# Job config to FFT (full fine-tune) Gemma 4 12B.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-12B-it
+#   - transformers >= 5.10 (for the gemma4_unified arch) — upgraded in `setup` below
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c oumi://configs/recipes/gemma4/sft/12b_full/gcp_job.yaml --cluster gemma4-12b-full
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: gemma4-12b-full
+
+resources:
+  cloud: gcp
+  accelerators: "A100:8"  # FFT holds the full fp32 optimizer state; 12B does not fit on 4.
+  use_spot: false
+  disk_size: 400  # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: gemma4-12b.full
+
+setup: |
+  set -e
+  pip install uv && uv pip install --system oumi[gpu] hf_transfer
+  # gemma4_unified arch needs transformers >= 5.10 (newer than oumi's pin).
+  uv pip install --system -U "transformers>=5.10"
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi distributed torchrun -m oumi train \
+      -c oumi://configs/recipes/gemma4/sft/12b_full/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/gemma4/sft/12b_full/train.yaml
+++ b/configs/recipes/gemma4/sft/12b_full/train.yaml
@@ -1,0 +1,76 @@
+# FFT (full fine-tune) config for Gemma 4 12B Unified.
+#
+# Model highlights:
+#   - 11.95B parameter unified multimodal model from Google
+#   - 48 text transformer layers
+#   - Multimodal: text + image + audio inputs
+#   - Full fine-tune: every parameter trains (unlike the 12b_lora recipe, which
+#     scopes LoRA to the text tower). FSDP FULL_SHARD splits the bf16 weights +
+#     gradients + fp32 Adam state across the GPUs, so this needs a multi-GPU node
+#     (the full optimizer state does not fit on one GPU).
+#
+# Requirements:
+#   - Run `uv pip install -U "transformers>=5.10"` (the gemma4_unified arch needs
+#     transformers >= 5.10, newer than oumi's pin).
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-12B-it
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/12b_full/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/*train.yaml
+
+model:
+  model_name: "google/gemma-4-12B-it"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: false
+  enable_liger_kernel: false  # Disabled (may conflict with Gemma output format).
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"  # 51,760 examples
+
+training:
+  trainer_type: "TRL_SFT"
+  save_steps: 0          # No intermediate checkpoints (avoids large FSDP optimizer dumps).
+  save_epoch: false
+  save_final_model: true
+  num_train_epochs: 1
+  # Effective batch size on the 8-GPU (A100:8) target: 1 * 2 * 8 = 16.
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 2
+  max_grad_norm: 1.0
+
+  enable_gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: false
+  ddp_find_unused_parameters: false
+  compile: false
+
+  optimizer: "adamw_torch_fused"
+  learning_rate: 1.5e-05
+  lr_scheduler_type: "cosine"
+  warmup_ratio: 0.05
+  weight_decay: 0.05
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 8
+  logging_steps: 5
+  empty_device_cache_steps: 50
+  output_dir: "output/gemma4_12b.fft"
+  include_performance_metrics: true
+  enable_wandb: true
+
+fsdp:
+  enable_fsdp: true
+  sharding_strategy: "FULL_SHARD"
+  forward_prefetch: true
+  auto_wrap_policy: "TRANSFORMER_BASED_WRAP"
+  transformer_layer_cls: "Gemma4UnifiedTextDecoderLayer"


### PR DESCRIPTION
# Description

Adds a full fine-tune (FFT) recipe for the encoder-free unified Gemma 4 12B:
- `configs/recipes/gemma4/sft/12b_full/train.yaml` (FSDP `FULL_SHARD` full fine-tune; `google/gemma-4-12B-it`)
- `configs/recipes/gemma4/sft/12b_full/gcp_job.yaml` (8×A100 launch)
- README: adds the Unified 12B entry, the `transformers >= 5.10` note, and the 12B FFT launch commands

The recipe targets **`google/gemma-4-12B-it`** — the instruct variant most people will fine-tune (per review on #2490). It's the `Gemma4UnifiedForConditionalGeneration` / `gemma4_unified` arch, so it needs `transformers >= 5.10` and FSDP `transformer_layer_cls: Gemma4UnifiedTextDecoderLayer`. The `-it` checkpoint ships its own chat template, so — unlike the base `google/gemma-4-12B` — **no `chat_template` override is needed**. FFT trains every parameter, so it needs a multi-GPU node (the full fp32 optimizer state doesn't fit on one) — the `gcp_job` uses 8×A100.

Hyperparameters follow the gemma FFT family (`gemma2/2b_full`, `gemma3/4b_full`, `gemma4/e4b_full`): LR `1.5e-5`, `weight_decay 0.05`, cosine schedule + 0.05 warmup, `adamw_torch_fused`, and the disk-safe save pattern `save_steps 0` + `save_epoch false` + `save_final_model true` (no large intermediate FSDP optimizer checkpoints). Effective batch size 16 on the A100:8 target.

## Validation

**FFT on the 12B unified arch** — `google/gemma-4-12B-it` full-fine-tuned on banking77 + PubMedQA and compared against the base `-it` checkpoint (generation accuracy, 500 test examples, 8×H100 FSDP `FULL_SHARD`, recipe hyperparameters, 3 epochs). FFT improves on both tasks:

| Task | Base (`-it`) | FFT | Δ |
|---|---|---|---|
| banking77 (intent acc) | 0.810 | **0.938** | **+0.128** |
| PubMedQA (yes/no/maybe acc) | 0.606 | **0.790** | **+0.184** |

> Direct `google/gemma-4-12B-it` runs (the recipe's shipped target). banking77 used the full train split (~10k); PubMedQA a 5k `pqa_artificial` subset evaluated on the disjoint `pqa_labeled` (no leakage). Training converged cleanly (banking77 `train_loss` 0.086 / token-acc 0.995; PubMedQA `train_loss` 0.146 / token-acc 0.996), and FSDP full-sharded the unified arch without issue — the non-text `embed_vision`/`embed_audio` modules simply receive no gradient on text-only data. The `-it` deltas are smaller than the untuned base `google/gemma-4-12B` checkpoint would show (its base scores far lower, ~0.71 / ~0.16) because the instruct checkpoint already starts strong — the same pattern as the sibling E2B/E4B-it FFT recipes.

oumi auto-detects the assistant-turn templates from the `-it` chat template (`response_template='<|turn>model'`, `end_of_turn_template='<turn|>\n'`, byte-identical to `e4b_full`), so the completions-only collator supervises only the assistant turn. Companion `-it` FFT recipes on the same template path (`e2b_full`, `e4b_full`) are validated end-to-end in #2496.

## Before submitting

- [x] This PR only changes configuration + documentation (recipe YAML + README; no code, no tests needed).
- [x] Read the contributor guidelines.
- [x] Related work: companion to the 12B LoRA recipe (#2490) and the E2B/E4B FFT recipes (#2496).

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
