### PR TITLE
fix(launcher): downgrade Slurm connection-check log from error to debug

### DIFF
--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -53,7 +53,9 @@ def _check_connection(user: str, slurm_host: str) -> None:
     if child.returncode == 0:
         return
     if error_msg:
-        logger.error(f"Error checking connection: {error_msg}")
+        # Recoverable: caller (_refresh_creds) catches this and opens a fresh
+        # tunnel. Logging at error spuriously pages on every first connect.
+        logger.debug(f"Error checking connection: {error_msg}")
         error_msg = f" Error: {error_msg}"
     raise _SlurmAuthException("Connection to Slurm host is closed." + error_msg)
 

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -63,6 +63,41 @@ def test_slurm_client_init(mock_subprocess):
     )
 
 
+def test_slurm_client_init_reconnect_does_not_log_error(mock_subprocess):
+    # No existing control socket -> recoverable; we open a fresh tunnel and must
+    # not log at error level (which spuriously pages on every first connect).
+    check_no_socket = Mock()
+    check_no_socket.returncode = 1
+    check_no_socket.stderr = (
+        b"Control socket connect(/root/.ssh/control-host-22-user): "
+        b"No such file or directory\n"
+    )
+    tunnel_ok = Mock()
+    tunnel_ok.returncode = 0
+    tunnel_ok.stdout = b""
+    tunnel_ok.stderr = b""
+    mock_subprocess.run.side_effect = [check_no_socket, tunnel_ok]
+    with patch("oumi.launcher.clients.slurm_client.logger") as mock_logger:
+        _ = SlurmClient("user", "host", "cluster_name")
+    mock_logger.error.assert_not_called()
+
+
+def test_slurm_client_init_tunnel_failure_logs_error_and_raises(mock_subprocess):
+    # Genuine connection failure (tunnel can't be established) must still surface.
+    check_no_socket = Mock()
+    check_no_socket.returncode = 1
+    check_no_socket.stderr = b"No such file or directory\n"
+    tunnel_fail = Mock()
+    tunnel_fail.returncode = 1
+    tunnel_fail.stdout = b""
+    tunnel_fail.stderr = b"Connection timed out"
+    mock_subprocess.run.side_effect = [check_no_socket, tunnel_fail]
+    with patch("oumi.launcher.clients.slurm_client.logger") as mock_logger:
+        with pytest.raises(RuntimeError, match="Failed to refresh Slurm credentials"):
+            _ = SlurmClient("user", "host", "cluster_name")
+    mock_logger.error.assert_called_once()
+
+
 def test_slurm_client_submit_job(mock_subprocess):
     mock_run = Mock()
     mock_subprocess.run.return_value = mock_run


### PR DESCRIPTION
# Description

`_check_connection` runs `ssh -O check` to test whether a live SSH ControlMaster (multiplexing) socket already exists for the Slurm head node. When no socket exists it logs at **error** level and raises `_SlurmAuthException`:

```python
if error_msg:
    logger.error(f"Error checking connection: {error_msg}")   # <- before
    error_msg = f" Error: {error_msg}"
raise _SlurmAuthException("Connection to Slurm host is closed." + error_msg)
```

But the caller, `_refresh_creds`, **catches that exception and opens a fresh tunnel** — so "no control socket yet" is the normal first-connect path, not a failure:

```python
try:
    _check_connection(self._user, self._slurm_host)
    return
except _SlurmAuthException:
    logger.warning("No connection found. Establishing a new SSH tunnel...")
# ... ssh -f -N -M ... establishes the ControlMaster
```

Because the `oumi` logger ships error-level records to Sentry, this fired on essentially **every job** launched onto a Slurm cluster (the master socket is absent on first connect), generating a spurious alert per job — e.g. `Error checking connection: Control socket connect(...): No such file or directory`.

This PR downgrades that line to **debug**. Genuine failures still surface: if the tunnel itself cannot be established, `_refresh_creds` logs at error and raises `RuntimeError("Failed to refresh Slurm credentials...")`, which is unchanged.

## Tests

- `test_slurm_client_init_reconnect_does_not_log_error` — missing-socket → fresh-tunnel path logs no error.
- `test_slurm_client_init_tunnel_failure_logs_error_and_raises` — genuine tunnel failure still logs error once and raises `RuntimeError`.

## Related issues

N/A — operational alert-noise fix.

## Before submitting

- [ ] This PR only changes documentation.
- [x] Did you read the contributor guideline Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
