### PR TITLE
feat(gemma4): add E2B FFT recipe; make E4B FFT save disk-safe

### DIFF
--- a/configs/recipes/gemma4/README.md
+++ b/configs/recipes/gemma4/README.md
@@ -5,7 +5,7 @@
 Configs for Google's Gemma 4 model family. See the [Hugging Face announcement](https://huggingface.co/blog/gemma4) and the [Google blog post](https://blog.google/technology/developers/gemma-4/) for more information. Models in this family include:
 
 - Efficient (edge-targeted, multimodal: text + image + audio)
-  - [google/gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it) (~5B) — **LoRA config available**
+  - [google/gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it) (~5B) — **FFT + LoRA configs available**
   - [google/gemma-4-E4B-it](https://huggingface.co/google/gemma-4-E4B-it) (~8B) — **FFT + LoRA configs available**
 - Larger (image + text, 256K context)
   - [google/gemma-4-26B-A4B-it](https://huggingface.co/google/gemma-4-26B-A4B-it) (MoE, 27B)
@@ -37,6 +37,18 @@ To launch Gemma 4 E4B FFT training on a remote GCP 4x A100 cluster:
 
 ```shell
 oumi launch up -c oumi://configs/recipes/gemma4/sft/e4b_full/gcp_job.yaml --cluster gemma4-e4b-full
+```
+
+To launch Gemma 4 E2B FFT training locally with FSDP:
+
+```shell
+oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/e2b_full/train.yaml
+```
+
+To launch Gemma 4 E2B FFT training on a remote GCP 4x A100 cluster:
+
+```shell
+oumi launch up -c oumi://configs/recipes/gemma4/sft/e2b_full/gcp_job.yaml --cluster gemma4-e2b-full
 ```
 
 ### LoRA Training

--- a/configs/recipes/gemma4/sft/e2b_full/gcp_job.yaml
+++ b/configs/recipes/gemma4/sft/e2b_full/gcp_job.yaml
@@ -1,0 +1,48 @@
+# Job config to FFT tune Gemma 4 E2B.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-E2B-it
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c oumi://configs/recipes/gemma4/sft/e2b_full/gcp_job.yaml --cluster gemma4-e2b-full
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: gemma4-e2b-full
+
+resources:
+  cloud: gcp
+  accelerators: "A100:4"
+  use_spot: false
+  disk_size: 300  # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: gemma4-e2b.full
+
+setup: |
+  set -e
+  pip install uv && uv pip install --system oumi[gpu] hf_transfer
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi distributed torchrun \
+      -m oumi train \
+      -c oumi://configs/recipes/gemma4/sft/e2b_full/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/gemma4/sft/e2b_full/train.yaml
+++ b/configs/recipes/gemma4/sft/e2b_full/train.yaml
@@ -6,7 +6,8 @@
 #   - Multimodal: text + image + audio inputs
 #
 # Requirements:
-#   - transformers >= 5.5.4
+#   - transformers >= 5.6 (5.5.x inflates reported loss ~4x under gradient
+#     accumulation; fixed in 5.6.0, see huggingface/transformers#40564)
 #   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-E2B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #

--- a/configs/recipes/gemma4/sft/e2b_full/train.yaml
+++ b/configs/recipes/gemma4/sft/e2b_full/train.yaml
@@ -1,17 +1,17 @@
-# FFT config for Gemma 4 E4B Instruct.
+# FFT config for Gemma 4 E2B Instruct.
 #
 # Model highlights:
-#   - ~8B parameter multimodal model from Google (Gemma 4 Efficient series)
+#   - ~5.1B parameter multimodal model from Google (Gemma 4 Efficient series)
 #   - 128K context length
 #   - Multimodal: text + image + audio inputs
 #
 # Requirements:
 #   - transformers >= 5.5.4
-#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-E4B-it
+#   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-E2B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #
 # Usage:
-#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/e4b_full/train.yaml
+#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/gemma4/sft/e2b_full/train.yaml
 #
 # See Also:
 #   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
@@ -20,7 +20,7 @@
 #   - Other training configs: configs/**/*train.yaml
 
 model:
-  model_name: "google/gemma-4-E4B-it"
+  model_name: "google/gemma-4-E2B-it"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"
@@ -55,10 +55,9 @@ training:
 
   dataloader_num_workers: "auto"
   dataloader_prefetch_factor: 8
-
   logging_steps: 5
   empty_device_cache_steps: 50
-  output_dir: "output/gemma4_e4b.fft"
+  output_dir: "output/gemma4_e2b.fft"
   include_performance_metrics: true
   enable_wandb: true
 

--- a/configs/recipes/gemma4/sft/e4b_full/train.yaml
+++ b/configs/recipes/gemma4/sft/e4b_full/train.yaml
@@ -6,7 +6,8 @@
 #   - Multimodal: text + image + audio inputs
 #
 # Requirements:
-#   - transformers >= 5.5.4
+#   - transformers >= 5.6 (5.5.x inflates reported loss ~4x under gradient
+#     accumulation; fixed in 5.6.0, see huggingface/transformers#40564)
 #   - Gemma license acceptance required: https://huggingface.co/google/gemma-4-E4B-it
 #   - Log into WandB (`wandb login`) or disable `enable_wandb`
 #


### PR DESCRIPTION
# Description

Extends Gemma 4 full fine-tuning to the Efficient series:

- **New `e2b_full` recipe** (`configs/recipes/gemma4/sft/e2b_full/{train,gcp_job}.yaml`) — full fine-tune for `google/gemma-4-E2B-it` (FSDP `FULL_SHARD`, 4×A100), mirroring `e4b_full`.
- **`e4b_full` made disk-safe**: `save_steps 200 → 0` + `save_epoch false` + `save_final_model true`, so it writes only the final model instead of large intermediate FSDP optimizer checkpoints (matching the gemma2/gemma3 full recipes). Also dropped the stale gradient-accumulation loss-inflation note — `Gemma4ForConditionalGeneration` sets `accepts_loss_kwargs=False` as of transformers 5.6.0 (huggingface/transformers#40564; verified on-cluster), so every install satisfying oumi's pins (uv override resolves to 5.7.x, plain pip to 5.9.x) gets the fix. The recipe headers now state `transformers >= 5.6` with a one-line warning, since 5.5.x is the remaining affected line.
- README: E2B now lists **FFT + LoRA**; adds the E2B FFT launch commands.

Both are the standard multimodal gemma4 arch (`-it` checkpoints with their own chat template, FSDP `transformer_layer_cls: Gemma4TextDecoderLayer`). Hyperparameters follow the gemma FFT family (LR 1.5e-5, weight_decay 0.05, cosine + 0.05 warmup, `adamw_torch_fused`).

## Validation

Validated on the real `-it` checkpoints (8×H100 FSDP `FULL_SHARD`, FFT vs base, generation accuracy on 500 test examples, recipe hyperparameters, 3 epochs; banking77 full train split, PubMedQA 5k `pqa_artificial` evaluated on the disjoint `pqa_labeled`). FFT improves over the already-instruct-tuned base on every cell:

| Model | Task | Base | FFT | Δ |
|---|---|---|---|---|
| E2B | banking77 | 0.652 | **0.916** | **+0.264** |
| E2B | PubMedQA | 0.344 | **0.714** | **+0.370** |
| E4B | banking77 | 0.742 | **0.954** | **+0.212** |
| E4B | PubMedQA | 0.640 | **0.768** | **+0.128** |

Companion to the 12B FFT recipe (#2495).

## Before submitting

- [x] This PR only changes configuration + documentation (recipe YAML + README; no code, no tests needed).
- [x] Read the contributor guidelines.
- [x] Related work linked above.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->

