### PR TITLE
fix(inference): fall back to Triton GDN-prefill backend on CUDA toolkit < 12.6

### DIFF
--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -15,9 +15,16 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
+import functools
 import json
 import math
+import os
+import re
+import shutil
+import subprocess
 import warnings
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast, get_args
 
@@ -91,6 +98,99 @@ except ModuleNotFoundError:
     _VLLM_V0_12 = False
     ToolParserManager = None  # type: ignore[assignment]
     _VLLM_TOOL_PARSERS_AVAILABLE = False
+
+
+def _parse_nvcc_release_version(nvcc_version_output: str) -> tuple[int, int] | None:
+    """Parse the ``release X.Y`` field of ``nvcc --version`` output into (X, Y)."""
+    match = re.search(r"release (\d+)\.(\d+)", nvcc_version_output)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _vllm_accepts_additional_config() -> bool:
+    """Whether this vLLM build's ``EngineArgs`` accepts ``additional_config``.
+
+    Only newer vLLM accepts it — and that is also the only range with GDN
+    support, so on older builds there is nothing to fix.
+    """
+    try:
+        from vllm.engine.arg_utils import (  # pyright: ignore[reportMissingImports]
+            EngineArgs,
+        )
+
+        return "additional_config" in {f.name for f in dataclasses.fields(EngineArgs)}
+    except Exception:
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def _cuda_toolkit_below_12_6() -> bool:
+    """Whether the system CUDA toolkit is older than 12.6 (or absent).
+
+    flashinfer's ``gdn_prefill_sm90`` kernel JIT-builds against the system
+    toolkit and needs the ``cuda::ptx`` tensormap intrinsics added in 12.6.
+    """
+    nvcc = shutil.which("nvcc")
+    if nvcc is None:
+        for cuda_home in (os.environ.get("CUDA_HOME"), "/usr/local/cuda"):
+            candidate = Path(cuda_home) / "bin" / "nvcc" if cuda_home else None
+            if candidate and candidate.is_file():
+                nvcc = str(candidate)
+                break
+    if nvcc is None:
+        return True  # no toolkit at all → the flashinfer JIT can't build either
+
+    try:
+        output = subprocess.run(
+            [nvcc, "--version"], capture_output=True, text=True, timeout=10
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return True
+
+    version = _parse_nvcc_release_version(output)
+    if version is None:
+        return False
+    return version < (12, 6)
+
+
+# Model families using a Gated Delta Net attention architecture, whose
+# flashinfer gdn_prefill_sm90 kernel JIT-builds against the CUDA toolkit.
+_GDN_MODEL_TYPES = frozenset({"qwen3_5", "qwen3_6", "qwen3_next"})
+
+
+@functools.cache
+def _model_uses_gdn(model_name: str, trust_remote_code: bool) -> bool:
+    """Best-effort check whether the model uses a GDN attention architecture.
+
+    Reads the HF config (resolves both Hub ids and local fine-tuned dirs).
+    Returns False if the config can't be read.
+    """
+    try:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code
+        )
+        return getattr(config, "model_type", None) in _GDN_MODEL_TYPES
+    except Exception:
+        return False
+
+
+def _should_force_triton_gdn_backend(model_name: str, trust_remote_code: bool) -> bool:
+    """Whether to force vLLM's Triton GDN-prefill backend for this model.
+
+    GDN models (e.g. Qwen3.5) JIT-compile a flashinfer ``gdn_prefill_sm90``
+    kernel that needs the system CUDA toolkit >= 12.6 (``cuda::ptx`` tensormap
+    intrinsics). On older toolkits the build fails and the engine hangs, so
+    fall back to the Triton/FLA GDN backend. No-op for non-GDN models and for
+    toolkits >= 12.6. Mirrors the intent of vllm-project/vllm#37507.
+    """
+    return (
+        _vllm_accepts_additional_config()
+        and _cuda_toolkit_below_12_6()
+        and _model_uses_gdn(model_name, trust_remote_code)
+    )
 
 
 class VLLMInferenceEngine(BaseInferenceEngine):
@@ -266,6 +366,20 @@ class VLLMInferenceEngine(BaseInferenceEngine):
         # Only add quantization if not already in vllm_kwargs and not None
         if quantization is not None and "quantization" not in vllm_kwargs:
             final_vllm_kwargs["quantization"] = quantization
+
+        # GDN-architecture models (e.g. Qwen3.5) hang when flashinfer's sm90
+        # GDN-prefill kernel can't JIT-build against an old (<12.6) CUDA
+        # toolkit; fall back to the Triton GDN backend. No-op for other models.
+        if _should_force_triton_gdn_backend(
+            model_params.model_name, model_params.trust_remote_code
+        ):
+            final_vllm_kwargs["additional_config"] = {  # pyright: ignore[reportArgumentType]
+                "gdn_prefill_backend": "triton"
+            }
+            logger.warning(
+                "System CUDA toolkit < 12.6: forcing vLLM Triton GDN-prefill "
+                "backend (the flashinfer sm90 GDN kernel would fail to build)."
+            )
 
         self._llm = vllm.LLM(**final_vllm_kwargs)  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue]
         # Ensure the tokenizer is set properly.

--- a/tests/unit/inference/test_vllm_gdn_backend.py
+++ b/tests/unit/inference/test_vllm_gdn_backend.py
@@ -1,0 +1,118 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from oumi.inference.vllm_inference_engine import (
+    _cuda_toolkit_below_12_6,
+    _model_uses_gdn,
+    _parse_nvcc_release_version,
+    _should_force_triton_gdn_backend,
+)
+
+_MODULE = "oumi.inference.vllm_inference_engine"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    _cuda_toolkit_below_12_6.cache_clear()
+    _model_uses_gdn.cache_clear()
+    yield
+    _cuda_toolkit_below_12_6.cache_clear()
+    _model_uses_gdn.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("Cuda compilation tools, release 12.4, V12.4.131", (12, 4)),
+        ("release 12.6, V12.6.20", (12, 6)),
+        ("release 13.0", (13, 0)),
+        ("no version here", None),
+        ("", None),
+    ],
+)
+def test_parse_nvcc_release_version(output, expected):
+    assert _parse_nvcc_release_version(output) == expected
+
+
+@pytest.mark.parametrize(
+    "release,expected",
+    [
+        ("release 12.4, V12.4.131", True),  # < 12.6
+        ("release 12.5, V12.5.0", True),
+        ("release 12.6, V12.6.20", False),  # >= 12.6
+        ("release 13.0, V13.0.0", False),
+        ("unparseable", False),  # unknown → don't change behavior
+    ],
+)
+def test_cuda_toolkit_below_12_6_by_version(release, expected):
+    with (
+        patch(f"{_MODULE}.shutil.which", return_value="/usr/local/cuda/bin/nvcc"),
+        patch(f"{_MODULE}.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.stdout = release
+        assert _cuda_toolkit_below_12_6() is expected
+
+
+def test_cuda_toolkit_below_12_6_no_nvcc():
+    # No nvcc on PATH and none under CUDA_HOME → treat as too old.
+    with (
+        patch(f"{_MODULE}.shutil.which", return_value=None),
+        patch.dict(f"{_MODULE}.os.environ", {}, clear=True),
+        patch(f"{_MODULE}.Path.is_file", return_value=False),
+    ):
+        assert _cuda_toolkit_below_12_6() is True
+
+
+@pytest.mark.parametrize(
+    "model_type,expected",
+    [
+        ("qwen3_5", True),
+        ("qwen3_next", True),
+        ("qwen3", False),  # non-GDN
+        ("llama", False),
+    ],
+)
+def test_model_uses_gdn(model_type, expected):
+    with patch("transformers.AutoConfig.from_pretrained") as mock_cfg:
+        mock_cfg.return_value = SimpleNamespace(model_type=model_type)
+        assert _model_uses_gdn("some/model", False) is expected
+
+
+def test_model_uses_gdn_unreadable_config():
+    # Config can't be loaded (e.g. bad path) → False, never raises.
+    with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError("boom")):
+        assert _model_uses_gdn("missing/model", False) is False
+
+
+@pytest.mark.parametrize(
+    "accepts,old_toolkit,is_gdn,expected",
+    [
+        (True, True, True, True),  # all conditions met → force triton
+        (True, True, False, False),  # non-GDN model → no-op
+        (True, False, True, False),  # modern toolkit → keep flashinfer
+        (False, True, True, False),  # vLLM can't take additional_config
+    ],
+)
+def test_should_force_triton_gdn_backend(accepts, old_toolkit, is_gdn, expected):
+    with (
+        patch(f"{_MODULE}._vllm_accepts_additional_config", return_value=accepts),
+        patch(f"{_MODULE}._cuda_toolkit_below_12_6", return_value=old_toolkit),
+        patch(f"{_MODULE}._model_uses_gdn", return_value=is_gdn),
+    ):
+        assert _should_force_triton_gdn_backend("some/model", False) is expected


### PR DESCRIPTION
## Summary

Gated Delta Net models (e.g. Qwen3.5) JIT-compile a flashinfer `gdn_prefill_sm90` kernel at serve time. It fails to build when the system CUDA toolkit is < 12.6 (`cuda::ptx` lacks the `tensormap` intrinsics added in 12.6), so the engine hangs. Detect the toolkit version and fall back to vLLM's Triton GDN backend instead. Mirrors vllm-project/vllm#37507.

Scoped to the GDN-prefill backend — a no-op for non-GDN models and for toolkits >= 12.6.

## Changes

- `_should_force_triton_gdn_backend()`: true when this vLLM build accepts `additional_config` and the system `nvcc` is < 12.6 (or absent).
- When true, set `additional_config={"gdn_prefill_backend": "triton"}` on the engine.
- Unit tests for `nvcc --version` parsing and the decision logic.