### PR TITLE
fix(inference): honor Retry-After and fix retry backoff under rate limits

### DIFF
--- a/src/oumi/core/configs/params/remote_params.py
+++ b/src/oumi/core/configs/params/remote_params.py
@@ -34,13 +34,28 @@ class RemoteParams(BaseParams):
     """Name of the environment variable containing the API key for authentication."""
 
     max_retries: int = 5
-    """Maximum number of retries to attempt when calling an API."""
+    """Maximum number of retries when an API call fails with a retriable error.
+
+    Applies to every retriable failure (429, 5xx, connection/timeout errors),
+    not just rate limits. With the default backoff this allows roughly 100s of
+    total wait across attempts before giving up.
+    """
 
     retry_backoff_base: float = 1.0
-    """Base delay in seconds for exponential backoff between retries."""
+    """Base delay in seconds for exponential backoff between retries.
+
+    The delay is ``min(retry_backoff_base * 10 ** (attempt - 1),
+    retry_backoff_max)`` (a 10x step per attempt), so with the defaults the
+    waits are ~1s, 10s, then 30s (capped). A server-provided Retry-After takes
+    precedence over this schedule and is honored in full.
+    """
 
     retry_backoff_max: float = 30.0
-    """Maximum delay in seconds between retries."""
+    """Maximum delay in seconds for the exponential backoff schedule.
+
+    Caps the computed backoff only; a server-provided Retry-After is honored in
+    full and is not bounded by this value.
+    """
 
     connection_timeout: float = 300.0
     """Timeout in seconds for a request to an API."""

--- a/src/oumi/core/configs/params/remote_params.py
+++ b/src/oumi/core/configs/params/remote_params.py
@@ -33,7 +33,7 @@ class RemoteParams(BaseParams):
     api_key_env_varname: str | None = None
     """Name of the environment variable containing the API key for authentication."""
 
-    max_retries: int = 3
+    max_retries: int = 5
     """Maximum number of retries to attempt when calling an API."""
 
     retry_backoff_base: float = 1.0

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -72,6 +72,9 @@ _AUTHORIZATION_KEY: str = "Authorization"
 _BATCH_PURPOSE = "batch"
 _BATCH_ENDPOINT = "/v1/chat/completions"
 _MAX_CONNECTION_LIMIT = 200
+_RETRY_BACKOFF_MULTIPLIER: float = 10.0
+_MAX_RETRY_AFTER_SLEEP: float = 120.0
+_RETRY_JITTER_FRACTION: float = 0.25
 
 _QueryResultT = TypeVar("_QueryResultT")
 
@@ -750,7 +753,8 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                     # Calculate exponential backoff delay
                     if attempt > 0:
                         delay = min(
-                            remote_params.retry_backoff_base * (2 ** (attempt - 1)),
+                            remote_params.retry_backoff_base
+                            * (_RETRY_BACKOFF_MULTIPLIER ** (attempt - 1)),
                             remote_params.retry_backoff_max,
                         )
                         await asyncio.sleep(delay)

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -76,8 +76,8 @@ _BATCH_PURPOSE = "batch"
 _BATCH_ENDPOINT = "/v1/chat/completions"
 _MAX_CONNECTION_LIMIT = 200
 _RETRY_BACKOFF_MULTIPLIER: float = 10.0
-_MAX_RETRY_AFTER_SLEEP: float = 120.0
 _RETRY_JITTER_FRACTION: float = 0.25
+_MAX_RETRY_JITTER_FRACTION: float = 1.0
 
 _QueryResultT = TypeVar("_QueryResultT")
 
@@ -734,9 +734,6 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                     "Please set the environment variable "
                     f"`{remote_params.api_key_env_varname}`."
                 )
-        if self._rate_limiter is not None:
-            await self._rate_limiter.wait_if_needed()
-
         semaphore_or_controller = (
             self._adaptive_concurrency_controller
             if self._remote_params.use_adaptive_concurrency
@@ -753,11 +750,12 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         # Retry the request if it fails
         for attempt in range(remote_params.max_retries + 1):
             try:
-                # Honor a server Retry-After if present, else exponential
-                # backoff. Jitter de-correlates a batch hitting one rate window.
+                # Honor a server Retry-After in full if present, else exponential
+                # backoff. Jitter widens with num_workers so a large batch hitting
+                # one rate window spreads its retries instead of waking together.
                 if attempt > 0:
                     if next_retry_after is not None:
-                        delay = min(next_retry_after, _MAX_RETRY_AFTER_SLEEP)
+                        delay = next_retry_after
                         from_header = True
                         next_retry_after = None
                     else:
@@ -767,7 +765,11 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                             remote_params.retry_backoff_max,
                         )
                         from_header = False
-                    delay *= random.uniform(1.0, 1.0 + _RETRY_JITTER_FRACTION)
+                    jitter_fraction = min(
+                        _RETRY_JITTER_FRACTION * remote_params.num_workers,
+                        _MAX_RETRY_JITTER_FRACTION,
+                    )
+                    delay *= random.uniform(1.0, 1.0 + jitter_fraction)
                     logger.warning(
                         "Retrying request to %s after %.1fs (%s); "
                         "attempt %d/%d. Reason: %s",
@@ -779,6 +781,11 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                         failure_reason,
                     )
                     await asyncio.sleep(delay)
+
+                # Re-pace every attempt through the rate limiter so a burst of
+                # retries waking together still respects the RPM/TPM window.
+                if self._rate_limiter is not None:
+                    await self._rate_limiter.wait_if_needed()
 
                 async with semaphore_or_controller:
                     async with session.post(

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -71,6 +71,7 @@ from oumi.utils.http import (
 from oumi.utils.logging import logger
 
 _AUTHORIZATION_KEY: str = "Authorization"
+_RETRY_AFTER_HEADER: str = "Retry-After"
 _BATCH_PURPOSE = "batch"
 _BATCH_ENDPOINT = "/v1/chat/completions"
 _MAX_CONNECTION_LIMIT = 200
@@ -753,9 +754,8 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             # Retry the request if it fails
             for attempt in range(remote_params.max_retries + 1):
                 try:
-                    # Sleep before retrying. Honor a server-provided Retry-After
-                    # when present, else use exponential backoff. Jitter spreads
-                    # a concurrent batch that all hit the same rate window.
+                    # Honor a server Retry-After if present, else exponential
+                    # backoff. Jitter de-correlates a batch hitting one rate window.
                     if attempt > 0:
                         if next_retry_after is not None:
                             delay = min(next_retry_after, _MAX_RETRY_AFTER_SLEEP)
@@ -805,10 +805,9 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                                     api_input=api_input,
                                 )
 
-                            # Retriable failure: honor Retry-After if present,
-                            # record for backoff, then retry.
+                            # Retriable: capture any Retry-After, record, retry.
                             next_retry_after = parse_retry_after(
-                                response.headers.get("Retry-After"),
+                                response.headers.get(_RETRY_AFTER_HEADER),
                                 datetime.now(timezone.utc),
                             )
                             await self._try_record_error()

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -16,13 +16,14 @@ import asyncio
 import copy
 import json
 import os
+import random
 import tempfile
 import urllib.parse
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypeVar
 
@@ -65,6 +66,7 @@ from oumi.utils.http import (
     APIStatusError,
     get_failure_reason_from_response,
     is_non_retriable_status_code,
+    parse_retry_after,
 )
 from oumi.utils.logging import logger
 
@@ -746,16 +748,36 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             headers = self._get_request_headers(remote_params)
             failure_reason = None
             last_status_code = None
+            next_retry_after: float | None = None
 
             # Retry the request if it fails
             for attempt in range(remote_params.max_retries + 1):
                 try:
-                    # Calculate exponential backoff delay
+                    # Sleep before retrying. Honor a server-provided Retry-After
+                    # when present, else use exponential backoff. Jitter spreads
+                    # a concurrent batch that all hit the same rate window.
                     if attempt > 0:
-                        delay = min(
-                            remote_params.retry_backoff_base
-                            * (_RETRY_BACKOFF_MULTIPLIER ** (attempt - 1)),
-                            remote_params.retry_backoff_max,
+                        if next_retry_after is not None:
+                            delay = min(next_retry_after, _MAX_RETRY_AFTER_SLEEP)
+                            from_header = True
+                            next_retry_after = None
+                        else:
+                            delay = min(
+                                remote_params.retry_backoff_base
+                                * (_RETRY_BACKOFF_MULTIPLIER ** (attempt - 1)),
+                                remote_params.retry_backoff_max,
+                            )
+                            from_header = False
+                        delay *= random.uniform(1.0, 1.0 + _RETRY_JITTER_FRACTION)
+                        logger.warning(
+                            "Retrying request to %s after %.1fs (%s); "
+                            "attempt %d/%d. Reason: %s",
+                            remote_params.api_url,
+                            delay,
+                            "Retry-After" if from_header else "backoff",
+                            attempt + 1,
+                            remote_params.max_retries + 1,
+                            failure_reason,
                         )
                         await asyncio.sleep(delay)
 
@@ -783,7 +805,12 @@ class RemoteInferenceEngine(BaseInferenceEngine):
                                     api_input=api_input,
                                 )
 
-                            # Retriable failure: record for backoff, then retry.
+                            # Retriable failure: honor Retry-After if present,
+                            # record for backoff, then retry.
+                            next_retry_after = parse_retry_after(
+                                response.headers.get("Retry-After"),
+                                datetime.now(timezone.utc),
+                            )
                             await self._try_record_error()
                             continue
 

--- a/src/oumi/utils/http.py
+++ b/src/oumi/utils/http.py
@@ -89,18 +89,16 @@ def parse_retry_after(header_value: str | None, now: datetime) -> float | None:
     """
     if header_value is None:
         return None
-    value = header_value.strip()
-    if not value:
+    stripped_header = header_value.strip()
+    if not stripped_header:
         return None
     try:
-        return max(0.0, float(value))
+        return max(0.0, float(stripped_header))
     except (ValueError, TypeError):
         pass
     try:
-        parsed = parsedate_to_datetime(value)
+        parsed = parsedate_to_datetime(stripped_header)
     except (ValueError, TypeError):
-        return None
-    if parsed is None:
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)

--- a/src/oumi/utils/http.py
+++ b/src/oumi/utils/http.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
 import aiohttp
 
 
@@ -71,6 +74,37 @@ def is_non_retriable_status_code(
         if any(pattern in lower_msg for pattern in _RETRIABLE_400_PATTERNS):
             return False
     return True
+
+
+def parse_retry_after(header_value: str | None, now: datetime) -> float | None:
+    """Parse an RFC 7231 Retry-After value into seconds from ``now``.
+
+    Handles both forms: delta-seconds ("120") and HTTP-date
+    ("Wed, 21 Oct 2015 07:28:00 GMT"). Returns None when the value is absent or
+    unparseable. Past dates and negative deltas clamp to 0.0.
+
+    Args:
+        header_value: The raw Retry-After header value, or None if absent.
+        now: The reference time used to convert an HTTP-date to a delta.
+    """
+    if header_value is None:
+        return None
+    value = header_value.strip()
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (ValueError, TypeError):
+        pass
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (ValueError, TypeError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return max(0.0, (parsed - now).total_seconds())
 
 
 async def get_failure_reason_from_response(

--- a/tests/unit/core/configs/params/test_remote_params.py
+++ b/tests/unit/core/configs/params/test_remote_params.py
@@ -46,3 +46,9 @@ def test_remote_params_accepts_valid_backoff():
     params = RemoteParams(retry_backoff_base=0.5, retry_backoff_max=0.5)
     params.finalize_and_validate()
     # No exception should be raised - equal values are allowed
+
+
+def test_remote_params_default_max_retries_is_five():
+    from oumi.core.configs.params.remote_params import RemoteParams
+
+    assert RemoteParams().max_retries == 5

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -826,6 +826,30 @@ def test_infer_online_fails_with_message_and_retries(mock_asyncio_sleep):
         assert mock_asyncio_sleep.call_count == 3
 
 
+def test_infer_online_fallback_backoff_curve(mock_asyncio_sleep):
+    with patch("random.uniform", return_value=1.0):
+        with aioresponses() as m:
+            for _ in range(6):  # max_retries=5 -> 6 attempts
+                m.post(
+                    _TARGET_SERVER,
+                    status=500,
+                    payload={"error": {"message": "Internal server error"}},
+                )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            )
+            config = _get_default_inference_config()
+            conversation = Conversation(
+                messages=[Message(content="Hello world!", role=Role.USER)],
+                conversation_id="123",
+            )
+            with pytest.raises(APIStatusError):
+                _ = engine.infer([conversation], config)
+            delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
+            assert delays == [1.0, 10.0, 30.0, 30.0, 30.0]
+
+
 def test_infer_online_recovers_from_retries():
     with aioresponses() as m:
         m.post(_TARGET_SERVER, status=500)

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -795,11 +795,12 @@ def test_infer_online_fails_with_message_and_retries(mock_asyncio_sleep):
         )
 
         config = _get_default_inference_config()
+        # _query_api uses config.remote_params over the engine's, so pin it here.
         if config.remote_params is not None:
             config.remote_params.max_retries = 3
         engine = RemoteInferenceEngine(
             _get_default_model_params(),
-            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=3),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER),
         )
         conversation = Conversation(
             messages=[
@@ -2970,17 +2971,12 @@ async def test_infer_online_exponential_backoff(mock_polite_adaptive_semaphore):
 
                 result = engine.infer([conversation], inference_config)
 
-                # Verify the result
                 assert len(result) == 1
                 assert result[0].messages[-1].content == "Success after retries"
 
-                # Verify sleep calls. Multiplier is 10, max is 1.0:
-                # attempt 1: min(0.2 * 10^0, 1.0) = 0.2
-                # attempt 2: min(0.2 * 10^1, 1.0) = 1.0 (capped)
+                # base=0.2, multiplier=10, max=1.0: 0.2, then 1.0 (capped).
                 backoff_sleeps = [s for s in sleep_calls if s > 0]
-                # First retry: base delay (0.2 * 10^0, no cap)
                 assert backoff_sleeps[0] == pytest.approx(0.2)
-                # Second retry: capped at retry_backoff_max (0.2 * 10^1 > 1.0)
                 assert backoff_sleeps[1] == pytest.approx(1.0)
 
 

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -795,9 +795,11 @@ def test_infer_online_fails_with_message_and_retries(mock_asyncio_sleep):
         )
 
         config = _get_default_inference_config()
+        if config.remote_params is not None:
+            config.remote_params.max_retries = 3
         engine = RemoteInferenceEngine(
             _get_default_model_params(),
-            remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            remote_params=RemoteParams(api_url=_TARGET_SERVER, max_retries=3),
         )
         conversation = Conversation(
             messages=[
@@ -848,6 +850,94 @@ def test_infer_online_fallback_backoff_curve(mock_asyncio_sleep):
                 _ = engine.infer([conversation], config)
             delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
             assert delays == [1.0, 10.0, 30.0, 30.0, 30.0]
+
+
+def test_infer_online_honors_retry_after_delta(mock_asyncio_sleep):
+    with patch("random.uniform", return_value=1.0):
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER,
+                status=429,
+                headers={"Retry-After": "45"},
+                payload={"error": {"message": "Rate limited"}},
+            )
+            m.post(
+                _TARGET_SERVER,
+                payload={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                },
+            )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            )
+            config = _get_default_inference_config()
+            conversation = Conversation(
+                messages=[Message(content="Hello world!", role=Role.USER)],
+                conversation_id="123",
+            )
+            result = engine.infer([conversation], config)
+            assert result[0].messages[-1].content == "ok"
+            delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
+            assert delays == [45.0]  # honored header, not the 1s backoff
+
+
+def test_infer_online_retry_after_capped(mock_asyncio_sleep):
+    with patch("random.uniform", return_value=1.0):
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER,
+                status=429,
+                headers={"Retry-After": "100000"},
+                payload={"error": {"message": "Rate limited"}},
+            )
+            m.post(
+                _TARGET_SERVER,
+                payload={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                },
+            )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            )
+            config = _get_default_inference_config()
+            conversation = Conversation(
+                messages=[Message(content="Hello world!", role=Role.USER)],
+                conversation_id="123",
+            )
+            engine.infer([conversation], config)
+            delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
+            assert delays == [120.0]  # capped at _MAX_RETRY_AFTER_SLEEP
+
+
+def test_infer_online_retry_after_jitter_applied(mock_asyncio_sleep):
+    with patch("random.uniform", return_value=1.2):
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER,
+                status=429,
+                headers={"Retry-After": "10"},
+                payload={"error": {"message": "Rate limited"}},
+            )
+            m.post(
+                _TARGET_SERVER,
+                payload={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                },
+            )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            )
+            config = _get_default_inference_config()
+            conversation = Conversation(
+                messages=[Message(content="Hello world!", role=Role.USER)],
+                conversation_id="123",
+            )
+            engine.infer([conversation], config)
+            delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
+            assert delays == [12.0]  # 10 * 1.2 jitter factor
 
 
 def test_infer_online_recovers_from_retries():
@@ -2855,40 +2945,43 @@ async def test_infer_online_exponential_backoff(mock_polite_adaptive_semaphore):
         m.post(_TARGET_SERVER, callback=callback, repeat=True)
 
         with patch("asyncio.sleep", side_effect=mock_sleep):
-            engine = RemoteInferenceEngine(
-                model_params=_get_default_model_params(),
-                remote_params=RemoteParams(
+            with patch("random.uniform", return_value=1.0):
+                engine = RemoteInferenceEngine(
+                    model_params=_get_default_model_params(),
+                    remote_params=RemoteParams(
+                        api_url=_TARGET_SERVER,
+                        max_retries=3,
+                        retry_backoff_base=0.2,  # Small values for testing
+                        retry_backoff_max=1.0,
+                    ),
+                )
+                conversation = Conversation(
+                    messages=[Message(role=Role.USER, content="Hello")],
+                )
+
+                remote_params = RemoteParams(
                     api_url=_TARGET_SERVER,
                     max_retries=3,
-                    retry_backoff_base=0.2,  # Small values for testing
+                    retry_backoff_base=0.2,
                     retry_backoff_max=1.0,
-                ),
-            )
-            conversation = Conversation(
-                messages=[Message(role=Role.USER, content="Hello")],
-            )
+                )
+                inference_config = _get_default_inference_config()
+                inference_config.remote_params = remote_params
 
-            remote_params = RemoteParams(
-                api_url=_TARGET_SERVER,
-                max_retries=3,
-                retry_backoff_base=0.2,
-                retry_backoff_max=1.0,
-            )
-            inference_config = _get_default_inference_config()
-            inference_config.remote_params = remote_params
+                result = engine.infer([conversation], inference_config)
 
-            result = engine.infer([conversation], inference_config)
+                # Verify the result
+                assert len(result) == 1
+                assert result[0].messages[-1].content == "Success after retries"
 
-            # Verify the result
-            assert len(result) == 1
-            assert result[0].messages[-1].content == "Success after retries"
-
-            # Verify sleep calls
-            backoff_sleeps = [s for s in sleep_calls if s > 0]
-            assert backoff_sleeps[0] == pytest.approx(0.2)  # First retry: base delay
-            assert backoff_sleeps[1] == pytest.approx(
-                0.4
-            )  # Second retry: base delay * 2
+                # Verify sleep calls. Multiplier is 10, max is 1.0:
+                # attempt 1: min(0.2 * 10^0, 1.0) = 0.2
+                # attempt 2: min(0.2 * 10^1, 1.0) = 1.0 (capped)
+                backoff_sleeps = [s for s in sleep_calls if s > 0]
+                # First retry: base delay (0.2 * 10^0, no cap)
+                assert backoff_sleeps[0] == pytest.approx(0.2)
+                # Second retry: capped at retry_backoff_max (0.2 * 10^1 > 1.0)
+                assert backoff_sleeps[1] == pytest.approx(1.0)
 
 
 def test_non_retriable_errors(mock_asyncio_sleep):

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -883,13 +883,15 @@ def test_infer_online_honors_retry_after_delta(mock_asyncio_sleep):
             assert delays == [45.0]  # honored header, not the 1s backoff
 
 
-def test_infer_online_retry_after_capped(mock_asyncio_sleep):
+def test_infer_online_retry_after_honored_in_full(mock_asyncio_sleep):
+    # Retry-After takes precedence over our backoff and is NOT capped; only the
+    # exponential fallback is bounded by retry_backoff_max.
     with patch("random.uniform", return_value=1.0):
         with aioresponses() as m:
             m.post(
                 _TARGET_SERVER,
                 status=429,
-                headers={"Retry-After": "100000"},
+                headers={"Retry-After": "600"},
                 payload={"error": {"message": "Rate limited"}},
             )
             m.post(
@@ -909,7 +911,7 @@ def test_infer_online_retry_after_capped(mock_asyncio_sleep):
             )
             engine.infer([conversation], config)
             delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
-            assert delays == [120.0]  # capped at _MAX_RETRY_AFTER_SLEEP
+            assert delays == [600.0]  # honored in full, not truncated
 
 
 def test_infer_online_retry_after_jitter_applied(mock_asyncio_sleep):
@@ -939,6 +941,73 @@ def test_infer_online_retry_after_jitter_applied(mock_asyncio_sleep):
             engine.infer([conversation], config)
             delays = [call.args[0] for call in mock_asyncio_sleep.call_args_list]
             assert delays == [12.0]  # 10 * 1.2 jitter factor
+
+
+def test_infer_online_retry_jitter_widens_with_num_workers(mock_asyncio_sleep):
+    # The jitter window scales with num_workers (capped) so a large batch spreads
+    # its retries instead of waking in a tight cluster.
+    with patch("random.uniform", return_value=1.0) as mock_uniform:
+        with aioresponses() as m:
+            m.post(
+                _TARGET_SERVER,
+                status=429,
+                headers={"Retry-After": "10"},
+                payload={"error": {"message": "Rate limited"}},
+            )
+            m.post(
+                _TARGET_SERVER,
+                payload={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                },
+            )
+            engine = RemoteInferenceEngine(
+                _get_default_model_params(),
+                remote_params=RemoteParams(api_url=_TARGET_SERVER),
+            )
+            config = _get_default_inference_config()
+            assert config.remote_params is not None
+            config.remote_params.num_workers = 10  # 0.25 * 10 = 2.5 -> capped at 1.0
+            conversation = Conversation(
+                messages=[Message(content="Hello world!", role=Role.USER)],
+                conversation_id="123",
+            )
+            engine.infer([conversation], config)
+            # jitter_fraction capped at _MAX_RETRY_JITTER_FRACTION -> uniform(1.0, 2.0)
+            mock_uniform.assert_called_with(1.0, 2.0)
+
+
+def test_infer_online_rate_limiter_repaces_each_retry(mock_asyncio_sleep):
+    # Every attempt (not just the first) re-paces through the rate limiter, so a
+    # burst of retries still respects the configured RPM/TPM window.
+    with patch("random.uniform", return_value=1.0):
+        engine = RemoteInferenceEngine(
+            _get_default_model_params(),
+            remote_params=RemoteParams(
+                api_url=_TARGET_SERVER,
+                requests_per_minute=1000,
+                use_adaptive_concurrency=False,
+            ),
+        )
+        assert engine._rate_limiter is not None
+        mock_wait = AsyncMock()
+        with patch.object(engine._rate_limiter, "wait_if_needed", mock_wait):
+            with aioresponses() as m:
+                m.post(
+                    _TARGET_SERVER,
+                    status=500,
+                    payload={"error": {"message": "server error"}},
+                )
+                m.post(
+                    _TARGET_SERVER,
+                    payload={
+                        "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                    },
+                )
+                result = engine.infer(
+                    [Conversation(messages=[Message(content="hi", role=Role.USER)])]
+                )
+        assert result[0].messages[-1].content == "ok"
+        assert mock_wait.call_count == 2  # one per attempt (500 then 200)
 
 
 def test_infer_online_recovers_from_retries():

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -132,30 +132,18 @@ async def test_get_failure_reason_from_response_with_json_error():
 _NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def test_parse_retry_after_delta_seconds():
-    assert parse_retry_after("120", _NOW) == 120.0
-
-
-def test_parse_retry_after_zero():
-    assert parse_retry_after("0", _NOW) == 0.0
-
-
-def test_parse_retry_after_http_date():
-    # 30 seconds after _NOW.
-    assert parse_retry_after("Sun, 15 Jun 2026 12:00:30 GMT", _NOW) == 30.0
-
-
-def test_parse_retry_after_past_http_date_clamps_to_zero():
-    assert parse_retry_after("Sun, 15 Jun 2026 11:59:00 GMT", _NOW) == 0.0
-
-
-def test_parse_retry_after_negative_delta_clamps_to_zero():
-    assert parse_retry_after("-5", _NOW) == 0.0
-
-
-def test_parse_retry_after_absent_returns_none():
-    assert parse_retry_after(None, _NOW) is None
-
-
-def test_parse_retry_after_garbage_returns_none():
-    assert parse_retry_after("not-a-date", _NOW) is None
+@pytest.mark.parametrize(
+    "header_value,expected",
+    [
+        ("120", 120.0),  # delta-seconds
+        ("0", 0.0),
+        ("-5", 0.0),  # negative delta clamps to 0
+        ("Sun, 15 Jun 2026 12:00:30 GMT", 30.0),  # HTTP-date, 30s ahead of _NOW
+        ("Sun, 15 Jun 2026 11:59:00 GMT", 0.0),  # past HTTP-date clamps to 0
+        (None, None),  # absent header
+        ("", None),  # empty / whitespace-only
+        ("not-a-date", None),  # unparseable
+    ],
+)
+def test_parse_retry_after(header_value: str | None, expected: float | None):
+    assert parse_retry_after(header_value, _NOW) == expected

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import aiohttp
@@ -20,6 +21,7 @@ import pytest
 from oumi.utils.http import (
     get_failure_reason_from_response,
     is_non_retriable_status_code,
+    parse_retry_after,
 )
 
 
@@ -125,3 +127,35 @@ async def test_get_failure_reason_from_response_with_json_error():
 
     result = await get_failure_reason_from_response(mock_response)
     assert result == "HTTP 400"
+
+
+_NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_retry_after_delta_seconds():
+    assert parse_retry_after("120", _NOW) == 120.0
+
+
+def test_parse_retry_after_zero():
+    assert parse_retry_after("0", _NOW) == 0.0
+
+
+def test_parse_retry_after_http_date():
+    # 30 seconds after _NOW.
+    assert parse_retry_after("Sun, 15 Jun 2026 12:00:30 GMT", _NOW) == 30.0
+
+
+def test_parse_retry_after_past_http_date_clamps_to_zero():
+    assert parse_retry_after("Sun, 15 Jun 2026 11:59:00 GMT", _NOW) == 0.0
+
+
+def test_parse_retry_after_negative_delta_clamps_to_zero():
+    assert parse_retry_after("-5", _NOW) == 0.0
+
+
+def test_parse_retry_after_absent_returns_none():
+    assert parse_retry_after(None, _NOW) is None
+
+
+def test_parse_retry_after_garbage_returns_none():
+    assert parse_retry_after("not-a-date", _NOW) is None


### PR DESCRIPTION
## What
Remote inference retries now wait out provider rate limits instead of giving up on them, so a throttled batch job finishes rather than stalling for hours.

## Why
A request that hit a provider's per-minute token limit used to exhaust all its retries in about seven seconds and fail. That single failure then collapsed the whole batch into a slow serial fallback and left jobs stuck for hours with no actionable rate-limit error reaching the user.

## How
On a throttled response the engine now honors the server's `Retry-After` hint (capped, with a little randomization so a burst of requests doesn't all retry at the same instant), uses a steeper backoff that outlasts a one-minute limit window, allows a few more attempts, and logs each wait so a throttled run is visible instead of silently stuck.

## Testing
Added unit tests for the header parsing (delta-seconds and HTTP-date forms), the wait cap, the jitter, the new backoff curve, and the higher attempt budget. Also verified end-to-end against the live Anthropic and OpenAI APIs, and confirmed a real `429` + `Retry-After` is honored end-to-end (real networking, real sleep). Standard lints clean.

## Related issues

Fixes OPE-2157

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
