### PR TITLE
feat(inference): forward user_id to OpenAI/Anthropic for abuse attribution

### DIFF
--- a/src/oumi/core/configs/params/remote_params.py
+++ b/src/oumi/core/configs/params/remote_params.py
@@ -33,6 +33,12 @@ class RemoteParams(BaseParams):
     api_key_env_varname: str | None = None
     """Name of the environment variable containing the API key for authentication."""
 
+    user_id: str | None = None
+    """Opaque end-user identifier forwarded to the provider for abuse attribution.
+
+    Sent as OpenAI ``user`` / Anthropic ``metadata.user_id``; omitted when unset.
+    """
+
     max_retries: int = 5
     """Maximum number of retries when an API call fails with a retriable error.
 

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -180,6 +180,9 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         if generation_params.top_p is not None:
             body["top_p"] = generation_params.top_p
 
+        if self._remote_params.user_id:
+            body["metadata"] = {"user_id": self._remote_params.user_id}
+
         if system_message:
             body["system"] = system_message
 

--- a/src/oumi/inference/openai_inference_engine.py
+++ b/src/oumi/inference/openai_inference_engine.py
@@ -107,11 +107,14 @@ class OpenAIInferenceEngine(RemoteInferenceEngine):
             # Reasoning models only support temperature = 1.0.
             generation_params.temperature = 1.0
 
-        return super()._convert_conversation_to_api_input(
+        api_input = super()._convert_conversation_to_api_input(
             conversation=conversation,
             generation_params=generation_params,
             model_params=model_params,
         )
+        if self._remote_params.user_id:
+            api_input["user"] = self._remote_params.user_id
+        return api_input
 
     @override
     def _default_remote_params(self) -> RemoteParams:

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -51,6 +51,34 @@ def test_convert_conversation_to_api_input(anthropic_engine):
     assert result["cache_control"] == {"type": "ephemeral"}
 
 
+def test_convert_conversation_includes_user_id_metadata():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-3"),
+        remote_params=RemoteParams(
+            api_key="test_api_key", api_url="<placeholder>", user_id="ORG-7"
+        ),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=100), engine._model_params
+    )
+
+    assert result["metadata"] == {"user_id": "ORG-7"}
+
+
+def test_convert_conversation_omits_metadata_without_user_id(anthropic_engine):
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = anthropic_engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(max_new_tokens=100),
+        anthropic_engine._model_params,
+    )
+
+    assert "metadata" not in result
+
+
 def test_convert_api_output_to_conversation(anthropic_engine):
     original_conversation = Conversation(
         messages=[

--- a/tests/unit/inference/test_openai_inference_engine.py
+++ b/tests/unit/inference/test_openai_inference_engine.py
@@ -32,6 +32,32 @@ def openai_engine():
     )
 
 
+def test_convert_conversation_includes_user_id():
+    engine = OpenAIInferenceEngine(
+        model_params=ModelParams(model_name="gpt-4"),
+        remote_params=RemoteParams(
+            api_key="test_api_key", api_url="<placeholder>", user_id="ORG-7"
+        ),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    api_input = engine._convert_conversation_to_api_input(
+        conversation, engine._generation_params, engine._model_params
+    )
+
+    assert api_input["user"] == "ORG-7"
+
+
+def test_convert_conversation_omits_user_without_user_id(openai_engine):
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    api_input = openai_engine._convert_conversation_to_api_input(
+        conversation, openai_engine._generation_params, openai_engine._model_params
+    )
+
+    assert "user" not in api_input
+
+
 def test_openai_init_with_custom_params():
     """Test initialization with custom parameters."""
     model_params = ModelParams(model_name="gpt-4")


### PR DESCRIPTION
## Summary

Add `RemoteParams.user_id` — an opaque end-user identifier forwarded to the provider so abuse controls act on that id rather than the shared API key. Useful when one key serves many end users (e.g., a hosted multi-tenant deployment): a misbehaving user gets flagged, not the key.

## Changes

- `RemoteParams.user_id: str | None = None`.
- `OpenAIInferenceEngine`: sends it as the OpenAI `user` field.
- `AnthropicInferenceEngine`: sends it as `metadata.user_id`.
- Opt-in: omitted from the request body when unset. Scoped to the OpenAI and Anthropic engines (other OpenAI-compatible providers may reject unknown body fields).

## Tests

- Body includes `user` / `metadata.user_id` when `user_id` is set, omits it when unset.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
