### PR TITLE
feat(inference): partial-inference result types + progress file reporter (1/5)

### DIFF
--- a/src/oumi/core/configs/inference_config.py
+++ b/src/oumi/core/configs/inference_config.py
@@ -40,14 +40,7 @@ class InferenceConfig(BaseConfig):
     """Path to the output file where the generated text will be saved."""
 
     progress_path: str | None = None
-    """Path to a JSON file where inference progress counters are written.
-
-    When set, partial inference (see `BaseInferenceEngine.infer_partial`)
-    periodically writes an atomic JSON snapshot of the form
-    ``{"total": N, "completed": n, "failed": f, "updated_at": "<iso8601 utc>"}``
-    so an external process can poll row-level progress. The run is complete
-    when ``completed + failed == total``.
-    """
+    """Path to a JSON file where inference progress counters are written."""
 
     engine: InferenceEngineType | None = None
     """The inference engine to use for generation.

--- a/src/oumi/core/configs/inference_config.py
+++ b/src/oumi/core/configs/inference_config.py
@@ -39,6 +39,16 @@ class InferenceConfig(BaseConfig):
     output_path: str | None = None
     """Path to the output file where the generated text will be saved."""
 
+    progress_path: str | None = None
+    """Path to a JSON file where inference progress counters are written.
+
+    When set, partial inference (see `BaseInferenceEngine.infer_partial`)
+    periodically writes an atomic JSON snapshot of the form
+    ``{"total": N, "completed": n, "failed": f, "updated_at": "<iso8601 utc>"}``
+    so an external process can poll row-level progress. The run is complete
+    when ``completed + failed == total``.
+    """
+
     engine: InferenceEngineType | None = None
     """The inference engine to use for generation.
 

--- a/src/oumi/core/inference/__init__.py
+++ b/src/oumi/core/inference/__init__.py
@@ -21,6 +21,7 @@ from oumi.core.inference.base_inference_engine import (
     BaseInferenceEngine,
     BatchResult,
     FailureDetail,
+    InferenceErrorType,
     InferenceResult,
 )
 from oumi.core.inference.progress_reporter import ProgressFileReporter
@@ -29,6 +30,7 @@ __all__ = [
     "BaseInferenceEngine",
     "BatchResult",
     "FailureDetail",
+    "InferenceErrorType",
     "InferenceResult",
     "ProgressFileReporter",
 ]

--- a/src/oumi/core/inference/__init__.py
+++ b/src/oumi/core/inference/__init__.py
@@ -17,9 +17,18 @@
 This module provides base classes for model inference in the Oumi framework.
 """
 
-from oumi.core.inference.base_inference_engine import BaseInferenceEngine, BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BaseInferenceEngine,
+    BatchResult,
+    FailureDetail,
+    InferenceResult,
+)
+from oumi.core.inference.progress_reporter import ProgressFileReporter
 
 __all__ = [
     "BaseInferenceEngine",
     "BatchResult",
+    "FailureDetail",
+    "InferenceResult",
+    "ProgressFileReporter",
 ]

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -55,6 +55,61 @@ class BatchResult:
         return len(self.failed_indices) > 0
 
 
+@dataclass(frozen=True)
+class FailureDetail:
+    """Details about a single failed inference request.
+
+    A retryable failure has already consumed the engine's internal retries
+    (``RemoteParams.max_retries``); ``is_retryable=True`` means a fresh
+    submission could plausibly succeed (transient cause), not that the engine
+    will retry it.
+    """
+
+    error_message: str
+    """Human-readable description of the failure."""
+
+    status_code: int | None = None
+    """HTTP status code of the final failed attempt, if applicable."""
+
+    is_retryable: bool = True
+    """Whether resubmitting this request could plausibly succeed."""
+
+    error_type: str = "unknown"
+    """Failure category: "api_status", "connection", "runtime", "config",
+    "parse_error", "engine_failure", or "unexpected"."""
+
+
+@dataclass
+class InferenceResult:
+    """Result of partial online inference, separating successes from failures.
+
+    Returned by :meth:`BaseInferenceEngine.infer_partial`. Unlike
+    :meth:`BaseInferenceEngine.infer`, which raises if any conversation fails,
+    this pairs each successful conversation with its original input index and
+    reports per-row failures separately so callers can keep successes and
+    decide which failures to resubmit.
+    """
+
+    successful: list[tuple[int, Conversation]]
+    """List of (original_index, conversation) for successful requests."""
+
+    failed_indices: list[int]
+    """Sorted indices of requests that failed."""
+
+    failures: dict[int, FailureDetail]
+    """Mapping of failed index to structured failure info."""
+
+    @property
+    def error_messages(self) -> dict[int, str]:
+        """Mapping of failed index to error message."""
+        return {i: detail.error_message for i, detail in self.failures.items()}
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True if any requests failed."""
+        return len(self.failed_indices) > 0
+
+
 class BaseInferenceEngine(ABC):
     """Base class for running model inference."""
 

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -105,11 +105,13 @@ class InferenceResult:
     successful: list[tuple[int, Conversation]]
     """List of (original_index, conversation) for successful requests."""
 
-    failed_indices: list[int]
-    """Sorted indices of requests that failed."""
-
     failures: dict[int, FailureDetail]
     """Mapping of failed index to structured failure info."""
+
+    @property
+    def failed_indices(self) -> list[int]:
+        """Sorted indices of requests that failed."""
+        return sorted(self.failures)
 
     @property
     def error_messages(self) -> dict[int, str]:
@@ -119,7 +121,7 @@ class InferenceResult:
     @property
     def has_failures(self) -> bool:
         """Return True if any requests failed."""
-        return len(self.failed_indices) > 0
+        return len(self.failures) > 0
 
 
 class BaseInferenceEngine(ABC):

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -57,7 +57,7 @@ class BatchResult:
 
 
 class InferenceErrorType(str, Enum):
-    """Failure category for a partial-inference request."""
+    """Failure category for an inference request."""
 
     API_STATUS = "api_status"
     """The API returned a non-success HTTP status code."""

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 import jsonlines
@@ -55,15 +56,34 @@ class BatchResult:
         return len(self.failed_indices) > 0
 
 
+class InferenceErrorType(str, Enum):
+    """Failure category for a partial-inference request."""
+
+    API_STATUS = "api_status"
+    """The API returned a non-success HTTP status code."""
+
+    CONNECTION = "connection"
+    """A network-level error prevented reaching the API."""
+
+    RUNTIME = "runtime"
+    """An error was raised while running inference."""
+
+    CONFIG = "config"
+    """The request failed due to invalid configuration."""
+
+    PARSE_ERROR = "parse_error"
+    """The API response could not be parsed into a conversation."""
+
+    ENGINE_FAILURE = "engine_failure"
+    """The inference engine itself failed."""
+
+    UNKNOWN = "unknown"
+    """Default and catch-all: the failure fits no other category."""
+
+
 @dataclass(frozen=True)
 class FailureDetail:
-    """Details about a single failed inference request.
-
-    A retryable failure has already consumed the engine's internal retries
-    (``RemoteParams.max_retries``); ``is_retryable=True`` means a fresh
-    submission could plausibly succeed (transient cause), not that the engine
-    will retry it.
-    """
+    """Details about a single failed inference request."""
 
     error_message: str
     """Human-readable description of the failure."""
@@ -74,21 +94,13 @@ class FailureDetail:
     is_retryable: bool = True
     """Whether resubmitting this request could plausibly succeed."""
 
-    error_type: str = "unknown"
-    """Failure category: "api_status", "connection", "runtime", "config",
-    "parse_error", "engine_failure", or "unexpected"."""
+    error_type: InferenceErrorType = InferenceErrorType.UNKNOWN
+    """Failure category for this request."""
 
 
 @dataclass
 class InferenceResult:
-    """Result of partial online inference, separating successes from failures.
-
-    Returned by :meth:`BaseInferenceEngine.infer_partial`. Unlike
-    :meth:`BaseInferenceEngine.infer`, which raises if any conversation fails,
-    this pairs each successful conversation with its original input index and
-    reports per-row failures separately so callers can keep successes and
-    decide which failures to resubmit.
-    """
+    """Result of partial online inference, separating successes from failures."""
 
     successful: list[tuple[int, Conversation]]
     """List of (original_index, conversation) for successful requests."""
@@ -102,7 +114,7 @@ class InferenceResult:
     @property
     def error_messages(self) -> dict[int, str]:
         """Mapping of failed index to error message."""
-        return {i: detail.error_message for i, detail in self.failures.items()}
+        return {idx: detail.error_message for idx, detail in self.failures.items()}
 
     @property
     def has_failures(self) -> bool:

--- a/src/oumi/core/inference/progress_reporter.py
+++ b/src/oumi/core/inference/progress_reporter.py
@@ -45,7 +45,8 @@ class ProgressFileReporter:
             total: Total number of rows in the run.
             min_write_interval: Minimum seconds between snapshot writes.
         """
-        self._path = path
+        self._path = Path(path)
+        self._tmp_path = self._path.with_name(self._path.name + ".tmp")
         self._total = total
         self._min_write_interval = min_write_interval
         self._completed = 0
@@ -91,13 +92,11 @@ class ProgressFileReporter:
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
         try:
-            path = Path(self._path)
-            path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.parent.mkdir(parents=True, exist_ok=True)
             # Write to a temp file in the same directory so the replace is atomic.
-            tmp_path = path.with_name(path.name + ".tmp")
-            with open(tmp_path, "w") as f:
+            with open(self._tmp_path, "w") as f:
                 json.dump(snapshot, f)
-            tmp_path.replace(path)
+            self._tmp_path.replace(self._path)
         except Exception as e:
             if not self._warned:
                 logger.warning(f"Failed to write inference progress file: {e}")

--- a/src/oumi/core/inference/progress_reporter.py
+++ b/src/oumi/core/inference/progress_reporter.py
@@ -1,0 +1,107 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from oumi.utils.logging import logger
+
+
+class ProgressFileReporter:
+    """Writes inference progress counters to a JSON file for external pollers.
+
+    The snapshot format is::
+
+        {"total": N, "completed": n, "failed": f, "updated_at": "<iso8601 utc>"}
+
+    The run is complete when ``completed + failed == total``. Writes are atomic
+    (temp file + ``os.replace``), so a polling process never observes partial
+    JSON, and are throttled to at most one per ``min_write_interval`` seconds
+    (``start()`` and ``finalize()`` always write).
+
+    Filesystem failures are logged and swallowed: a broken progress path must
+    never kill inference. Counter updates are thread-safe.
+    """
+
+    def __init__(self, path: str, total: int, min_write_interval: float = 1.0):
+        """Initializes the reporter.
+
+        Args:
+            path: Destination file for the JSON snapshot.
+            total: Total number of rows in the run.
+            min_write_interval: Minimum seconds between snapshot writes.
+        """
+        self._path = path
+        self._total = total
+        self._min_write_interval = min_write_interval
+        self._completed = 0
+        self._failed = 0
+        self._last_write_time = 0.0
+        self._warned = False
+        self._lock = threading.Lock()
+
+    def start(self, completed: int = 0, failed: int = 0) -> None:
+        """Initializes counters and writes the first snapshot."""
+        with self._lock:
+            self._completed = completed
+            self._failed = failed
+            self._write_snapshot()
+
+    def record_completed(self, n: int = 1) -> None:
+        """Records n successfully completed rows."""
+        with self._lock:
+            self._completed += n
+            self._maybe_write_snapshot()
+
+    def record_failed(self, n: int = 1) -> None:
+        """Records n failed rows."""
+        with self._lock:
+            self._failed += n
+            self._maybe_write_snapshot()
+
+    def finalize(self) -> None:
+        """Writes a final snapshot, bypassing the throttle."""
+        with self._lock:
+            self._write_snapshot()
+
+    def _maybe_write_snapshot(self) -> None:
+        if time.monotonic() - self._last_write_time >= self._min_write_interval:
+            self._write_snapshot()
+
+    def _write_snapshot(self) -> None:
+        self._last_write_time = time.monotonic()
+        snapshot = {
+            "total": self._total,
+            "completed": self._completed,
+            "failed": self._failed,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            path = Path(self._path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Write to a temp file in the same directory so os.replace is atomic.
+            tmp_path = str(path) + ".tmp"
+            with open(tmp_path, "w") as f:
+                json.dump(snapshot, f)
+            os.replace(tmp_path, str(path))
+        except Exception as e:
+            if not self._warned:
+                logger.warning(f"Failed to write inference progress file: {e}")
+                self._warned = True
+            else:
+                logger.debug(f"Failed to write inference progress file: {e}")

--- a/src/oumi/core/inference/progress_reporter.py
+++ b/src/oumi/core/inference/progress_reporter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import os
 import threading
 import time
 from datetime import datetime, timezone
@@ -94,11 +93,11 @@ class ProgressFileReporter:
         try:
             path = Path(self._path)
             path.parent.mkdir(parents=True, exist_ok=True)
-            # Write to a temp file in the same directory so os.replace is atomic.
-            tmp_path = str(path) + ".tmp"
+            # Write to a temp file in the same directory so the replace is atomic.
+            tmp_path = path.with_name(path.name + ".tmp")
             with open(tmp_path, "w") as f:
                 json.dump(snapshot, f)
-            os.replace(tmp_path, str(path))
+            tmp_path.replace(path)
         except Exception as e:
             if not self._warned:
                 logger.warning(f"Failed to write inference progress file: {e}")

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -466,7 +466,6 @@ def test_inference_result_error_messages_derived_from_failures():
     )
     result = InferenceResult(
         successful=[(0, conversation)],
-        failed_indices=[1, 2],
         failures={
             1: FailureDetail(
                 error_message="timeout", error_type=InferenceErrorType.RUNTIME
@@ -481,6 +480,7 @@ def test_inference_result_error_messages_derived_from_failures():
     )
 
     assert result.has_failures
+    assert result.failed_indices == [1, 2]
     assert result.error_messages == {1: "timeout", 2: "bad request"}
     assert result.failures[2].status_code == 400
     assert not result.failures[2].is_retryable
@@ -488,9 +488,10 @@ def test_inference_result_error_messages_derived_from_failures():
 
 
 def test_inference_result_no_failures():
-    result = InferenceResult(successful=[], failed_indices=[], failures={})
+    result = InferenceResult(successful=[], failures={})
 
     assert not result.has_failures
+    assert result.failed_indices == []
     assert result.error_messages == {}
 
 

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -7,7 +7,7 @@ import jsonlines
 import pytest
 
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
-from oumi.core.inference import BaseInferenceEngine
+from oumi.core.inference import BaseInferenceEngine, FailureDetail, InferenceResult
 from oumi.core.types.conversation import Conversation, Message, Role
 
 
@@ -453,3 +453,43 @@ def test_final_conversations_saved_to_output_file(mock_engine):
         assert not scratch_path.exists(), (
             "Scratch file should be cleaned up after successful inference"
         )
+
+
+def test_inference_result_error_messages_derived_from_failures():
+    conversation = Conversation(
+        messages=[Message(role=Role.USER, content="hi")],
+    )
+    result = InferenceResult(
+        successful=[(0, conversation)],
+        failed_indices=[1, 2],
+        failures={
+            1: FailureDetail(error_message="timeout", error_type="runtime"),
+            2: FailureDetail(
+                error_message="bad request",
+                status_code=400,
+                is_retryable=False,
+                error_type="api_status",
+            ),
+        },
+    )
+
+    assert result.has_failures
+    assert result.error_messages == {1: "timeout", 2: "bad request"}
+    assert result.failures[2].status_code == 400
+    assert not result.failures[2].is_retryable
+    assert result.failures[1].is_retryable
+
+
+def test_inference_result_no_failures():
+    result = InferenceResult(successful=[], failed_indices=[], failures={})
+
+    assert not result.has_failures
+    assert result.error_messages == {}
+
+
+def test_failure_detail_defaults():
+    detail = FailureDetail(error_message="boom")
+
+    assert detail.status_code is None
+    assert detail.is_retryable
+    assert detail.error_type == "unknown"

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -7,7 +7,12 @@ import jsonlines
 import pytest
 
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
-from oumi.core.inference import BaseInferenceEngine, FailureDetail, InferenceResult
+from oumi.core.inference import (
+    BaseInferenceEngine,
+    FailureDetail,
+    InferenceErrorType,
+    InferenceResult,
+)
 from oumi.core.types.conversation import Conversation, Message, Role
 
 
@@ -463,12 +468,14 @@ def test_inference_result_error_messages_derived_from_failures():
         successful=[(0, conversation)],
         failed_indices=[1, 2],
         failures={
-            1: FailureDetail(error_message="timeout", error_type="runtime"),
+            1: FailureDetail(
+                error_message="timeout", error_type=InferenceErrorType.RUNTIME
+            ),
             2: FailureDetail(
                 error_message="bad request",
                 status_code=400,
                 is_retryable=False,
-                error_type="api_status",
+                error_type=InferenceErrorType.API_STATUS,
             ),
         },
     )
@@ -492,4 +499,4 @@ def test_failure_detail_defaults():
 
     assert detail.status_code is None
     assert detail.is_retryable
-    assert detail.error_type == "unknown"
+    assert detail.error_type == InferenceErrorType.UNKNOWN

--- a/tests/unit/inference/test_progress_reporter.py
+++ b/tests/unit/inference/test_progress_reporter.py
@@ -1,0 +1,145 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oumi.core.inference import ProgressFileReporter
+
+
+@pytest.fixture
+def progress_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield str(Path(temp_dir) / "progress.json")
+
+
+def _read_snapshot(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def test_start_writes_initial_snapshot(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["total"] == 10
+    assert snapshot["completed"] == 0
+    assert snapshot["failed"] == 0
+    assert "updated_at" in snapshot
+
+
+def test_start_with_resumed_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start(completed=4, failed=1)
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 4
+    assert snapshot["failed"] == 1
+
+
+def test_finalize_writes_final_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=3)
+    reporter.start()
+    reporter.record_completed()
+    reporter.record_completed()
+    reporter.record_failed()
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["total"] == 3
+    assert snapshot["completed"] == 2
+    assert snapshot["failed"] == 1
+    assert snapshot["completed"] + snapshot["failed"] == snapshot["total"]
+
+
+def test_record_batch_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start()
+    reporter.record_completed(n=7)
+    reporter.record_failed(n=3)
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 7
+    assert snapshot["failed"] == 3
+
+
+def test_writes_throttled_between_ticks(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=100, min_write_interval=60.0)
+    reporter.start()
+    # Ticks within the interval should not rewrite the file.
+    reporter.record_completed()
+    reporter.record_completed()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 0
+
+    # finalize bypasses the throttle.
+    reporter.finalize()
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 2
+
+
+def test_writes_not_throttled_after_interval(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=100, min_write_interval=0.0)
+    reporter.start()
+    reporter.record_completed()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 1
+
+
+def test_atomic_write_leaves_no_temp_file(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=1, min_write_interval=0.0)
+    reporter.start()
+    reporter.record_completed()
+    reporter.finalize()
+
+    parent = Path(progress_path).parent
+    assert [p.name for p in parent.iterdir()] == ["progress.json"]
+
+
+def test_creates_parent_directories(progress_path):
+    nested = str(Path(progress_path).parent / "a" / "b" / "progress.json")
+    reporter = ProgressFileReporter(nested, total=1)
+    reporter.start()
+
+    assert _read_snapshot(nested)["total"] == 1
+
+
+def test_write_failure_never_raises(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        reporter.start()
+        reporter.record_completed()
+        reporter.record_failed()
+        reporter.finalize()
+
+    assert not os.path.exists(progress_path)
+
+
+def test_write_failure_warns_once(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch(
+        "oumi.core.inference.progress_reporter.logger.warning"
+    ) as mock_warning:
+        with patch("os.replace", side_effect=OSError("disk full")):
+            reporter.start()
+            reporter.record_completed()
+            reporter.finalize()
+
+    assert mock_warning.call_count == 1
+
+
+def test_recovers_after_transient_write_failure(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        reporter.start()
+    reporter.record_completed()
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 1

--- a/tests/unit/inference/test_progress_reporter.py
+++ b/tests/unit/inference/test_progress_reporter.py
@@ -123,9 +123,7 @@ def test_write_failure_never_raises(progress_path):
 
 def test_write_failure_warns_once(progress_path):
     reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
-    with patch(
-        "oumi.core.inference.progress_reporter.logger.warning"
-    ) as mock_warning:
+    with patch("oumi.core.inference.progress_reporter.logger.warning") as mock_warning:
         with patch("os.replace", side_effect=OSError("disk full")):
             reporter.start()
             reporter.record_completed()


### PR DESCRIPTION
### 📚 Stack — partial-failure support for online inference
1. **#2498 — core types + progress reporter ◀ this PR**
2. #2499 — base-engine `infer_partial()` template
3. #2500 — remote-engine per-row failures
4. #2501 — `judge_partial()`
5. #2502 — `synthesize_partial()`

---

Foundation types for `infer_partial()` (lands in part 2/5):

- `FailureDetail` — per-row failure info: `error_message`, `status_code`, `is_retryable`, `error_type`. A retryable failure has already consumed the engine's internal `max_retries`; `is_retryable=True` means a fresh submission could plausibly succeed.
- `InferenceErrorType` — `str` enum of failure categories (`api_status`, `connection`, `runtime`, `config`, `parse_error`, `engine_failure`, `unknown`) stamped onto `FailureDetail.error_type`.
- `InferenceResult` — `successful: list[(idx, Conversation)]` + `failed_indices` + `failures`, with `error_messages`/`has_failures` derived. Field names mirror `BatchResult` so duck-typed consumers work unchanged; `BatchResult` itself is untouched.
- `ProgressFileReporter` — atomic (temp + `os.replace`), throttled JSON progress snapshots (`{total, completed, failed, updated_at}`) for cross-process pollers (e.g. a SkyPilot job wrapper). Write failures are logged and swallowed — a broken progress path never kills inference.
- `InferenceConfig.progress_path` — YAML-serializable config field for the snapshot location.
