### PR TITLE
[DO NOT MERGE] Combined preview: partial-inference stack (#2498–#2502)

### DIFF
--- a/docs/user_guides/infer/inference_engines.md
+++ b/docs/user_guides/infer/inference_engines.md
@@ -876,6 +876,56 @@ for failure in partial.failures:
 
 This returns a `BatchResult` containing successful conversations and a structured list of failures (with per-row error details), rather than raising on the first error. Combined with the partial-retry support in `RemoteInferenceEngine`, this lets you re-submit only the failed rows instead of re-running the whole batch.
 
+## Partial-Failure Online Inference
+
+By default, `infer()` raises if any conversation fails after exhausting its retries, losing the rest of the call. `infer_partial()` instead tolerates per-row failures: it returns an `InferenceResult` pairing each successful conversation with its original input index and reporting failures separately, so you can keep the successes and decide which rows to re-submit.
+
+```python
+result = engine.infer_partial(conversations, inference_config)
+
+for index, conversation in result.successful:
+    print(f"Row {index}: {conversation.last_message().content}")
+
+for index in result.failed_indices:
+    detail = result.failures[index]
+    print(f"Row {index} failed ({detail.error_type}): {detail.error_message}")
+
+# Re-submit only the rows worth retrying.
+retry_rows = [
+    conversations[i]
+    for i in result.failed_indices
+    if result.failures[i].is_retryable
+]
+```
+
+Each failure carries a `FailureDetail` with the error message, the HTTP status code of the final attempt (if applicable), an `error_type` category, and an `is_retryable` flag. A retryable failure has already consumed the engine's internal retries (`RemoteParams.max_retries`); `is_retryable=True` means a fresh submission could plausibly succeed (e.g. a 429 or timeout), while `is_retryable=False` marks deterministic failures (e.g. a 400/422 or a missing API key) that would fail again.
+
+Remote engines (everything derived from `RemoteInferenceEngine`, including OpenRouter, OpenAI, Anthropic, etc.) isolate failures per row: one conversation exhausting its retries does not affect the others. Local engines (vLLM, native, LlamaCPP) fall back to all-or-nothing behavior, crediting any conversations already checkpointed to the scratch file as successes.
+
+Row-level failures never raise — even configuration errors such as a missing API key are reported as per-row failures with `error_type="config"` and `is_retryable=False`, so check `result.has_failures` rather than relying on exceptions. Invalid call shapes (duplicate conversation IDs, or providing both `input` and `input_path`) still raise.
+
+Successful conversations are checkpointed to the scratch file as they complete. When the result has failures, the scratch file is retained, so calling `infer_partial()` again with the identical input and config resumes from the completed conversations instead of re-running them. If `output_path` is set, only successful conversations are written.
+
+### Progress Reporting
+
+For long runs polled by another process (e.g. a job wrapper on a remote cluster), set a progress path and `infer_partial()` will periodically write an atomic JSON snapshot of its counters:
+
+```python
+result = engine.infer_partial(
+    conversations,
+    inference_config,
+    progress_path="/tmp/progress.json",  # or InferenceConfig.progress_path
+)
+```
+
+The file contains:
+
+```json
+{"total": 1000, "completed": 412, "failed": 3, "updated_at": "2026-06-10T18:02:11.512345+00:00"}
+```
+
+The run is complete when `completed + failed == total`. Writes are atomic (a poller never sees partial JSON) and throttled to about one per second; conversations resumed from the scratch file are counted as completed in the first snapshot. The `progress_path` argument takes precedence over `InferenceConfig.progress_path`. A progress file that cannot be written is logged and ignored — it never fails the inference call.
+
 ### Listing Available Models
 
 Every `InferenceEngine` exposes a `list_models()` method that returns the model IDs usable with that engine:

--- a/docs/user_guides/judge/judge.md
+++ b/docs/user_guides/judge/judge.md
@@ -229,6 +229,27 @@ print(f"Succeeded: {len(result.successful)}, failed: {len(result.failed_indices)
 
 `judge_batch_submit` returns the provider batch ID and the `Conversation`s used to build it — you must pass both back to `judge_batch_result(_partial)` so that inputs and outputs can be re-aligned. Rule-based judges don't call inference, so batch judging does not apply to them.
 
+## Partial Results for Online Judging
+
+`judge()` raises if any row's inference fails. For online (non-batch) judging that should tolerate per-row failures — e.g. against providers without a batch API, like OpenRouter — use `judge_partial`:
+
+```python
+result = judge.judge_partial(inputs)
+
+for index, judge_output in result.successful:
+    print(f"Row {index}: {judge_output.field_values}")
+
+for index in result.failed_indices:
+    detail = result.failures[index]
+    print(f"Row {index} failed ({detail.error_type}): {detail.error_message}")
+
+retry_rows = [
+    inputs[i] for i in result.failed_indices if result.failures[i].is_retryable
+]
+```
+
+This returns a `JudgePartialResult` pairing each successful `JudgeOutput` with its original input index. Inference failures carry through the engine's `FailureDetail` (status code, `error_type`, `is_retryable`); judge responses that complete but cannot be parsed are reported with `error_type="parse_error"` and are retryable, since re-sampling can plausibly produce a parseable output. It is built on {py:meth}`~oumi.core.inference.BaseInferenceEngine.infer_partial`, so per-row progress can be reported to an external poller via the `progress_path` argument (see {doc}`inference_engines <../infer/inference_engines>`).
+
 ## Token Usage Tracking
 
 Both `SimpleJudge` and `RuleBasedJudge` inherit from `BaseJudge`, which accumulates per-request token usage across every call to `judge()` / `judge_batch_result()`. After a run you can read:

--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -708,6 +708,27 @@ partial = synth.get_batch_results_partial(batch_id, samples, generated_attribute
 
 Batches are typically 50% cheaper than online inference at the cost of a 24-hour completion window. Attributes are batched one at a time (not across attributes), so chained `generated_attributes` still run sequentially.
 
+## Partial Results for Online Synthesis
+
+For providers without a batch API (e.g. OpenRouter), online synthesis with `synthesize()` raises if any row fails. Use `synthesize_partial` to tolerate per-row failures instead:
+
+```python
+result = synth.synthesize_partial(samples, generated_attribute)
+
+for index, attribute_dict in result.successful:
+    print(f"Sample {index}: {attribute_dict}")
+
+for index in result.failed_indices:
+    detail = result.failures[index]
+    print(f"Sample {index} failed ({detail.error_type}): {detail.error_message}")
+
+retry_samples = [
+    samples[i] for i in result.failed_indices if result.failures[i].is_retryable
+]
+```
+
+This returns a `SynthPartialResult` pairing each successfully synthesized attribute dict with its original sample index. Inference failures carry through the engine's `FailureDetail` (status code, `error_type`, `is_retryable`); responses that complete but cannot be processed are reported with `error_type="parse_error"` and are retryable. It is built on {py:meth}`~oumi.core.inference.BaseInferenceEngine.infer_partial`, so per-row progress can be reported to an external poller via the `progress_path` argument (see {doc}`/user_guides/infer/inference_engines`).
+
 ## Token Usage Tracking
 
 `AttributeSynthesizer` accumulates token usage across every online and batch call:

--- a/src/oumi/core/configs/inference_config.py
+++ b/src/oumi/core/configs/inference_config.py
@@ -39,6 +39,9 @@ class InferenceConfig(BaseConfig):
     output_path: str | None = None
     """Path to the output file where the generated text will be saved."""
 
+    progress_path: str | None = None
+    """Path to a JSON file where inference progress counters are written."""
+
     engine: InferenceEngineType | None = None
     """The inference engine to use for generation.
 

--- a/src/oumi/core/inference/__init__.py
+++ b/src/oumi/core/inference/__init__.py
@@ -17,9 +17,20 @@
 This module provides base classes for model inference in the Oumi framework.
 """
 
-from oumi.core.inference.base_inference_engine import BaseInferenceEngine, BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BaseInferenceEngine,
+    BatchResult,
+    FailureDetail,
+    InferenceErrorType,
+    InferenceResult,
+)
+from oumi.core.inference.progress_reporter import ProgressFileReporter
 
 __all__ = [
     "BaseInferenceEngine",
     "BatchResult",
+    "FailureDetail",
+    "InferenceErrorType",
+    "InferenceResult",
+    "ProgressFileReporter",
 ]

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 import jsonlines
@@ -31,6 +32,7 @@ from oumi.core.configs import (
     InferenceConfig,
     ModelParams,
 )
+from oumi.core.inference.progress_reporter import ProgressFileReporter
 from oumi.core.types.conversation import Conversation
 from oumi.utils.logging import logger
 from oumi.utils.math_utils import is_power_of_two
@@ -53,6 +55,89 @@ class BatchResult:
     def has_failures(self) -> bool:
         """Return True if any requests failed."""
         return len(self.failed_indices) > 0
+
+
+class InferenceErrorType(str, Enum):
+    """Failure category for a partial-inference request."""
+
+    API_STATUS = "api_status"
+    """The API returned a non-success HTTP status code."""
+
+    CONNECTION = "connection"
+    """A network-level error prevented reaching the API."""
+
+    RUNTIME = "runtime"
+    """An error was raised while running inference."""
+
+    CONFIG = "config"
+    """The request failed due to invalid configuration."""
+
+    PARSE_ERROR = "parse_error"
+    """The API response could not be parsed into a conversation."""
+
+    ENGINE_FAILURE = "engine_failure"
+    """The inference engine itself failed."""
+
+    UNKNOWN = "unknown"
+    """Default and catch-all: the failure fits no other category."""
+
+
+@dataclass(frozen=True)
+class FailureDetail:
+    """Details about a single failed inference request."""
+
+    error_message: str
+    """Human-readable description of the failure."""
+
+    status_code: int | None = None
+    """HTTP status code of the final failed attempt, if applicable."""
+
+    is_retryable: bool = True
+    """Whether resubmitting this request could plausibly succeed."""
+
+    error_type: InferenceErrorType = InferenceErrorType.UNKNOWN
+    """Failure category for this request."""
+
+
+@dataclass
+class InferenceResult:
+    """Result of partial online inference, separating successes from failures."""
+
+    successful: list[tuple[int, Conversation]]
+    """List of (original_index, conversation) for successful requests."""
+
+    failed_indices: list[int]
+    """Sorted indices of requests that failed."""
+
+    failures: dict[int, FailureDetail]
+    """Mapping of failed index to structured failure info."""
+
+    @property
+    def error_messages(self) -> dict[int, str]:
+        """Mapping of failed index to error message."""
+        return {idx: detail.error_message for idx, detail in self.failures.items()}
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True if any requests failed."""
+        return len(self.failed_indices) > 0
+
+
+@dataclass
+class _PreparedInferenceRun:
+    """Validated inputs shared by infer() and infer_partial()."""
+
+    inference_config: InferenceConfig | None
+    """The inference config, possibly updated with the engine's generation params."""
+
+    conversations: list[Conversation]
+    """All conversations to process, with conversation ids assigned."""
+
+    completed_from_scratch: list[Conversation]
+    """Conversations already completed in a previous run, loaded from scratch."""
+
+    remaining: list[Conversation]
+    """Conversations that still need inference."""
 
 
 class BaseInferenceEngine(ABC):
@@ -87,20 +172,19 @@ class BaseInferenceEngine(ABC):
         self._latency_histogram_from_file = HdrHistogram(20, 180 * 1000, 1)
         self._dataset_hash = None
 
-    def infer(
+    def _prepare_inference_run(
         self,
         input: list[Conversation] | None = None,
         inference_config: InferenceConfig | None = None,
-    ) -> list[Conversation]:
-        """Runs model inference.
+    ) -> _PreparedInferenceRun:
+        """Validates inputs and prepares conversations for an inference run.
 
         Args:
             input: A list of conversations to run inference on. Optional.
             inference_config: Parameters for inference.
-                If not specified, a default config is inferred.
 
         Returns:
-            List[Conversation]: Inference output.
+            _PreparedInferenceRun: The validated, prepared run inputs.
         """
         if input is not None and (
             inference_config and inference_config.input_path is not None
@@ -140,7 +224,7 @@ class BaseInferenceEngine(ABC):
             )
 
         unique_conversation_ids = set()
-        for i, conversation in enumerate(conversations_to_process):
+        for idx, conversation in enumerate(conversations_to_process):
             if conversation.conversation_id is not None:
                 if conversation.conversation_id in unique_conversation_ids:
                     raise ValueError(
@@ -159,7 +243,7 @@ class BaseInferenceEngine(ABC):
                 ]
             )
             content_hash = hashlib.sha256(all_str_message_content.encode()).hexdigest()
-            id_name = str(i) + "_" + content_hash
+            id_name = str(idx) + "_" + content_hash
 
             conversation.conversation_id = str(
                 uuid.uuid5(
@@ -192,6 +276,34 @@ class BaseInferenceEngine(ABC):
                 f"Found {len(completed_conversations)} completed conversations. "
                 f"Processing remaining {len(remaining_conversations)} conversations."
             )
+
+        return _PreparedInferenceRun(
+            inference_config=inference_config,
+            conversations=conversations_to_process,
+            completed_from_scratch=completed_conversations,
+            remaining=remaining_conversations,
+        )
+
+    def infer(
+        self,
+        input: list[Conversation] | None = None,
+        inference_config: InferenceConfig | None = None,
+    ) -> list[Conversation]:
+        """Runs model inference.
+
+        Args:
+            input: A list of conversations to run inference on. Optional.
+            inference_config: Parameters for inference.
+                If not specified, a default config is inferred.
+
+        Returns:
+            List[Conversation]: Inference output.
+        """
+        prepared = self._prepare_inference_run(input, inference_config)
+        inference_config = prepared.inference_config
+        conversations_to_process = prepared.conversations
+        remaining_conversations = prepared.remaining
+        output_path = inference_config.output_path if inference_config else None
 
         # Run inference only on remaining conversations
         start_time = time.perf_counter()
@@ -235,6 +347,185 @@ class BaseInferenceEngine(ABC):
             self._save_conversations(final_results, inference_config.output_path)
 
         return final_results
+
+    def infer_partial(
+        self,
+        input: list[Conversation] | None = None,
+        inference_config: InferenceConfig | None = None,
+        *,
+        progress_path: str | None = None,
+    ) -> InferenceResult:
+        """Runs model inference, tolerating per-row failures.
+
+        Unlike infer(), which raises if any conversation fails, this returns
+        an InferenceResult pairing each successful conversation with its
+        original input index and reporting per-row failures separately, so
+        callers can keep successes and decide which failures to resubmit.
+
+        Args:
+            input: A list of conversations to run inference on. Optional.
+            inference_config: Parameters for inference.
+            progress_path: Path to a JSON file where progress counters are
+                periodically written for external pollers. Takes precedence
+                over inference_config.progress_path.
+
+        Returns:
+            InferenceResult: Successful conversations and per-row failures.
+        """
+        prepared = self._prepare_inference_run(input, inference_config)
+        inference_config = prepared.inference_config
+        output_path = inference_config.output_path if inference_config else None
+
+        id_to_index = {
+            conversation.conversation_id: idx
+            for idx, conversation in enumerate(prepared.conversations)
+        }
+
+        # Seed successes with conversations completed in a previous run,
+        # ignoring stale scratch entries that aren't part of this input.
+        successful: list[tuple[int, Conversation]] = [
+            (id_to_index[conversation.conversation_id], conversation)
+            for conversation in prepared.completed_from_scratch
+            if conversation.conversation_id in id_to_index
+        ]
+
+        if progress_path is None and inference_config:
+            progress_path = inference_config.progress_path
+        progress: ProgressFileReporter | None = None
+        if progress_path:
+            progress = ProgressFileReporter(
+                progress_path, total=len(prepared.conversations)
+            )
+            progress.start(completed=len(successful))
+
+        try:
+            start_time = time.perf_counter()
+            histogram = self._latency_histogram_online
+            outcomes = self._infer_online_partial(
+                prepared.remaining, inference_config, progress
+            )
+            histogram.record_value((time.perf_counter() - start_time) * 1e3)
+            self._maybe_log_latency_histogram(histogram)
+        finally:
+            if progress:
+                progress.finalize()
+
+        if len(outcomes) != len(prepared.remaining):
+            raise RuntimeError(
+                f"_infer_online_partial returned {len(outcomes)} outcomes for "
+                f"{len(prepared.remaining)} conversations."
+            )
+
+        failures: dict[int, FailureDetail] = {}
+        for conversation, outcome in zip(prepared.remaining, outcomes):
+            index = id_to_index[conversation.conversation_id]
+            if isinstance(outcome, FailureDetail):
+                failures[index] = outcome
+            else:
+                successful.append((index, outcome))
+
+        result = InferenceResult(
+            successful=sorted(successful, key=lambda pair: pair[0]),
+            failed_indices=sorted(failures),
+            failures=failures,
+        )
+
+        # Keep the scratch file when there are failures so that re-invoking
+        # with the same input and config resumes from completed conversations.
+        if not result.has_failures:
+            self._cleanup_scratch_file(output_path)
+
+        if inference_config and inference_config.output_path:
+            self._save_conversations(
+                [conversation for _, conversation in result.successful],
+                inference_config.output_path,
+            )
+
+        return result
+
+    def _infer_online_partial(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+        progress: ProgressFileReporter | None = None,
+    ) -> list["Conversation | FailureDetail"]:
+        """Runs online inference, capturing per-row failures.
+
+        Returns a list aligned 1:1 with input: a Conversation for each row
+        that succeeded, or a FailureDetail for each row that failed.
+
+        Args:
+            input: A list of conversations to run inference on.
+            inference_config: Parameters for inference.
+            progress: Optional progress reporter, ticked as rows complete.
+
+        Returns:
+            list[Conversation | FailureDetail]: Per-row outcomes, aligned
+                with input.
+        """
+        if not input:
+            return []
+        output_path = inference_config.output_path if inference_config else None
+        try:
+            results = self._infer_online(input, inference_config)
+        except Exception as e:
+            completed_by_id = {
+                conversation.conversation_id: conversation
+                for conversation in self._load_from_scratch(output_path)
+                if conversation.conversation_id is not None
+            }
+            failure = FailureDetail(
+                error_message=str(e),
+                status_code=getattr(e, "status_code", None),
+                is_retryable=True,
+                error_type=InferenceErrorType.ENGINE_FAILURE,
+            )
+            outcomes: list[Conversation | FailureDetail] = []
+            num_completed = 0
+            for conversation in input:
+                conversation_id = conversation.conversation_id
+                checkpointed = (
+                    completed_by_id.get(conversation_id) if conversation_id else None
+                )
+                if checkpointed is not None:
+                    outcomes.append(checkpointed)
+                    num_completed += 1
+                else:
+                    outcomes.append(failure)
+            if progress:
+                if num_completed:
+                    progress.record_completed(num_completed)
+                progress.record_failed(len(input) - num_completed)
+            return outcomes
+
+        # Map results by conversation id to guard against engines returning
+        # results in a different order than the input.
+        results_by_id = {
+            conversation.conversation_id: conversation
+            for conversation in results
+            if conversation.conversation_id is not None
+        }
+        missing = FailureDetail(
+            error_message="Engine returned no result for this conversation.",
+            is_retryable=True,
+            error_type=InferenceErrorType.ENGINE_FAILURE,
+        )
+        outcomes = []
+        num_completed = 0
+        for conversation in input:
+            conversation_id = conversation.conversation_id
+            match = results_by_id.get(conversation_id) if conversation_id else None
+            if match is not None:
+                outcomes.append(match)
+                num_completed += 1
+            else:
+                outcomes.append(missing)
+        if progress:
+            if num_completed:
+                progress.record_completed(num_completed)
+            if num_completed != len(input):
+                progress.record_failed(len(input) - num_completed)
+        return outcomes
 
     def _maybe_log_latency_histogram(self, histogram: HdrHistogram | None) -> None:
         """Logs the histogram if it is not None.

--- a/src/oumi/core/inference/progress_reporter.py
+++ b/src/oumi/core/inference/progress_reporter.py
@@ -1,0 +1,106 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from oumi.utils.logging import logger
+
+
+class ProgressFileReporter:
+    """Writes inference progress counters to a JSON file for external pollers.
+
+    The snapshot format is::
+
+        {"total": N, "completed": n, "failed": f, "updated_at": "<iso8601 utc>"}
+
+    The run is complete when ``completed + failed == total``. Writes are atomic
+    (temp file + ``os.replace``), so a polling process never observes partial
+    JSON, and are throttled to at most one per ``min_write_interval`` seconds
+    (``start()`` and ``finalize()`` always write).
+
+    Filesystem failures are logged and swallowed: a broken progress path must
+    never kill inference. Counter updates are thread-safe.
+    """
+
+    def __init__(self, path: str, total: int, min_write_interval: float = 1.0):
+        """Initializes the reporter.
+
+        Args:
+            path: Destination file for the JSON snapshot.
+            total: Total number of rows in the run.
+            min_write_interval: Minimum seconds between snapshot writes.
+        """
+        self._path = path
+        self._total = total
+        self._min_write_interval = min_write_interval
+        self._completed = 0
+        self._failed = 0
+        self._last_write_time = 0.0
+        self._warned = False
+        self._lock = threading.Lock()
+
+    def start(self, completed: int = 0, failed: int = 0) -> None:
+        """Initializes counters and writes the first snapshot."""
+        with self._lock:
+            self._completed = completed
+            self._failed = failed
+            self._write_snapshot()
+
+    def record_completed(self, n: int = 1) -> None:
+        """Records n successfully completed rows."""
+        with self._lock:
+            self._completed += n
+            self._maybe_write_snapshot()
+
+    def record_failed(self, n: int = 1) -> None:
+        """Records n failed rows."""
+        with self._lock:
+            self._failed += n
+            self._maybe_write_snapshot()
+
+    def finalize(self) -> None:
+        """Writes a final snapshot, bypassing the throttle."""
+        with self._lock:
+            self._write_snapshot()
+
+    def _maybe_write_snapshot(self) -> None:
+        if time.monotonic() - self._last_write_time >= self._min_write_interval:
+            self._write_snapshot()
+
+    def _write_snapshot(self) -> None:
+        self._last_write_time = time.monotonic()
+        snapshot = {
+            "total": self._total,
+            "completed": self._completed,
+            "failed": self._failed,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            path = Path(self._path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Write to a temp file in the same directory so the replace is atomic.
+            tmp_path = path.with_name(path.name + ".tmp")
+            with open(tmp_path, "w") as f:
+                json.dump(snapshot, f)
+            tmp_path.replace(path)
+        except Exception as e:
+            if not self._warned:
+                logger.warning(f"Failed to write inference progress file: {e}")
+                self._warned = True
+            else:
+                logger.debug(f"Failed to write inference progress file: {e}")

--- a/src/oumi/core/synthesis/attribute_synthesizer.py
+++ b/src/oumi/core/synthesis/attribute_synthesizer.py
@@ -24,7 +24,11 @@ from oumi.core.configs.params.synthesis_params import (
     GeneratedAttributePostprocessingParams,
     TextMessage,
 )
-from oumi.core.inference.base_inference_engine import BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BatchResult,
+    FailureDetail,
+    InferenceErrorType,
+)
 from oumi.core.synthesis.attribute_formatter import AttributeFormatter
 from oumi.core.types.conversation import Conversation, Message
 from oumi.inference.remote_inference_engine import BatchInfo
@@ -47,6 +51,36 @@ class SynthBatchResult:
     @property
     def has_failures(self) -> bool:
         """Return True if any items in the batch failed synthesis."""
+        return len(self.failed_indices) > 0
+
+
+@dataclass
+class SynthPartialResult:
+    """Result from partial online synthesis, separating successes from failures.
+
+    Returned by :meth:`AttributeSynthesizer.synthesize_partial`. Unlike
+    synthesize(), which raises if any row's inference fails, this pairs each
+    successfully synthesized attribute dict with its original sample index and
+    reports inference and processing failures separately.
+    """
+
+    successful: list[tuple[int, dict[str, str]]]
+    """List of (original_index, attribute_dict) for successfully synthesized items."""
+
+    failed_indices: list[int]
+    """Sorted indices of items that failed synthesis."""
+
+    failures: dict[int, FailureDetail]
+    """Mapping of failed index to structured failure info."""
+
+    @property
+    def error_messages(self) -> dict[int, str]:
+        """Mapping of failed index to error message."""
+        return {idx: detail.error_message for idx, detail in self.failures.items()}
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True if any items failed synthesis."""
         return len(self.failed_indices) > 0
 
 
@@ -121,6 +155,77 @@ class AttributeSynthesizer:
         self._accumulate_token_usage(inference_results)
 
         return self.process_inference_results(inference_results, generated_attribute)
+
+    def synthesize_partial(
+        self,
+        samples: list[dict],
+        generated_attribute: GeneratedAttribute,
+        *,
+        progress_path: str | None = None,
+    ) -> SynthPartialResult:
+        """Synthesize attribute values online, tolerating per-row failures.
+
+        Unlike synthesize(), which raises if any row's inference fails, this
+        returns a SynthPartialResult pairing each successfully synthesized
+        attribute dict with its original sample index and reporting inference
+        failures and processing failures separately, so callers can keep
+        successes and decide which samples to resubmit.
+
+        Args:
+            samples: The samples to synthesize values for.
+            generated_attribute: The generated attribute to synthesize a value for.
+            progress_path: Path to a JSON file where inference progress
+                counters are periodically written for external pollers.
+
+        Returns:
+            SynthPartialResult with successful outputs and failure info.
+        """
+        if not samples:
+            return SynthPartialResult(successful=[], failed_indices=[], failures={})
+
+        conversations = self.build_batch_conversations(samples, generated_attribute)
+
+        result = self._inference_engine.infer_partial(
+            conversations,
+            inference_config=self._inference_config,
+            progress_path=progress_path,
+        )
+
+        successful_outputs: list[tuple[int, dict[str, str]]] = []
+        failed_indices: list[int] = list(result.failed_indices)
+        failures: dict[int, FailureDetail] = dict(result.failures)
+        parse_failures = 0
+
+        for idx, conv in result.successful:
+            # Tokens were spent even if processing the output fails below.
+            self._accumulate_token_usage([conv])
+            try:
+                processed = self.process_inference_results([conv], generated_attribute)
+                successful_outputs.append((idx, processed[0]))
+            except Exception as e:
+                parse_failures += 1
+                failed_indices.append(idx)
+                failures[idx] = FailureDetail(
+                    error_message=f"Failed to process synthesis output: {e}",
+                    is_retryable=True,
+                    error_type=InferenceErrorType.PARSE_ERROR,
+                )
+                logger.warning(
+                    f"Request {idx}: failed to process synthesis output: {e}"
+                )
+
+        logger.info(
+            f"Online synthesis results: "
+            f"{len(successful_outputs)} processed successfully, "
+            f"{len(result.failed_indices)} inference failures, "
+            f"{parse_failures} parse failures"
+        )
+
+        return SynthPartialResult(
+            successful=successful_outputs,
+            failed_indices=sorted(failed_indices),
+            failures=failures,
+        )
 
     def synthesize_batch(
         self,

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -19,12 +19,12 @@ import os
 import tempfile
 import urllib.parse
 import warnings
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TypeVar
 
 import aiofiles
 import aiofiles.os
@@ -45,7 +45,10 @@ from oumi.core.configs.params.remote_params import AdaptiveConcurrencyParams
 from oumi.core.inference import BaseInferenceEngine
 from oumi.core.inference.base_inference_engine import (
     BatchResult,
+    FailureDetail,
+    InferenceErrorType,
 )
+from oumi.core.inference.progress_reporter import ProgressFileReporter
 from oumi.core.types.conversation import (
     Conversation,
     FinishReason,
@@ -69,6 +72,8 @@ _AUTHORIZATION_KEY: str = "Authorization"
 _BATCH_PURPOSE = "batch"
 _BATCH_ENDPOINT = "/v1/chat/completions"
 _MAX_CONNECTION_LIMIT = 200
+
+_QueryResultT = TypeVar("_QueryResultT")
 
 
 class BatchStatus(Enum):
@@ -208,6 +213,48 @@ class FileListResponse:
 
     files: list[FileInfo]
     has_more: bool = False
+
+
+def _failure_detail_from_exception(e: Exception) -> FailureDetail:
+    """Maps an exception raised by _query_api to a FailureDetail.
+
+    Retryability reflects whether a fresh submission could plausibly succeed;
+    the engine's internal retries (RemoteParams.max_retries) have already been
+    exhausted by the time an exception reaches this mapper.
+    """
+    if isinstance(e, APIStatusError):
+        return FailureDetail(
+            error_message=str(e),
+            status_code=e.status_code,
+            is_retryable=not is_non_retriable_status_code(e.status_code, str(e)),
+            error_type=InferenceErrorType.API_STATUS,
+        )
+    if isinstance(e, (aiohttp.ClientError, asyncio.TimeoutError)):
+        # Defensive: _query_api wraps these in RuntimeError after retries.
+        return FailureDetail(
+            error_message=str(e),
+            is_retryable=True,
+            error_type=InferenceErrorType.CONNECTION,
+        )
+    if isinstance(e, ValueError):
+        # Missing api_url/api_key: deterministic, resubmission is futile.
+        return FailureDetail(
+            error_message=str(e),
+            is_retryable=False,
+            error_type=InferenceErrorType.CONFIG,
+        )
+    if isinstance(e, RuntimeError):
+        # Retries-exhausted parse/conversion/connection/unexpected errors.
+        return FailureDetail(
+            error_message=str(e),
+            is_retryable=True,
+            error_type=InferenceErrorType.RUNTIME,
+        )
+    return FailureDetail(
+        error_message=str(e),
+        is_retryable=False,
+        error_type=InferenceErrorType.UNKNOWN,
+    )
 
 
 class RemoteInferenceEngine(BaseInferenceEngine):
@@ -818,6 +865,33 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                 )
             raise RuntimeError(message)
 
+    async def _gather_query_tasks(
+        self,
+        input: list[Conversation],
+        make_task: Callable[
+            [Conversation, PoliteAdaptiveSemaphore, aiohttp.ClientSession],
+            Awaitable[_QueryResultT],
+        ],
+    ) -> list[_QueryResultT]:
+        """Gathers one task per conversation under a shared session/semaphore.
+
+        ``make_task`` builds the coroutine for each conversation, letting callers
+        pick the raising (``_query_api``) or guarded (``_query_api_guarded``) path.
+        """
+        # Limit number of HTTP connections to prevent file descriptor exhaustion.
+        connector = aiohttp.TCPConnector(limit=self._get_connection_limit())
+        # Control the number of concurrent tasks via a semaphore.
+        semaphore = PoliteAdaptiveSemaphore(
+            capacity=self._remote_params.num_workers,
+            politeness_policy=self._remote_params.politeness_policy,
+        )
+        async with aiohttp.ClientSession(connector=connector) as session:
+            tasks = [
+                make_task(conversation, semaphore, session) for conversation in input
+            ]
+            disable_tqdm = len(tasks) < 2
+            return await tqdm.gather(*tasks, disable=disable_tqdm)
+
     async def _infer(
         self,
         input: list[Conversation],
@@ -833,27 +907,15 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         Returns:
             List[Conversation]: Inference output.
         """
-        # Limit number of HTTP connections to prevent file descriptor exhaustion.
-        connector = aiohttp.TCPConnector(limit=self._get_connection_limit())
-        # Control the number of concurrent tasks via a semaphore.
-        semaphore = PoliteAdaptiveSemaphore(
-            capacity=self._remote_params.num_workers,
-            politeness_policy=self._remote_params.politeness_policy,
+        return await self._gather_query_tasks(
+            input,
+            lambda conversation, semaphore, session: self._query_api(
+                conversation,
+                semaphore,
+                session,
+                inference_config=inference_config,
+            ),
         )
-        async with aiohttp.ClientSession(connector=connector) as session:
-            tasks = [
-                self._query_api(
-                    conversation,
-                    semaphore,
-                    session,
-                    inference_config=inference_config,
-                )
-                for conversation in input
-            ]
-
-            disable_tqdm = len(tasks) < 2
-            results = await tqdm.gather(*tasks, disable=disable_tqdm)
-            return results
 
     @override
     def _infer_online(
@@ -872,6 +934,81 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         """
         conversations = safe_asyncio_run(self._infer(input, inference_config))
         return conversations
+
+    @override
+    def _infer_online_partial(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+        progress: ProgressFileReporter | None = None,
+    ) -> list[Conversation | FailureDetail]:
+        """Runs online inference, capturing failures per conversation.
+
+        Unlike the base implementation, each conversation fails independently:
+        one row exhausting its retries does not affect the others.
+        """
+        if not input:
+            return []
+        return safe_asyncio_run(self._infer_partial(input, inference_config, progress))
+
+    async def _query_api_guarded(
+        self,
+        conversation: Conversation,
+        semaphore: PoliteAdaptiveSemaphore,
+        session: aiohttp.ClientSession,
+        inference_config: InferenceConfig | None = None,
+        progress: ProgressFileReporter | None = None,
+    ) -> Conversation | FailureDetail:
+        """Queries the API, converting per-row exceptions to FailureDetails.
+
+        CancelledError and other BaseExceptions propagate so cancellation
+        still works.
+        """
+        try:
+            result = await self._query_api(
+                conversation,
+                semaphore,
+                session,
+                inference_config=inference_config,
+            )
+        except Exception as e:
+            if progress:
+                progress.record_failed()
+            return _failure_detail_from_exception(e)
+        if progress:
+            progress.record_completed()
+        return result
+
+    async def _infer_partial(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+        progress: ProgressFileReporter | None = None,
+    ) -> list[Conversation | FailureDetail]:
+        """Runs model inference on the provided input, tolerating failures.
+
+        Like _infer(), but wraps each per-conversation task in a guard so one
+        failed row cannot fail the whole call.
+
+        Args:
+            input: A list of conversations to run inference on.
+            inference_config: Parameters for inference.
+            progress: Optional progress reporter, ticked as rows complete.
+
+        Returns:
+            list[Conversation | FailureDetail]: Per-row outcomes, aligned
+                with input.
+        """
+        return await self._gather_query_tasks(
+            input,
+            lambda conversation, semaphore, session: self._query_api_guarded(
+                conversation,
+                semaphore,
+                session,
+                inference_config=inference_config,
+                progress=progress,
+            ),
+        )
 
     @override
     def get_supported_params(self) -> set[str]:

--- a/src/oumi/judges/__init__.py
+++ b/src/oumi/judges/__init__.py
@@ -20,8 +20,10 @@ different criteria such as helpfulness, honesty, and safety.
 
 from oumi.judges.base_judge import (
     BaseJudge,
+    JudgeBatchResult,
     JudgeOutput,
     JudgeOutputField,
+    JudgePartialResult,
 )
 from oumi.judges.rule_based_judge import RuleBasedJudge
 from oumi.judges.rules import BaseRule, RegexRule
@@ -30,8 +32,10 @@ from oumi.judges.simple_judge import SimpleJudge
 __all__ = [
     "BaseJudge",
     "BaseRule",
+    "JudgeBatchResult",
     "JudgeOutput",
     "JudgeOutputField",
+    "JudgePartialResult",
     "RegexRule",
     "RuleBasedJudge",
     "SimpleJudge",

--- a/src/oumi/judges/base_judge.py
+++ b/src/oumi/judges/base_judge.py
@@ -25,7 +25,11 @@ from oumi.core.configs.params.judge_params import (
     JudgeResponseFormat,
 )
 from oumi.core.inference import BaseInferenceEngine
-from oumi.core.inference.base_inference_engine import BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BatchResult,
+    FailureDetail,
+    InferenceErrorType,
+)
 from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.inference.remote_inference_engine import RemoteInferenceEngine
 from oumi.utils.placeholders import resolve_placeholders
@@ -325,6 +329,35 @@ class JudgeBatchResult:
         return len(self.failed_indices) > 0
 
 
+@dataclass
+class JudgePartialResult:
+    """Result from partial online judging, separating successes from failures.
+
+    Returned by :meth:`BaseJudge.judge_partial`. Unlike judge(), which raises
+    if inference fails, this pairs each successful JudgeOutput with its
+    original input index and reports inference and parse failures separately.
+    """
+
+    successful: list[tuple[int, JudgeOutput]]
+    """List of (original_index, JudgeOutput) for successfully judged items."""
+
+    failed_indices: list[int]
+    """Sorted indices of items that failed judging."""
+
+    failures: dict[int, FailureDetail]
+    """Mapping of failed index to structured failure info."""
+
+    @property
+    def error_messages(self) -> dict[int, str]:
+        """Mapping of failed index to error message."""
+        return {idx: detail.error_message for idx, detail in self.failures.items()}
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True if any items failed judgment."""
+        return len(self.failed_indices) > 0
+
+
 class BaseJudge:
     """Base class for implementing judges that evaluate model outputs.
 
@@ -396,6 +429,99 @@ class BaseJudge:
         )
         completed_conversations = self._infer(conversations)
         return self.parse_judge_outputs(completed_conversations)
+
+    def judge_partial(
+        self,
+        inputs: list[Conversation] | list[dict[str, str]],
+        *,
+        progress_path: str | None = None,
+    ) -> JudgePartialResult:
+        """Evaluate a batch of inputs online, tolerating per-row failures.
+
+        Unlike judge(), which raises if any row's inference fails, this
+        returns a JudgePartialResult pairing each successful JudgeOutput with
+        its original input index and reporting inference failures and parse
+        failures separately, so callers can keep successes and decide which
+        rows to resubmit.
+
+        Args:
+            inputs: Either a list of pre-built Conversation objects, or a list
+                    of dictionaries containing input data for evaluation. When
+                    dicts are provided, each must contain values for all
+                    prompt_template placeholders.
+            progress_path: Path to a JSON file where inference progress
+                counters are periodically written for external pollers.
+
+        Returns:
+            JudgePartialResult with successful outputs and failure info.
+
+        Raises:
+            ValueError: If inference_engine is None.
+        """
+        conversations: list[Conversation] = (
+            self.build_conversations(inputs)  # type: ignore[arg-type]
+            if inputs and isinstance(inputs[0], dict)
+            else inputs
+        )
+        if not conversations:
+            return JudgePartialResult(successful=[], failed_indices=[], failures={})
+
+        if self.inference_engine is None:
+            raise ValueError(
+                "Cannot run inference: inference_engine is None. "
+                "Subclasses that don't use inference should override the "
+                "judge() method."
+            )
+
+        # Preserve original metadata from input conversations
+        original_metadata = [conv.metadata for conv in conversations]
+
+        result = self.inference_engine.infer_partial(
+            input=conversations, progress_path=progress_path
+        )
+
+        successful_outputs: list[tuple[int, JudgeOutput]] = []
+        failed_indices = list(result.failed_indices)
+        failures = dict(result.failures)
+        parse_failures = 0
+
+        for idx, conv in result.successful:
+            # Restore original metadata by original index: partial results may
+            # be out of order or have gaps, so a positional zip would misalign.
+            conv.metadata.update(original_metadata[idx])
+
+            usage = conv.metadata.get("usage", {})
+            self._total_input_tokens += usage.get("prompt_tokens", 0)
+            self._total_output_tokens += usage.get("completion_tokens", 0)
+            self._total_cached_tokens += usage.get("cached_tokens", 0)
+
+            try:
+                self._validate_completed_conversation(conv)
+                raw_output = str(conv.messages[-1].content)
+                judge_output = self._transform_judge_output(raw_output)
+                successful_outputs.append((idx, judge_output))
+            except Exception as e:
+                parse_failures += 1
+                failed_indices.append(idx)
+                failures[idx] = FailureDetail(
+                    error_message=f"Failed to parse judge output: {e}",
+                    is_retryable=True,
+                    error_type=InferenceErrorType.PARSE_ERROR,
+                )
+                logger.warning(f"Request {idx}: failed to parse judge output: {e}")
+
+        logger.info(
+            f"Online judge results: "
+            f"{len(successful_outputs)} parsed successfully, "
+            f"{len(result.failed_indices)} inference failures, "
+            f"{parse_failures} parse failures"
+        )
+
+        return JudgePartialResult(
+            successful=successful_outputs,
+            failed_indices=sorted(failed_indices),
+            failures=failures,
+        )
 
     def judge_batch_submit(
         self, inputs: list[Conversation] | list[dict[str, str]]

--- a/tests/unit/core/synthesis/test_attribute_synthesizer.py
+++ b/tests/unit/core/synthesis/test_attribute_synthesizer.py
@@ -28,10 +28,16 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttributeValue,
     TextMessage,
 )
-from oumi.core.inference.base_inference_engine import BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BatchResult,
+    FailureDetail,
+    InferenceErrorType,
+    InferenceResult,
+)
 from oumi.core.synthesis.attribute_synthesizer import (
     AttributeSynthesizer,
     SynthBatchResult,
+    SynthPartialResult,
 )
 from oumi.core.types.conversation import Conversation, Message, Role
 
@@ -1288,3 +1294,247 @@ def test_process_inference_results_with_empty_results(
     results = synthesizer.process_inference_results([], mock_generated_attribute)
 
     assert results == []
+
+
+def _completed_conversation(response: str, usage: dict | None = None) -> Conversation:
+    return Conversation(
+        messages=[
+            Message(role=Role.USER, content="Test query"),
+            Message(role=Role.ASSISTANT, content=response),
+        ],
+        metadata={"usage": usage} if usage else {},
+    )
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_all_successful(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[
+            (0, _completed_conversation("Test response 1")),
+            (1, _completed_conversation("Test response 2")),
+        ],
+        failed_indices=[],
+        failures={},
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+    samples = [
+        {"style": "formal", "topic": "tech"},
+        {"style": "casual", "topic": "science"},
+    ]
+
+    result = synthesizer.synthesize_partial(samples, mock_generated_attribute)
+
+    assert isinstance(result, SynthPartialResult)
+    assert not result.has_failures
+    assert [idx for idx, _ in result.successful] == [0, 1]
+    assert result.successful[0][1] == {"generated_content": "Test response 1"}
+    assert result.successful[1][1] == {"generated_content": "Test response 2"}
+    call_kwargs = mock_inference_engine.infer_partial.call_args.kwargs
+    assert call_kwargs["inference_config"] is mock_inference_config
+    assert call_kwargs["progress_path"] is None
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_with_inference_failures(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    detail = FailureDetail(
+        error_message="HTTP 500: Internal server error",
+        status_code=500,
+        is_retryable=True,
+        error_type=InferenceErrorType.API_STATUS,
+    )
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[(1, _completed_conversation("Test response 2"))],
+        failed_indices=[0],
+        failures={0: detail},
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+    samples = [
+        {"style": "formal", "topic": "tech"},
+        {"style": "casual", "topic": "science"},
+    ]
+
+    result = synthesizer.synthesize_partial(samples, mock_generated_attribute)
+
+    assert result.has_failures
+    assert result.failed_indices == [0]
+    assert result.failures[0] is detail
+    assert result.error_messages[0] == "HTTP 500: Internal server error"
+    assert [idx for idx, _ in result.successful] == [1]
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_with_processing_failure(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    # An empty conversation makes messages[-1] raise during processing.
+    malformed = Conversation(messages=[])
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[
+            (0, _completed_conversation("Test response 1")),
+            (1, malformed),
+        ],
+        failed_indices=[],
+        failures={},
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+    samples = [
+        {"style": "formal", "topic": "tech"},
+        {"style": "casual", "topic": "science"},
+    ]
+
+    result = synthesizer.synthesize_partial(samples, mock_generated_attribute)
+
+    assert result.failed_indices == [1]
+    detail = result.failures[1]
+    assert detail.error_type == InferenceErrorType.PARSE_ERROR
+    assert detail.is_retryable
+    assert detail.error_message.startswith("Failed to process synthesis output")
+    assert [idx for idx, _ in result.successful] == [0]
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_empty_samples(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+
+    result = synthesizer.synthesize_partial([], mock_generated_attribute)
+
+    assert result.successful == []
+    assert not result.has_failures
+    mock_inference_engine.infer_partial.assert_not_called()
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_token_usage_including_processing_failures(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    usage_ok = {"prompt_tokens": 100, "completion_tokens": 20, "cached_tokens": 5}
+    usage_failed = {"prompt_tokens": 150, "completion_tokens": 30, "cached_tokens": 10}
+    malformed = Conversation(messages=[], metadata={"usage": usage_failed})
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[
+            (0, _completed_conversation("Test response 1", usage=usage_ok)),
+            (1, malformed),
+        ],
+        failed_indices=[],
+        failures={},
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+    samples = [
+        {"style": "formal", "topic": "tech"},
+        {"style": "casual", "topic": "science"},
+    ]
+
+    result = synthesizer.synthesize_partial(samples, mock_generated_attribute)
+
+    # Tokens were spent on the processing-failed row too.
+    assert result.failed_indices == [1]
+    assert synthesizer.total_input_tokens == 250
+    assert synthesizer.total_output_tokens == 50
+    assert synthesizer.total_cached_tokens == 15
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_with_postprocessing(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_inference_config,
+):
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[(0, _completed_conversation("  Test response  "))],
+        failed_indices=[],
+        failures={},
+    )
+    generated_attribute = GeneratedAttribute(
+        id="generated_content",
+        instruction_messages=[
+            TextMessage(role=Role.USER, content="Write about {topic}."),
+        ],
+        postprocessing_params=GeneratedAttributePostprocessingParams(
+            id="processed_content",
+            strip_whitespace=True,
+        ),
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+
+    result = synthesizer.synthesize_partial([{"topic": "tech"}], generated_attribute)
+
+    assert [idx for idx, _ in result.successful] == [0]
+    assert result.successful[0][1]["processed_content"] == "Test response"
+
+
+@patch("oumi.core.synthesis.attribute_synthesizer.build_inference_engine")
+def test_synthesize_partial_passes_progress_path(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_generated_attribute,
+    mock_inference_config,
+):
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    mock_inference_engine.infer_partial.return_value = InferenceResult(
+        successful=[], failed_indices=[], failures={}
+    )
+
+    synthesizer = AttributeSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+
+    synthesizer.synthesize_partial(
+        [{"style": "formal", "topic": "tech"}],
+        mock_generated_attribute,
+        progress_path="/tmp/progress.json",
+    )
+
+    call_kwargs = mock_inference_engine.infer_partial.call_args.kwargs
+    assert call_kwargs["progress_path"] == "/tmp/progress.json"

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -7,7 +7,12 @@ import jsonlines
 import pytest
 
 from oumi.core.configs import GenerationParams, InferenceConfig, ModelParams
-from oumi.core.inference import BaseInferenceEngine
+from oumi.core.inference import (
+    BaseInferenceEngine,
+    FailureDetail,
+    InferenceErrorType,
+    InferenceResult,
+)
 from oumi.core.types.conversation import Conversation, Message, Role
 
 
@@ -453,3 +458,278 @@ def test_final_conversations_saved_to_output_file(mock_engine):
         assert not scratch_path.exists(), (
             "Scratch file should be cleaned up after successful inference"
         )
+
+
+def test_inference_result_error_messages_derived_from_failures():
+    conversation = Conversation(
+        messages=[Message(role=Role.USER, content="hi")],
+    )
+    result = InferenceResult(
+        successful=[(0, conversation)],
+        failed_indices=[1, 2],
+        failures={
+            1: FailureDetail(
+                error_message="timeout", error_type=InferenceErrorType.RUNTIME
+            ),
+            2: FailureDetail(
+                error_message="bad request",
+                status_code=400,
+                is_retryable=False,
+                error_type=InferenceErrorType.API_STATUS,
+            ),
+        },
+    )
+
+    assert result.has_failures
+    assert result.error_messages == {1: "timeout", 2: "bad request"}
+    assert result.failures[2].status_code == 400
+    assert not result.failures[2].is_retryable
+    assert result.failures[1].is_retryable
+
+
+def test_inference_result_no_failures():
+    result = InferenceResult(successful=[], failed_indices=[], failures={})
+
+    assert not result.has_failures
+    assert result.error_messages == {}
+
+
+def test_failure_detail_defaults():
+    detail = FailureDetail(error_message="boom")
+
+    assert detail.status_code is None
+    assert detail.is_retryable
+    assert detail.error_type == InferenceErrorType.UNKNOWN
+
+
+class FailAfterFirstMockEngine(MockInferenceEngine):
+    """Mock engine that checkpoints the first conversation then fails."""
+
+    def _infer_online(
+        self,
+        input: list[Conversation],
+        inference_config: InferenceConfig | None = None,
+    ) -> list[Conversation]:
+        for idx, conv in enumerate(input):
+            if idx >= 1:
+                raise RuntimeError("Simulated failure")
+            new_conv = conv.model_copy(deep=True)
+            new_conv.messages.append(
+                Message(role=Role.ASSISTANT, content=f"Mock response {idx}")
+            )
+            self._save_conversation_to_scratch(
+                new_conv,
+                inference_config.output_path if inference_config else None,
+            )
+        raise RuntimeError("Simulated failure")
+
+
+@pytest.fixture
+def failing_engine():
+    return FailAfterFirstMockEngine(model_params=ModelParams(model_name="test-model"))
+
+
+def test_infer_partial_all_success(mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = mock_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert not result.has_failures
+        assert result.failed_indices == []
+        assert result.error_messages == {}
+        assert [idx for idx, _ in result.successful] == [0, 1, 2]
+        for idx, conv in result.successful:
+            assert conv.conversation_id == f"test-{idx}"
+            assert conv.messages[-1].role == Role.ASSISTANT
+
+        # Scratch cleaned up on success; output contains all successes.
+        scratch_path = Path(mock_engine._get_scratch_filepath(output_path))
+        assert not scratch_path.exists()
+        with jsonlines.open(output_path) as reader:
+            saved = [Conversation.from_dict(line) for line in reader]
+        assert len(saved) == 3
+
+
+def test_infer_partial_parity_with_infer(mock_engine):
+    conversations = [create_test_conversation(idx) for idx in range(3)]
+
+    infer_results = mock_engine.infer(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+    partial_result = mock_engine.infer_partial(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+
+    assert [c.conversation_id for c in infer_results] == [
+        conv.conversation_id for _, conv in partial_result.successful
+    ]
+    assert [str(c.messages[-1].content) for c in infer_results] == [
+        str(conv.messages[-1].content) for _, conv in partial_result.successful
+    ]
+
+
+def test_infer_partial_default_wrapper_credits_checkpointed_rows(failing_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = failing_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert result.has_failures
+        assert [idx for idx, _ in result.successful] == [0]
+        assert result.failed_indices == [1, 2]
+        for idx in result.failed_indices:
+            assert result.failures[idx].error_type == InferenceErrorType.ENGINE_FAILURE
+            assert result.failures[idx].is_retryable
+            assert "Simulated failure" in result.failures[idx].error_message
+
+        # Scratch retained on failure for resume.
+        scratch_path = Path(failing_engine._get_scratch_filepath(output_path))
+        assert scratch_path.exists()
+
+        # Output contains only the successful conversation.
+        with jsonlines.open(output_path) as reader:
+            saved = [Conversation.from_dict(line) for line in reader]
+        assert len(saved) == 1
+        assert saved[0].conversation_id == "test-0"
+
+
+def test_infer_partial_resumes_from_scratch_after_failure(failing_engine, mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        first = failing_engine.infer_partial(
+            input=[c.model_copy(deep=True) for c in conversations],
+            inference_config=inference_config,
+        )
+        assert first.failed_indices == [1, 2]
+
+        # Re-run with a healthy engine: row 0 must come from scratch, only
+        # the remaining rows are re-processed.
+        with patch.object(
+            mock_engine, "_infer_online", wraps=mock_engine._infer_online
+        ) as mock_infer:
+            second = mock_engine.infer_partial(
+                input=[c.model_copy(deep=True) for c in conversations],
+                inference_config=inference_config,
+            )
+
+        assert not second.has_failures
+        assert [idx for idx, _ in second.successful] == [0, 1, 2]
+        processed_ids = [c.conversation_id for c in mock_infer.call_args[0][0]]
+        assert processed_ids == ["test-1", "test-2"]
+
+        # Scratch cleaned after the fully successful run.
+        scratch_path = Path(mock_engine._get_scratch_filepath(output_path))
+        assert not scratch_path.exists()
+
+
+def test_infer_partial_empty_input(mock_engine):
+    result = mock_engine.infer_partial(input=[])
+
+    assert result.successful == []
+    assert result.failed_indices == []
+    assert not result.has_failures
+
+
+def test_infer_partial_duplicate_conversation_ids_raise(mock_engine):
+    conversations = [create_test_conversation(1), create_test_conversation(1)]
+
+    with pytest.raises(ValueError, match="is not unique"):
+        mock_engine.infer_partial(input=conversations)
+
+
+def test_infer_partial_writes_progress_file(mock_engine):
+    import json as json_lib
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        mock_engine.infer_partial(input=conversations, progress_path=progress_path)
+
+        with open(progress_path) as f:
+            snapshot = json_lib.load(f)
+        assert snapshot["total"] == 3
+        assert snapshot["completed"] == 3
+        assert snapshot["failed"] == 0
+
+
+def test_infer_partial_progress_file_via_config_with_failures(failing_engine):
+    import json as json_lib
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        inference_config = InferenceConfig(
+            output_path=output_path,
+            progress_path=progress_path,
+            generation=GenerationParams(max_new_tokens=10),
+        )
+        conversations = [create_test_conversation(idx) for idx in range(3)]
+
+        result = failing_engine.infer_partial(
+            input=conversations, inference_config=inference_config
+        )
+
+        assert result.failed_indices == [1, 2]
+        with open(progress_path) as f:
+            snapshot = json_lib.load(f)
+        assert snapshot["total"] == 3
+        assert snapshot["completed"] == 1
+        assert snapshot["failed"] == 2
+        assert snapshot["completed"] + snapshot["failed"] == snapshot["total"]
+
+
+def test_infer_partial_progress_write_failure_does_not_raise(mock_engine):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        conversations = [create_test_conversation(idx) for idx in range(2)]
+
+        with patch("os.replace", side_effect=OSError("disk full")):
+            result = mock_engine.infer_partial(
+                input=conversations, progress_path=progress_path
+            )
+
+        assert not result.has_failures
+        assert len(result.successful) == 2
+
+
+def test_infer_partial_outcome_count_mismatch_raises(mock_engine):
+    conversations = [create_test_conversation(idx) for idx in range(2)]
+
+    with patch.object(mock_engine, "_infer_online_partial", return_value=[]):
+        with pytest.raises(RuntimeError, match="returned 0 outcomes"):
+            mock_engine.infer_partial(input=conversations)
+
+
+def test_existing_infer_tests_unaffected_by_partial_run(mock_engine):
+    """infer() after infer_partial() on the same engine behaves normally."""
+    conversations = [create_test_conversation(idx) for idx in range(2)]
+
+    partial = mock_engine.infer_partial(
+        input=[c.model_copy(deep=True) for c in conversations]
+    )
+    results = mock_engine.infer(input=[c.model_copy(deep=True) for c in conversations])
+
+    assert len(partial.successful) == 2
+    assert len(results) == 2

--- a/tests/unit/inference/test_progress_reporter.py
+++ b/tests/unit/inference/test_progress_reporter.py
@@ -1,0 +1,143 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oumi.core.inference import ProgressFileReporter
+
+
+@pytest.fixture
+def progress_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield str(Path(temp_dir) / "progress.json")
+
+
+def _read_snapshot(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def test_start_writes_initial_snapshot(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["total"] == 10
+    assert snapshot["completed"] == 0
+    assert snapshot["failed"] == 0
+    assert "updated_at" in snapshot
+
+
+def test_start_with_resumed_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start(completed=4, failed=1)
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 4
+    assert snapshot["failed"] == 1
+
+
+def test_finalize_writes_final_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=3)
+    reporter.start()
+    reporter.record_completed()
+    reporter.record_completed()
+    reporter.record_failed()
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["total"] == 3
+    assert snapshot["completed"] == 2
+    assert snapshot["failed"] == 1
+    assert snapshot["completed"] + snapshot["failed"] == snapshot["total"]
+
+
+def test_record_batch_counts(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=10)
+    reporter.start()
+    reporter.record_completed(n=7)
+    reporter.record_failed(n=3)
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 7
+    assert snapshot["failed"] == 3
+
+
+def test_writes_throttled_between_ticks(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=100, min_write_interval=60.0)
+    reporter.start()
+    # Ticks within the interval should not rewrite the file.
+    reporter.record_completed()
+    reporter.record_completed()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 0
+
+    # finalize bypasses the throttle.
+    reporter.finalize()
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 2
+
+
+def test_writes_not_throttled_after_interval(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=100, min_write_interval=0.0)
+    reporter.start()
+    reporter.record_completed()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 1
+
+
+def test_atomic_write_leaves_no_temp_file(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=1, min_write_interval=0.0)
+    reporter.start()
+    reporter.record_completed()
+    reporter.finalize()
+
+    parent = Path(progress_path).parent
+    assert [p.name for p in parent.iterdir()] == ["progress.json"]
+
+
+def test_creates_parent_directories(progress_path):
+    nested = str(Path(progress_path).parent / "a" / "b" / "progress.json")
+    reporter = ProgressFileReporter(nested, total=1)
+    reporter.start()
+
+    assert _read_snapshot(nested)["total"] == 1
+
+
+def test_write_failure_never_raises(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        reporter.start()
+        reporter.record_completed()
+        reporter.record_failed()
+        reporter.finalize()
+
+    assert not os.path.exists(progress_path)
+
+
+def test_write_failure_warns_once(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch("oumi.core.inference.progress_reporter.logger.warning") as mock_warning:
+        with patch("os.replace", side_effect=OSError("disk full")):
+            reporter.start()
+            reporter.record_completed()
+            reporter.finalize()
+
+    assert mock_warning.call_count == 1
+
+
+def test_recovers_after_transient_write_failure(progress_path):
+    reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        reporter.start()
+    reporter.record_completed()
+    reporter.finalize()
+
+    snapshot = _read_snapshot(progress_path)
+    assert snapshot["completed"] == 1

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -4150,3 +4150,301 @@ def test_response_combines_reasoning_with_tool_calls():
     assert assistant.reasoning_content == "i should call the tool"
     assert assistant.tool_calls is not None
     assert assistant.tool_calls[0].function.name == "get_weather"
+
+
+#
+# infer_partial
+#
+def _simple_conversation(content: str, conversation_id: str) -> Conversation:
+    return Conversation(
+        messages=[Message(content=content, role=Role.USER)],
+        conversation_id=conversation_id,
+    )
+
+
+def _content_keyed_callback(responses_by_content: dict):
+    """Returns an aioresponses callback that routes by first-message content."""
+
+    def callback(url: str, **kwargs: Any) -> CallbackResult:
+        request = kwargs.get("json", {})
+        content = request.get("messages", [{}])[0].get("content", "")
+        key = content if isinstance(content, str) else content[0].get("text")
+        response = responses_by_content[key]
+        return CallbackResult(status=response["status"], payload=response["payload"])
+
+    return callback
+
+
+def _success_payload(text: str) -> dict:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+def test_infer_partial_mixed_success_and_failure(mock_asyncio_sleep):
+    responses = {
+        "ok": {"status": 200, "payload": _success_payload("fine")},
+        "boom": {
+            "status": 500,
+            "payload": {"error": {"message": "Internal server error"}},
+        },
+        "ok2": {"status": 200, "payload": _success_payload("also fine")},
+    }
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "output.jsonl")
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER, callback=_content_keyed_callback(responses), repeat=True
+            )
+
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+            )
+            conversations = [
+                _simple_conversation("ok", "c0"),
+                _simple_conversation("boom", "c1"),
+                _simple_conversation("ok2", "c2"),
+            ]
+            inference_config = InferenceConfig(
+                generation=GenerationParams(max_new_tokens=5),
+                output_path=output_path,
+                remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+            )
+
+            result = engine.infer_partial(conversations, inference_config)
+
+        assert [idx for idx, _ in result.successful] == [0, 2]
+        assert result.failed_indices == [1]
+        assert result.has_failures
+        detail = result.failures[1]
+        assert detail.status_code == 500
+        assert detail.is_retryable
+        assert detail.error_type == "api_status"
+        assert "Internal server error" in detail.error_message
+        assert result.error_messages[1] == detail.error_message
+
+        successful_by_index = dict(result.successful)
+        assert str(successful_by_index[0].messages[-1].content) == "fine"
+        assert str(successful_by_index[2].messages[-1].content) == "also fine"
+
+        # Scratch retained on failure; output contains only successes.
+        scratch_path = Path(engine._get_scratch_filepath(output_path))
+        assert scratch_path.exists()
+        with jsonlines.open(output_path) as reader:
+            saved = [Conversation.from_dict(line) for line in reader]
+        assert [c.conversation_id for c in saved] == ["c0", "c2"]
+
+
+def test_infer_partial_all_success_matches_infer():
+    responses = {
+        "one": {"status": 200, "payload": _success_payload("first")},
+        "two": {"status": 200, "payload": _success_payload("second")},
+    }
+    conversations = [
+        _simple_conversation("one", "c0"),
+        _simple_conversation("two", "c1"),
+    ]
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=_content_keyed_callback(responses), repeat=True)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+        )
+        infer_results = engine.infer(
+            [c.model_copy(deep=True) for c in conversations],
+            _get_default_inference_config(),
+        )
+        partial_result = engine.infer_partial(
+            [c.model_copy(deep=True) for c in conversations],
+            _get_default_inference_config(),
+        )
+
+    assert not partial_result.has_failures
+    assert [idx for idx, _ in partial_result.successful] == [0, 1]
+    assert [c for c in infer_results] == [conv for _, conv in partial_result.successful]
+
+
+def test_infer_partial_non_retriable_fails_fast(mock_asyncio_sleep):
+    request_count = 0
+
+    def callback(url: str, **kwargs: Any) -> CallbackResult:
+        nonlocal request_count
+        request_count += 1
+        return CallbackResult(
+            status=401, payload={"error": {"message": "Unauthorized"}}
+        )
+
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback, repeat=True)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=3),
+        )
+        result = engine.infer_partial(
+            [_simple_conversation("hello", "c0")],
+            _get_default_inference_config(),
+        )
+
+    assert result.failed_indices == [0]
+    detail = result.failures[0]
+    assert detail.status_code == 401
+    assert not detail.is_retryable
+    assert detail.error_type == "api_status"
+    # 401 fails fast: no retries despite max_retries=3.
+    assert request_count == 1
+    assert mock_asyncio_sleep.call_count == 0
+
+
+def test_infer_partial_all_fail_does_not_raise(mock_asyncio_sleep):
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=503,
+            payload={"error": {"message": "Service unavailable"}},
+            repeat=True,
+        )
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+        )
+        conversations = [
+            _simple_conversation("a", "c0"),
+            _simple_conversation("b", "c1"),
+        ]
+        inference_config = InferenceConfig(
+            generation=GenerationParams(max_new_tokens=5),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+        )
+
+        result = engine.infer_partial(conversations, inference_config)
+
+    assert result.successful == []
+    assert result.failed_indices == [0, 1]
+    for detail in result.failures.values():
+        assert detail.status_code == 503
+        assert detail.is_retryable
+
+
+def test_infer_partial_connection_error(mock_asyncio_sleep):
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            exception=aiohttp.ClientConnectionError("Connection refused"),
+            repeat=True,
+        )
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+        )
+        inference_config = InferenceConfig(
+            generation=GenerationParams(max_new_tokens=5),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+        )
+
+        result = engine.infer_partial(
+            [_simple_conversation("hello", "c0")], inference_config
+        )
+
+    assert result.failed_indices == [0]
+    detail = result.failures[0]
+    assert detail.status_code is None
+    assert detail.is_retryable
+    assert detail.error_type == "runtime"
+    assert "Connection refused" in detail.error_message
+
+
+def test_infer_partial_missing_api_key_is_config_failure(monkeypatch):
+    monkeypatch.delenv("OUMI_TEST_NONEXISTENT_API_KEY", raising=False)
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(),
+        remote_params=RemoteParams(
+            api_url=_TARGET_SERVER,
+            api_key_env_varname="OUMI_TEST_NONEXISTENT_API_KEY",
+        ),
+    )
+    conversations = [
+        _simple_conversation("a", "c0"),
+        _simple_conversation("b", "c1"),
+    ]
+
+    result = engine.infer_partial(conversations)
+
+    assert result.successful == []
+    assert result.failed_indices == [0, 1]
+    for detail in result.failures.values():
+        assert not detail.is_retryable
+        assert detail.error_type == "config"
+        assert "API key" in detail.error_message
+
+
+def test_infer_partial_writes_progress_file(mock_asyncio_sleep):
+    responses = {
+        "ok": {"status": 200, "payload": _success_payload("fine")},
+        "boom": {
+            "status": 500,
+            "payload": {"error": {"message": "Internal server error"}},
+        },
+    }
+    with tempfile.TemporaryDirectory() as temp_dir:
+        progress_path = str(Path(temp_dir) / "progress.json")
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER, callback=_content_keyed_callback(responses), repeat=True
+            )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+            )
+            inference_config = InferenceConfig(
+                generation=GenerationParams(max_new_tokens=5),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=0),
+            )
+            conversations = [
+                _simple_conversation("ok", "c0"),
+                _simple_conversation("boom", "c1"),
+            ]
+
+            result = engine.infer_partial(
+                conversations, inference_config, progress_path=progress_path
+            )
+
+        assert result.failed_indices == [1]
+        with open(progress_path) as f:
+            snapshot = json.load(f)
+        assert snapshot["total"] == 2
+        assert snapshot["completed"] == 1
+        assert snapshot["failed"] == 1
+
+
+def test_infer_partial_retriable_400_pattern_retried_and_retryable(mock_asyncio_sleep):
+    request_count = 0
+
+    def callback(url: str, **kwargs: Any) -> CallbackResult:
+        nonlocal request_count
+        request_count += 1
+        return CallbackResult(
+            status=400,
+            payload={"error": {"message": "Could not parse the JSON body"}},
+        )
+
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=callback, repeat=True)
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=1),
+        )
+        inference_config = InferenceConfig(
+            generation=GenerationParams(max_new_tokens=5),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=1),
+        )
+
+        result = engine.infer_partial(
+            [_simple_conversation("hello", "c0")], inference_config
+        )
+
+    # The known-transient 400 pattern is retried, and reported retryable
+    # after retries are exhausted.
+    assert request_count == 2
+    assert result.failed_indices == [0]
+    detail = result.failures[0]
+    assert detail.status_code == 400
+    assert detail.is_retryable

--- a/tests/unit/judges/test_base_judge.py
+++ b/tests/unit/judges/test_base_judge.py
@@ -17,7 +17,12 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from oumi.core.configs.params.judge_params import JudgeOutputType, JudgeResponseFormat
-from oumi.core.inference.base_inference_engine import BatchResult
+from oumi.core.inference.base_inference_engine import (
+    BatchResult,
+    FailureDetail,
+    InferenceErrorType,
+    InferenceResult,
+)
 from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.judges.base_judge import BaseJudge, JudgeOutput, JudgeOutputField
 
@@ -1182,3 +1187,290 @@ class TestBaseJudge:
         assert base_judge.total_input_tokens == 22
         assert base_judge.total_output_tokens == 11
         assert base_judge.total_cached_tokens == 11
+
+
+class TestJudgePartial:
+    """Test cases for BaseJudge.judge_partial."""
+
+    @pytest.fixture
+    def sample_output_fields(self):
+        return [
+            JudgeOutputField(
+                field_key="judgment",
+                field_type=JudgeOutputType.BOOL,
+                field_scores=None,
+            )
+        ]
+
+    def _create_judge(self, mock_engine, sample_output_fields):
+        return BaseJudge(
+            prompt_template="Is this helpful? Question: {question}, Answer: {answer}",
+            prompt_template_placeholders={"question", "answer"},
+            system_instruction=None,
+            example_field_values=[],
+            response_format=JudgeResponseFormat.XML,
+            output_fields=sample_output_fields,
+            inference_engine=mock_engine,
+        )
+
+    def _judged_conversation(
+        self, judgment: str = "True", metadata: dict | None = None
+    ) -> Conversation:
+        return Conversation(
+            messages=[
+                Message(content="Test prompt", role=Role.USER),
+                Message(
+                    content=f"<judgment>{judgment}</judgment>", role=Role.ASSISTANT
+                ),
+            ],
+            metadata=metadata or {},
+        )
+
+    def test_judge_partial_all_success(self, sample_output_fields):
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[
+                (0, self._judged_conversation("True")),
+                (1, self._judged_conversation("False")),
+            ],
+            failed_indices=[],
+            failures={},
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        inputs = [
+            {"question": "What is 1+1?", "answer": "2"},
+            {"question": "What is 2+2?", "answer": "5"},
+        ]
+        result = judge.judge_partial(inputs)
+
+        assert not result.has_failures
+        assert [idx for idx, _ in result.successful] == [0, 1]
+        assert result.successful[0][1].field_values == {"judgment": True}
+        assert result.successful[1][1].field_values == {"judgment": False}
+        mock_engine.infer_partial.assert_called_once()
+        call_kwargs = mock_engine.infer_partial.call_args.kwargs
+        assert len(call_kwargs["input"]) == 2
+        assert call_kwargs["progress_path"] is None
+
+    def test_judge_partial_inference_failures_pass_through(self, sample_output_fields):
+        detail = FailureDetail(
+            error_message="HTTP 429: Too many requests",
+            status_code=429,
+            is_retryable=True,
+            error_type=InferenceErrorType.API_STATUS,
+        )
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[(0, self._judged_conversation("True"))],
+            failed_indices=[1],
+            failures={1: detail},
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        result = judge.judge_partial(
+            [
+                {"question": "q1", "answer": "a1"},
+                {"question": "q2", "answer": "a2"},
+            ]
+        )
+
+        assert result.has_failures
+        assert result.failed_indices == [1]
+        assert result.failures[1] is detail
+        assert result.error_messages[1] == "HTTP 429: Too many requests"
+        assert [idx for idx, _ in result.successful] == [0]
+
+    def test_judge_partial_parse_failure(self, sample_output_fields):
+        malformed = Conversation(
+            messages=[Message(content="Test prompt", role=Role.USER)]
+        )
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[
+                (0, self._judged_conversation("True")),
+                (1, malformed),
+            ],
+            failed_indices=[],
+            failures={},
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        result = judge.judge_partial(
+            [
+                {"question": "q1", "answer": "a1"},
+                {"question": "q2", "answer": "a2"},
+            ]
+        )
+
+        assert result.failed_indices == [1]
+        detail = result.failures[1]
+        assert detail.error_type == InferenceErrorType.PARSE_ERROR
+        assert detail.is_retryable
+        assert detail.error_message.startswith("Failed to parse judge output")
+        assert [idx for idx, _ in result.successful] == [0]
+
+    def test_judge_partial_all_fail(self, sample_output_fields):
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[],
+            failed_indices=[0, 1],
+            failures={
+                0: FailureDetail(
+                    error_message="boom", error_type=InferenceErrorType.RUNTIME
+                ),
+                1: FailureDetail(
+                    error_message="boom", error_type=InferenceErrorType.RUNTIME
+                ),
+            },
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        result = judge.judge_partial(
+            [
+                {"question": "q1", "answer": "a1"},
+                {"question": "q2", "answer": "a2"},
+            ]
+        )
+
+        assert result.successful == []
+        assert result.failed_indices == [0, 1]
+
+    def test_judge_partial_empty_input(self, sample_output_fields):
+        mock_engine = MagicMock()
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        result = judge.judge_partial([])
+
+        assert result.successful == []
+        assert not result.has_failures
+        mock_engine.infer_partial.assert_not_called()
+
+    def test_judge_partial_no_engine_raises(self, sample_output_fields):
+        judge = self._create_judge(None, sample_output_fields)
+
+        with pytest.raises(ValueError, match="inference_engine is None"):
+            judge.judge_partial([{"question": "q", "answer": "a"}])
+
+    def test_judge_partial_metadata_reattached_by_index(self, sample_output_fields):
+        """Out-of-order/gapped successful indices must get their own metadata.
+
+        This is the regression test for the positional-zip bug class: _infer()
+        zips metadata positionally, which would misalign under partial results.
+        """
+        conv_for_2 = self._judged_conversation("True")
+        conv_for_0 = self._judged_conversation("False")
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[(2, conv_for_2), (0, conv_for_0)],
+            failed_indices=[1],
+            failures={
+                1: FailureDetail(
+                    error_message="boom", error_type=InferenceErrorType.RUNTIME
+                )
+            },
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        inputs = [
+            Conversation(
+                messages=[Message(content=f"prompt {idx}", role=Role.USER)],
+                metadata={"original_index": idx},
+            )
+            for idx in range(3)
+        ]
+        result = judge.judge_partial(inputs)
+
+        assert conv_for_2.metadata["original_index"] == 2
+        assert conv_for_0.metadata["original_index"] == 0
+        assert sorted(idx for idx, _ in result.successful) == [0, 2]
+
+    def test_judge_partial_token_usage_accumulated_including_parse_failures(
+        self, sample_output_fields
+    ):
+        malformed = Conversation(
+            messages=[Message(content="Test prompt", role=Role.USER)],
+            metadata={
+                "usage": {
+                    "prompt_tokens": 150,
+                    "completion_tokens": 30,
+                    "cached_tokens": 10,
+                }
+            },
+        )
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[
+                (
+                    0,
+                    self._judged_conversation(
+                        "True",
+                        metadata={
+                            "usage": {
+                                "prompt_tokens": 100,
+                                "completion_tokens": 20,
+                                "cached_tokens": 5,
+                            }
+                        },
+                    ),
+                ),
+                (1, malformed),
+            ],
+            failed_indices=[],
+            failures={},
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        result = judge.judge_partial(
+            [
+                {"question": "q1", "answer": "a1"},
+                {"question": "q2", "answer": "a2"},
+            ]
+        )
+
+        # Tokens were spent on the parse-failed row too.
+        assert result.failed_indices == [1]
+        assert judge.total_input_tokens == 250
+        assert judge.total_output_tokens == 50
+        assert judge.total_cached_tokens == 15
+
+    def test_judge_partial_matches_judge_outputs(self, sample_output_fields):
+        completed = [
+            self._judged_conversation("True"),
+            self._judged_conversation("False"),
+        ]
+        mock_engine = MagicMock()
+        mock_engine.infer.return_value = [c.model_copy(deep=True) for c in completed]
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[
+                (idx, c.model_copy(deep=True)) for idx, c in enumerate(completed)
+            ],
+            failed_indices=[],
+            failures={},
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+        inputs = [
+            {"question": "q1", "answer": "a1"},
+            {"question": "q2", "answer": "a2"},
+        ]
+
+        judge_outputs = judge.judge(inputs)
+        partial_result = judge.judge_partial(inputs)
+
+        assert [o.field_values for o in judge_outputs] == [
+            o.field_values for _, o in partial_result.successful
+        ]
+
+    def test_judge_partial_passes_progress_path(self, sample_output_fields):
+        mock_engine = MagicMock()
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[], failed_indices=[], failures={}
+        )
+        judge = self._create_judge(mock_engine, sample_output_fields)
+
+        judge.judge_partial(
+            [{"question": "q", "answer": "a"}], progress_path="/tmp/progress.json"
+        )
+
+        call_kwargs = mock_engine.infer_partial.call_args.kwargs
+        assert call_kwargs["progress_path"] == "/tmp/progress.json"

--- a/tests/unit/judges/test_simple_judge.py
+++ b/tests/unit/judges/test_simple_judge.py
@@ -646,3 +646,66 @@ inference_config:
             match="Could not resolve JudgeConfig from path: unknown_judge",
         ):
             SimpleJudge(judge_config="unknown_judge")
+
+
+class TestSimpleJudgePartial:
+    """Smoke test for the judge_partial method inherited from BaseJudge."""
+
+    @pytest.fixture
+    def xml_config(self):
+        return JudgeConfig(
+            judge_params=JudgeParams(
+                prompt_template="Is this helpful? {question}",
+                response_format=JudgeResponseFormat.XML,
+                judgment_type=JudgeOutputType.BOOL,
+                include_explanation=False,
+            ),
+            inference_config=InferenceConfig(
+                model=ModelParams(model_name="gpt-4.1"),
+                engine=InferenceEngineType.OPENAI,
+            ),
+        )
+
+    @patch("oumi.judges.simple_judge.SimpleJudge._create_inference_engine")
+    def test_judge_partial_inherited(self, mock_create_engine, xml_config):
+        from oumi.core.inference.base_inference_engine import (
+            FailureDetail,
+            InferenceErrorType,
+            InferenceResult,
+        )
+        from oumi.core.types.conversation import Conversation, Message, Role
+
+        mock_engine = Mock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.infer_partial.return_value = InferenceResult(
+            successful=[
+                (
+                    0,
+                    Conversation(
+                        messages=[
+                            Message(content="prompt", role=Role.USER),
+                            Message(
+                                content="<judgment>True</judgment>",
+                                role=Role.ASSISTANT,
+                            ),
+                        ]
+                    ),
+                )
+            ],
+            failed_indices=[1],
+            failures={
+                1: FailureDetail(
+                    error_message="HTTP 500",
+                    status_code=500,
+                    error_type=InferenceErrorType.API_STATUS,
+                )
+            },
+        )
+
+        judge = SimpleJudge(judge_config=xml_config)
+        result = judge.judge_partial([{"question": "q1"}, {"question": "q2"}])
+
+        assert [idx for idx, _ in result.successful] == [0]
+        assert result.successful[0][1].field_values == {JUDGMENT_KEY: True}
+        assert result.failed_indices == [1]
+        assert result.failures[1].status_code == 500


### PR DESCRIPTION
> [!WARNING]
> **NOT FOR MERGE — review aid only.** This PR squashes the entire partial-inference stack into a single diff so the whole change can be reviewed against `main` in one view. The real changes land via the stacked PRs below. Do not merge this branch.

### 📚 Stack — partial-failure support for online inference
1. #2498 — core types + progress reporter
2. #2499 — base-engine `infer_partial()` template
3. #2500 — remote-engine per-row failures
4. #2501 — `judge_partial()`
5. #2502 — `synthesize_partial()`

This branch (`partial-inference/combined-preview`) is a snapshot of the top of that stack squashed onto `main` — its tree is byte-identical to the tip of #2502.

### What's in the combined diff
- **Core types** (`base_inference_engine.py`, `progress_reporter.py`): `FailureDetail`, `InferenceErrorType` enum, `InferenceResult`, `ProgressFileReporter`, `InferenceConfig.progress_path`.
- **Base engine**: `infer_partial()` + shared `_prepare_inference_run()` preamble; default whole-batch `_infer_online_partial()` hook.
- **Remote engine**: true per-row failures via `_query_api_guarded` + `_failure_detail_from_exception`.
- **Judge**: `BaseJudge.judge_partial()` → `JudgePartialResult`.
- **Synthesis**: `AttributeSynthesizer.synthesize_partial()` → `SynthPartialResult`.
- Docs in `inference_engines.md`, `judge.md`, `synth.md`.

17 files, ~+2227. Batch paths and `BatchResult`/`JudgeBatchResult`/`SynthBatchResult` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
