### PR TITLE
fix: avoid duplicate revision kwarg in tokenizer/processor loads

### DIFF
--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -418,6 +418,8 @@ def build_tokenizer(
     )
 
     tokenizer_kwargs = {**model_params.tokenizer_kwargs}
+    # `revision` may already be pinned via tokenizer_kwargs; don't pass it twice.
+    tokenizer_kwargs.setdefault("revision", model_params.model_revision)
     if internal_config is not None:
         if (
             "padding_side" not in tokenizer_kwargs
@@ -436,7 +438,6 @@ def build_tokenizer(
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_name,
         trust_remote_code=model_params.trust_remote_code,
-        revision=model_params.model_revision,
         **tokenizer_kwargs,
     )
 

--- a/src/oumi/builders/processors.py
+++ b/src/oumi/builders/processors.py
@@ -70,16 +70,14 @@ def build_processor(
         # Override model-specific params with user-defined ones.
         effective_processor_kwargs.update(processor_kwargs)
 
+    # `revision` may already be pinned via processor_kwargs; don't pass it twice.
+    effective_processor_kwargs.setdefault("revision", model_revision)
     create_processor_fn = functools.partial(
         transformers.AutoProcessor.from_pretrained,
         processor_name,
         trust_remote_code=trust_remote_code,
-        revision=model_revision,
     )
-    if len(effective_processor_kwargs) > 0:
-        worker_processor = create_processor_fn(**effective_processor_kwargs)
-    else:
-        worker_processor = create_processor_fn()
+    worker_processor = create_processor_fn(**effective_processor_kwargs)
 
     return DefaultProcessor(
         processor_name,

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -308,15 +308,16 @@ def test_build_tokenizer_does_not_duplicate_revision_from_tokenizer_kwargs():
         build_tokenizer(
             ModelParams(
                 model_name="test-model",
-                model_revision="abc123",
-                tokenizer_kwargs={"revision": "abc123"},
+                model_revision="from-model-revision",
+                tokenizer_kwargs={"revision": "from-kwargs"},
             )
         )
 
+    # An explicit revision in tokenizer_kwargs wins over model_revision.
     mock_from_pretrained.assert_called_once_with(
         "test-model",
         trust_remote_code=False,
-        revision="abc123",
+        revision="from-kwargs",
     )
 
 

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -287,6 +287,39 @@ def test_build_tokenizer_passes_model_revision_to_hf_loads():
     )
 
 
+def test_build_tokenizer_does_not_duplicate_revision_from_tokenizer_kwargs():
+    """A revision pinned in tokenizer_kwargs must not collide with model_revision."""
+    tokenizer = Mock()
+    tokenizer.pad_token = "<pad>"
+    tokenizer.pad_token_id = 0
+    tokenizer.chat_template = "test template"
+
+    with (
+        patch(
+            "oumi.builders.models.find_internal_model_config_using_model_name"
+        ) as mock_find_internal_config,
+        patch(
+            "oumi.builders.models.transformers.AutoTokenizer.from_pretrained"
+        ) as mock_from_pretrained,
+    ):
+        mock_find_internal_config.return_value = None
+        mock_from_pretrained.return_value = tokenizer
+
+        build_tokenizer(
+            ModelParams(
+                model_name="test-model",
+                model_revision="abc123",
+                tokenizer_kwargs={"revision": "abc123"},
+            )
+        )
+
+    mock_from_pretrained.assert_called_once_with(
+        "test-model",
+        trust_remote_code=False,
+        revision="abc123",
+    )
+
+
 def test_build_huggingface_model_passes_model_kwargs_to_find_model_hf_config():
     """Test that build_huggingface_model passes model_kwargs to find_model_hf_config."""
     model_kwargs = {

--- a/tests/unit/builders/test_processors.py
+++ b/tests/unit/builders/test_processors.py
@@ -73,6 +73,39 @@ def test_build_processor_passes_model_revision_to_hf_loads(mock_tokenizer):
     )
 
 
+def test_build_processor_does_not_duplicate_revision_from_processor_kwargs(
+    mock_tokenizer,
+):
+    """A revision pinned in processor_kwargs must not collide with model_revision."""
+    processor = Mock()
+    wrapped_processor = Mock(spec=BaseProcessor)
+
+    with (
+        patch(
+            "oumi.builders.processors.find_internal_model_config_using_model_name"
+        ) as mock_find_internal_config,
+        patch(
+            "oumi.builders.processors.transformers.AutoProcessor.from_pretrained"
+        ) as mock_from_pretrained,
+        patch("oumi.builders.processors.DefaultProcessor") as mock_default_processor,
+    ):
+        mock_find_internal_config.return_value = None
+        mock_from_pretrained.return_value = processor
+        mock_default_processor.return_value = wrapped_processor
+
+        build_processor(
+            "test-model",
+            mock_tokenizer,
+            trust_remote_code=True,
+            model_revision="abc123",
+            processor_kwargs={"revision": "abc123"},
+        )
+
+    mock_from_pretrained.assert_called_once_with(
+        "test-model", trust_remote_code=True, revision="abc123"
+    )
+
+
 @pytest.mark.parametrize(
     "processor_kwargs",
     [

--- a/tests/unit/builders/test_processors.py
+++ b/tests/unit/builders/test_processors.py
@@ -97,12 +97,13 @@ def test_build_processor_does_not_duplicate_revision_from_processor_kwargs(
             "test-model",
             mock_tokenizer,
             trust_remote_code=True,
-            model_revision="abc123",
-            processor_kwargs={"revision": "abc123"},
+            model_revision="from-model-revision",
+            processor_kwargs={"revision": "from-kwargs"},
         )
 
+    # An explicit revision in processor_kwargs wins over model_revision.
     mock_from_pretrained.assert_called_once_with(
-        "test-model", trust_remote_code=True, revision="abc123"
+        "test-model", trust_remote_code=True, revision="from-kwargs"
     )
 
 


### PR DESCRIPTION
# Description

Follow-up to #2523. That PR threaded `model_revision` into `build_tokenizer` / `build_processor` by passing `revision=` explicitly to `AutoTokenizer.from_pretrained` / `AutoProcessor.from_pretrained`. But configs commonly pin the revision via `tokenizer_kwargs` / `processor_kwargs` (the pre-existing mechanism), which are also splatted into the same call — so the revision is passed twice:

```
TypeError: AutoTokenizer.from_pretrained() got multiple values for keyword argument 'revision'
```

This crashed real distributed training for revision-pinned models (caught in an e2e run; the original unit tests mocked `from_pretrained` with empty kwargs so they didn't surface it).

Fix: merge `model_revision` into the kwargs dict with `setdefault` instead of passing it as a separate argument. An explicit `revision` in `tokenizer_kwargs`/`processor_kwargs` wins (preserving prior behavior); otherwise `model_revision` is used; never both.

Adds regression tests that pass `revision` in both places (these raise the `TypeError` at the call site without the fix).

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
