### PR TITLE
fix(inference): re-pace retries through the adaptive concurrency controller

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -736,25 +736,25 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             if self._remote_params.use_adaptive_concurrency
             else semaphore
         )
-        async with semaphore_or_controller:
-            api_input = self._convert_conversation_to_api_input(
-                conversation, generation_params, model_params
-            )
-            headers = self._get_request_headers(remote_params)
-            failure_reason = None
-            last_status_code = None
+        api_input = self._convert_conversation_to_api_input(
+            conversation, generation_params, model_params
+        )
+        headers = self._get_request_headers(remote_params)
+        failure_reason = None
+        last_status_code = None
 
-            # Retry the request if it fails
-            for attempt in range(remote_params.max_retries + 1):
-                try:
-                    # Calculate exponential backoff delay
-                    if attempt > 0:
-                        delay = min(
-                            remote_params.retry_backoff_base * (2 ** (attempt - 1)),
-                            remote_params.retry_backoff_max,
-                        )
-                        await asyncio.sleep(delay)
+        # Retry the request if it fails
+        for attempt in range(remote_params.max_retries + 1):
+            try:
+                # Calculate exponential backoff delay
+                if attempt > 0:
+                    delay = min(
+                        remote_params.retry_backoff_base * (2 ** (attempt - 1)),
+                        remote_params.retry_backoff_max,
+                    )
+                    await asyncio.sleep(delay)
 
+                async with semaphore_or_controller:
                     async with session.post(
                         remote_params.api_url,
                         json=api_input,
@@ -834,40 +834,40 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                                 raise RuntimeError(failure_reason) from e
                             continue
 
-                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-                    # Connection or timeout errors are retriable.
-                    failure_reason = f"Connection error: {str(e)}"
-                    await self._try_record_error()
-                    if attempt >= remote_params.max_retries:
-                        raise RuntimeError(
-                            f"Failed to query API after {attempt + 1} attempts due to "
-                            f"connection error: {str(e)}"
-                        ) from e
-                    continue
-                except RuntimeError:
-                    # RuntimeError is raised by our code, so we don't need to retry.
-                    raise
-                except Exception as e:
-                    # If we get here, we've hit an unexpected error.
-                    failure_reason = f"Unexpected error: {str(e)}"
-                    await self._try_record_error()
-                    if attempt >= remote_params.max_retries:
-                        raise RuntimeError(
-                            f"Failed to query API after {attempt + 1} attempts due to "
-                            f"unexpected error: {str(e)}"
-                        ) from e
-                    continue
-            # This should only be reached if all retries failed
-            message = f"Failed to query API after {attempt + 1} attempts. " + (
-                f"Reason: {failure_reason}" if failure_reason else ""
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                # Connection or timeout errors are retriable.
+                failure_reason = f"Connection error: {str(e)}"
+                await self._try_record_error()
+                if attempt >= remote_params.max_retries:
+                    raise RuntimeError(
+                        f"Failed to query API after {attempt + 1} attempts due to "
+                        f"connection error: {str(e)}"
+                    ) from e
+                continue
+            except RuntimeError:
+                # RuntimeError is raised by our code, so we don't need to retry.
+                raise
+            except Exception as e:
+                # If we get here, we've hit an unexpected error.
+                failure_reason = f"Unexpected error: {str(e)}"
+                await self._try_record_error()
+                if attempt >= remote_params.max_retries:
+                    raise RuntimeError(
+                        f"Failed to query API after {attempt + 1} attempts due to "
+                        f"unexpected error: {str(e)}"
+                    ) from e
+                continue
+        # This should only be reached if all retries failed
+        message = f"Failed to query API after {attempt + 1} attempts. " + (
+            f"Reason: {failure_reason}" if failure_reason else ""
+        )
+        if last_status_code is not None:
+            raise APIStatusError(
+                message,
+                status_code=last_status_code,
+                api_input=api_input,
             )
-            if last_status_code is not None:
-                raise APIStatusError(
-                    message,
-                    status_code=last_status_code,
-                    api_input=api_input,
-                )
-            raise RuntimeError(message)
+        raise RuntimeError(message)
 
     async def _gather_query_tasks(
         self,

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -3521,7 +3521,8 @@ async def test_adaptive_concurrency_full_adjustment_cycle():
                     )
                 elif attempt_count >= recovery_step:
                     # Two good windows have passed, so we should warmup again
-                    assert current_concurrency == backoff_concurrency + step_size
+                    assert not controller._in_backoff
+                    assert current_concurrency >= backoff_concurrency + step_size
                     return CallbackResult(
                         status=200,
                         payload={
@@ -3579,6 +3580,60 @@ async def test_adaptive_concurrency_full_adjustment_cycle():
             assert len(result) == 50
 
         assert asserts_passed
+
+
+@pytest.mark.asyncio
+async def test_retriable_failure_reacquires_controller_each_attempt():
+    """A retriable failure re-acquires the controller slot on each attempt.
+
+    Each retry is re-paced at the controller's current concurrency instead of
+    retrying inside one held slot, and the request still succeeds.
+    """
+    statuses = [500, 200]
+
+    def get_response(*args, **kwargs):
+        status = statuses.pop(0)
+        if status != 200:
+            return CallbackResult(
+                status=status, payload={"error": {"message": "rate limited"}}
+            )
+        return CallbackResult(
+            status=200,
+            payload={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+        )
+
+    with aioresponses() as m:
+        m.post(_TARGET_SERVER, callback=get_response, repeat=True)
+        remote_params = RemoteParams(
+            api_url=_TARGET_SERVER,
+            use_adaptive_concurrency=True,
+            num_workers=20,
+            max_retries=1,
+            retry_backoff_base=0.001,
+        )
+        engine = RemoteInferenceEngine(
+            model_params=_get_default_model_params(),
+            remote_params=remote_params,
+        )
+        controller = engine._adaptive_concurrency_controller
+        acquisitions = 0
+        original_acquire = controller.acquire
+
+        async def counting_acquire():
+            nonlocal acquisitions
+            acquisitions += 1
+            await original_acquire()
+
+        controller.acquire = counting_acquire
+
+        result = engine.infer(
+            [Conversation(messages=[Message(content="hi", role=Role.USER)])]
+        )
+
+    assert len(result) == 1
+    # Two attempts (500 then 200) -> two acquisitions. Holding the slot around
+    # the whole retry loop would acquire once.
+    assert acquisitions == 2
 
 
 # FinishReason extraction tests


### PR DESCRIPTION
## Summary

A request that hits a **transient rate limit** can fail even though the adaptive concurrency controller exists to absorb exactly that. `_query_api` acquired the concurrency slot **once around** the whole retry loop, so a request's exponential-backoff budget ran entirely inside one held slot — while the controller only re-evaluates concurrency at *acquire* time (no sooner than `min_update_time`). A request dispatched into a saturated limit exhausts its retries and raises before the controller has throttled the offered load.

## Change

Acquire the slot **inside** the retry loop instead of around it:
- a retriable failure releases the slot, backs off **outside** it (holding no capacity while waiting), and **re-acquires** — so each attempt is re-paced at the controller's current (possibly lowered) concurrency;
- the controller throttles the offered load until requests succeed, then warms back up via the normal recovery path;
- a healthy first-try request is unchanged — exactly one acquire/release.

Net effect: a transient rate limit becomes "wait for the controller to make room" rather than "fail after N in-slot attempts."

## Blast radius

- No-error path: identical (one acquire/release per request).
- Error path only: the slot is freed during backoff (better utilization) and each retry re-enters concurrency adjustment.

## Tests

`test_adaptive_concurrency_full_adjustment_cycle` is updated for the new cadence: with per-attempt acquire, a retried request gets an extra concurrency-adjustment opportunity, so the recovery phase's exact warmup count is no longer fixed. The warmup→backoff→recovery phases are still asserted exactly; the recovery assertion now checks "recovered and climbing" rather than a single exact step. All inference unit tests pass.