### PR TITLE
fix(inference): let adaptive concurrency recover from backoff

### DIFF
--- a/src/oumi/core/configs/params/remote_params.py
+++ b/src/oumi/core/configs/params/remote_params.py
@@ -228,10 +228,12 @@ class AdaptiveConcurrencyParams(BaseParams):
     is 100, and the backoff factor is 0.8, the concurrency will be reduced to 80).
     """
 
-    recovery_threshold: float = 0.00
-    """Error rate threshold (0.00 = 0%) to allow recovery.
+    recovery_threshold: float = 0.005
+    """Error rate at or below which recovery from backoff is allowed.
 
-    If the error rate is less than this threshold, recovery will be triggered.
+    Sits just below ``error_threshold`` to form a hysteresis band: back off above
+    ``error_threshold``, recover at or below ``recovery_threshold``, hold between.
+    A value of ``0.0`` would require a perfectly error-free window to ever recover.
     """
 
     min_window_size: int = 10

--- a/tests/unit/inference/test_adaptive_concurrency_controller.py
+++ b/tests/unit/inference/test_adaptive_concurrency_controller.py
@@ -375,6 +375,53 @@ async def test_warmup_on_low_error_rate(mock_time):
 
 
 @pytest.mark.asyncio
+async def test_recovers_from_backoff_with_low_residual_errors(mock_time):
+    """A low, non-zero error rate within the recovery band exits backoff."""
+    config = create_config(
+        min_concurrency=1,
+        max_concurrency=50,
+        concurrency_step=5,
+        error_threshold=0.5,
+        recovery_threshold=0.1,
+        min_window_size=10,
+        min_update_time=0.1,
+    )
+    controller = AdaptiveConcurrencyController(
+        config, politeness_policy=_DEFAULT_POLITENESS_POLICY
+    )
+    await controller._update_concurrency(40)
+
+    # Drive a high error rate to force backoff.
+    for _ in range(10):
+        await controller.record_error()
+    mock_time.time.return_value = 1.0
+    controller._last_adjustment_time = 0
+    await controller._try_adjust_concurrency()
+    assert controller._in_backoff
+
+    # Residual error rate of 1/20 = 5% sits within the recovery band (<= 10%).
+    required = controller._consecutive_good_windows_required_for_recovery
+    elapsed = 1.0
+    for _ in range(required):
+        for _ in range(19):
+            await controller.record_success()
+        await controller.record_error()
+        elapsed += 1.0
+        mock_time.time.return_value = elapsed
+        controller._last_adjustment_time = elapsed - 1.0
+        await controller._try_adjust_concurrency()
+
+    assert not controller._in_backoff
+
+
+def test_default_recovery_threshold_allows_recovery():
+    """The default recovery threshold is positive and below ``error_threshold``."""
+    params = AdaptiveConcurrencyParams()
+    assert params.recovery_threshold > 0.0
+    assert params.recovery_threshold < params.error_threshold
+
+
+@pytest.mark.asyncio
 async def test_warmup_max_concurrency_limit(mock_time):
     """Test that warmup doesn't exceed max concurrency."""
     config = create_config(


### PR DESCRIPTION
## Summary

`AdaptiveConcurrencyParams.recovery_threshold` defaults to `0.0`, so recovery from backoff is only allowed in a *perfectly* error-free window — and while in backoff, any nonzero error rate is instead treated as a reason to back off further. Once concurrency collapses it therefore cannot climb back while even a trickle of errors remains, even after the underlying overload has cleared.

## Change

Default `recovery_threshold` to `0.005`, just below the default `error_threshold` (`0.01`), so the two form a hysteresis band: back off above `error_threshold`, recover at/below `recovery_threshold`, hold in between. A low residual error rate now drives recovery instead of further backoff.

## Tests

- `test_recovers_from_backoff_with_low_residual_errors` — a 5% residual error rate (within the recovery band) exits backoff; with a `0.0` threshold it would not.
- `test_default_recovery_threshold_allows_recovery` — the default is positive and below `error_threshold`.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
