### PR TITLE
fix(tests): install e2e test deps with uv pip so dependency overrides apply

### DIFF
--- a/tests/scripts/e2e_tests_job.yaml
+++ b/tests/scripts/e2e_tests_job.yaml
@@ -34,7 +34,7 @@ run: |
   set -xe  # Exit if any command failed.
   source "./configs/examples/misc/sky_init.sh"
 
-  pip install -e ".[ci_gpu]" hf_transfer
+  pip install uv && uv pip install --system -e ".[ci_gpu]" hf_transfer
   pip install -U flash-attn --no-build-isolation
 
   echo "Node ${SKYPILOT_NODE_RANK} starting..."


### PR DESCRIPTION
# Description

The GCP e2e tests job (`tests/scripts/e2e_tests_job.yaml`) installs oumi with plain `pip install -e ".[ci_gpu]"`. Since #2344 added `[tool.uv] override-dependencies = ["transformers>=5.5,<5.8"]` to `pyproject.toml`, the dependency set is only cleanly resolvable with uv — pip ignores the `[tool.uv]` section entirely.

As a result, pip's resolver backtracks heavily (vllm 0.21→0.14, verl 0.7→0.5, huggingface_hub 1.18→0.3x) and eventually walks mlflow's `scipy<2` constraint down to scipy 1.6.1, which has no Python 3.10 wheel. pip then attempts a source build that fails with `No BLAS/LAPACK libraries found`, killing the job before any tests run.

This switches the install to `uv pip install --system`, matching what `runpod_e2e_tests_job.yaml` already does (updated in #2344, but the GCP job was missed).

Verified on a GCP `A100:4` cluster: installation succeeds and the e2e suite passes (`10 passed, 3 skipped, 5094 deselected in 1:00:59`).

## Related issues

N/A — found while running the e2e suite; no tracking issue exists.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
