### PR TITLE
feat(inference): infer_partial() template in BaseInferenceEngine (2/5)

### DIFF
--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -32,6 +32,7 @@ from oumi.core.configs import (
     InferenceConfig,
     ModelParams,
 )
+from oumi.core.inference.progress_reporter import ProgressFileReporter
 from oumi.core.types.conversation import Conversation
 from oumi.utils.logging import logger
 from oumi.utils.math_utils import is_power_of_two
@@ -124,6 +125,23 @@ class InferenceResult:
         return len(self.failures) > 0
 
 
+@dataclass
+class _PreparedInferenceRun:
+    """Validated inputs shared by infer() and infer_partial()."""
+
+    inference_config: InferenceConfig | None
+    """The inference config, possibly updated with the engine's generation params."""
+
+    conversations: list[Conversation]
+    """All conversations to process, with conversation ids assigned."""
+
+    completed_from_scratch: list[Conversation]
+    """Conversations already completed in a previous run, loaded from scratch."""
+
+    remaining: list[Conversation]
+    """Conversations that still need inference."""
+
+
 class BaseInferenceEngine(ABC):
     """Base class for running model inference."""
 
@@ -156,20 +174,19 @@ class BaseInferenceEngine(ABC):
         self._latency_histogram_from_file = HdrHistogram(20, 180 * 1000, 1)
         self._dataset_hash = None
 
-    def infer(
+    def _prepare_inference_run(
         self,
         input: list[Conversation] | None = None,
         inference_config: InferenceConfig | None = None,
-    ) -> list[Conversation]:
-        """Runs model inference.
+    ) -> _PreparedInferenceRun:
+        """Validates inputs and prepares conversations for an inference run.
 
         Args:
             input: A list of conversations to run inference on. Optional.
             inference_config: Parameters for inference.
-                If not specified, a default config is inferred.
 
         Returns:
-            List[Conversation]: Inference output.
+            _PreparedInferenceRun: The validated, prepared run inputs.
         """
         if input is not None and (
             inference_config and inference_config.input_path is not None
@@ -209,7 +226,7 @@ class BaseInferenceEngine(ABC):
             )
 
         unique_conversation_ids = set()
-        for i, conversation in enumerate(conversations_to_process):
+        for idx, conversation in enumerate(conversations_to_process):
             if conversation.conversation_id is not None:
                 if conversation.conversation_id in unique_conversation_ids:
                     raise ValueError(
@@ -228,7 +245,7 @@ class BaseInferenceEngine(ABC):
                 ]
             )
             content_hash = hashlib.sha256(all_str_message_content.encode()).hexdigest()
-            id_name = str(i) + "_" + content_hash
+            id_name = str(idx) + "_" + content_hash
 
             conversation.conversation_id = str(
                 uuid.uuid5(
@@ -261,6 +278,34 @@ class BaseInferenceEngine(ABC):
                 f"Found {len(completed_conversations)} completed conversations. "
                 f"Processing remaining {len(remaining_conversations)} conversations."
             )
+
+        return _PreparedInferenceRun(
+            inference_config=inference_config,
+            conversations=conversations_to_process,
+            completed_from_scratch=completed_conversations,
+            remaining=remaining_conversations,
+        )
+
+    def infer(
+        self,
+        input: list[Conversation] | None = None,
+        inference_config: InferenceConfig | None = None,
+    ) -> list[Conversation]:
+        """Runs model inference.
+
+        Args:
+            input: A list of conversations to run inference on. Optional.
+            inference_config: Parameters for inference.
+                If not specified, a default config is inferred.
+
+        Returns:
+            List[Conversation]: Inference output.
+        """
+        prepared = self._prepare_inference_run(input, inference_config)
+        inference_config = prepared.inference_config
+        conversations_to_process = prepared.conversations
+        remaining_conversations = prepared.remaining
+        output_path = inference_config.output_path if inference_config else None
 
         # Run inference only on remaining conversations
         start_time = time.perf_counter()
@@ -304,6 +349,184 @@ class BaseInferenceEngine(ABC):
             self._save_conversations(final_results, inference_config.output_path)
 
         return final_results
+
+    def infer_partial(
+        self,
+        input: list[Conversation] | None = None,
+        inference_config: InferenceConfig | None = None,
+        *,
+        progress_path: str | None = None,
+    ) -> InferenceResult:
+        """Runs model inference, tolerating per-row failures.
+
+        Unlike infer(), which raises if any conversation fails, this returns
+        an InferenceResult pairing each successful conversation with its
+        original input index and reporting per-row failures separately, so
+        callers can keep successes and decide which failures to resubmit.
+
+        Args:
+            input: A list of conversations to run inference on. Optional.
+            inference_config: Parameters for inference.
+            progress_path: Path to a JSON file where progress counters are
+                periodically written for external pollers. Takes precedence
+                over inference_config.progress_path.
+
+        Returns:
+            InferenceResult: Successful conversations and per-row failures.
+        """
+        prepared = self._prepare_inference_run(input, inference_config)
+        inference_config = prepared.inference_config
+        output_path = inference_config.output_path if inference_config else None
+
+        id_to_index = {
+            conversation.conversation_id: idx
+            for idx, conversation in enumerate(prepared.conversations)
+        }
+
+        # Seed successes with conversations completed in a previous run,
+        # ignoring stale scratch entries that aren't part of this input.
+        successful: list[tuple[int, Conversation]] = [
+            (id_to_index[conversation.conversation_id], conversation)
+            for conversation in prepared.completed_from_scratch
+            if conversation.conversation_id in id_to_index
+        ]
+
+        if progress_path is None and inference_config:
+            progress_path = inference_config.progress_path
+        progress: ProgressFileReporter | None = None
+        if progress_path:
+            progress = ProgressFileReporter(
+                progress_path, total=len(prepared.conversations)
+            )
+            progress.start(completed=len(successful))
+
+        try:
+            start_time = time.perf_counter()
+            histogram = self._latency_histogram_online
+            outcomes = self._infer_online_partial(
+                prepared.remaining, inference_config, progress
+            )
+            histogram.record_value((time.perf_counter() - start_time) * 1e3)
+            self._maybe_log_latency_histogram(histogram)
+        finally:
+            if progress:
+                progress.finalize()
+
+        if len(outcomes) != len(prepared.remaining):
+            raise RuntimeError(
+                f"_infer_online_partial returned {len(outcomes)} outcomes for "
+                f"{len(prepared.remaining)} conversations."
+            )
+
+        failures: dict[int, FailureDetail] = {}
+        for conversation, outcome in zip(prepared.remaining, outcomes):
+            index = id_to_index[conversation.conversation_id]
+            if isinstance(outcome, FailureDetail):
+                failures[index] = outcome
+            else:
+                successful.append((index, outcome))
+
+        result = InferenceResult(
+            successful=sorted(successful, key=lambda pair: pair[0]),
+            failures=failures,
+        )
+
+        # Keep the scratch file when there are failures so that re-invoking
+        # with the same input and config resumes from completed conversations.
+        if not result.has_failures:
+            self._cleanup_scratch_file(output_path)
+
+        if inference_config and inference_config.output_path:
+            self._save_conversations(
+                [conversation for _, conversation in result.successful],
+                inference_config.output_path,
+            )
+
+        return result
+
+    def _infer_online_partial(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+        progress: ProgressFileReporter | None = None,
+    ) -> list["Conversation | FailureDetail"]:
+        """Runs online inference, capturing per-row failures.
+
+        Returns a list aligned 1:1 with input: a Conversation for each row
+        that succeeded, or a FailureDetail for each row that failed.
+
+        Args:
+            input: A list of conversations to run inference on.
+            inference_config: Parameters for inference.
+            progress: Optional progress reporter, ticked as rows complete.
+
+        Returns:
+            list[Conversation | FailureDetail]: Per-row outcomes, aligned
+                with input.
+        """
+        if not input:
+            return []
+        output_path = inference_config.output_path if inference_config else None
+        try:
+            results = self._infer_online(input, inference_config)
+        except Exception as e:
+            completed_by_id = {
+                conversation.conversation_id: conversation
+                for conversation in self._load_from_scratch(output_path)
+                if conversation.conversation_id is not None
+            }
+            failure = FailureDetail(
+                error_message=str(e),
+                status_code=getattr(e, "status_code", None),
+                is_retryable=True,
+                error_type=InferenceErrorType.ENGINE_FAILURE,
+            )
+            outcomes: list[Conversation | FailureDetail] = []
+            num_completed = 0
+            for conversation in input:
+                conversation_id = conversation.conversation_id
+                checkpointed = (
+                    completed_by_id.get(conversation_id) if conversation_id else None
+                )
+                if checkpointed is not None:
+                    outcomes.append(checkpointed)
+                    num_completed += 1
+                else:
+                    outcomes.append(failure)
+            if progress:
+                if num_completed:
+                    progress.record_completed(num_completed)
+                progress.record_failed(len(input) - num_completed)
+            return outcomes
+
+        # Map results by conversation id to guard against engines returning
+        # results in a different order than the input.
+        results_by_id = {
+            conversation.conversation_id: conversation
+            for conversation in results
+            if conversation.conversation_id is not None
+        }
+        missing = FailureDetail(
+            error_message="Engine returned no result for this conversation.",
+            is_retryable=True,
+            error_type=InferenceErrorType.ENGINE_FAILURE,
+        )
+        outcomes = []
+        num_completed = 0
+        for conversation in input:
+            conversation_id = conversation.conversation_id
+            match = results_by_id.get(conversation_id) if conversation_id else None
+            if match is not None:
+                outcomes.append(match)
+                num_completed += 1
+            else:
+                outcomes.append(missing)
+        if progress:
+            if num_completed:
+                progress.record_completed(num_completed)
+            if num_completed != len(input):
+                progress.record_failed(len(input) - num_completed)
+        return outcomes
 
     def _maybe_log_latency_histogram(self, histogram: HdrHistogram | None) -> None:
         """Logs the histogram if it is not None.

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -501,3 +501,236 @@ def test_failure_detail_defaults():
     assert detail.status_code is None
     assert detail.is_retryable
     assert detail.error_type == InferenceErrorType.UNKNOWN
+
+
+class FailAfterFirstMockEngine(MockInferenceEngine):
+    """Mock engine that checkpoints the first conversation then fails."""
+
+    def _infer_online(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+    ) -> list[Conversation]:
+        for idx, conv in enumerate(input):
+            if idx >= 1:
+                raise RuntimeError("Simulated failure")
+            new_conv = conv.model_copy(deep=True)
+            new_conv.messages.append(
+                Message(role=Role.ASSISTANT, content=f"Mock response {idx}")
+            )
+            self._save_conversation_to_scratch(
+                new_conv,
+                inference_config.output_path if inference_config else None,
+            )
+        raise RuntimeError("Simulated failure")
+
+
+@pytest.fixture
+def failing_engine():
+    return FailAfterFirstMockEngine(model_params=ModelParams(model_name="test-model"))
+
+
+def test_infer_partial_all_success(mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = mock_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert not result.has_failures
+        assert result.failed_indices == []
+        assert result.error_messages == {}
+        assert [idx for idx, _ in result.successful] == [0, 1, 2]
+        for idx, conv in result.successful:
+            assert conv.conversation_id == f"test-{idx}"
+            assert conv.messages[-1].role == Role.ASSISTANT
+
+        # Scratch cleaned up on success; output contains all successes.
+        scratch_path = Path(mock_engine._get_scratch_filepath(output_path))
+        assert not scratch_path.exists()
+        with jsonlines.open(output_path) as reader:
+            saved = [Conversation.from_dict(line) for line in reader]
+        assert len(saved) == 3
+
+
+def test_infer_partial_parity_with_infer(mock_engine):
+    conversations = [create_test_conversation(idx) for idx in range(3)]
+
+    infer_results = mock_engine.infer(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+    partial_result = mock_engine.infer_partial(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+
+    assert [c.conversation_id for c in infer_results] == [
+        conv.conversation_id for _, conv in partial_result.successful
+    ]
+    assert [str(c.messages[-1].content) for c in infer_results] == [
+        str(conv.messages[-1].content) for _, conv in partial_result.successful
+    ]
+
+
+def test_infer_partial_default_wrapper_credits_checkpointed_rows(failing_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = failing_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert result.has_failures
+        assert [idx for idx, _ in result.successful] == [0]
+        assert result.failed_indices == [1, 2]
+        for idx in result.failed_indices:
+            assert result.failures[idx].error_type == InferenceErrorType.ENGINE_FAILURE
+            assert result.failures[idx].is_retryable
+            assert "Simulated failure" in result.failures[idx].error_message
+
+        # Scratch retained on failure for resume.
+        scratch_path = Path(failing_engine._get_scratch_filepath(output_path))
+        assert scratch_path.exists()
+
+        # Output contains only the successful conversation.
+        with jsonlines.open(output_path) as reader:
+            saved = [Conversation.from_dict(line) for line in reader]
+        assert len(saved) == 1
+        assert saved[0].conversation_id == "test-0"
+
+
+def test_infer_partial_resumes_from_scratch_after_failure(failing_engine, mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        first = failing_engine.infer_partial(
+            input=[c.model_copy(deep=True) for c in conversations],
+            inference_config=inference_config,
+        )
+        assert first.failed_indices == [1, 2]
+
+        # Re-run with a healthy engine: row 0 must come from scratch, only
+        # the remaining rows are re-processed.
+        with patch.object(
+            mock_engine, "_infer_online", wraps=mock_engine._infer_online
+        ) as mock_infer:
+            second = mock_engine.infer_partial(
+                input=[c.model_copy(deep=True) for c in conversations],
+                inference_config=inference_config,
+            )
+
+        assert not second.has_failures
+        assert [idx for idx, _ in second.successful] == [0, 1, 2]
+        processed_ids = [c.conversation_id for c in mock_infer.call_args[0][0]]
+        assert processed_ids == ["test-1", "test-2"]
+
+        # Scratch cleaned after the fully successful run.
+        scratch_path = Path(mock_engine._get_scratch_filepath(output_path))
+        assert not scratch_path.exists()
+
+
+def test_infer_partial_empty_input(mock_engine):
+    result = mock_engine.infer_partial(input=[])
+
+    assert result.successful == []
+    assert result.failed_indices == []
+    assert not result.has_failures
+
+
+def test_infer_partial_duplicate_conversation_ids_raise(mock_engine):
+    conversations = [create_test_conversation(1), create_test_conversation(1)]
+
+    with pytest.raises(ValueError, match="is not unique"):
+        mock_engine.infer_partial(input=conversations)
+
+
+def test_infer_partial_writes_progress_file(mock_engine):
+    import json as json_lib
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        mock_engine.infer_partial(input=conversations, progress_path=progress_path)
+
+        with open(progress_path) as f:
+            snapshot = json_lib.load(f)
+        assert snapshot["total"] == 3
+        assert snapshot["completed"] == 3
+        assert snapshot["failed"] == 0
+
+
+def test_infer_partial_progress_file_via_config_with_failures(failing_engine):
+    import json as json_lib
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            progress_path=progress_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = failing_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert result.failed_indices == [1, 2]
+        with open(progress_path) as f:
+            snapshot = json_lib.load(f)
+        assert snapshot["total"] == 3
+        assert snapshot["completed"] == 1
+        assert snapshot["failed"] == 2
+        assert snapshot["completed"] + snapshot["failed"] == snapshot["total"]
+
+
+def test_infer_partial_progress_write_failure_does_not_raise(mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        conversations = [create_test_conversation(idx) for idx in range(2)]
+
+        with patch("os.replace", side_effect=OSError("disk full")):
+            result = mock_engine.infer_partial(
+                input=conversations, progress_path=progress_path
+            )
+
+        assert not result.has_failures
+        assert len(result.successful) == 2
+
+
+def test_infer_partial_outcome_count_mismatch_raises(mock_engine):
+    conversations = [create_test_conversation(idx) for idx in range(2)]
+
+    with patch.object(mock_engine, "_infer_online_partial", return_value=[]):
+        with pytest.raises(RuntimeError, match="returned 0 outcomes"):
+            mock_engine.infer_partial(input=conversations)
+
+
+def test_existing_infer_tests_unaffected_by_partial_run(mock_engine):
+    """infer() after infer_partial() on the same engine behaves normally."""
+    conversations = [create_test_conversation(idx) for idx in range(2)]
+
+    partial = mock_engine.infer_partial(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+    results = mock_engine.infer(input=[c.model_copy(deep=True) for c in conversations])
+
+    assert len(partial.successful) == 2
+    assert len(results) == 2


### PR DESCRIPTION
### 📚 Stack — partial-failure support for online inference
1. #2498 — core types + progress reporter
2. **#2499 — base-engine `infer_partial()` template ◀ this PR**
3. #2500 — remote-engine per-row failures
4. #2501 — `judge_partial()`
5. #2502 — `synthesize_partial()`

**Base PR:** #2498

---

Adds `BaseInferenceEngine.infer_partial()`:

- Extracts `infer()`'s preamble (validation, generation-params merge, input loading, deterministic conversation ids, dataset hash, scratch dedup) into `_prepare_inference_run()`, shared by both entry points. `infer()` is byte-equivalent after the refactor — the existing test suites pass unmodified (519 passed).
- `infer_partial()` returns an `InferenceResult` instead of raising on row failures: scratch-resumed rows are credited as successes (and counted as completed in the initial progress snapshot), the scratch file is retained on failure so re-invoking with identical input/config resumes, and `output_path` receives successes only. Row-level failures never raise; invalid call shapes (duplicate ids, both input + input_path) still do.
- Default `_infer_online_partial()` hook wraps `_infer_online()` whole-batch: every engine (vllm/native/llama_cpp) gets a working all-or-nothing implementation today, with scratch-checkpointed rows credited as successes when the batch raises. True per-row support for remote engines lands in part 3/5.
- Progress reporting via the `progress_path` param (takes precedence) or `InferenceConfig.progress_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
