### PR TITLE
fix(modal): use CUDA-devel base image so flashinfer can JIT-compile

### DIFF
--- a/src/oumi/launcher/clients/modal_client.py
+++ b/src/oumi/launcher/clients/modal_client.py
@@ -83,8 +83,15 @@ def _build_image(modal_lib: Any, job: JobConfig) -> Any:
     """Builds a ``modal.Image`` from the JobConfig.
 
     ``resources.image_id`` (``docker:<ref>``) → ``Image.from_registry(<ref>)``.
-    Otherwise we start from a generic Python base image with ``apt`` tooling
-    baked in for the common setup paths.
+    Otherwise we start from a CUDA-devel base with ``apt`` tooling baked in
+    for the common setup paths.
+
+    The default base ships the CUDA toolkit (``nvcc`` at ``/usr/local/cuda``)
+    rather than a runtime-only image. Models whose vLLM path JIT-compiles
+    flashinfer kernels at runtime — e.g. Qwen3.5 / Qwen3-Next GDN linear
+    attention — need ``nvcc`` on the first forward pass; a runtime-only base
+    fails with "Could not find nvcc". A ``debian_slim`` base does not provide
+    it, whereas most managed GPU images do.
 
     Note: ``job.setup`` is intentionally NOT baked into the image. Modal's
     image build runs without secrets attached, so any setup step that
@@ -103,7 +110,9 @@ def _build_image(modal_lib: Any, job: JobConfig) -> Any:
     # ``pip_install`` — uv is faster and Modal handles its bootstrap
     # internally so we don't need to install uv as a separate step.
     return (
-        modal_lib.Image.debian_slim()
+        modal_lib.Image.from_registry(
+            "nvidia/cuda:12.6.2-devel-ubuntu22.04", add_python="3.11"
+        )
         .apt_install("zip", "curl", "git")
         .uv_pip_install("awscli")
     )

--- a/tests/unit/launcher/clients/test_modal_client.py
+++ b/tests/unit/launcher/clients/test_modal_client.py
@@ -45,7 +45,8 @@ def fake_modal():
     """Constructs a fake ``modal`` SDK with the surface area we touch."""
     fake = MagicMock(name="modal")
 
-    # Image chain: Image.debian_slim().apt_install(...).uv_pip_install(...).
+    # Image chain: Image.from_registry(...).apt_install(...).uv_pip_install(...)
+    # for the default base, or Image.from_registry(<ref>) for docker: image_ids.
     image_obj = MagicMock(name="Image")
     image_obj.apt_install.return_value = image_obj
     image_obj.pip_install.return_value = image_obj
@@ -106,15 +107,20 @@ def test_launch_mounts_hf_cache_volume(fake_modal):
     assert "/root/.cache/huggingface" in kwargs["volumes"]
 
 
-def test_launch_default_image_uses_uv_pip_install(fake_modal):
-    """Default image installs awscli via uv_pip_install (Modal-recommended)."""
+def test_launch_default_image_is_cuda_devel_with_nvcc(fake_modal):
+    """Default base is a CUDA-devel image so flashinfer can JIT-compile GDN
+    kernels (needs nvcc); awscli still installed via uv_pip_install."""
     with patch(
         "oumi.launcher.clients.modal_client._import_modal", return_value=fake_modal
     ):
         ModalClient().launch(_job())
-    image_obj = fake_modal.Image.debian_slim.return_value
-    image_obj.uv_pip_install.assert_called_once_with("awscli")
+    fake_modal.Image.from_registry.assert_called_once_with(
+        "nvidia/cuda:12.6.2-devel-ubuntu22.04", add_python="3.11"
+    )
+    fake_modal.Image.debian_slim.assert_not_called()
+    image_obj = fake_modal.Image.from_registry.return_value
     image_obj.apt_install.assert_called_once_with("zip", "curl", "git")
+    image_obj.uv_pip_install.assert_called_once_with("awscli")
 
 
 def test_launch_uses_sandbox_id_as_cluster_when_name_omitted(fake_modal):
@@ -181,7 +187,10 @@ def test_launch_uses_image_from_registry_when_image_id_set(fake_modal):
         "oumi.launcher.clients.modal_client._import_modal", return_value=fake_modal
     ):
         ModalClient().launch(_job(image_id="docker:my/repo:tag"))
-    fake_modal.Image.from_registry.assert_called()
+    # A caller-supplied docker: image is used verbatim (no add_python, no
+    # apt/awscli layer) — distinct from the default CUDA-devel base.
+    fake_modal.Image.from_registry.assert_called_once_with("my/repo:tag")
+    fake_modal.Image.debian_slim.assert_not_called()
 
 
 def test_launch_omits_secrets_when_envs_empty(fake_modal):


### PR DESCRIPTION
## Summary

Modal jobs ran on `modal.Image.debian_slim()`, which ships the CUDA **runtime** but not the CUDA **toolkit** (`nvcc`). Models whose vLLM path JIT-compiles flashinfer kernels at runtime — Qwen3.5 / Qwen3-Next **GDN linear attention** — fail on the first forward pass with `RuntimeError: Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist`. Most managed GPU base images include `nvcc`; `debian_slim` does not.

## Changes

- `_build_image` default base: `debian_slim()` → `from_registry("nvidia/cuda:12.6.2-devel-ubuntu22.04", add_python="3.11")`, keeping the existing `apt_install`/`uv_pip_install("awscli")` layer.
- The `docker:<ref>` `image_id` path is unchanged.
- Update `test_modal_client` to assert the default base is the CUDA-devel image (and that a caller-supplied `docker:` image is still used verbatim).

## Validation

- `tests/unit/launcher/clients/test_modal_client.py` — 18 passed; full modal suite (client + cluster + cloud) 32 passed.
- The image build only fully exercises on Modal, so end-to-end confirmation is a Modal run of a Qwen3.5 / Qwen3-Next model.