### PR TITLE
fix: resolve offline model loads at the pinned model_revision

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -369,6 +369,7 @@ def build_collator_from_config(
         collator_kwargs["trust_remote_code"] = collator_kwargs.get(
             "trust_remote_code", config.model.trust_remote_code
         )
+        collator_kwargs["model_revision"] = config.model.model_revision
 
     # --- Resolve train_target and templates ---
     config_collator_kwargs = train_split.collator_kwargs or {}

--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -365,11 +365,11 @@ def _get_transformers_model_class(config):
 
 
 def is_image_text_llm_using_model_name(
-    model_name: str, trust_remote_code: bool
+    model_name: str, trust_remote_code: bool, revision: str | None = None
 ) -> bool:
     """Determines whether the model is a basic image+text LLM."""
     model_config = find_internal_model_config_using_model_name(
-        model_name, trust_remote_code=trust_remote_code
+        model_name, trust_remote_code=trust_remote_code, revision=revision
     )
     return model_config is not None and model_config.visual_config is not None
 
@@ -377,7 +377,9 @@ def is_image_text_llm_using_model_name(
 def is_image_text_llm(model_params: ModelParams) -> bool:
     """Determines whether the model is a basic image+text LLM."""
     return is_image_text_llm_using_model_name(
-        model_params.model_name, model_params.trust_remote_code
+        model_params.model_name,
+        model_params.trust_remote_code,
+        revision=model_params.model_revision,
     )
 
 
@@ -411,6 +413,7 @@ def build_tokenizer(
         find_internal_model_config_using_model_name(
             model_name=tokenizer_name,
             trust_remote_code=model_params.trust_remote_code,
+            revision=model_params.model_revision,
         )
     )
 
@@ -433,6 +436,7 @@ def build_tokenizer(
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_name,
         trust_remote_code=model_params.trust_remote_code,
+        revision=model_params.model_revision,
         **tokenizer_kwargs,
     )
 

--- a/src/oumi/builders/processors.py
+++ b/src/oumi/builders/processors.py
@@ -32,6 +32,7 @@ def build_processor(
     *,
     processor_kwargs: dict[str, Any] | None = None,
     trust_remote_code: bool = False,
+    model_revision: str | None = None,
 ) -> BaseProcessor:
     """Builds a processor.
 
@@ -44,6 +45,7 @@ def build_processor(
         trust_remote_code: Whether to allow loading remote code for this processor
             Some processors come with downloadable executable Python files,
             which can be a potential security risk, unless it's from a trusted source.
+        model_revision: The HuggingFace model revision to load, if any.
 
     Returns:
         BaseProcessor: The newly created processor.
@@ -52,7 +54,7 @@ def build_processor(
         raise ValueError("Empty model name.")
 
     model_config = find_internal_model_config_using_model_name(
-        processor_name, trust_remote_code=trust_remote_code
+        processor_name, trust_remote_code=trust_remote_code, revision=model_revision
     )
 
     # Initialize model-specific params.
@@ -72,6 +74,7 @@ def build_processor(
         transformers.AutoProcessor.from_pretrained,
         processor_name,
         trust_remote_code=trust_remote_code,
+        revision=model_revision,
     )
     if len(effective_processor_kwargs) > 0:
         worker_processor = create_processor_fn(**effective_processor_kwargs)

--- a/src/oumi/core/collators/vision_language_sft_collator.py
+++ b/src/oumi/core/collators/vision_language_sft_collator.py
@@ -82,6 +82,7 @@ class VisionLanguageSftCollator:
         label_ignore_index: int | None = None,
         allow_multi_image_inputs: bool = True,
         trust_remote_code: bool = False,
+        model_revision: str | None = None,
         train_on_completions_only: bool = False,
         response_template: str | None = None,
         instruction_template: str | None = None,
@@ -122,6 +123,8 @@ class VisionLanguageSftCollator:
             trust_remote_code: Whether to trust and execute remote code when loading
                 the processor. Required for some models (e.g., Qwen2-VL) that use
                 custom processing code.
+
+            model_revision: The HuggingFace model revision to load, if any.
 
             process_individually: Whether to process each conversation individually
                 and then collate features by padding to max dimensions. When True:
@@ -190,6 +193,7 @@ class VisionLanguageSftCollator:
                 processor_name=processor_name,
                 processor_kwargs=processor_kwargs,
                 trust_remote_code=trust_remote_code,
+                model_revision=model_revision,
                 return_tensors="pt",
                 truncation=truncation,
                 truncation_side=truncation_side,

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -658,7 +658,7 @@ def is_custom_model(model_name: str) -> bool:
 
 
 def find_internal_model_config_using_model_name(
-    model_name: str, trust_remote_code: bool
+    model_name: str, trust_remote_code: bool, revision: str | None = None
 ) -> InternalModelConfig | None:
     """Finds an internal model config for supported models using model name.
 
@@ -669,6 +669,7 @@ def find_internal_model_config_using_model_name(
             - A custom model name registered in Oumi
         trust_remote_code: Whether to trust external code associated with the model.
             Required for some models like Qwen2-VL that use custom code.
+        revision: The HuggingFace model revision to load, if any.
 
     Returns:
         InternalModelConfig for the model if it's supported, or None if:
@@ -678,7 +679,9 @@ def find_internal_model_config_using_model_name(
     if is_custom_model(model_name):
         return None
 
-    hf_config = find_model_hf_config(model_name, trust_remote_code=trust_remote_code)
+    hf_config = find_model_hf_config(
+        model_name, trust_remote_code=trust_remote_code, revision=revision
+    )
     llm_info = get_all_models_map().get(hf_config.model_type, None)
     return llm_info.config if llm_info is not None else None
 
@@ -695,5 +698,7 @@ def find_internal_model_config(
         Model config, or `None` if model is not recognized.
     """
     return find_internal_model_config_using_model_name(
-        model_params.model_name, model_params.trust_remote_code
+        model_params.model_name,
+        model_params.trust_remote_code,
+        revision=model_params.model_revision,
     )

--- a/src/oumi/core/datasets/vision_language_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dataset.py
@@ -71,6 +71,7 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
         processor_kwargs: dict[str, Any] | None = None,
         limit: int | None = None,
         trust_remote_code: bool = False,
+        model_revision: str | None = None,
         max_images: int | None = None,
         **kwargs,
     ) -> None:
@@ -91,6 +92,7 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
                 They can override model-specific parameters.
             limit: An optional limit on the number of examples to load.
             trust_remote_code: Whether to trust remote code execution for the processor.
+            model_revision: The HuggingFace model revision to load, if any.
             return_conversations: Whether to return raw `Conversation` objects.
             max_images: The maximum number of images per conversation.
                 If the limit is exceeded, the first N images are kept.
@@ -111,6 +113,7 @@ class VisionLanguageSftDataset(BaseSftDataset, ABC):
                 processor_name=processor_name,
                 processor_kwargs=processor_kwargs,
                 trust_remote_code=trust_remote_code,
+                model_revision=model_revision,
                 return_tensors=self._return_tensors,
             )
         )

--- a/src/oumi/core/datasets/vision_language_dpo_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dpo_dataset.py
@@ -75,6 +75,7 @@ class VisionLanguageDpoDataset(BaseDpoDataset):
         processor: Any | None = None,
         processor_name: str | None = None,
         trust_remote_code: bool = False,
+        model_revision: str | None = None,
         processor_kwargs: dict[str, Any] | None = None,
         max_size: int | None = None,
         prompt_key: str = _PROMPT_KEY,
@@ -98,6 +99,7 @@ class VisionLanguageDpoDataset(BaseDpoDataset):
             split: The split of the dataset.
             processor_name: The name of the processor to use.
             trust_remote_code: Whether to trust remote code.
+            model_revision: The HuggingFace model revision to load, if any.
             processor_kwargs: Additional keyword arguments to pass to the processor.
             max_size: The maximum size of the longest edge of the image in pixels.
             prompt_key: The key for the prompt.
@@ -124,13 +126,16 @@ class VisionLanguageDpoDataset(BaseDpoDataset):
                 self._tokenizer,
                 trust_remote_code=True,
                 processor_kwargs=processor_kwargs,
+                model_revision=model_revision,
             )
         else:
             raise ValueError("Processor is not set.")
 
         self._internal_model_config: InternalModelConfig = (
             find_internal_model_config_using_model_name(
-                self._processor.processor_name, trust_remote_code=True
+                self._processor.processor_name,
+                trust_remote_code=True,
+                revision=model_revision,
             )
             or get_default_vlm_model_config()
         )

--- a/src/oumi/core/evaluation/backends/lm_harness.py
+++ b/src/oumi/core/evaluation/backends/lm_harness.py
@@ -496,6 +496,7 @@ def _add_multimodal_args(
             tokenizer,
             trust_remote_code=model_params.trust_remote_code,
             processor_kwargs=model_params.processor_kwargs,
+            model_revision=model_params.model_revision,
         )
         if image_token := processor.image_token:
             model_args["image_string"] = image_token

--- a/src/oumi/core/evaluation/backends/lm_harness.py
+++ b/src/oumi/core/evaluation/backends/lm_harness.py
@@ -284,6 +284,7 @@ def evaluate(
     is_multimodal = is_image_text_llm_using_model_name(
         model_name=config.model.model_name,
         trust_remote_code=config.model.trust_remote_code,
+        revision=config.model.model_revision,
     )
 
     # Identify the proper LM Harness model (`lm_harness_model`) to use.

--- a/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
+++ b/src/oumi/core/feature_generators/vision_language_conversation_feature_generator.py
@@ -74,6 +74,7 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
         processor_name: str | None = None,
         processor_kwargs: dict[str, Any] | None = None,
         trust_remote_code: bool = False,
+        model_revision: str | None = None,
         return_tensors: str | None = None,
         max_length: int | None = None,
         truncation: bool = False,
@@ -141,6 +142,7 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
                 tokenizer,
                 trust_remote_code=trust_remote_code,
                 processor_kwargs=processor_kwargs,
+                model_revision=model_revision,
             )
         else:
             raise ValueError(
@@ -156,7 +158,9 @@ class VisionLanguageConversationFeatureGenerator(BaseConversationFeatureGenerato
 
         self._internal_model_config: InternalModelConfig = (
             find_internal_model_config_using_model_name(
-                self._processor.processor_name, trust_remote_code=trust_remote_code
+                self._processor.processor_name,
+                trust_remote_code=trust_remote_code,
+                revision=model_revision,
             )
             or get_default_vlm_model_config()
         )

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -83,10 +83,12 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
                 self._tokenizer,
                 trust_remote_code=self._model_params.trust_remote_code,
                 processor_kwargs=self._model_params.processor_kwargs,
+                model_revision=self._model_params.model_revision,
             )
             internal_model_config = find_internal_model_config_using_model_name(
                 self._model_params.model_name,
                 trust_remote_code=self._model_params.trust_remote_code,
+                revision=self._model_params.model_revision,
             )
 
             self._supports_multiple_images = (

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -110,10 +110,12 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
                 self._tokenizer,
                 trust_remote_code=self._model_params.trust_remote_code,
                 processor_kwargs=self._model_params.processor_kwargs,
+                model_revision=self._model_params.model_revision,
             )
             internal_model_config = find_internal_model_config_using_model_name(
                 self._model_params.model_name,
                 trust_remote_code=self._model_params.trust_remote_code,
+                revision=self._model_params.model_revision,
             )
             self._supports_multiple_images = (
                 (internal_model_config is not None)

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -342,6 +342,7 @@ def train(
             tokenizer,
             trust_remote_code=config.model.trust_remote_code,
             processor_kwargs=config.model.processor_kwargs,
+            model_revision=config.model.model_revision,
         )
         # Setting remove_unused_columns to False is needed for VLM training with the
         # TRL_SFT trainer.

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -253,6 +253,40 @@ def test_find_model_hf_config_logs_unused_kwargs():
         )
 
 
+def test_build_tokenizer_passes_model_revision_to_hf_loads():
+    tokenizer = Mock()
+    tokenizer.pad_token = "<pad>"
+    tokenizer.pad_token_id = 0
+    tokenizer.chat_template = "test template"
+
+    with (
+        patch(
+            "oumi.builders.models.find_internal_model_config_using_model_name"
+        ) as mock_find_internal_config,
+        patch(
+            "oumi.builders.models.transformers.AutoTokenizer.from_pretrained"
+        ) as mock_from_pretrained,
+    ):
+        mock_find_internal_config.return_value = None
+        mock_from_pretrained.return_value = tokenizer
+
+        result = build_tokenizer(
+            ModelParams(model_name="test-model", model_revision="abc123")
+        )
+
+    assert result == tokenizer
+    mock_find_internal_config.assert_called_once_with(
+        model_name="test-model",
+        trust_remote_code=False,
+        revision="abc123",
+    )
+    mock_from_pretrained.assert_called_once_with(
+        "test-model",
+        trust_remote_code=False,
+        revision="abc123",
+    )
+
+
 def test_build_huggingface_model_passes_model_kwargs_to_find_model_hf_config():
     """Test that build_huggingface_model passes model_kwargs to find_model_hf_config."""
     model_kwargs = {

--- a/tests/unit/builders/test_processors.py
+++ b/tests/unit/builders/test_processors.py
@@ -1,5 +1,6 @@
 import base64
 from typing import Any, Final
+from unittest.mock import Mock, patch
 
 import numpy as np
 import PIL.Image
@@ -37,6 +38,39 @@ _SMALL_B64_IMAGE: Final[str] = (
 def test_build_processor_empty_name(trust_remote_code, mock_tokenizer):
     with pytest.raises(ValueError, match="Empty model name"):
         build_processor("", mock_tokenizer, trust_remote_code=trust_remote_code)
+
+
+def test_build_processor_passes_model_revision_to_hf_loads(mock_tokenizer):
+    processor = Mock()
+    wrapped_processor = Mock(spec=BaseProcessor)
+
+    with (
+        patch(
+            "oumi.builders.processors.find_internal_model_config_using_model_name"
+        ) as mock_find_internal_config,
+        patch(
+            "oumi.builders.processors.transformers.AutoProcessor.from_pretrained"
+        ) as mock_from_pretrained,
+        patch("oumi.builders.processors.DefaultProcessor") as mock_default_processor,
+    ):
+        mock_find_internal_config.return_value = None
+        mock_from_pretrained.return_value = processor
+        mock_default_processor.return_value = wrapped_processor
+
+        result = build_processor(
+            "test-model",
+            mock_tokenizer,
+            trust_remote_code=True,
+            model_revision="abc123",
+        )
+
+    assert result == wrapped_processor
+    mock_find_internal_config.assert_called_once_with(
+        "test-model", trust_remote_code=True, revision="abc123"
+    )
+    mock_from_pretrained.assert_called_once_with(
+        "test-model", trust_remote_code=True, revision="abc123"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/evaluation/test_backend_lm_harness.py
+++ b/tests/unit/core/evaluation/test_backend_lm_harness.py
@@ -235,6 +235,7 @@ def test_generate_lm_harness_model_args(
             mock_build_tokenizer.return_value,
             trust_remote_code=model_params.trust_remote_code,
             processor_kwargs={},
+            model_revision=model_params.model_revision,
         )
     else:
         mock_build_tokenizer.assert_not_called()

--- a/tests/unit/core/evaluation/test_backend_lm_harness.py
+++ b/tests/unit/core/evaluation/test_backend_lm_harness.py
@@ -315,6 +315,7 @@ def test_evaluate(mock_patches_for_evaluate):
     mock_is_image_text_llm.assert_called_once_with(
         model_name=evaluation_config.model.model_name,
         trust_remote_code=evaluation_config.model.trust_remote_code,
+        revision=evaluation_config.model.model_revision,
     )
     mock_get_task_dict.assert_called_once_with(task_params)
     mock_generate_lm_harness_model_args.assert_called_once_with(


### PR DESCRIPTION
# Description

When a model is loaded under `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` after being pre-fetched at a pinned revision SHA, the config/processor lookups still resolve the default `main` revision — which isn't in the offline cache — and the load fails with `LocalEntryNotFoundError` / `OSError: We couldn't connect to 'https://huggingface.co'`.

This threads `model_revision` through the HuggingFace `from_pretrained`-backed lookups so offline loads resolve the pre-fetched pinned snapshot:

- `find_internal_model_config_using_model_name` / `find_model_hf_config` now accept a `revision`.
- `build_tokenizer` and `build_processor` pass `model_params.model_revision` to both the internal-config lookup and the `AutoTokenizer` / `AutoProcessor` `from_pretrained` calls.
- Revision is wired through the call sites that build processors/configs: training (`train`), inference (`NativeTextInferenceEngine`, `SGLangInferenceEngine`), eval (`lm_harness`), and the VLM dataset / collator / feature-generator paths.

No behavior change when `model_revision` is unset (defaults to `None` → resolves `main` as before).

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
