### PR TITLE
feat(environments): ExecutableEnvironment + ExecutableTool base

### DIFF
--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -71,8 +71,10 @@ class ToolParams(BaseParams):
     """Optional dotted import path to a callable that executes this tool.
 
     When set, the host env dispatches calls to it instead of LLM-simulating.
-    ``SyntheticEnvironment`` passes ``(arguments, state)`` when
-    ``state_params`` is set, else ``(arguments,)``.
+    The callable is invoked with keyword arguments — always ``arguments`` (the
+    tool-call args), plus a per-env context keyword: ``state`` for a stateful
+    ``SyntheticEnvironment``, ``context`` for an ``ExecutableEnvironment`` — and
+    must return a ``ToolResult``.
     """
 
     @classmethod

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -44,10 +44,11 @@ class ToolArgumentError(ToolError):
 
 
 class ToolLookupError(ToolError):
-    """Raised when a tool cannot resolve an output for the given arguments.
+    """Raised when a tool call cannot be resolved.
 
-    Currently used by ``DeterministicEnvironment`` when no configured
-    ``LookupEntry`` matches the provided arguments.
+    Covers a tool id that isn't registered in the environment
+    (``ExecutableEnvironment``) and a ``DeterministicEnvironment``
+    ``LookupEntry`` that matches none of the provided arguments.
     """
 
 

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -37,6 +37,8 @@ from oumi.environments.deterministic_environment import (
     DeterministicEnvironmentKwargs,
     ToolLookupEntry,
 )
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
 from oumi.environments.synthetic_environment import (
     SyntheticEnvironment,
     SyntheticEnvironmentKwargs,
@@ -47,6 +49,8 @@ __all__ = [
     "BaseEnvironment",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
+    "ExecutableEnvironment",
+    "ExecutableTool",
     "GroundingConfig",
     "GroundingFact",
     "JSONSchema",

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -1,0 +1,108 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstract base for envs backed by user-supplied dotted-path executors."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from typing import Any, ClassVar
+
+import jsonschema
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.tool_params import ToolError, ToolLookupError, ToolParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class ExecutableEnvironment(BaseEnvironment):
+    """Abstract base for envs that run user-supplied dotted-path executors.
+
+    Subclasses supply the per-call execution context (DB connection, HTTP
+    client, FS root, ...) by implementing ``_build_execution_context`` as a
+    context manager. The base owns executor resolution, result validation,
+    schema validation, the ``_absorb_result`` post-hook, and the ``close``
+    lifecycle.
+    """
+
+    tool_params_cls: type[ToolParams] = ExecutableTool
+
+    #: Keyword name under which subclasses pass the execution context to
+    #: user executors. Defaults to ``"context"``; concrete subclasses such
+    #: as ``DatabaseExecutableEnvironment`` override this (e.g. to ``"db"``).
+    _executor_context_kwarg: ClassVar[str] = "context"
+
+    _params: EnvironmentParams
+    _executors: dict[str, Callable[..., Any]]
+
+    @abstractmethod
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> AbstractContextManager[Any]:
+        """Yield the per-call execution context (DB conn, HTTP client, ...)."""
+
+    def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
+        """Post-hook called after a successful executor call. Default no-op."""
+        return None
+
+    def close(self) -> None:
+        """Release any resources owned by this env. Default no-op."""
+        return None
+
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch of tool calls; results are returned in input order."""
+        return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]
+
+    def _lookup_tool(self, tool_id: str) -> ExecutableTool:
+        for tool in self._params.tools:
+            if tool.id == tool_id:
+                return tool
+        raise ToolLookupError(
+            f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
+            f"Available tools: {[t.id for t in self._params.tools]}"
+        )
+
+    def _validate_result(self, tool: ExecutableTool, result: Any) -> ToolResult:
+        if not isinstance(result, ToolResult):
+            raise ToolError(
+                f"Tool '{tool.id}' executor must return ToolResult, got "
+                f"{type(result).__name__}."
+            )
+        if tool.output_schema is not None:
+            try:
+                jsonschema.validate(result.output, tool.output_schema)
+            except jsonschema.ValidationError as e:
+                raise ToolError(
+                    f"Tool '{tool.id}' executor output failed schema validation: {e}"
+                ) from e
+        return result
+
+    def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
+        tool = self._lookup_tool(tool_id)
+        tool.validate_arguments(arguments)
+        with self._build_execution_context(tool, arguments) as ctx:
+            result = self._invoke_executor(self._executors[tool_id], arguments, ctx)
+        validated = self._validate_result(tool, result)
+        self._absorb_result(tool, validated)
+        return validated
+
+    def _invoke_executor(
+        self, executor: Callable[..., Any], arguments: dict[str, Any], ctx: Any
+    ) -> Any:
+        """Call the resolved executor and return its raw result."""
+        return executor(**{"arguments": arguments, self._executor_context_kwarg: ctx})

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -39,7 +39,9 @@ class ExecutableEnvironment(BaseEnvironment):
     argument and result validation, the ``_absorb_result`` post-hook, and the
     ``close`` lifecycle. Executors are invoked as
     ``executor(arguments=<dict>, context=<ctx>)`` and must return a
-    ``ToolResult``.
+    ``ToolResult``. Result validation runs inside the execution context so a
+    transactional context manager sees a validation failure and can roll back;
+    ``_absorb_result`` runs only after the context exits cleanly.
     """
 
     tool_params_cls: type[ToolParams] = ExecutableTool
@@ -81,6 +83,6 @@ class ExecutableEnvironment(BaseEnvironment):
         tool.validate_arguments(arguments)
         with self._build_execution_context(tool, arguments) as ctx:
             result = self._executors[tool_id](arguments=arguments, context=ctx)
-        validated = validate_executor_result(tool, result)
+            validated = validate_executor_result(tool, result)
         self._absorb_result(tool, validated)
         return validated

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -19,36 +19,37 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from typing import Any, ClassVar
-
-import jsonschema
+from typing import Any
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
-from oumi.core.configs.params.tool_params import ToolError, ToolLookupError, ToolParams
+from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.executable_tool import ExecutableTool
+from oumi.environments.utils import import_executor, validate_executor_result
 
 
 class ExecutableEnvironment(BaseEnvironment):
-    """Abstract base for envs that run user-supplied dotted-path executors.
+    """Abstract base for envs that dispatch tool calls to Python executors.
 
-    Subclasses supply the per-call execution context (DB connection, HTTP
-    client, FS root, ...) by implementing ``_build_execution_context`` as a
-    context manager. The base owns executor resolution, result validation,
-    schema validation, the ``_absorb_result`` post-hook, and the ``close``
-    lifecycle.
+    Each tool declares its executor as a dotted import path; the base resolves
+    them into ``_executors`` at construction. Subclasses supply the per-call
+    execution context (DB connection, HTTP client, FS root, ...) by
+    implementing ``_build_execution_context``. The base owns tool lookup,
+    argument and result validation, the ``_absorb_result`` post-hook, and the
+    ``close`` lifecycle. Executors are invoked as
+    ``executor(arguments=<dict>, context=<ctx>)`` and must return a
+    ``ToolResult``.
     """
 
     tool_params_cls: type[ToolParams] = ExecutableTool
 
-    #: Keyword name under which subclasses pass the execution context to
-    #: user executors. Defaults to ``"context"``; concrete subclasses such
-    #: as ``DatabaseExecutableEnvironment`` override this (e.g. to ``"db"``).
-    _executor_context_kwarg: ClassVar[str] = "context"
-
-    _params: EnvironmentParams
-    _executors: dict[str, Callable[..., Any]]
+    def __init__(self, params: EnvironmentParams) -> None:
+        """Resolve each tool's dotted-path executor into ``_executors``."""
+        self._params = params
+        self._executors: dict[str, Callable[..., Any]] = {
+            tool.id: import_executor(tool.executor, tool.id) for tool in params.tools
+        }
 
     @abstractmethod
     def _build_execution_context(
@@ -58,11 +59,9 @@ class ExecutableEnvironment(BaseEnvironment):
 
     def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
         """Post-hook called after a successful executor call. Default no-op."""
-        return None
 
     def close(self) -> None:
         """Release any resources owned by this env. Default no-op."""
-        return None
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
         """Execute a batch of tool calls; results are returned in input order."""
@@ -77,32 +76,11 @@ class ExecutableEnvironment(BaseEnvironment):
             f"Available tools: {[t.id for t in self._params.tools]}"
         )
 
-    def _validate_result(self, tool: ExecutableTool, result: Any) -> ToolResult:
-        if not isinstance(result, ToolResult):
-            raise ToolError(
-                f"Tool '{tool.id}' executor must return ToolResult, got "
-                f"{type(result).__name__}."
-            )
-        if tool.output_schema is not None:
-            try:
-                jsonschema.validate(result.output, tool.output_schema)
-            except jsonschema.ValidationError as e:
-                raise ToolError(
-                    f"Tool '{tool.id}' executor output failed schema validation: {e}"
-                ) from e
-        return result
-
     def _step_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
         tool = self._lookup_tool(tool_id)
         tool.validate_arguments(arguments)
         with self._build_execution_context(tool, arguments) as ctx:
-            result = self._invoke_executor(self._executors[tool_id], arguments, ctx)
-        validated = self._validate_result(tool, result)
+            result = self._executors[tool_id](arguments=arguments, context=ctx)
+        validated = validate_executor_result(tool, result)
         self._absorb_result(tool, validated)
         return validated
-
-    def _invoke_executor(
-        self, executor: Callable[..., Any], arguments: dict[str, Any], ctx: Any
-    ) -> Any:
-        """Call the resolved executor and return its raw result."""
-        return executor(**{"arguments": arguments, self._executor_context_kwarg: ctx})

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -1,0 +1,40 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared base class for tools that resolve a dotted-path Python executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oumi.core.configs.params.tool_params import ToolParams
+
+
+@dataclass
+class ExecutableTool(ToolParams):
+    """`ToolParams` variant for envs that take user-supplied dotted-path executors.
+
+    Subclasses inherit this and may add transport-specific per-tool overrides.
+    """
+
+    executor: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate inherited fields and enforce non-empty executor."""
+        super().__post_init__()
+        if not self.executor:
+            raise ValueError(
+                f"{type(self).__name__} '{self.id}' must declare a non-empty "
+                f"executor (dotted import path)."
+            )

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared base class for tools that resolve a dotted-path Python executor."""
+"""Tool params base for tools that declare a dotted-path executor."""
 
 from __future__ import annotations
 
@@ -23,12 +23,7 @@ from oumi.core.configs.params.tool_params import ToolParams
 
 @dataclass
 class ExecutableTool(ToolParams):
-    """`ToolParams` variant for envs that take user-supplied dotted-path executors.
-
-    Subclasses inherit this and may add transport-specific per-tool overrides.
-    """
-
-    executor: str = ""
+    """`ToolParams` variant for envs that take user-supplied dotted-path executors."""
 
     def __post_init__(self) -> None:
         """Validate inherited fields and enforce non-empty executor."""

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-import importlib
 import json
 import random
 from collections.abc import Callable
@@ -48,6 +47,7 @@ from oumi.core.registry import register_environment
 from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.utils import import_executor, validate_executor_result
 from oumi.utils.str_utils import extract_json
 
 if TYPE_CHECKING:
@@ -98,32 +98,6 @@ class SyntheticEnvironmentKwargs(BaseParams):
             )
 
 
-def _import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
-    """Resolve a dotted import path to a callable. Raises ValueError on failure."""
-    module_path, _, attr = dotted.rpartition(".")
-    if not module_path or not attr:
-        raise ValueError(
-            f"Tool '{tool_id}': executor '{dotted}' must be a dotted import "
-            f"path (e.g. 'pkg.module.fn')."
-        )
-    try:
-        module = importlib.import_module(module_path)
-    except ImportError as e:
-        raise ValueError(
-            f"Tool '{tool_id}': cannot import executor module '{module_path}': {e}"
-        ) from e
-    executor = getattr(module, attr, None)
-    if executor is None:
-        raise ValueError(
-            f"Tool '{tool_id}': module '{module_path}' has no attribute '{attr}'."
-        )
-    if not callable(executor):
-        raise ValueError(
-            f"Tool '{tool_id}': executor '{dotted}' resolved to a non-callable."
-        )
-    return executor
-
-
 @register_environment("synthetic")
 class SyntheticEnvironment(BaseEnvironment):
     """LLM-simulated environment with optional mutable state.
@@ -161,7 +135,7 @@ class SyntheticEnvironment(BaseEnvironment):
                 f"initial_state is required)."
             )
         self._executors: dict[str, Callable[..., Any]] = {
-            tool.id: _import_executor(tool.executor, tool.id)
+            tool.id: import_executor(tool.executor, tool.id)
             for tool in params.tools
             if tool.executor
         }
@@ -325,7 +299,7 @@ class SyntheticEnvironment(BaseEnvironment):
         tool = self._lookup_tool(tool_id)
         tool.validate_arguments(arguments)
         result = self._executors[tool_id](arguments=arguments)
-        self._validate_executor_output(tool, result)
+        validate_executor_result(tool, result)
         if result.updated_state is not None:
             raise ToolError(
                 f"Tool '{tool.id}' executor returned updated_state but the "
@@ -347,7 +321,7 @@ class SyntheticEnvironment(BaseEnvironment):
         tool.validate_arguments(arguments)
         state_in = copy.deepcopy(self._state)
         result = self._executors[tool_id](arguments=arguments, state=state_in)
-        self._validate_executor_output(tool, result)
+        validate_executor_result(tool, result)
         if result.updated_state is not None:
             if tool.read_only:
                 raise ToolError(
@@ -364,21 +338,6 @@ class SyntheticEnvironment(BaseEnvironment):
                     ) from e
             self._state = copy.deepcopy(result.updated_state)
         return result
-
-    def _validate_executor_output(self, tool: ToolParams, result: Any) -> None:
-        """Validate executor return type + ``output_schema`` conformance."""
-        if not isinstance(result, ToolResult):
-            raise ToolError(
-                f"Tool '{tool.id}' executor must return ToolResult, got "
-                f"{type(result).__name__}."
-            )
-        if tool.output_schema is not None:
-            try:
-                jsonschema.validate(result.output, tool.output_schema)
-            except jsonschema.ValidationError as e:
-                raise ToolError(
-                    f"Tool '{tool.id}' executor output failed schema validation: {e}"
-                ) from e
 
     def sample_grounding(
         self,

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -16,10 +16,59 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+from collections.abc import Callable
 from typing import Any
 
+import jsonschema
+
 from oumi.core.configs.params.grounding_params import GroundingFact
+from oumi.core.configs.params.tool_params import ToolError, ToolParams
+from oumi.core.types.tool_call import ToolResult
+
+
+def import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
+    """Resolve a dotted import path to a callable. Raises ValueError on failure."""
+    module_path, _, attr = dotted.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' must be a dotted import "
+            f"path (e.g. 'pkg.module.fn')."
+        )
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise ValueError(
+            f"Tool '{tool_id}': cannot import executor module '{module_path}': {e}"
+        ) from e
+    executor = getattr(module, attr, None)
+    if executor is None:
+        raise ValueError(
+            f"Tool '{tool_id}': module '{module_path}' has no attribute '{attr}'."
+        )
+    if not callable(executor):
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{dotted}' resolved to a non-callable."
+        )
+    return executor
+
+
+def validate_executor_result(tool: ToolParams, result: Any) -> ToolResult:
+    """Check an executor return is a ToolResult conforming to ``output_schema``."""
+    if not isinstance(result, ToolResult):
+        raise ToolError(
+            f"Tool '{tool.id}' executor must return ToolResult, got "
+            f"{type(result).__name__}."
+        )
+    if tool.output_schema is not None:
+        try:
+            jsonschema.validate(result.output, tool.output_schema)
+        except jsonschema.ValidationError as e:
+            raise ToolError(
+                f"Tool '{tool.id}' executor output failed schema validation: {e}"
+            ) from e
+    return result
 
 
 def _format_grounding_value(value: Any) -> str:

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -58,7 +58,8 @@ def test_default_tool_params_cls_is_executable_tool():
 def test_close_is_noop():
     """Default close() returns None without raising."""
     env = _MinimalExecEnv()
-    assert env.close() is None
+    result = env.close()
+    assert result is None
 
 
 def test_absorb_result_is_noop():

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -1,0 +1,131 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableEnvironment."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+class _MinimalExecEnv(ExecutableEnvironment):
+    """Smallest concrete subclass that satisfies the abstract surface."""
+
+    def __init__(self) -> None:
+        self._params = EnvironmentParams(
+            id="test", name="test", description="d", env_type="executable"
+        )
+        self._executors = {}
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield None
+
+
+def test_cannot_instantiate_abstract_base():
+    """ExecutableEnvironment is abstract — _build_execution_context must be supplied."""
+    with pytest.raises(TypeError, match="abstract"):
+        ExecutableEnvironment()  # type: ignore[abstract]
+
+
+def test_default_tool_params_cls_is_executable_tool():
+    """ExecutableEnvironment binds to ExecutableTool by default."""
+    assert ExecutableEnvironment.tool_params_cls is ExecutableTool
+
+
+def test_close_is_noop():
+    """Default close() returns None without raising."""
+    env = _MinimalExecEnv()
+    assert env.close() is None
+
+
+def test_absorb_result_is_noop():
+    """Default _absorb_result returns None for any ToolResult."""
+    env = _MinimalExecEnv()
+    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
+    assert env._absorb_result(tool, ToolResult(output={"ok": True})) is None
+
+
+def test_step_batch_dispatches_to_step_one():
+    """Batch step() dispatches each call to _step_one, which looks up the tool."""
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
+    env = _MinimalExecEnv()
+    with pytest.raises(ToolLookupError):
+        env.step([("tool_a", {})])
+
+
+def test_step_one_unknown_tool_raises_lookup_error_minimal():
+    """_step_one raises a lookup error when the tool id is unknown."""
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
+    env = _MinimalExecEnv()
+    with pytest.raises(ToolLookupError):
+        env._step_one("tool_a", {})
+
+
+class _EchoExecEnv(ExecutableEnvironment):
+    """Concrete env whose executor echoes the context it was handed."""
+
+    def __init__(self, tools: list[ExecutableTool]) -> None:
+        self._params = EnvironmentParams(
+            id="echo", name="echo", description="d", env_type="executable", tools=tools
+        )
+        self._executors = {t.id: _echo_executor for t in tools}
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield {"ctx_for": tool.id}
+
+
+def _echo_executor(*, arguments: dict[str, Any], context: Any) -> ToolResult:
+    return ToolResult(output={"args": arguments, "context": context})
+
+
+def test_step_one_dispatches_to_executor_with_context():
+    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
+    env = _EchoExecEnv([tool])
+    [result] = env.step([("t", {"a": 1})])
+    assert result.output == {"args": {"a": 1}, "context": {"ctx_for": "t"}}
+
+
+def test_step_one_unknown_tool_raises_lookup_error():
+    from oumi.core.configs.params.tool_params import ToolLookupError
+
+    env = _EchoExecEnv([])
+    with pytest.raises(ToolLookupError):
+        env.step([("missing", {})])
+
+
+def test_step_one_rejects_non_toolresult_executor_return():
+    from oumi.core.configs.params.tool_params import ToolError
+
+    tool = ExecutableTool(id="bad", name="bad", description="d", executor="x.y")
+    env = _EchoExecEnv([tool])
+    env._executors["bad"] = lambda **_: {"not": "a ToolResult"}
+    with pytest.raises(ToolError):
+        env.step([("bad", {})])

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -45,6 +45,10 @@ def _bad_return_executor(arguments, context):
     return {"not": "a ToolResult"}
 
 
+def _raising_executor(arguments, context):
+    raise RuntimeError("boom")
+
+
 class _EchoExecEnv(ExecutableEnvironment):
     """Concrete env whose executor echoes the context it was handed."""
 
@@ -82,11 +86,13 @@ def test_default_tool_params_cls_is_executable_tool():
 
 
 def test_close_is_noop():
-    assert _env([]).close() is None
+    result = _env([]).close()
+    assert result is None
 
 
 def test_absorb_result_is_noop():
-    assert _env([])._absorb_result(_tool("t"), ToolResult(output={"ok": True})) is None
+    result = _env([])._absorb_result(_tool("t"), ToolResult(output={"ok": True}))
+    assert result is None
 
 
 def test_step_dispatches_to_executor_with_context():
@@ -180,9 +186,16 @@ def test_context_manager_teardown_runs_after_executor():
     assert env.events == ["enter", "exit"]
 
 
-def test_context_manager_teardown_runs_when_executor_fails():
+def test_context_manager_teardown_runs_when_result_invalid():
     env = _tracking_env([_tool("bad", executor=f"{__name__}._bad_return_executor")])
     with pytest.raises(ToolError):
+        env.step([("bad", {})])
+    assert env.events == ["enter", "exit"]
+
+
+def test_context_manager_teardown_runs_when_executor_raises():
+    env = _tracking_env([_tool("bad", executor=f"{__name__}._raising_executor")])
+    with pytest.raises(RuntimeError, match="boom"):
         env.step([("bad", {})])
     assert env.events == ["enter", "exit"]
 

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -23,78 +23,30 @@ from typing import Any
 import pytest
 
 from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolError,
+    ToolLookupError,
+)
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.executable_environment import ExecutableEnvironment
 from oumi.environments.executable_tool import ExecutableTool
 
 
-class _MinimalExecEnv(ExecutableEnvironment):
-    """Smallest concrete subclass that satisfies the abstract surface."""
-
-    def __init__(self) -> None:
-        self._params = EnvironmentParams(
-            id="test", name="test", description="d", env_type="executable"
-        )
-        self._executors = {}
-
-    @contextmanager
-    def _build_execution_context(
-        self, tool: ExecutableTool, arguments: dict[str, Any]
-    ) -> Iterator[Any]:
-        yield None
+def _echo_executor(arguments, context):
+    return ToolResult(output={"args": arguments, "context": context})
 
 
-def test_cannot_instantiate_abstract_base():
-    """ExecutableEnvironment is abstract — _build_execution_context must be supplied."""
-    with pytest.raises(TypeError, match="abstract"):
-        ExecutableEnvironment()  # type: ignore[abstract]
+def _echo_n(arguments, context):
+    return ToolResult(output={"n": arguments["n"]})
 
 
-def test_default_tool_params_cls_is_executable_tool():
-    """ExecutableEnvironment binds to ExecutableTool by default."""
-    assert ExecutableEnvironment.tool_params_cls is ExecutableTool
-
-
-def test_close_is_noop():
-    """Default close() returns None without raising."""
-    env = _MinimalExecEnv()
-    result = env.close()
-    assert result is None
-
-
-def test_absorb_result_is_noop():
-    """Default _absorb_result returns None for any ToolResult."""
-    env = _MinimalExecEnv()
-    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
-    assert env._absorb_result(tool, ToolResult(output={"ok": True})) is None
-
-
-def test_step_batch_dispatches_to_step_one():
-    """Batch step() dispatches each call to _step_one, which looks up the tool."""
-    from oumi.core.configs.params.tool_params import ToolLookupError
-
-    env = _MinimalExecEnv()
-    with pytest.raises(ToolLookupError):
-        env.step([("tool_a", {})])
-
-
-def test_step_one_unknown_tool_raises_lookup_error_minimal():
-    """_step_one raises a lookup error when the tool id is unknown."""
-    from oumi.core.configs.params.tool_params import ToolLookupError
-
-    env = _MinimalExecEnv()
-    with pytest.raises(ToolLookupError):
-        env._step_one("tool_a", {})
+def _bad_return_executor(arguments, context):
+    return {"not": "a ToolResult"}
 
 
 class _EchoExecEnv(ExecutableEnvironment):
     """Concrete env whose executor echoes the context it was handed."""
-
-    def __init__(self, tools: list[ExecutableTool]) -> None:
-        self._params = EnvironmentParams(
-            id="echo", name="echo", description="d", env_type="executable", tools=tools
-        )
-        self._executors = {t.id: _echo_executor for t in tools}
 
     @contextmanager
     def _build_execution_context(
@@ -103,30 +55,158 @@ class _EchoExecEnv(ExecutableEnvironment):
         yield {"ctx_for": tool.id}
 
 
-def _echo_executor(*, arguments: dict[str, Any], context: Any) -> ToolResult:
-    return ToolResult(output={"args": arguments, "context": context})
+def _tool(tool_id: str, executor: str = f"{__name__}._echo_executor", **overrides):
+    return ExecutableTool(
+        id=tool_id, name=tool_id, description="d", executor=executor, **overrides
+    )
 
 
-def test_step_one_dispatches_to_executor_with_context():
-    tool = ExecutableTool(id="t", name="t", description="d", executor="x.y")
-    env = _EchoExecEnv([tool])
-    [result] = env.step([("t", {"a": 1})])
+def _env(tools: list[ExecutableTool]) -> _EchoExecEnv:
+    return _EchoExecEnv(
+        EnvironmentParams(
+            id="echo", name="echo", description="d", env_type="executable", tools=tools
+        )
+    )
+
+
+def test_cannot_instantiate_abstract_base():
+    """ExecutableEnvironment is abstract — _build_execution_context must be supplied."""
+    with pytest.raises(TypeError, match="abstract"):
+        ExecutableEnvironment(  # type: ignore[abstract]
+            EnvironmentParams(id="t", name="t", description="d", env_type="executable")
+        )
+
+
+def test_default_tool_params_cls_is_executable_tool():
+    assert ExecutableEnvironment.tool_params_cls is ExecutableTool
+
+
+def test_close_is_noop():
+    assert _env([]).close() is None
+
+
+def test_absorb_result_is_noop():
+    assert _env([])._absorb_result(_tool("t"), ToolResult(output={"ok": True})) is None
+
+
+def test_step_dispatches_to_executor_with_context():
+    [result] = _env([_tool("t")]).step([("t", {"a": 1})])
     assert result.output == {"args": {"a": 1}, "context": {"ctx_for": "t"}}
 
 
-def test_step_one_unknown_tool_raises_lookup_error():
-    from oumi.core.configs.params.tool_params import ToolLookupError
+def test_step_preserves_batch_order():
+    results = _env([_tool("a"), _tool("b")]).step([("b", {}), ("a", {})])
+    assert [r.output for r in results] == [
+        {"args": {}, "context": {"ctx_for": "b"}},
+        {"args": {}, "context": {"ctx_for": "a"}},
+    ]
 
-    env = _EchoExecEnv([])
+
+def test_unknown_tool_raises_lookup_error():
     with pytest.raises(ToolLookupError):
-        env.step([("missing", {})])
+        _env([]).step([("missing", {})])
 
 
-def test_step_one_rejects_non_toolresult_executor_return():
-    from oumi.core.configs.params.tool_params import ToolError
+def test_unresolvable_executor_raises_at_construction():
+    with pytest.raises(ValueError, match="executor"):
+        _env([_tool("t", executor="oumi.does.not.exist_fn")])
 
-    tool = ExecutableTool(id="bad", name="bad", description="d", executor="x.y")
-    env = _EchoExecEnv([tool])
-    env._executors["bad"] = lambda **_: {"not": "a ToolResult"}
+
+def test_bad_arguments_rejected_before_dispatch():
+    tool = _tool(
+        "t",
+        parameters={
+            "type": "object",
+            "properties": {"x": {"type": "integer"}},
+            "required": ["x"],
+        },
+    )
+    with pytest.raises(ToolArgumentError):
+        _env([tool]).step([("t", {})])
+
+
+def test_rejects_non_toolresult_executor_return():
+    with pytest.raises(ToolError):
+        _env([_tool("bad", executor=f"{__name__}._bad_return_executor")]).step(
+            [("bad", {})]
+        )
+
+
+def test_output_schema_conforming_output_passes():
+    schema = {"type": "object", "properties": {"n": {"type": "integer"}}}
+    [result] = _env(
+        [_tool("t", executor=f"{__name__}._echo_n", output_schema=schema)]
+    ).step([("t", {"n": 3})])
+    assert result.output == {"n": 3}
+
+
+def test_output_schema_violation_raises():
+    schema = {"type": "object", "properties": {"n": {"type": "string"}}}
+    with pytest.raises(ToolError, match="schema"):
+        _env([_tool("t", executor=f"{__name__}._echo_n", output_schema=schema)]).step(
+            [("t", {"n": 3})]
+        )
+
+
+class _TrackingExecEnv(ExecutableEnvironment):
+    """Records context-manager enter/exit ordering."""
+
+    def __init__(self, params: EnvironmentParams) -> None:
+        super().__init__(params)
+        self.events: list[str] = []
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        self.events.append("enter")
+        try:
+            yield None
+        finally:
+            self.events.append("exit")
+
+
+def _tracking_env(tools: list[ExecutableTool]) -> _TrackingExecEnv:
+    return _TrackingExecEnv(
+        EnvironmentParams(
+            id="t", name="t", description="d", env_type="executable", tools=tools
+        )
+    )
+
+
+def test_context_manager_teardown_runs_after_executor():
+    env = _tracking_env([_tool("t")])
+    env.step([("t", {})])
+    assert env.events == ["enter", "exit"]
+
+
+def test_context_manager_teardown_runs_when_executor_fails():
+    env = _tracking_env([_tool("bad", executor=f"{__name__}._bad_return_executor")])
     with pytest.raises(ToolError):
         env.step([("bad", {})])
+    assert env.events == ["enter", "exit"]
+
+
+class _AbsorbingExecEnv(_EchoExecEnv):
+    """Captures every result handed to the _absorb_result post-hook."""
+
+    def __init__(self, params: EnvironmentParams) -> None:
+        super().__init__(params)
+        self.absorbed: list[ToolResult] = []
+
+    def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
+        self.absorbed.append(result)
+
+
+def test_absorb_result_receives_the_validated_result():
+    env = _AbsorbingExecEnv(
+        EnvironmentParams(
+            id="e",
+            name="e",
+            description="d",
+            env_type="executable",
+            tools=[_tool("t")],
+        )
+    )
+    [result] = env.step([("t", {"a": 1})])
+    assert env.absorbed == [result]

--- a/tests/unit/environments/test_executable_environment.py
+++ b/tests/unit/environments/test_executable_environment.py
@@ -223,3 +223,19 @@ def test_absorb_result_receives_the_validated_result():
     )
     [result] = env.step([("t", {"a": 1})])
     assert env.absorbed == [result]
+
+
+def test_absorb_result_skipped_when_result_invalid():
+    """The post-hook must not fire when the executor call fails validation."""
+    env = _AbsorbingExecEnv(
+        EnvironmentParams(
+            id="e",
+            name="e",
+            description="d",
+            env_type="executable",
+            tools=[_tool("bad", executor=f"{__name__}._bad_return_executor")],
+        )
+    )
+    with pytest.raises(ToolError):
+        env.step([("bad", {})])
+    assert env.absorbed == []

--- a/tests/unit/environments/test_executable_tool.py
+++ b/tests/unit/environments/test_executable_tool.py
@@ -1,0 +1,35 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skeleton-shape tests for ExecutableTool."""
+
+from __future__ import annotations
+
+import pytest
+
+from oumi.environments.executable_tool import ExecutableTool
+
+
+def test_rejects_empty_executor():
+    """An ExecutableTool with no executor dotted path is invalid at construction."""
+    with pytest.raises(ValueError, match="executor"):
+        ExecutableTool(id="t", name="t", description="d")
+
+
+def test_accepts_dotted_path():
+    """Dotted-path executor is stored as-is."""
+    tool = ExecutableTool(
+        id="t", name="t", description="d", executor="oumi.examples.foo.bar"
+    )
+    assert tool.executor == "oumi.examples.foo.bar"


### PR DESCRIPTION
## What

Base layer for executable environments: an abstract `ExecutableEnvironment` that runs user-supplied dotted-path executors, and the `ExecutableTool` `ToolParams` variant that carries the executor path.

- `ExecutableEnvironment` owns executor resolution, argument/result validation, JSON-schema output validation, the `_absorb_result` post-hook, and the `close` lifecycle. Subclasses supply the per-call execution context via `_build_execution_context`; executors are invoked with a fixed `context=` keyword.
- `ExecutableTool` enforces a non-empty `executor`.

This matches the approved design from #2467 (skeleton), filling in the `_step_one` dispatch the skeleton left abstract — no interface changes.

## Why

Foundation for `DatabaseExecutableEnvironment` (stacked PR), and any future transport-specific executable env (HTTP, FS, ...).

## Test

`tests/unit/environments/test_executable_environment.py`, `test_executable_tool.py` — 19 tests pass.

Draft: first PR in a stacked pair (base executable env → DB executable env).

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
