### PR TITLE
fix(launcher): populate JobStatus.start_at for Slurm jobs

### DIFF
--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -119,11 +119,11 @@ def _parse_slurm_epoch(value: str | None) -> float | None:
 
 
 def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
-    """Parses one row of ``squeue --noheader --format='%i %j %u %T %V %R'``."""
-    parts = line.strip().split(None, 5)
-    if len(parts) < 5:
+    """Parses one row of ``squeue --noheader --format='%i %j %u %T %V %S %R'``."""
+    parts = line.strip().split(None, 6)
+    if len(parts) < 6:
         return None
-    job_id, name, _user, raw_state, submit = parts[:5]
+    job_id, name, _user, raw_state, submit, start = parts[:6]
     state = _get_job_state(raw_state)
     return JobStatus(
         id=job_id,
@@ -134,6 +134,7 @@ def _parse_squeue_line(line: str, cluster_name: str) -> JobStatus | None:
         done=_is_job_done(state),
         state=state,
         submit_time=_parse_slurm_epoch(submit),
+        start_at=_parse_slurm_epoch(start),
     )
 
 
@@ -158,6 +159,7 @@ def _parse_scontrol_show_job(output: str, cluster_name: str) -> JobStatus | None
         done=_is_job_done(state),
         state=state,
         submit_time=_parse_slurm_epoch(fields.get("SubmitTime")),
+        start_at=_parse_slurm_epoch(fields.get("StartTime")),
     )
 
 
@@ -746,10 +748,10 @@ class SlurmClient:
 
     def _list_active_jobs_squeue(self) -> list[JobStatus]:
         """Lists active jobs via ``squeue``."""
-        # SLURM_TIME_FORMAT=%s renders %V (submit time) as a tz-safe Unix epoch.
+        # SLURM_TIME_FORMAT=%s renders %V (submit) and %S (start) as tz-safe epochs.
         command = (
             "SLURM_TIME_FORMAT=%s "
-            f"squeue --user={self._user} --noheader --format='%i %j %u %T %V %R'"
+            f"squeue --user={self._user} --noheader --format='%i %j %u %T %V %S %R'"
         )
         result = self.run_commands([command])
         if result.exit_code != 0:

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -433,7 +433,7 @@ def _mock_refresh_creds_run() -> Mock:
 
 def test_slurm_client_get_job_returns_active_job_from_squeue(mock_subprocess):
     squeue_ok = Mock()
-    squeue_ok.stdout = b"100 myjob user RUNNING 1700000000 node-1\n"
+    squeue_ok.stdout = b"100 myjob user RUNNING 1700000000 1700000005 node-1\n"
     squeue_ok.stderr = b""
     squeue_ok.returncode = 0
 
@@ -450,6 +450,29 @@ def test_slurm_client_get_job_returns_active_job_from_squeue(mock_subprocess):
     assert job_status.id == "100"
     assert job_status.state == JobState.RUNNING
     assert job_status.submit_time == 1700000000.0
+    assert job_status.start_at == 1700000005.0
+
+
+def test_slurm_client_get_job_pending_has_no_start_at(mock_subprocess):
+    squeue_pending = Mock()
+    squeue_pending.stdout = b"102 myjob user PENDING 1700000000 N/A (Resources)\n"
+    squeue_pending.stderr = b""
+    squeue_pending.returncode = 0
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_pending,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    job_status = client.get_job("102")
+
+    assert job_status is not None
+    assert job_status.state == JobState.PENDING
+    assert job_status.submit_time == 1700000000.0
+    # Never started -> no start time -> consumer treats it as "did not run".
+    assert job_status.start_at is None
 
 
 def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
@@ -486,6 +509,7 @@ def test_slurm_client_get_job_falls_back_to_scontrol_for_terminal_state(
     assert job_status.state == JobState.SUCCEEDED
     assert job_status.done is True
     assert job_status.submit_time == 1700000000.0
+    assert job_status.start_at == 1700000050.0
 
 
 def test_slurm_client_get_job_returns_none_when_purged(mock_subprocess):


### PR DESCRIPTION
## Summary

`SlurmClient` populated `JobStatus.submit_time` but never `start_at`. A Slurm `JobStatus` therefore never carried the time the job began running, so consumers couldn't distinguish a job that **failed before ever starting** from one that **ran and then failed**.

## Changes

- Add `%S` (start time) to the `squeue` format string; parse it into `start_at` in `_parse_squeue_line`.
- Parse `StartTime` into `start_at` in `_parse_scontrol_show_job`.
- `start_at` stays `None` for jobs that never started (`N/A`/`Unknown` are nulled by `_parse_slurm_epoch`), so it cleanly signals whether the job ran.
- Tests: assert `start_at` on the running (squeue) and terminal (scontrol) paths; add a pending-job case asserting `start_at is None`.
