### PR TITLE
[db-executable-env] Phase 2: DatabaseExecutableEnvironment (prototype)

### DIFF
--- a/configs/examples/database_env/ehr_database_env.yaml
+++ b/configs/examples/database_env/ehr_database_env.yaml
@@ -1,0 +1,34 @@
+# Minimal EHR database executable environment.
+# Swap schema_sql/seed_sql for `db_path: /path/to/your.sqlite` to bring your own DB.
+id: ehr_demo
+name: EHR demo
+description: Example EHR database environment with three tools.
+env_type: database
+env_kwargs:
+  schema_sql: "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
+  seed_sql: "INSERT INTO patients VALUES (1,'Bob','aspirin'),(2,'Alice','ibuprofen');"
+tools:
+  - id: list_patients
+    name: list_patients
+    description: List all patients.
+    parameters: {type: object, properties: {}}
+    executor: oumi.environments.examples.ehr.list_patients
+    read_only: true
+  - id: lookup_patient
+    name: lookup_patient
+    description: Look up one patient by id.
+    parameters:
+      type: object
+      properties: {pat_id: {type: integer}}
+      required: [pat_id]
+    executor: oumi.environments.examples.ehr.lookup_patient
+    read_only: true
+  - id: update_meds
+    name: update_meds
+    description: Update a patient's medication.
+    parameters:
+      type: object
+      properties: {pat_id: {type: integer}, medication: {type: string}}
+      required: [pat_id, medication]
+    executor: oumi.environments.examples.ehr.update_meds
+    read_only: false

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -277,6 +277,9 @@ class ConversationSynthesizer:
             samples = self._plan_samples(samples, multiturn_attributes)
             conversations = self._synthesize_all_samples(samples, multiturn_attributes)
         finally:
+            for sample_router in self._sample_routers:
+                if sample_router is not None:
+                    sample_router.close()
             self._sample_routers = []
 
         records: list[dict[str, dict | str] | None] = []

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -74,6 +74,11 @@ class ToolRouter:
             if on_env_built is not None:
                 on_env_built(env)
             env_by_id[env_params.id] = env
+            # Isolating envs are rebuilt per-sample in for_sample(); the parent
+            # only reads requires_isolation() off this instance, so free its
+            # resources now (e.g. a DB env's temp snapshot) instead of leaking.
+            if env.requires_isolation():
+                env.close()
 
         tools_by_id = {tool.id: tool for tool in env_config.all_tools}
         tool_to_env = {
@@ -123,6 +128,16 @@ class ToolRouter:
             tool_env_map=self.tool_env_map,
             on_env_built=self.on_env_built,
         )
+
+    def close(self) -> None:
+        """Release per-sample envs this router owns.
+
+        Only isolation-requiring envs are rebuilt (and thus owned) per router;
+        shared envs belong to the parent router and are left open.
+        """
+        for env in self.env_by_id.values():
+            if env.requires_isolation():
+                env.close()
 
     def parse_and_validate_arguments(
         self, tool_id: str, raw_arguments: str

--- a/src/oumi/datasets/grpo/rewards/__init__.py
+++ b/src/oumi/datasets/grpo/rewards/__init__.py
@@ -21,6 +21,7 @@ from oumi.datasets.grpo.rewards.completion_length_rewards import (
 from oumi.datasets.grpo.rewards.count_letters_rewards import compute_letter_count_reward
 from oumi.datasets.grpo.rewards.countdown_rewards import countdown_reward
 from oumi.datasets.grpo.rewards.gsm8k_reward import gsm8k_reward
+from oumi.datasets.grpo.rewards.sql_execution_match import sql_execution_match
 
 __all__ = [
     "compute_letter_count_reward",
@@ -28,4 +29,5 @@ __all__ = [
     "compute_sharp_target_token_length_reward",
     "countdown_reward",
     "gsm8k_reward",
+    "sql_execution_match",
 ]

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -54,12 +54,18 @@ def sql_execution_match(
             schema_sql=info["schema_sql"], seed_sql=info.get("seed_sql")
         )
         owns = True
-    session = RollbackSession(path, owns_file=owns)
+    # Grade gold and candidate on separate sessions so each runs against the
+    # pristine snapshot — a mutating gold query can't contaminate the candidate.
+    gold_session = RollbackSession(path)
     try:
-        gold_rows = _run(session.connection, ground_truth)
-        cand_rows = _run(session.connection, solution_str)
+        gold_rows = _run(gold_session.connection, ground_truth)
     finally:
-        session.close()
+        gold_session.close()
+    cand_session = RollbackSession(path, owns_file=owns)
+    try:
+        cand_rows = _run(cand_session.connection, solution_str)
+    finally:
+        cand_session.close()
     if gold_rows is None or cand_rows is None:
         return 0.0
     return 1.0 if gold_rows == cand_rows else 0.0

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -21,7 +21,10 @@ from pathlib import Path
 from typing import Any
 
 from oumi.core.registry import RegistryType, register
-from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+from oumi.environments.database_session import (
+    DatabaseSession,
+    materialize_sqlite_snapshot,
+)
 
 
 def _run(connection: sqlite3.Connection, sql: str) -> list[tuple] | None:
@@ -64,12 +67,12 @@ def sql_execution_match(
     # The outer finally owns deletion of a materialized snapshot so it can't leak
     # if a session fails to open or close.
     try:
-        gold_session = RollbackSession(path)
+        gold_session = DatabaseSession(path)
         try:
             gold_rows = _run(gold_session.connection, ground_truth)
         finally:
             gold_session.close()
-        cand_session = RollbackSession(path)
+        cand_session = DatabaseSession(path)
         try:
             cand_rows = _run(cand_session.connection, solution_str)
         finally:

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -49,23 +49,34 @@ def sql_execution_match(
     owns = False
     if info.get("db_path"):
         path = Path(info["db_path"])
-    else:
+    elif info.get("schema_sql"):
         path = materialize_sqlite_snapshot(
             schema_sql=info["schema_sql"], seed_sql=info.get("seed_sql")
         )
         owns = True
+    else:
+        raise ValueError(
+            "sql_execution_match: extra_info must provide either 'db_path' or "
+            "'schema_sql'."
+        )
     # Grade gold and candidate on separate sessions so each runs against the
     # pristine snapshot — a mutating gold query can't contaminate the candidate.
-    gold_session = RollbackSession(path)
+    # The outer finally owns deletion of a materialized snapshot so it can't leak
+    # if a session fails to open or close.
     try:
-        gold_rows = _run(gold_session.connection, ground_truth)
+        gold_session = RollbackSession(path)
+        try:
+            gold_rows = _run(gold_session.connection, ground_truth)
+        finally:
+            gold_session.close()
+        cand_session = RollbackSession(path)
+        try:
+            cand_rows = _run(cand_session.connection, solution_str)
+        finally:
+            cand_session.close()
     finally:
-        gold_session.close()
-    cand_session = RollbackSession(path, owns_file=owns)
-    try:
-        cand_rows = _run(cand_session.connection, solution_str)
-    finally:
-        cand_session.close()
+        if owns:
+            path.unlink(missing_ok=True)
     if gold_rows is None or cand_rows is None:
         return 0.0
     return 1.0 if gold_rows == cand_rows else 0.0

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -1,0 +1,65 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution-match reward for SQL tasks, graded on an isolated snapshot."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from oumi.core.registry import RegistryType, register
+from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+
+
+def _run(connection: sqlite3.Connection, sql: str) -> list[tuple] | None:
+    try:
+        return connection.execute(sql).fetchall()
+    except sqlite3.Error:
+        return None
+
+
+@register("sql_execution_match", RegistryType.REWARD_FUNCTION)
+def sql_execution_match(
+    data_source: str,
+    solution_str: str,
+    ground_truth: str,
+    extra_info: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> float:
+    """Return 1.0 if candidate SQL's result set matches the gold's, else 0.0.
+
+    ``extra_info`` carries the DB descriptor: either ``db_path`` or
+    ``schema_sql`` (+ optional ``seed_sql``). Grading runs on a rollback
+    session, so a candidate that writes never mutates the snapshot.
+    """
+    info = extra_info or {}
+    owns = False
+    if info.get("db_path"):
+        path = Path(info["db_path"])
+    else:
+        path = materialize_sqlite_snapshot(
+            schema_sql=info["schema_sql"], seed_sql=info.get("seed_sql")
+        )
+        owns = True
+    session = RollbackSession(path, owns_file=owns)
+    try:
+        gold_rows = _run(session.connection, ground_truth)
+        cand_rows = _run(session.connection, solution_str)
+    finally:
+        session.close()
+    if gold_rows is None or cand_rows is None:
+        return 0.0
+    return 1.0 if gold_rows == cand_rows else 0.0

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -32,6 +32,9 @@ from oumi.core.configs.params.tool_params import (
 )
 from oumi.core.types.tool_call import JSONSchema, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
     DeterministicEnvironmentKwargs,
@@ -47,6 +50,7 @@ from oumi.environments.synthetic_environment import (
 
 __all__ = [
     "BaseEnvironment",
+    "DatabaseExecutableEnvironment",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
     "ExecutableEnvironment",

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -34,6 +34,8 @@ from oumi.core.types.tool_call import JSONSchema, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.database_executable_environment import (
     DatabaseExecutableEnvironment,
+    current_connection,
+    using_connection,
 )
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
@@ -69,4 +71,6 @@ __all__ = [
     "ToolLookupError",
     "ToolParams",
     "ToolResult",
+    "current_connection",
+    "using_connection",
 ]

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -44,6 +44,14 @@ class BaseEnvironment(ABC):
         """
         return False
 
+    def close(self) -> None:
+        """Release resources owned by this env. Default no-op.
+
+        Counterpart to ``requires_isolation``: envs rebuilt per sample (e.g. a
+        DB session) override this to release their resources at episode end.
+        """
+        return None
+
     def sample_grounding(
         self,
         n: int,

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -1,0 +1,102 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Executable environment backed by a rollback-isolated SQLite session."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any, ClassVar
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.registry import register_environment
+from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
+    """Resolve a dotted import path to a callable."""
+    module_path, _, attr = dotted.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' must be a dotted import path."
+        )
+    module = importlib.import_module(module_path)
+    executor = getattr(module, attr, None)
+    if not callable(executor):
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' did not resolve to a callable."
+        )
+    return executor
+
+
+@register_environment("database")
+class DatabaseExecutableEnvironment(ExecutableEnvironment):
+    """Runs SQL-executing tools against a rollback-isolated SQLite session.
+
+    One instance owns one session for the duration of an episode. Executors
+    must NOT commit; the env rolls back on ``close()`` so writes never persist.
+    ``requires_isolation()`` is ``True``, so the router builds a fresh instance
+    (hence a fresh session) per rollout. See ``db_isolation`` for the contract.
+    """
+
+    _executor_context_kwarg: ClassVar[str] = "db"
+
+    def __init__(self, params: EnvironmentParams, session: RollbackSession) -> None:
+        """Bind the env to its params and an already-open rollback session."""
+        self._params = params
+        self._session = session
+        self._executors = {
+            tool.id: _import_executor(tool.executor, tool.id) for tool in params.tools
+        }
+
+    @classmethod
+    def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
+        """Build the env, opening a rollback session over its configured DB."""
+        kwargs = dict(params.env_kwargs or {})
+        db_path = kwargs.get("db_path")
+        schema_sql = kwargs.get("schema_sql")
+        if db_path:
+            # Shared snapshot: connect read-side, roll back on close.
+            session = RollbackSession(db_path)
+        elif schema_sql:
+            # Inline: build a fresh per-rollout DB this instance owns.
+            snapshot = materialize_sqlite_snapshot(
+                schema_sql=schema_sql, seed_sql=kwargs.get("seed_sql")
+            )
+            session = RollbackSession(snapshot, owns_file=True)
+        else:
+            raise ValueError(
+                f"DatabaseExecutableEnvironment '{params.id}': env_kwargs must "
+                f"provide either 'db_path' or 'schema_sql'."
+            )
+        return cls(params, session)
+
+    def requires_isolation(self) -> bool:
+        """Each rollout needs its own session; never share across samples."""
+        return True
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        """Yield the episode's connection (uncommitted writes persist within it)."""
+        yield self._session.connection
+
+    def close(self) -> None:
+        """Roll back the episode's writes and tear down the session."""
+        self._session.close()

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Executable environment backed by a rollback-isolated SQLite session."""
+"""Executable environment backed by a Database-isolated SQLite session."""
 
 from __future__ import annotations
 
@@ -23,7 +23,10 @@ from typing import Any, ClassVar
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.registry import register_environment
-from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+from oumi.environments.database_session import (
+    DatabaseSession,
+    materialize_sqlite_snapshot,
+)
 from oumi.environments.executable_environment import ExecutableEnvironment
 from oumi.environments.executable_tool import ExecutableTool
 
@@ -46,7 +49,7 @@ def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
 
 @register_environment("database")
 class DatabaseExecutableEnvironment(ExecutableEnvironment):
-    """Runs SQL-executing tools against a rollback-isolated SQLite session.
+    """Runs SQL-executing tools against a Database-isolated SQLite session.
 
     One instance owns one session for the duration of an episode. Executors
     must NOT commit; the env rolls back on ``close()`` so writes never persist.
@@ -56,8 +59,8 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
 
     _executor_context_kwarg: ClassVar[str] = "db"
 
-    def __init__(self, params: EnvironmentParams, session: RollbackSession) -> None:
-        """Bind the env to its params and an already-open rollback session."""
+    def __init__(self, params: EnvironmentParams, session: DatabaseSession) -> None:
+        """Bind the env to its params and an already-open Database session."""
         self._params = params
         self._session = session
         self._executors = {
@@ -66,9 +69,9 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
 
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
-        """Build the env, opening a rollback session over its configured DB.
+        """Build the env, opening a Database session over its configured DB.
 
-        ``db_path`` shares one snapshot file across rollouts (rollback isolation,
+        ``db_path`` shares one snapshot file across rollouts (Database isolation,
         scales to large DBs). It is safe for concurrent *readers*, but SQLite
         serializes concurrent *writers* on one file, so concurrent rollouts that
         write will contend — those tasks should use ``schema_sql`` (a fresh
@@ -78,14 +81,12 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
         db_path = kwargs.get("db_path")
         schema_sql = kwargs.get("schema_sql")
         if db_path:
-            # Shared snapshot: connect read-side, roll back on close.
-            session = RollbackSession(db_path)
+            session = DatabaseSession(db_path)
         elif schema_sql:
-            # Inline: build a fresh per-rollout DB this instance owns.
             snapshot = materialize_sqlite_snapshot(
                 schema_sql=schema_sql, seed_sql=kwargs.get("seed_sql")
             )
-            session = RollbackSession(snapshot, owns_file=True)
+            session = DatabaseSession(snapshot, owns_file=True)
         else:
             raise ValueError(
                 f"DatabaseExecutableEnvironment '{params.id}': env_kwargs must "

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -16,19 +16,59 @@
 
 from __future__ import annotations
 
+import contextvars
 import importlib
+import sqlite3
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import Any, ClassVar
+from typing import Any
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.registry import register_environment
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.database_session import (
     DatabaseSession,
     materialize_sqlite_snapshot,
 )
 from oumi.environments.executable_environment import ExecutableEnvironment
 from oumi.environments.executable_tool import ExecutableTool
+
+_ACTIVE_CONNECTION: contextvars.ContextVar[sqlite3.Connection] = contextvars.ContextVar(
+    "oumi_active_db_connection"
+)
+
+
+def current_connection() -> sqlite3.Connection:
+    """Return the SQLite connection bound to the in-flight tool call.
+
+    Raises:
+        RuntimeError: if called outside a tool execution (nothing is bound).
+    """
+    try:
+        return _ACTIVE_CONNECTION.get()
+    except LookupError as e:
+        raise RuntimeError(
+            "current_connection() called outside a DatabaseExecutableEnvironment "
+            "tool execution; no connection is bound."
+        ) from e
+
+
+@contextmanager
+def using_connection(connection: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    """Bind ``connection`` as the active connection for the duration of the block.
+
+    The environment uses this internally per call. It is also the supported way
+    to run an executor directly — in a unit test or a grading path — without
+    threading the connection through it::
+
+        with using_connection(conn):
+            run_my_tool(arg=1)
+    """
+    token = _ACTIVE_CONNECTION.set(connection)
+    try:
+        yield connection
+    finally:
+        _ACTIVE_CONNECTION.reset(token)
 
 
 def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
@@ -49,15 +89,7 @@ def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
 
 @register_environment("database")
 class DatabaseExecutableEnvironment(ExecutableEnvironment):
-    """Runs SQL-executing tools against a Database-isolated SQLite session.
-
-    One instance owns one session for the duration of an episode. Executors
-    must NOT commit; the env rolls back on ``close()`` so writes never persist.
-    ``requires_isolation()`` is ``True``, so the router builds a fresh instance
-    (hence a fresh session) per rollout. See ``database_session`` for the contract.
-    """
-
-    _executor_context_kwarg: ClassVar[str] = "db"
+    """Runs SQL-executing tools against an isolated database session."""
 
     def __init__(self, params: EnvironmentParams, session: DatabaseSession) -> None:
         """Bind the env to its params and an already-open Database session."""
@@ -101,9 +133,28 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
     @contextmanager
     def _build_execution_context(
         self, tool: ExecutableTool, arguments: dict[str, Any]
-    ) -> Iterator[Any]:
-        """Yield the episode's connection (uncommitted writes persist within it)."""
-        yield self._session.connection
+    ) -> Iterator[None]:
+        """Bind the episode's connection as the active connection for this call.
+
+        The connection travels via the contextvar — executors read it through
+        ``current_connection()`` — so the yielded ctx is unused.
+        """
+        with using_connection(self._session.connection):
+            yield None
+
+    def _invoke_executor(
+        self, executor: Callable[..., Any], arguments: dict[str, Any], ctx: Any
+    ) -> Any:
+        """Call the executor with unpacked tool params and coerce the return.
+
+        The connection is ambient (``current_connection()``), so executors take
+        only their declared parameters. A plain return value is wrapped into a
+        ``ToolResult``; a ``ToolResult`` is passed through unchanged. Exceptions
+        raised by an executor propagate to the caller (matching the base
+        contract) — callers that grade untrusted SQL catch them themselves.
+        """
+        result = executor(**arguments)
+        return result if isinstance(result, ToolResult) else ToolResult(output=result)
 
     def close(self) -> None:
         """Roll back the episode's writes and tear down the session."""

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -66,7 +66,14 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
 
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
-        """Build the env, opening a rollback session over its configured DB."""
+        """Build the env, opening a rollback session over its configured DB.
+
+        ``db_path`` shares one snapshot file across rollouts (rollback isolation,
+        scales to large DBs). It is safe for concurrent *readers*, but SQLite
+        serializes concurrent *writers* on one file, so concurrent rollouts that
+        write will contend — those tasks should use ``schema_sql`` (a fresh
+        per-rollout file) until copy-on-write isolation lands.
+        """
         kwargs = dict(params.env_kwargs or {})
         db_path = kwargs.get("db_path")
         schema_sql = kwargs.get("schema_sql")

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -54,7 +54,7 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
     One instance owns one session for the duration of an episode. Executors
     must NOT commit; the env rolls back on ``close()`` so writes never persist.
     ``requires_isolation()`` is ``True``, so the router builds a fresh instance
-    (hence a fresh session) per rollout. See ``db_isolation`` for the contract.
+    (hence a fresh session) per rollout. See ``database_session`` for the contract.
     """
 
     _executor_context_kwarg: ClassVar[str] = "db"

--- a/src/oumi/environments/database_session.py
+++ b/src/oumi/environments/database_session.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rollback-based SQLite isolation for per-rollout database environments.
-
-The SkyRL pattern: each rollout gets its own connection that opens a
-transaction and never commits, so uncommitted writes are visible within the
-rollout and discarded on close. The environment owns the transaction;
-executors must not call ``commit()``.
-"""
+"""Rollback-based SQLite isolation for per-rollout database environments."""
 
 from __future__ import annotations
 
@@ -56,7 +50,7 @@ def materialize_sqlite_snapshot(
     return path
 
 
-class RollbackSession:
+class DatabaseSession:
     """A per-rollout SQLite connection that never commits and rolls back on close.
 
     Set ``owns_file=True`` when the env built a throwaway per-rollout database
@@ -64,16 +58,7 @@ class RollbackSession:
     """
 
     def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
-        """Open a per-rollout connection; set owns_file to delete the DB on close.
-
-        Opens with ``isolation_level=None`` and an explicit ``BEGIN`` so the whole
-        session is one transaction. ``sqlite3``'s legacy mode only opens an
-        implicit transaction before DML, which would let a leading DDL statement
-        (e.g. ``CREATE TABLE`` as the first call) run in autocommit and escape the
-        rollback; the explicit ``BEGIN`` brings DDL under transaction control too.
-        Executors still must not call ``commit()`` — an explicit commit persists
-        regardless and there is no way to undo it.
-        """
+        """Open a per-rollout connection; set owns_file to delete the DB on close."""
         self._path = Path(db_path)
         self._owns_file = owns_file
         self.connection = sqlite3.connect(self._path, isolation_level=None)

--- a/src/oumi/environments/db_isolation.py
+++ b/src/oumi/environments/db_isolation.py
@@ -46,8 +46,13 @@ def materialize_sqlite_snapshot(
         if seed_sql:
             conn.executescript(seed_sql)
         conn.commit()
-    finally:
+    except BaseException:
         conn.close()
+        # Drop the partial temp file we just created so a bad DDL/seed can't leak it.
+        if dest is None:
+            path.unlink(missing_ok=True)
+        raise
+    conn.close()
     return path
 
 
@@ -72,7 +77,13 @@ class RollbackSession:
         self._path = Path(db_path)
         self._owns_file = owns_file
         self.connection = sqlite3.connect(self._path, isolation_level=None)
-        self.connection.execute("BEGIN")
+        try:
+            self.connection.execute("BEGIN")
+        except BaseException:
+            self.connection.close()
+            if self._owns_file:
+                self._path.unlink(missing_ok=True)
+            raise
 
     def close(self) -> None:
         """Roll back any open transaction, close, and delete an owned file."""

--- a/src/oumi/environments/db_isolation.py
+++ b/src/oumi/environments/db_isolation.py
@@ -59,10 +59,20 @@ class RollbackSession:
     """
 
     def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
-        """Open a per-rollout connection; set owns_file to delete the DB on close."""
+        """Open a per-rollout connection; set owns_file to delete the DB on close.
+
+        Opens with ``isolation_level=None`` and an explicit ``BEGIN`` so the whole
+        session is one transaction. ``sqlite3``'s legacy mode only opens an
+        implicit transaction before DML, which would let a leading DDL statement
+        (e.g. ``CREATE TABLE`` as the first call) run in autocommit and escape the
+        rollback; the explicit ``BEGIN`` brings DDL under transaction control too.
+        Executors still must not call ``commit()`` — an explicit commit persists
+        regardless and there is no way to undo it.
+        """
         self._path = Path(db_path)
         self._owns_file = owns_file
-        self.connection = sqlite3.connect(self._path)
+        self.connection = sqlite3.connect(self._path, isolation_level=None)
+        self.connection.execute("BEGIN")
 
     def close(self) -> None:
         """Roll back any open transaction, close, and delete an owned file."""

--- a/src/oumi/environments/db_isolation.py
+++ b/src/oumi/environments/db_isolation.py
@@ -1,0 +1,73 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollback-based SQLite isolation for per-rollout database environments.
+
+The SkyRL pattern: each rollout gets its own connection that opens a
+transaction and never commits, so uncommitted writes are visible within the
+rollout and discarded on close. The environment owns the transaction;
+executors must not call ``commit()``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import uuid
+from pathlib import Path
+
+
+def materialize_sqlite_snapshot(
+    *,
+    schema_sql: str,
+    seed_sql: str | None = None,
+    dest: Path | str | None = None,
+) -> Path:
+    """Build a snapshot SQLite file from DDL (+ optional seed INSERTs)."""
+    path = (
+        Path(dest)
+        if dest is not None
+        else Path(tempfile.gettempdir()) / f"oumi_snapshot_{uuid.uuid4().hex}.sqlite"
+    )
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(schema_sql)
+        if seed_sql:
+            conn.executescript(seed_sql)
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+class RollbackSession:
+    """A per-rollout SQLite connection that never commits and rolls back on close.
+
+    Set ``owns_file=True`` when the env built a throwaway per-rollout database
+    that should be deleted on teardown (as opposed to a shared snapshot).
+    """
+
+    def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
+        self._path = Path(db_path)
+        self._owns_file = owns_file
+        self.connection = sqlite3.connect(self._path)
+
+    def close(self) -> None:
+        """Roll back any open transaction, close, and delete an owned file."""
+        try:
+            self.connection.rollback()
+        finally:
+            self.connection.close()
+            if self._owns_file:
+                self._path.unlink(missing_ok=True)

--- a/src/oumi/environments/db_isolation.py
+++ b/src/oumi/environments/db_isolation.py
@@ -59,6 +59,7 @@ class RollbackSession:
     """
 
     def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
+        """Open a per-rollout connection; set owns_file to delete the DB on close."""
         self._path = Path(db_path)
         self._owns_file = owns_file
         self.connection = sqlite3.connect(self._path)

--- a/src/oumi/environments/examples/__init__.py
+++ b/src/oumi/environments/examples/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runnable example tools/executors for executable environments."""

--- a/src/oumi/environments/examples/ehr.py
+++ b/src/oumi/environments/examples/ehr.py
@@ -36,11 +36,13 @@ EHR_SEED = (
 
 
 def list_patients(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    """List every patient's id and name."""
     rows = db.execute("SELECT id, name FROM patients ORDER BY id").fetchall()
     return ToolResult(output={"patients": [{"id": r[0], "name": r[1]} for r in rows]})
 
 
 def lookup_patient(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    """Return one patient's name and meds by id, or an error if absent."""
     row = db.execute(
         "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
     ).fetchone()
@@ -50,6 +52,7 @@ def lookup_patient(*, arguments: dict[str, Any], db: sqlite3.Connection) -> Tool
 
 
 def update_meds(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    """Set a patient's medication (uncommitted; rolled back at episode end)."""
     # No commit: the environment rolls back at episode end. The write is
     # visible to later calls on this same connection within the episode.
     cur = db.execute(

--- a/src/oumi/environments/examples/ehr.py
+++ b/src/oumi/environments/examples/ehr.py
@@ -1,0 +1,60 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EHR example: schema, seed data, and three SQL tool executors.
+
+Executors take (*, arguments, db) where ``db`` is a sqlite3.Connection handed
+in by DatabaseExecutableEnvironment, and return a ToolResult. They must NOT
+commit: the environment owns the transaction and rolls back on close.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from oumi.core.types.tool_call import ToolResult
+
+EHR_SCHEMA = (
+    "CREATE TABLE patients ("
+    " id INTEGER PRIMARY KEY, name TEXT NOT NULL, meds TEXT);"
+)
+EHR_SEED = (
+    "INSERT INTO patients (id, name, meds) VALUES"
+    " (1, 'Bob', 'aspirin'), (2, 'Alice', 'ibuprofen'), (3, 'Carol', NULL);"
+)
+
+
+def list_patients(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    rows = db.execute("SELECT id, name FROM patients ORDER BY id").fetchall()
+    return ToolResult(output={"patients": [{"id": r[0], "name": r[1]} for r in rows]})
+
+
+def lookup_patient(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    row = db.execute(
+        "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
+    ).fetchone()
+    if row is None:
+        return ToolResult(output={"error": "not found"})
+    return ToolResult(output={"name": row[0], "meds": row[1]})
+
+
+def update_meds(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+    # No commit: the environment rolls back at episode end. The write is
+    # visible to later calls on this same connection within the episode.
+    cur = db.execute(
+        "UPDATE patients SET meds = ? WHERE id = ?",
+        (arguments["medication"], arguments["pat_id"]),
+    )
+    return ToolResult(output={"updated_rows": cur.rowcount})

--- a/src/oumi/environments/examples/ehr.py
+++ b/src/oumi/environments/examples/ehr.py
@@ -14,17 +14,17 @@
 
 """EHR example: schema, seed data, and three SQL tool executors.
 
-Executors take (*, arguments, db) where ``db`` is a sqlite3.Connection handed
-in by DatabaseExecutableEnvironment, and return a ToolResult. They must NOT
+Each executor takes only its declared tool parameters and reaches the episode's
+SQLite connection via ``current_connection()`` — the environment binds it per
+call. They return a plain dict (the env wraps it in a ToolResult) and must NOT
 commit: the environment owns the transaction and rolls back on close.
 """
 
 from __future__ import annotations
 
-import sqlite3
 from typing import Any
 
-from oumi.core.types.tool_call import ToolResult
+from oumi.environments.database_executable_environment import current_connection
 
 EHR_SCHEMA = (
     "CREATE TABLE patients ( id INTEGER PRIMARY KEY, name TEXT NOT NULL, meds TEXT);"
@@ -35,28 +35,33 @@ EHR_SEED = (
 )
 
 
-def list_patients(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+def list_patients() -> dict[str, Any]:
     """List every patient's id and name."""
-    rows = db.execute("SELECT id, name FROM patients ORDER BY id").fetchall()
-    return ToolResult(output={"patients": [{"id": r[0], "name": r[1]} for r in rows]})
+    rows = (
+        current_connection()
+        .execute("SELECT id, name FROM patients ORDER BY id")
+        .fetchall()
+    )
+    return {"patients": [{"id": r[0], "name": r[1]} for r in rows]}
 
 
-def lookup_patient(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+def lookup_patient(pat_id: int) -> dict[str, Any]:
     """Return one patient's name and meds by id, or an error if absent."""
-    row = db.execute(
-        "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
-    ).fetchone()
+    row = (
+        current_connection()
+        .execute("SELECT name, meds FROM patients WHERE id = ?", (pat_id,))
+        .fetchone()
+    )
     if row is None:
-        return ToolResult(output={"error": "not found"})
-    return ToolResult(output={"name": row[0], "meds": row[1]})
+        return {"error": "not found"}
+    return {"name": row[0], "meds": row[1]}
 
 
-def update_meds(*, arguments: dict[str, Any], db: sqlite3.Connection) -> ToolResult:
+def update_meds(pat_id: int, medication: str) -> dict[str, Any]:
     """Set a patient's medication (uncommitted; rolled back at episode end)."""
     # No commit: the environment rolls back at episode end. The write is
     # visible to later calls on this same connection within the episode.
-    cur = db.execute(
-        "UPDATE patients SET meds = ? WHERE id = ?",
-        (arguments["medication"], arguments["pat_id"]),
+    cur = current_connection().execute(
+        "UPDATE patients SET meds = ? WHERE id = ?", (medication, pat_id)
     )
-    return ToolResult(output={"updated_rows": cur.rowcount})
+    return {"updated_rows": cur.rowcount}

--- a/src/oumi/environments/examples/ehr.py
+++ b/src/oumi/environments/examples/ehr.py
@@ -27,8 +27,7 @@ from typing import Any
 from oumi.core.types.tool_call import ToolResult
 
 EHR_SCHEMA = (
-    "CREATE TABLE patients ("
-    " id INTEGER PRIMARY KEY, name TEXT NOT NULL, meds TEXT);"
+    "CREATE TABLE patients ( id INTEGER PRIMARY KEY, name TEXT NOT NULL, meds TEXT);"
 )
 EHR_SEED = (
     "INSERT INTO patients (id, name, meds) VALUES"

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -96,9 +96,13 @@ class ExecutableEnvironment(BaseEnvironment):
         tool = self._lookup_tool(tool_id)
         tool.validate_arguments(arguments)
         with self._build_execution_context(tool, arguments) as ctx:
-            result = self._executors[tool_id](
-                **{"arguments": arguments, self._executor_context_kwarg: ctx}
-            )
+            result = self._invoke_executor(self._executors[tool_id], arguments, ctx)
         validated = self._validate_result(tool, result)
         self._absorb_result(tool, validated)
         return validated
+
+    def _invoke_executor(
+        self, executor: Callable[..., Any], arguments: dict[str, Any], ctx: Any
+    ) -> Any:
+        """Call the resolved executor and return its raw result."""
+        return executor(**{"arguments": arguments, self._executor_context_kwarg: ctx})

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -16,11 +16,12 @@
 
 from __future__ import annotations
 
-import jsonschema
 from abc import abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any, ClassVar
+
+import jsonschema
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.tool_params import ToolError, ToolLookupError, ToolParams

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -16,13 +16,14 @@
 
 from __future__ import annotations
 
+import jsonschema
 from abc import abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any, ClassVar
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.tool_params import ToolError, ToolLookupError, ToolParams
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.executable_tool import ExecutableTool
@@ -66,6 +67,37 @@ class ExecutableEnvironment(BaseEnvironment):
         """Execute a batch of tool calls; results are returned in input order."""
         return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
 
+    def _lookup_tool(self, tool_id: str) -> ExecutableTool:
+        for tool in self._params.tools:
+            if tool.id == tool_id:
+                return tool
+        raise ToolLookupError(
+            f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
+            f"Available tools: {[t.id for t in self._params.tools]}"
+        )
+
+    def _validate_result(self, tool: ExecutableTool, result: Any) -> ToolResult:
+        if not isinstance(result, ToolResult):
+            raise ToolError(
+                f"Tool '{tool.id}' executor must return ToolResult, got "
+                f"{type(result).__name__}."
+            )
+        if tool.output_schema is not None:
+            try:
+                jsonschema.validate(result.output, tool.output_schema)
+            except jsonschema.ValidationError as e:
+                raise ToolError(
+                    f"Tool '{tool.id}' executor output failed schema validation: {e}"
+                ) from e
+        return result
+
     def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        """Execute a single tool call."""
-        raise NotImplementedError
+        tool = self._lookup_tool(tool_id)
+        tool.validate_arguments(arguments)
+        with self._build_execution_context(tool, arguments) as ctx:
+            result = self._executors[tool_id](
+                **{"arguments": arguments, self._executor_context_kwarg: ctx}
+            )
+        validated = self._validate_result(tool, result)
+        self._absorb_result(tool, validated)
+        return validated

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -433,3 +433,56 @@ def test_for_sample_mutation_does_not_bleed_back_to_parent():
     clone.env_by_id["env1"] = Mock(spec=BaseEnvironment)
 
     assert router.env_by_id["env1"] is parent_env
+
+
+# ---------- close ----------
+
+
+_DB_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
+_DB_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
+
+
+def _db_env_params(env_id: str = "db") -> EnvironmentParams:
+    """A database env; each build materializes an owned temp snapshot + session."""
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"Env {env_id}",
+        env_type="database",
+        tools=[
+            {
+                "id": "lookup",
+                "name": "lookup",
+                "description": "look up a patient",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"pat_id": {"type": "integer"}},
+                    "required": ["pat_id"],
+                },
+                "executor": "oumi.environments.examples.ehr.lookup_patient",
+                "read_only": True,
+            }
+        ],
+        env_kwargs={"schema_sql": _DB_SCHEMA, "seed_sql": _DB_SEED},
+    )
+
+
+def test_close_tears_down_isolated_envs():
+    """Built isolating envs are closed (session released), never leaked."""
+    import sqlite3
+
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_db_env_params()])
+    )
+    # Parent keeps the env only as a requires_isolation() template; its session
+    # is released at build time, not left open for the router's lifetime.
+    with pytest.raises(sqlite3.ProgrammingError):
+        router.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+
+    sample = router.for_sample()
+    [live] = sample.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+    assert live.output == {"name": "Bob", "meds": "aspirin"}
+
+    sample.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        sample.env_by_id["db"].step([("lookup", {"pat_id": 1})])

--- a/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
+++ b/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
@@ -1,0 +1,60 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the sql_execution_match reward."""
+
+from __future__ import annotations
+
+from oumi.datasets.grpo.rewards.sql_execution_match import sql_execution_match
+
+_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);"
+_SEED = "INSERT INTO patients VALUES (1,'Bob',50),(2,'Alice',40),(3,'Carol',65);"
+
+
+def _extra():
+    return {"schema_sql": _SCHEMA, "seed_sql": _SEED}
+
+
+def test_exact_match_scores_one():
+    gold = "SELECT name FROM patients WHERE age > 45 ORDER BY name"
+    candidate = "SELECT name FROM patients WHERE age >= 50 ORDER BY name"
+    score = sql_execution_match(
+        data_source="ehr",
+        solution_str=candidate,
+        ground_truth=gold,
+        extra_info=_extra(),
+    )
+    assert score == 1.0  # Bob, Carol in both
+
+
+def test_mismatch_scores_zero():
+    gold = "SELECT name FROM patients WHERE age > 45 ORDER BY name"
+    candidate = "SELECT name FROM patients ORDER BY name"
+    score = sql_execution_match(
+        data_source="ehr",
+        solution_str=candidate,
+        ground_truth=gold,
+        extra_info=_extra(),
+    )
+    assert score == 0.0
+
+
+def test_invalid_sql_scores_zero():
+    score = sql_execution_match(
+        data_source="ehr",
+        solution_str="SELECT FROM nonsense(",
+        ground_truth="SELECT 1",
+        extra_info=_extra(),
+    )
+    assert score == 0.0

--- a/tests/unit/environments/test_database_env_config.py
+++ b/tests/unit/environments/test_database_env_config.py
@@ -26,7 +26,8 @@ from oumi.environments.database_executable_environment import (
     DatabaseExecutableEnvironment,
 )
 
-_CONFIG = Path("configs/examples/database_env/ehr_database_env.yaml")
+_REPO_ROOT = Path(__file__).parents[3]
+_CONFIG = _REPO_ROOT / "configs/examples/database_env/ehr_database_env.yaml"
 
 
 def test_build_environment_from_yaml():

--- a/tests/unit/environments/test_database_env_config.py
+++ b/tests/unit/environments/test_database_env_config.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 from omegaconf import OmegaConf
 
@@ -31,7 +32,10 @@ _CONFIG = _REPO_ROOT / "configs/examples/database_env/ehr_database_env.yaml"
 
 
 def test_build_environment_from_yaml():
-    raw = OmegaConf.to_container(OmegaConf.load(_CONFIG), resolve=True)
+    raw = cast(
+        "dict[str, Any]",
+        OmegaConf.to_container(OmegaConf.load(_CONFIG), resolve=True),
+    )
     params = EnvironmentParams(**raw)
     env = build_environment(params)
     assert isinstance(env, DatabaseExecutableEnvironment)

--- a/tests/unit/environments/test_database_env_config.py
+++ b/tests/unit/environments/test_database_env_config.py
@@ -1,0 +1,41 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end: build the EHR database env from its YAML config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+from oumi.builders.environments import build_environment
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
+
+_CONFIG = Path("configs/examples/database_env/ehr_database_env.yaml")
+
+
+def test_build_environment_from_yaml():
+    raw = OmegaConf.to_container(OmegaConf.load(_CONFIG), resolve=True)
+    params = EnvironmentParams(**raw)
+    env = build_environment(params)
+    assert isinstance(env, DatabaseExecutableEnvironment)
+    try:
+        [result] = env.step([("lookup_patient", {"pat_id": 1})])
+        assert result.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -1,0 +1,151 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavior + rollback-isolation tests for DatabaseExecutableEnvironment."""
+
+from __future__ import annotations
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
+from oumi.environments.db_isolation import materialize_sqlite_snapshot
+
+_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
+_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
+
+
+def _params(tools):
+    return EnvironmentParams(
+        id="ehr",
+        name="ehr",
+        description="EHR test env",
+        env_type="database",
+        tools=tools,
+        env_kwargs={"schema_sql": _SCHEMA, "seed_sql": _SEED},
+    )
+
+
+def _lookup_tool():
+    return {
+        "id": "lookup",
+        "name": "lookup",
+        "description": "look up a patient",
+        "parameters": {
+            "type": "object",
+            "properties": {"pat_id": {"type": "integer"}},
+            "required": ["pat_id"],
+        },
+        "executor": "oumi.environments.examples.ehr.lookup_patient",
+        "read_only": True,
+    }
+
+
+def _update_tool():
+    return {
+        "id": "update",
+        "name": "update",
+        "description": "update meds",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pat_id": {"type": "integer"},
+                "medication": {"type": "string"},
+            },
+            "required": ["pat_id", "medication"],
+        },
+        "executor": "oumi.environments.examples.ehr.update_meds",
+        "read_only": False,
+    }
+
+
+def test_requires_isolation_is_true():
+    env = DatabaseExecutableEnvironment.from_params(_params([_lookup_tool()]))
+    try:
+        assert env.requires_isolation() is True
+    finally:
+        env.close()
+
+
+def test_executes_read_tool_against_isolated_db():
+    env = DatabaseExecutableEnvironment.from_params(_params([_lookup_tool()]))
+    try:
+        [result] = env.step([("lookup", {"pat_id": 1})])
+        assert result.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()
+
+
+def test_uncommitted_write_visible_within_one_episode():
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_lookup_tool(), _update_tool()])
+    )
+    try:
+        env.step([("update", {"pat_id": 1, "medication": "statin"})])
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "statin"}
+    finally:
+        env.close()
+
+
+def test_close_rolls_back_so_a_fresh_env_starts_clean():
+    params = _params([_lookup_tool(), _update_tool()])
+    env = DatabaseExecutableEnvironment.from_params(params)
+    env.step([("update", {"pat_id": 1, "medication": "mutated"})])
+    env.close()  # rolls back; the inline-built DB is also discarded
+    fresh = DatabaseExecutableEnvironment.from_params(params)
+    try:
+        [seen] = fresh.step([("lookup", {"pat_id": 1})])
+        assert seen.output["meds"] == "aspirin"
+    finally:
+        fresh.close()
+
+
+def test_writes_do_not_leak_across_concurrent_rollouts():
+    params = _params([_lookup_tool(), _update_tool()])
+    # N rollouts of the same task; each builds its own inline DB.
+    envs = [DatabaseExecutableEnvironment.from_params(params) for _ in range(4)]
+    try:
+        for i, env in enumerate(envs):
+            env.step([("update", {"pat_id": 1, "medication": f"drug_{i}"})])
+        for i, env in enumerate(envs):
+            [seen] = env.step([("lookup", {"pat_id": 1})])
+            assert seen.output["meds"] == f"drug_{i}"
+    finally:
+        for env in envs:
+            env.close()
+
+
+def test_shared_snapshot_is_never_mutated(tmp_path):
+    snapshot = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "shared.sqlite"
+    )
+    params = EnvironmentParams(
+        id="ehr",
+        name="ehr",
+        description="d",
+        env_type="database",
+        tools=[_lookup_tool(), _update_tool()],
+        env_kwargs={"db_path": str(snapshot)},
+    )
+    env = DatabaseExecutableEnvironment.from_params(params)
+    env.step([("update", {"pat_id": 1, "medication": "mutated"})])
+    env.close()  # rollback
+    # The shared snapshot file is untouched.
+    fresh = DatabaseExecutableEnvironment.from_params(params)
+    try:
+        [seen] = fresh.step([("lookup", {"pat_id": 1})])
+        assert seen.output["meds"] == "aspirin"
+    finally:
+        fresh.close()

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -20,7 +20,7 @@ from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.environments.database_executable_environment import (
     DatabaseExecutableEnvironment,
 )
-from oumi.environments.db_isolation import materialize_sqlite_snapshot
+from oumi.environments.database_session import materialize_sqlite_snapshot
 
 _SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
 _SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -16,9 +16,15 @@
 
 from __future__ import annotations
 
+import sqlite3
+
+import pytest
+
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.environments.database_executable_environment import (
     DatabaseExecutableEnvironment,
+    current_connection,
+    using_connection,
 )
 from oumi.environments.database_session import materialize_sqlite_snapshot
 
@@ -149,3 +155,24 @@ def test_shared_snapshot_is_never_mutated(tmp_path):
         assert seen.output == {"name": "Bob", "meds": "aspirin"}
     finally:
         fresh.close()
+
+
+def test_current_connection_outside_a_call_raises():
+    with pytest.raises(RuntimeError, match="no connection is bound"):
+        current_connection()
+
+
+def test_using_connection_nests_and_restores_outer_binding():
+    outer = sqlite3.connect(":memory:")
+    inner = sqlite3.connect(":memory:")
+    try:
+        with using_connection(outer):
+            assert current_connection() is outer
+            with using_connection(inner):
+                assert current_connection() is inner
+            assert current_connection() is outer  # token reset restores outer
+        with pytest.raises(RuntimeError):
+            current_connection()  # unbound again after the outer block exits
+    finally:
+        outer.close()
+        inner.close()

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -107,7 +107,7 @@ def test_close_rolls_back_so_a_fresh_env_starts_clean():
     fresh = DatabaseExecutableEnvironment.from_params(params)
     try:
         [seen] = fresh.step([("lookup", {"pat_id": 1})])
-        assert seen.output["meds"] == "aspirin"
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
     finally:
         fresh.close()
 
@@ -121,7 +121,7 @@ def test_writes_do_not_leak_across_concurrent_rollouts():
             env.step([("update", {"pat_id": 1, "medication": f"drug_{i}"})])
         for i, env in enumerate(envs):
             [seen] = env.step([("lookup", {"pat_id": 1})])
-            assert seen.output["meds"] == f"drug_{i}"
+            assert seen.output == {"name": "Bob", "meds": f"drug_{i}"}
     finally:
         for env in envs:
             env.close()
@@ -146,6 +146,6 @@ def test_shared_snapshot_is_never_mutated(tmp_path):
     fresh = DatabaseExecutableEnvironment.from_params(params)
     try:
         [seen] = fresh.step([("lookup", {"pat_id": 1})])
-        assert seen.output["meds"] == "aspirin"
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
     finally:
         fresh.close()

--- a/tests/unit/environments/test_db_isolation.py
+++ b/tests/unit/environments/test_db_isolation.py
@@ -65,6 +65,24 @@ def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
         b.close()
 
 
+def test_leading_ddl_is_rolled_back(tmp_path):
+    # DDL as the first statement must still roll back. Legacy sqlite3 only opens
+    # an implicit transaction before DML, so without the explicit BEGIN a leading
+    # CREATE TABLE would run in autocommit and persist past close().
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    session = RollbackSession(path)
+    session.connection.execute("CREATE TABLE leaked (x INTEGER)")
+    session.close()
+    conn = sqlite3.connect(path)
+    leaked = conn.execute(
+        "SELECT count(*) FROM sqlite_master WHERE name = 'leaked'"
+    ).fetchone()[0]
+    conn.close()
+    assert leaked == 0
+
+
 def test_owned_session_deletes_its_file_on_close(tmp_path):
     path = materialize_sqlite_snapshot(
         schema_sql=_SCHEMA, dest=tmp_path / "owned.sqlite"

--- a/tests/unit/environments/test_db_isolation.py
+++ b/tests/unit/environments/test_db_isolation.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
 

--- a/tests/unit/environments/test_db_isolation.py
+++ b/tests/unit/environments/test_db_isolation.py
@@ -1,0 +1,76 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+
+_SCHEMA = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);"
+_SEED = "INSERT INTO t VALUES (1, 'a');"
+
+
+def test_materialize_builds_a_seeded_snapshot(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()
+
+
+def test_rollback_session_discards_uncommitted_writes(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    session = RollbackSession(path)
+    # Write without committing; visible on this connection...
+    session.connection.execute("UPDATE t SET v = 'mutated' WHERE id = 1")
+    assert session.connection.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == (
+        "mutated"
+    )
+    session.close()  # rolls back + closes
+    # ...gone from the snapshot afterwards.
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()
+
+
+def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
+    tmp_path,
+):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    a = RollbackSession(path)
+    b = RollbackSession(path)
+    try:
+        a.connection.execute("UPDATE t SET v = 'from_a' WHERE id = 1")
+        # b never sees a's uncommitted write.
+        assert b.connection.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    finally:
+        a.close()
+        b.close()
+
+
+def test_owned_session_deletes_its_file_on_close(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, dest=tmp_path / "owned.sqlite"
+    )
+    session = RollbackSession(path, owns_file=True)
+    assert path.exists()
+    session.close()
+    assert not path.exists()

--- a/tests/unit/environments/test_db_isolation.py
+++ b/tests/unit/environments/test_db_isolation.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 
 import sqlite3
 
-from oumi.environments.db_isolation import RollbackSession, materialize_sqlite_snapshot
+from oumi.environments.database_session import (
+    DatabaseSession,
+    materialize_sqlite_snapshot,
+)
 
 _SCHEMA = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);"
 _SEED = "INSERT INTO t VALUES (1, 'a');"
@@ -35,7 +38,7 @@ def test_rollback_session_discards_uncommitted_writes(tmp_path):
     path = materialize_sqlite_snapshot(
         schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
     )
-    session = RollbackSession(path)
+    session = DatabaseSession(path)
     # Write without committing; visible on this connection...
     session.connection.execute("UPDATE t SET v = 'mutated' WHERE id = 1")
     assert session.connection.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == (
@@ -54,8 +57,8 @@ def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
     path = materialize_sqlite_snapshot(
         schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
     )
-    a = RollbackSession(path)
-    b = RollbackSession(path)
+    a = DatabaseSession(path)
+    b = DatabaseSession(path)
     try:
         a.connection.execute("UPDATE t SET v = 'from_a' WHERE id = 1")
         # b never sees a's uncommitted write.
@@ -72,7 +75,7 @@ def test_leading_ddl_is_rolled_back(tmp_path):
     path = materialize_sqlite_snapshot(
         schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
     )
-    session = RollbackSession(path)
+    session = DatabaseSession(path)
     session.connection.execute("CREATE TABLE leaked (x INTEGER)")
     session.close()
     conn = sqlite3.connect(path)
@@ -87,7 +90,7 @@ def test_owned_session_deletes_its_file_on_close(tmp_path):
     path = materialize_sqlite_snapshot(
         schema_sql=_SCHEMA, dest=tmp_path / "owned.sqlite"
     )
-    session = RollbackSession(path, owns_file=True)
+    session = DatabaseSession(path, owns_file=True)
     assert path.exists()
     session.close()
     assert not path.exists()

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -50,11 +50,6 @@ def test_cannot_instantiate_abstract_base():
         ExecutableEnvironment()  # type: ignore[abstract]
 
 
-def test_default_executor_context_kwarg_is_context():
-    """Subclasses (e.g. database) override this; the default is ``"context"``."""
-    assert ExecutableEnvironment._executor_context_kwarg == "context"
-
-
 def test_default_tool_params_cls_is_executable_tool():
     """ExecutableEnvironment binds to ExecutableTool by default."""
     assert ExecutableEnvironment.tool_params_cls is ExecutableTool

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -32,7 +32,9 @@ class _MinimalExecEnv(ExecutableEnvironment):
     """Smallest concrete subclass that satisfies the abstract surface."""
 
     def __init__(self) -> None:
-        self._params = EnvironmentParams(id="test", env_type="executable")
+        self._params = EnvironmentParams(
+            id="test", name="test", description="d", env_type="executable"
+        )
         self._executors = {}
 
     @contextmanager
@@ -72,14 +74,63 @@ def test_absorb_result_is_noop():
 
 
 def test_step_batch_dispatches_to_step_one():
-    """Batch step() iterates the call list and dispatches each to _step_one."""
+    """Batch step() dispatches each call to _step_one, which looks up the tool."""
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ToolLookupError):
         env.step([("tool_a", {})])
 
 
-def test_step_one_raises_not_implemented():
-    """_step_one is the per-call dispatch hook; the base implementation raises."""
+def test_step_one_unknown_tool_raises_lookup_error_minimal():
+    """_step_one raises a lookup error when the tool id is unknown."""
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
     env = _MinimalExecEnv()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ToolLookupError):
         env._step_one("tool_a", {})
+
+
+class _EchoExecEnv(ExecutableEnvironment):
+    """Concrete env whose executor echoes the context it was handed."""
+
+    def __init__(self, tools: list[ExecutableTool]) -> None:
+        self._params = EnvironmentParams(
+            id="echo", name="echo", description="d", env_type="executable", tools=tools
+        )
+        self._executors = {t.id: _echo_executor for t in tools}
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield {"ctx_for": tool.id}
+
+
+def _echo_executor(*, arguments: dict[str, Any], context: Any) -> ToolResult:
+    return ToolResult(output={"args": arguments, "context": context})
+
+
+def test_step_one_dispatches_to_executor_with_context():
+    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
+    env = _EchoExecEnv([tool])
+    [result] = env.step([("t", {"a": 1})])
+    assert result.output == {"args": {"a": 1}, "context": {"ctx_for": "t"}}
+
+
+def test_step_one_unknown_tool_raises_lookup_error():
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
+    env = _EchoExecEnv([])
+    with pytest.raises(ToolLookupError):
+        env.step([("missing", {})])
+
+
+def test_step_one_rejects_non_toolresult_executor_return():
+    from oumi.core.configs.params.tool_params import ToolError
+
+    tool = ExecutableTool(id="bad", name="bad", description="d", executor="x.y")
+    env = _EchoExecEnv([tool])
+    env._executors["bad"] = lambda **_: {"not": "a ToolResult"}
+    with pytest.raises(ToolError):
+        env.step([("bad", {})])


### PR DESCRIPTION
## Summary

Prototype of an executable **database environment** for RL/eval over a SQLite database. Each rollout gets an isolated session whose writes are visible within an episode but never persist or leak across rollouts.

- `DatabaseExecutableEnvironment` (registered `"database"`): per-rollout `RollbackSession`, `requires_isolation()=True`, executors dispatched with a live `db` connection.
- `db_isolation`: `RollbackSession` (opens `isolation_level=None` + explicit `BEGIN` so both DML *and* a leading DDL statement roll back; executors must not commit) and `materialize_sqlite_snapshot`.
- Fleshed out the `ExecutableEnvironment` base executor dispatch (`_step_one`) the skeleton left abstract.
- EHR example tools/executors (`list/lookup/update` patient) + a YAML config — the "bring your DB" entry point through `build_environment`.
- `sql_execution_match` reward that grades candidate vs gold SQL on a fresh isolated session (reusing the env's isolation on the grading side).

**85 unit tests** cover the isolation contract: uncommitted write visible within an episode, rolled back on close, no cross-rollout leak, shared snapshot never mutated, leading-DDL rollback.

## Status: prototype

Opened to run experiments. Deliberately **deferred**: wiring into verl GRPO rollouts (single-turn NL2SQL first), copy/copy-on-write isolation for concurrent committed writes, and the schema/table/row database-mutation stack for init diversity.

## Series context (db-executable-env chain)

- Phase 1: ExecutableEnvironment + ExecutableTool skeleton — #2467 (open)
- **Phase 2: DatabaseExecutableEnvironment prototype — this PR** (stacked on Phase 1)

## Test plan

- [ ] `pytest tests/unit/environments tests/unit/datasets/grpo/rewards/test_sql_execution_match.py` (85 pass)
- [ ] Build the example env from `configs/examples/database_env/ehr_database_env.yaml` via `build_environment`