### PR TITLE
feat(launcher): expose JobStatus.submit_time (slurm + sky)

### DIFF
--- a/src/oumi/core/launcher/base_cluster.py
+++ b/src/oumi/core/launcher/base_cluster.py
@@ -62,6 +62,10 @@ class JobStatus:
     #: Includes all nodes. None if cost information is unavailable.
     cost_per_hour: float | None = None
 
+    #: Unix timestamp when the job was submitted to the queue.
+    #: None if timing data is unavailable.
+    submit_time: float | None = None
+
     #: Unix timestamp when the job started running.
     #: None if the job hasn't started yet or timing data is unavailable.
     start_at: float | None = None

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -109,11 +109,7 @@ def _is_job_done(job_state: JobState) -> bool:
 
 
 def _parse_slurm_epoch(value: str | None) -> float | None:
-    """Parses a Unix-epoch time string from Slurm into a float.
-
-    Slurm renders times as epoch seconds when ``SLURM_TIME_FORMAT=%s`` is set
-    (tz-safe). Returns None for missing or sentinel values (``Unknown``, ``N/A``).
-    """
+    """Parses a Slurm epoch-seconds time string, or None for sentinel values."""
     if not value or value in ("Unknown", "N/A", "(null)"):
         return None
     try:

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -108,12 +108,26 @@ def _is_job_done(job_state: JobState) -> bool:
     )
 
 
-def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
-    """Parses one row of ``squeue --noheader --format='%i %j %u %T %R'``."""
-    parts = line.strip().split(None, 4)
-    if len(parts) < 4:
+def _parse_slurm_epoch(value: str | None) -> float | None:
+    """Parses a Unix-epoch time string from Slurm into a float.
+
+    Slurm renders times as epoch seconds when ``SLURM_TIME_FORMAT=%s`` is set
+    (tz-safe). Returns None for missing or sentinel values (``Unknown``, ``N/A``).
+    """
+    if not value or value in ("Unknown", "N/A", "(null)"):
         return None
-    job_id, name, _user, raw_state = parts[0], parts[1], parts[2], parts[3]
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
+    """Parses one row of ``squeue --noheader --format='%i %j %u %T %V %R'``."""
+    parts = line.strip().split(None, 5)
+    if len(parts) < 5:
+        return None
+    job_id, name, _user, raw_state, submit = parts[:5]
     state = _get_job_state(raw_state)
     return JobStatus(
         id=job_id,
@@ -123,6 +137,7 @@ def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
         metadata=line,
         done=_is_job_done(state),
         state=state,
+        submit_time=_parse_slurm_epoch(submit),
     )
 
 
@@ -146,6 +161,7 @@ def _parse_scontrol_show_job(output: str, cluster_name: str) -> JobStatus | None
         metadata=output,
         done=_is_job_done(state),
         state=state,
+        submit_time=_parse_slurm_epoch(fields.get("SubmitTime")),
     )
 
 
@@ -734,7 +750,11 @@ class SlurmClient:
 
     def _list_active_jobs_squeue(self) -> list[JobStatus]:
         """Lists active jobs via ``squeue``."""
-        command = f"squeue --user={self._user} --noheader --format='%i %j %u %T %R'"
+        # SLURM_TIME_FORMAT=%s renders %V (submit time) as a tz-safe Unix epoch.
+        command = (
+            "SLURM_TIME_FORMAT=%s "
+            f"squeue --user={self._user} --noheader --format='%i %j %u %T %V %R'"
+        )
         result = self.run_commands([command])
         if result.exit_code != 0:
             raise RuntimeError(
@@ -751,7 +771,7 @@ class SlurmClient:
 
     def _scontrol_get_job(self, job_id: str) -> JobStatus | None:
         """Looks up a single job via ``scontrol show job <id>``."""
-        command = f"scontrol show job {job_id}"
+        command = f"SLURM_TIME_FORMAT=%s scontrol show job {job_id}"
         result = self.run_commands([command])
         if result.exit_code != 0:
             return None

--- a/src/oumi/launcher/clusters/sky_cluster.py
+++ b/src/oumi/launcher/clusters/sky_cluster.py
@@ -78,6 +78,7 @@ class SkyCluster(BaseCluster):
             or state == JobState.CANCELLED,
             state=state,
             cost_per_hour=cost_per_hour,
+            submit_time=sky_job.get("submitted_at") or None,
             start_at=sky_job.get("start_at") or None,
             end_at=sky_job.get("end_at") or None,
         )

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -433,7 +433,7 @@ def _mock_refresh_creds_run() -> Mock:
 
 def test_slurm_client_get_job_returns_active_job_from_squeue(mock_subprocess):
     squeue_ok = Mock()
-    squeue_ok.stdout = b"100 myjob user RUNNING node-1\n"
+    squeue_ok.stdout = b"100 myjob user RUNNING 1700000000 node-1\n"
     squeue_ok.stderr = b""
     squeue_ok.returncode = 0
 
@@ -449,6 +449,7 @@ def test_slurm_client_get_job_returns_active_job_from_squeue(mock_subprocess):
     assert job_status is not None
     assert job_status.id == "100"
     assert job_status.state == JobState.RUNNING
+    assert job_status.submit_time == 1700000000.0
 
 
 def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
@@ -464,6 +465,7 @@ def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
         b"JobId=100 JobName=myjob\n"
         b"   UserId=user(1000) GroupId=user(1000) MCS_label=N/A\n"
         b"   JobState=COMPLETED Reason=None Dependency=(null)\n"
+        b"   SubmitTime=1700000000 StartTime=1700000050\n"
     )
     scontrol_ok.stderr = b""
     scontrol_ok.returncode = 0
@@ -483,6 +485,7 @@ def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
     assert job_status.id == "100"
     assert job_status.state == JobState.SUCCEEDED
     assert job_status.done is True
+    assert job_status.submit_time == 1700000000.0
 
 
 def test_slurm_client_get_job_returns_none_when_purged(mock_subprocess):
@@ -532,7 +535,7 @@ def test_slurm_client_cancel_success(mock_subprocess):
     scancel_ok.returncode = 0
 
     squeue_ok = Mock()
-    squeue_ok.stdout = b"7.batch batch user RUNNING node-1\n"
+    squeue_ok.stdout = b"7.batch batch user RUNNING 1700000000 node-1\n"
     squeue_ok.stderr = b""
     squeue_ok.returncode = 0
 

--- a/tests/unit/launcher/clusters/test_sky_cluster.py
+++ b/tests/unit/launcher/clusters/test_sky_cluster.py
@@ -282,13 +282,14 @@ def test_convert_sky_job_populates_cost_per_hour(mock_sky_client):
     mock_sky_client.get_cluster_hourly_price.assert_called_once_with("test-cluster")
 
 
-def test_convert_sky_job_populates_start_at_and_end_at(mock_sky_client):
-    """Test that start_at and end_at are extracted from sky job dict."""
+def test_convert_sky_job_populates_timestamps(mock_sky_client):
+    """Test that submit/start/end timestamps are extracted from sky job dict."""
     cluster = SkyCluster("test-cluster", mock_sky_client)
     sky_job = {
         "job_id": 1,
         "job_name": "test-job",
         "status": "JobStatus.SUCCEEDED",
+        "submitted_at": 1699999000.0,
         "start_at": 1700000000.0,
         "end_at": 1700003600.0,
     }
@@ -296,12 +297,13 @@ def test_convert_sky_job_populates_start_at_and_end_at(mock_sky_client):
     jobs = cluster.get_jobs()
 
     assert len(jobs) == 1
+    assert jobs[0].submit_time == 1699999000.0
     assert jobs[0].start_at == 1700000000.0
     assert jobs[0].end_at == 1700003600.0
 
 
 def test_convert_sky_job_handles_missing_timestamps(mock_sky_client):
-    """Test that missing start_at/end_at default to None."""
+    """Test that missing submit/start/end timestamps default to None."""
     cluster = SkyCluster("test-cluster", mock_sky_client)
     sky_job = {
         "job_id": 1,
@@ -312,5 +314,6 @@ def test_convert_sky_job_handles_missing_timestamps(mock_sky_client):
     jobs = cluster.get_jobs()
 
     assert len(jobs) == 1
+    assert jobs[0].submit_time is None
     assert jobs[0].start_at is None
     assert jobs[0].end_at is None


### PR DESCRIPTION
## Summary

Adds `submit_time` (Unix epoch) to `JobStatus`, populated by the Slurm client. Lets consumers measure how long a job has sat queued from the scheduler's own record, rather than tracking a first-seen timestamp themselves.

## Changes

- `JobStatus.submit_time: float | None = None` — mirrors the existing `start_at` / `end_at` epoch fields
- Slurm client populates it from `squeue %V` and `scontrol SubmitTime`
- Both commands set `SLURM_TIME_FORMAT=%s` so the value is a tz-safe Unix epoch instead of a locale-formatted string
- `_parse_slurm_epoch` helper returns `None` for `Unknown` / `N/A` / unparseable values

## Notes

- Defaults to `None`; clouds that don't populate it (e.g. SkyPilot) are unaffected.
- `SLURM_TIME_FORMAT=%s` only affects time fields; the parsers read no other time field, so no existing parsing changes.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
