### PR TITLE
fix(inference): don't feed non-retriable errors to the adaptive concurrency controller

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -715,13 +715,14 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                         timeout=remote_params.connection_timeout,
                     ) as response:
                         if response.status != 200:
-                            await self._try_record_error()
                             last_status_code = response.status
                             failure_reason = await get_failure_reason_from_response(
                                 response
                             )
 
-                            # Check for non-retriable status codes to fail fast.
+                            # Non-retriable statuses are terminal request errors,
+                            # not load signals: fail fast without recording them
+                            # against adaptive concurrency.
                             if is_non_retriable_status_code(
                                 response.status, failure_reason
                             ):
@@ -730,6 +731,9 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                                     status_code=response.status,
                                     api_input=api_input,
                                 )
+
+                            # Retriable failure: record for backoff, then retry.
+                            await self._try_record_error()
                             continue
 
                         # Try to parse the response as JSON

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -2908,6 +2908,66 @@ def test_non_retriable_errors(mock_asyncio_sleep):
             mock_asyncio_sleep.reset_mock()
 
 
+def test_non_retriable_error_not_recorded_in_adaptive_concurrency():
+    """A non-retriable 4xx fails fast without notifying the adaptive controller."""
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=403,
+            payload={"error": {"message": "forbidden"}},
+        )
+
+        engine = RemoteInferenceEngine(
+            model_params=_get_default_model_params(),
+            remote_params=RemoteParams(
+                api_url=_TARGET_SERVER,
+                use_adaptive_concurrency=True,
+                num_workers=10,
+                max_retries=3,
+            ),
+        )
+        conversation = create_test_text_only_conversation()
+
+        mock_controller = AsyncContextManagerMock()
+        with patch.object(engine, "_adaptive_concurrency_controller", mock_controller):
+            with pytest.raises(APIStatusError) as exc_info:
+                engine._infer_online([conversation])
+
+        assert exc_info.value.status_code == 403
+        mock_controller.record_error.assert_not_called()
+        mock_controller.record_success.assert_not_called()
+
+
+def test_retriable_error_recorded_in_adaptive_concurrency(mock_asyncio_sleep):
+    """A retriable status (429) still drives the controller so backoff engages."""
+    with aioresponses() as m:
+        m.post(
+            _TARGET_SERVER,
+            status=429,
+            payload={"error": {"message": "rate limit"}},
+            repeat=True,
+        )
+
+        engine = RemoteInferenceEngine(
+            model_params=_get_default_model_params(),
+            remote_params=RemoteParams(
+                api_url=_TARGET_SERVER,
+                use_adaptive_concurrency=True,
+                num_workers=10,
+                max_retries=2,
+            ),
+        )
+        conversation = create_test_text_only_conversation()
+
+        mock_controller = AsyncContextManagerMock()
+        with patch.object(engine, "_adaptive_concurrency_controller", mock_controller):
+            with pytest.raises((APIStatusError, RuntimeError)):
+                engine._infer_online([conversation])
+
+        mock_controller.record_error.assert_called()
+        mock_controller.record_success.assert_not_called()
+
+
 def test_response_processing_error(mock_polite_adaptive_semaphore, mock_asyncio_sleep):
     """Test handling of errors during response processing."""
     with aioresponses() as m:


### PR DESCRIPTION
## Summary

`RemoteInferenceEngine._query_api` records every non-200 response against the adaptive concurrency controller (`_try_record_error()`) *before* checking whether the status is retriable. Non-retriable statuses (401/403/404/422, and 400 without a known-transient pattern) are terminal request errors, not load signals — recording them drives the controller's error rate up and collapses concurrency to the minimum with no recovery. A single such response (e.g. an OpenAI `403 "organization must be verified"`) can push an entire batch into minimum concurrency, turning a fast failure into a multi-hour one.

## Change

Move `_try_record_error()` below the `is_non_retriable_status_code()` check: non-retriable statuses raise `APIStatusError` immediately without touching the controller; retriable failures (429 / 5xx / timeouts) still record an error so backoff continues to work.

## Tests

- `test_non_retriable_error_not_recorded_in_adaptive_concurrency` — a 403 fails fast and the controller is never notified.
- `test_retriable_error_recorded_in_adaptive_concurrency` — a 429 still records an error, preserving backoff.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
