### PR TITLE
feat(environments): DatabaseExecutableEnvironment (implementation)

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -304,6 +304,9 @@ class ConversationSynthesizer:
             samples = self._plan_samples(samples, multiturn_attributes)
             conversations = self._synthesize_all_samples(samples, multiturn_attributes)
         finally:
+            for sample_router in self._sample_routers:
+                if sample_router is not None:
+                    sample_router.close()
             self._sample_routers = []
 
         records: list[dict[str, dict | str] | None] = []

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -136,14 +136,34 @@ class ConversationSynthesizer:
         """Replace ``self._sample_routers`` with one router clone per sample.
 
         Each sample's tool dispatch and grounding read hit an env with state
-        independent of every other sample's. ``synthesize()`` calls this at
-        batch entry and clears the list in ``finally``.
+        independent of every other sample's. Callers must pair this with
+        ``_close_sample_routers`` to release the per-sample envs.
         """
         self._sample_routers = (
             [self._router.for_sample() for _ in range(n_samples)]
             if self._router is not None
             else [None] * n_samples
         )
+
+    def _close_sample_routers(self, *, suppress_errors: bool) -> None:
+        """Close each per-sample router, guarding so one failure can't leak the rest.
+
+        Clears the list first, then closes each router; re-raises the first close
+        error unless ``suppress_errors`` (set when a body exception is already
+        propagating and must not be masked).
+        """
+        routers, self._sample_routers = self._sample_routers, []
+        first_error: BaseException | None = None
+        for router in routers:
+            if router is None:
+                continue
+            try:
+                router.close()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None and not suppress_errors:
+            raise first_error
 
     def _wire_inference(self, env: BaseEnvironment) -> None:
         """Inject the synthesizer's engine + base config into synthetic envs."""
@@ -303,11 +323,11 @@ class ConversationSynthesizer:
             self._attach_grounding_facts(samples, multiturn_attributes)
             samples = self._plan_samples(samples, multiturn_attributes)
             conversations = self._synthesize_all_samples(samples, multiturn_attributes)
-        finally:
-            for sample_router in self._sample_routers:
-                if sample_router is not None:
-                    sample_router.close()
-            self._sample_routers = []
+        except BaseException:
+            self._close_sample_routers(suppress_errors=True)
+            raise
+        else:
+            self._close_sample_routers(suppress_errors=False)
 
         records: list[dict[str, dict | str] | None] = []
         plan_key = f"{multiturn_attributes.id}_plan"
@@ -353,9 +373,16 @@ class ConversationSynthesizer:
         """
         self._validate_roles(multiturn_attribute)
         self._prepare_sample_routers(len(samples))
-        self._warn_on_grounding_placeholder(multiturn_attribute)
-        self._attach_grounding_facts(samples, multiturn_attribute)
-        return self._render_planner_prompts(samples, multiturn_attribute)
+        try:
+            self._warn_on_grounding_placeholder(multiturn_attribute)
+            self._attach_grounding_facts(samples, multiturn_attribute)
+            prompts = self._render_planner_prompts(samples, multiturn_attribute)
+        except BaseException:
+            self._close_sample_routers(suppress_errors=True)
+            raise
+        else:
+            self._close_sample_routers(suppress_errors=False)
+            return prompts
 
     def _render_planner_prompts(
         self,

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -74,6 +74,11 @@ class ToolRouter:
             if on_env_built is not None:
                 on_env_built(env)
             env_by_id[env_params.id] = env
+            # Isolating envs are rebuilt per-sample in for_sample(); the parent
+            # only reads requires_isolation() off this instance, so free its
+            # resources now (e.g. a DB env's temp snapshot) instead of leaking.
+            if env.requires_isolation():
+                env.close()
 
         tools_by_id = {tool.id: tool for tool in env_config.all_tools}
         tool_to_env = {
@@ -123,6 +128,16 @@ class ToolRouter:
             tool_env_map=self.tool_env_map,
             on_env_built=self.on_env_built,
         )
+
+    def close(self) -> None:
+        """Release per-sample envs this router owns.
+
+        Only isolation-requiring envs are rebuilt (and thus owned) per router;
+        shared envs belong to the parent router and are left open.
+        """
+        for env in self.env_by_id.values():
+            if env.requires_isolation():
+                env.close()
 
     def parse_and_validate_arguments(
         self, tool_id: str, raw_arguments: str

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -74,9 +74,8 @@ class ToolRouter:
             if on_env_built is not None:
                 on_env_built(env)
             env_by_id[env_params.id] = env
-            # Isolating envs are rebuilt per-sample in for_sample(); the parent
-            # only reads requires_isolation() off this instance, so free its
-            # resources now (e.g. a DB env's temp snapshot) instead of leaking.
+            # Parent only reads requires_isolation() off this template; for_sample()
+            # rebuilds it per-sample, so free it now (e.g. a DB temp snapshot).
             if env.requires_isolation():
                 env.close()
 
@@ -133,11 +132,20 @@ class ToolRouter:
         """Release per-sample envs this router owns.
 
         Only isolation-requiring envs are rebuilt (and thus owned) per router;
-        shared envs belong to the parent router and are left open.
+        shared envs belong to the parent router and are left open. Each close is
+        guarded so one env's failure can't leak the rest; the first error re-raises.
         """
+        first_error: BaseException | None = None
         for env in self.env_by_id.values():
-            if env.requires_isolation():
+            if not env.requires_isolation():
+                continue
+            try:
                 env.close()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def parse_and_validate_arguments(
         self, tool_id: str, raw_arguments: str

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -32,6 +32,9 @@ from oumi.core.configs.params.tool_params import (
 )
 from oumi.core.types.tool_call import JSONSchema, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
 from oumi.environments.deterministic_environment import (
     DeterministicEnvironment,
     DeterministicEnvironmentKwargs,
@@ -47,6 +50,7 @@ from oumi.environments.synthetic_environment import (
 
 __all__ = [
     "BaseEnvironment",
+    "DatabaseExecutableEnvironment",
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
     "ExecutableEnvironment",

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -44,6 +44,14 @@ class BaseEnvironment(ABC):
         """
         return False
 
+    def close(self) -> None:
+        """Release resources owned by this env. Default no-op.
+
+        Counterpart to ``requires_isolation``: envs rebuilt per sample (e.g. a
+        DB session) override this to release their resources at episode end.
+        """
+        return None
+
     def sample_grounding(
         self,
         n: int,

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -16,11 +16,10 @@
 
 from __future__ import annotations
 
-import dataclasses
 import sqlite3
 import uuid
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -35,6 +34,7 @@ from oumi.environments.database_session import (
 )
 from oumi.environments.executable_environment import ExecutableEnvironment
 from oumi.environments.executable_tool import ExecutableTool
+from oumi.environments.utils import parse_env_kwargs
 
 
 @dataclass
@@ -61,8 +61,10 @@ def _savepoint(connection: sqlite3.Connection, name: str) -> Iterator[None]:
     try:
         yield
     except BaseException:
-        connection.execute(f"ROLLBACK TO SAVEPOINT {sp}")
-        connection.execute(f"RELEASE SAVEPOINT {sp}")
+        # Best-effort rollback: a cleanup failure must not mask the real error.
+        with suppress(sqlite3.Error):
+            connection.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+            connection.execute(f"RELEASE SAVEPOINT {sp}")
         raise
     else:
         connection.execute(f"RELEASE SAVEPOINT {sp}")
@@ -79,27 +81,18 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
 
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
-        """Build the env, opening a Database session over its configured DB.
+        """Build the env, opening a session over its configured DB.
 
-        ``db_path`` shares one snapshot file across rollouts (Database isolation,
-        scales to large DBs). It is safe for concurrent *readers*, but SQLite
-        serializes concurrent *writers* on one file, so concurrent rollouts that
-        write will contend — those tasks should use ``schema_sql`` (a fresh
-        per-rollout file) until copy-on-write isolation lands.
+        ``db_path`` shares one snapshot file across rollouts (scales to large DBs)
+        and is safe for concurrent *readers*, but SQLite serializes concurrent
+        *writers* on one file, so write-heavy concurrent rollouts should use
+        ``schema_sql`` (a fresh per-rollout file) instead.
         """
-        raw_kwargs = params.env_kwargs or {}
-        known = {
-            field.name
-            for field in dataclasses.fields(DatabaseExecutableEnvironmentKwargs)
-        }
-        unknown = set(raw_kwargs) - known
-        if unknown:
-            raise ValueError(
-                "DatabaseExecutableEnvironment got unknown env_kwargs: "
-                f"{sorted(unknown)}. Known: {sorted(known)}"
-            )
-        kwargs = DatabaseExecutableEnvironmentKwargs(**raw_kwargs)
-        kwargs.finalize_and_validate()
+        kwargs = parse_env_kwargs(
+            DatabaseExecutableEnvironmentKwargs,
+            params,
+            env_label="DatabaseExecutableEnvironment",
+        )
         if kwargs.db_path:
             path = Path(kwargs.db_path)
             if not path.is_file():
@@ -142,7 +135,9 @@ class DatabaseExecutableEnvironment(ExecutableEnvironment):
                 yield connection
         finally:
             if tool.read_only:
-                connection.execute("PRAGMA query_only = OFF")
+                # Best-effort reset: don't let it mask an in-flight executor error.
+                with suppress(sqlite3.Error):
+                    connection.execute("PRAGMA query_only = OFF")
 
     def close(self) -> None:
         """Roll back the episode's writes and tear down the session."""

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import dataclasses
 import sqlite3
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -54,15 +55,17 @@ class DatabaseExecutableEnvironmentKwargs(BaseParams):
 
 @contextmanager
 def _savepoint(connection: sqlite3.Connection, name: str) -> Iterator[None]:
-    connection.execute(f"SAVEPOINT {name}")
+    # Randomized so model SQL can't RELEASE/ROLLBACK TO our savepoint and break cleanup.
+    sp = f"{name}_{uuid.uuid4().hex}"
+    connection.execute(f"SAVEPOINT {sp}")
     try:
         yield
     except BaseException:
-        connection.execute(f"ROLLBACK TO SAVEPOINT {name}")
-        connection.execute(f"RELEASE SAVEPOINT {name}")
+        connection.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+        connection.execute(f"RELEASE SAVEPOINT {sp}")
         raise
     else:
-        connection.execute(f"RELEASE SAVEPOINT {name}")
+        connection.execute(f"RELEASE SAVEPOINT {sp}")
 
 
 @register_environment("database")

--- a/src/oumi/environments/database_executable_environment.py
+++ b/src/oumi/environments/database_executable_environment.py
@@ -1,0 +1,146 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Executable environment backed by a Database-isolated SQLite session."""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.registry import register_environment
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.database_session import (
+    DatabaseSession,
+    materialize_sqlite_snapshot,
+)
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+
+
+@dataclass
+class DatabaseExecutableEnvironmentKwargs(BaseParams):
+    """Type-specific kwargs for :class:`DatabaseExecutableEnvironment`."""
+
+    db_path: Path | str | None = None
+    schema_sql: str | None = None
+    seed_sql: str | None = None
+
+    def __finalize_and_validate__(self) -> None:
+        """Validate the database source configuration."""
+        if self.seed_sql and not self.schema_sql:
+            raise ValueError("seed_sql requires schema_sql.")
+        if bool(self.db_path) == bool(self.schema_sql):
+            raise ValueError("Provide exactly one of db_path or schema_sql.")
+
+
+@contextmanager
+def _savepoint(connection: sqlite3.Connection, name: str) -> Iterator[None]:
+    connection.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        connection.execute(f"ROLLBACK TO SAVEPOINT {name}")
+        connection.execute(f"RELEASE SAVEPOINT {name}")
+        raise
+    else:
+        connection.execute(f"RELEASE SAVEPOINT {name}")
+
+
+@register_environment("database")
+class DatabaseExecutableEnvironment(ExecutableEnvironment):
+    """Runs SQL-executing tools against an isolated database session."""
+
+    def __init__(self, params: EnvironmentParams, session: DatabaseSession) -> None:
+        """Bind the env to its params and an already-open Database session."""
+        super().__init__(params)
+        self._session = session
+
+    @classmethod
+    def from_params(cls, params: EnvironmentParams) -> DatabaseExecutableEnvironment:
+        """Build the env, opening a Database session over its configured DB.
+
+        ``db_path`` shares one snapshot file across rollouts (Database isolation,
+        scales to large DBs). It is safe for concurrent *readers*, but SQLite
+        serializes concurrent *writers* on one file, so concurrent rollouts that
+        write will contend — those tasks should use ``schema_sql`` (a fresh
+        per-rollout file) until copy-on-write isolation lands.
+        """
+        raw_kwargs = params.env_kwargs or {}
+        known = {
+            field.name
+            for field in dataclasses.fields(DatabaseExecutableEnvironmentKwargs)
+        }
+        unknown = set(raw_kwargs) - known
+        if unknown:
+            raise ValueError(
+                "DatabaseExecutableEnvironment got unknown env_kwargs: "
+                f"{sorted(unknown)}. Known: {sorted(known)}"
+            )
+        kwargs = DatabaseExecutableEnvironmentKwargs(**raw_kwargs)
+        kwargs.finalize_and_validate()
+        if kwargs.db_path:
+            path = Path(kwargs.db_path)
+            if not path.is_file():
+                raise ValueError(
+                    f"DatabaseExecutableEnvironment '{params.id}': db_path "
+                    f"must reference an existing file: {path}"
+                )
+            session = DatabaseSession(path)
+        else:
+            assert kwargs.schema_sql is not None
+            snapshot = materialize_sqlite_snapshot(
+                schema_sql=kwargs.schema_sql, seed_sql=kwargs.seed_sql
+            )
+            session = DatabaseSession(snapshot, owns_file=True)
+        try:
+            return cls(params, session)
+        except BaseException:
+            session.close()
+            raise
+
+    def requires_isolation(self) -> bool:
+        """Each rollout needs its own session; never share across samples."""
+        return True
+
+    def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
+        """Execute a batch atomically within the rollout transaction."""
+        with _savepoint(self._session.connection, "oumi_batch"):
+            return super().step(calls)
+
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[sqlite3.Connection]:
+        """Bind a savepoint-scoped connection and enforce read-only tools."""
+        connection = self._session.connection
+        if tool.read_only:
+            connection.execute("PRAGMA query_only = ON")
+        try:
+            with _savepoint(connection, "oumi_tool_call"):
+                yield connection
+        finally:
+            if tool.read_only:
+                connection.execute("PRAGMA query_only = OFF")
+
+    def close(self) -> None:
+        """Roll back the episode's writes and tear down the session."""
+        self._session.close()

--- a/src/oumi/environments/database_session.py
+++ b/src/oumi/environments/database_session.py
@@ -28,19 +28,9 @@ def materialize_sqlite_snapshot(
     *,
     schema_sql: str,
     seed_sql: str | None = None,
-    dest: Path | str | None = None,
 ) -> Path:
     """Build a snapshot SQLite file from DDL (+ optional seed INSERTs)."""
-    destination = (
-        Path(dest)
-        if dest is not None
-        else Path(tempfile.gettempdir()) / f"oumi_snapshot_{uuid.uuid4().hex}.sqlite"
-    )
-    path = (
-        destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
-        if dest is not None
-        else destination
-    )
+    path = Path(tempfile.gettempdir()) / f"oumi_snapshot_{uuid.uuid4().hex}.sqlite"
     try:
         with closing(sqlite3.connect(path)) as connection:
             _enable_foreign_keys(connection)
@@ -48,12 +38,10 @@ def materialize_sqlite_snapshot(
             if seed_sql:
                 connection.executescript(seed_sql)
             connection.commit()
-        if dest is not None:
-            path.replace(destination)
     except BaseException:
         path.unlink(missing_ok=True)
         raise
-    return destination
+    return path
 
 
 def _enable_foreign_keys(connection: sqlite3.Connection) -> None:
@@ -82,7 +70,7 @@ class DatabaseSession:
     """
 
     def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
-        """Open a per-rollout connection; set owns_file to delete the DB on close."""
+        """Open a per-rollout connection over ``db_path``."""
         self._path = Path(db_path)
         self._owns_file = owns_file
         self._closed = False

--- a/src/oumi/environments/database_session.py
+++ b/src/oumi/environments/database_session.py
@@ -1,0 +1,140 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollback-based SQLite isolation for per-rollout database environments."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import uuid
+from collections.abc import Callable
+from contextlib import closing
+from pathlib import Path
+
+
+def materialize_sqlite_snapshot(
+    *,
+    schema_sql: str,
+    seed_sql: str | None = None,
+    dest: Path | str | None = None,
+) -> Path:
+    """Build a snapshot SQLite file from DDL (+ optional seed INSERTs)."""
+    destination = (
+        Path(dest)
+        if dest is not None
+        else Path(tempfile.gettempdir()) / f"oumi_snapshot_{uuid.uuid4().hex}.sqlite"
+    )
+    path = (
+        destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+        if dest is not None
+        else destination
+    )
+    try:
+        with closing(sqlite3.connect(path)) as connection:
+            _enable_foreign_keys(connection)
+            connection.executescript(schema_sql)
+            if seed_sql:
+                connection.executescript(seed_sql)
+            connection.commit()
+        if dest is not None:
+            path.replace(destination)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    return destination
+
+
+def _enable_foreign_keys(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys = ON")
+    if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+        raise RuntimeError("Failed to enable SQLite foreign-key enforcement.")
+
+
+def _deny_transaction_control(
+    action_code: int,
+    _arg1: str | None,
+    _arg2: str | None,
+    _database_name: str | None,
+    _trigger_name: str | None,
+) -> int:
+    if action_code == sqlite3.SQLITE_TRANSACTION:
+        return sqlite3.SQLITE_DENY
+    return sqlite3.SQLITE_OK
+
+
+class DatabaseSession:
+    """A per-rollout SQLite connection that never commits and rolls back on close.
+
+    Set ``owns_file=True`` when the env built a throwaway per-rollout database
+    that should be deleted on teardown (as opposed to a shared snapshot).
+    """
+
+    def __init__(self, db_path: Path | str, *, owns_file: bool = False) -> None:
+        """Open a per-rollout connection; set owns_file to delete the DB on close."""
+        self._path = Path(db_path)
+        self._owns_file = owns_file
+        self._closed = False
+        try:
+            self.connection = sqlite3.connect(self._path, isolation_level=None)
+        except BaseException:
+            if self._owns_file:
+                try:
+                    self._path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            raise
+        transaction_started = False
+        try:
+            _enable_foreign_keys(self.connection)
+            self.connection.execute("BEGIN")
+            transaction_started = True
+            self.connection.set_authorizer(_deny_transaction_control)
+        except BaseException:
+            self._cleanup(rollback=transaction_started, suppress_errors=True)
+            raise
+
+    def _cleanup(self, *, rollback: bool, suppress_errors: bool = False) -> None:
+        operations: list[Callable[[], object]] = []
+        if rollback:
+            operations.extend(
+                (
+                    lambda: self.connection.set_authorizer(None),
+                    self.connection.rollback,
+                )
+            )
+        operations.append(self.connection.close)
+        if self._owns_file:
+            operations.append(lambda: self._path.unlink(missing_ok=True))
+
+        first_error: BaseException | None = None
+        for operation in operations:
+            try:
+                operation()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None and not suppress_errors:
+            raise first_error
+
+    def close(self) -> None:
+        """Roll back any open transaction, close, and delete an owned file.
+
+        Idempotent: a router may close the same session more than once (build-time
+        teardown plus an explicit ``close()``), so a second call is a no-op.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._cleanup(rollback=True)

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 import json
 import random
 from dataclasses import dataclass, field
@@ -29,6 +28,7 @@ from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.registry import register_environment
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.utils import parse_env_kwargs
 from oumi.utils.logging import logger
 
 
@@ -148,16 +148,11 @@ class DeterministicEnvironment(BaseEnvironment):
     @classmethod
     def from_params(cls, params: EnvironmentParams) -> DeterministicEnvironment:
         """Build a DeterministicEnvironment from its params object."""
-        raw_kwargs = params.env_kwargs or {}
-        known = {f.name for f in dataclasses.fields(DeterministicEnvironmentKwargs)}
-        unknown = set(raw_kwargs) - known
-        if unknown:
-            raise ValueError(
-                f"DeterministicEnvironment got unknown env_kwargs: "
-                f"{sorted(unknown)}. Known: {sorted(known)}"
-            )
-        kwargs = DeterministicEnvironmentKwargs(**raw_kwargs)
-        kwargs.finalize_and_validate()
+        kwargs = parse_env_kwargs(
+            DeterministicEnvironmentKwargs,
+            params,
+            env_label="DeterministicEnvironment",
+        )
         return cls(params, kwargs)
 
     def _validate_lookup_table(self) -> None:

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -62,9 +62,6 @@ class ExecutableEnvironment(BaseEnvironment):
     def _absorb_result(self, tool: ExecutableTool, result: ToolResult) -> None:
         """Post-hook called after a successful executor call. Default no-op."""
 
-    def close(self) -> None:
-        """Release any resources owned by this env. Default no-op."""
-
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
         """Execute a batch of tool calls; results are returned in input order."""
         return [self._step_one(tool_id, arguments) for tool_id, arguments in calls]

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -16,16 +16,42 @@
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeVar
 
 import jsonschema
 
+from oumi.core.configs.params.base_params import BaseParams
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.types.tool_call import ToolResult
+
+_KwargsT = TypeVar("_KwargsT", bound=BaseParams)
+
+
+def parse_env_kwargs(
+    kwargs_cls: type[_KwargsT], params: EnvironmentParams, *, env_label: str
+) -> _KwargsT:
+    """Build a validated env-kwargs dataclass from ``params.env_kwargs``.
+
+    Rejects unrecognized keys (naming them) before constructing and
+    finalize-validating the dataclass. Shared by concrete environments.
+    """
+    raw_kwargs = params.env_kwargs or {}
+    known = {field.name for field in dataclasses.fields(kwargs_cls)}
+    unknown = set(raw_kwargs) - known
+    if unknown:
+        raise ValueError(
+            f"{env_label} got unknown env_kwargs: {sorted(unknown)}. "
+            f"Known: {sorted(known)}"
+        )
+    kwargs = kwargs_cls(**raw_kwargs)
+    kwargs.finalize_and_validate()
+    return kwargs
 
 
 def import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -433,3 +433,64 @@ def test_for_sample_mutation_does_not_bleed_back_to_parent():
     clone.env_by_id["env1"] = Mock(spec=BaseEnvironment)
 
     assert router.env_by_id["env1"] is parent_env
+
+
+# ---------- close ----------
+
+
+_DB_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
+_DB_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
+
+
+# Local executor so this suite doesn't depend on the EHR example.
+def _db_lookup_patient(arguments: dict, context) -> ToolResult:
+    row = context.execute(
+        "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
+    ).fetchone()
+    return ToolResult(output={"name": row[0], "meds": row[1]})
+
+
+def _db_env_params(env_id: str = "db") -> EnvironmentParams:
+    """A database env; each build materializes an owned temp snapshot + session."""
+    return EnvironmentParams(
+        id=env_id,
+        name=env_id,
+        description=f"Env {env_id}",
+        env_type="database",
+        tools=[
+            {
+                "id": "lookup",
+                "name": "lookup",
+                "description": "look up a patient",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"pat_id": {"type": "integer"}},
+                    "required": ["pat_id"],
+                },
+                "executor": f"{__name__}._db_lookup_patient",
+                "read_only": True,
+            }
+        ],
+        env_kwargs={"schema_sql": _DB_SCHEMA, "seed_sql": _DB_SEED},
+    )
+
+
+def test_close_tears_down_isolated_envs():
+    """Built isolating envs are closed (session released), never leaked."""
+    import sqlite3
+
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_db_env_params()])
+    )
+    # Parent keeps the env only as a requires_isolation() template; its session
+    # is released at build time, not left open for the router's lifetime.
+    with pytest.raises(sqlite3.ProgrammingError):
+        router.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+
+    sample = router.for_sample()
+    [live] = sample.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+    assert live.output == {"name": "Bob", "meds": "aspirin"}
+
+    sample.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        sample.env_by_id["db"].step([("lookup", {"pat_id": 1})])

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sqlite3
 from typing import Any
 from unittest.mock import Mock
 
@@ -443,7 +444,7 @@ _DB_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
 
 
 # Local executor so this suite doesn't depend on the EHR example.
-def _db_lookup_patient(arguments: dict, context) -> ToolResult:
+def _db_lookup_patient(arguments: dict, context: sqlite3.Connection) -> ToolResult:
     row = context.execute(
         "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
     ).fetchone()
@@ -477,8 +478,6 @@ def _db_env_params(env_id: str = "db") -> EnvironmentParams:
 
 def test_close_tears_down_isolated_envs():
     """Built isolating envs are closed (session released), never leaked."""
-    import sqlite3
-
     router = ToolRouter.from_environment_config(
         EnvironmentConfig(environments=[_db_env_params()])
     )

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -1,0 +1,172 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavior + rollback-isolation tests for DatabaseExecutableEnvironment."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
+from oumi.environments.database_session import materialize_sqlite_snapshot
+
+_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
+_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
+
+
+# Minimal executors, kept local so this suite doesn't depend on the EHR example.
+def lookup_patient(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    row = context.execute(
+        "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
+    ).fetchone()
+    if row is None:
+        return ToolResult(output={"error": "not found"})
+    return ToolResult(output={"name": row[0], "meds": row[1]})
+
+
+def update_meds(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    cursor = context.execute(
+        "UPDATE patients SET meds = ? WHERE id = ?",
+        (arguments["medication"], arguments["pat_id"]),
+    )
+    return ToolResult(output={"updated_rows": cursor.rowcount})
+
+
+def _params(tools):
+    return EnvironmentParams(
+        id="ehr",
+        name="ehr",
+        description="EHR test env",
+        env_type="database",
+        tools=tools,
+        env_kwargs={"schema_sql": _SCHEMA, "seed_sql": _SEED},
+    )
+
+
+def _lookup_tool():
+    return {
+        "id": "lookup",
+        "name": "lookup",
+        "description": "look up a patient",
+        "parameters": {
+            "type": "object",
+            "properties": {"pat_id": {"type": "integer"}},
+            "required": ["pat_id"],
+        },
+        "executor": f"{__name__}.lookup_patient",
+        "read_only": True,
+    }
+
+
+def _update_tool():
+    return {
+        "id": "update",
+        "name": "update",
+        "description": "update meds",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pat_id": {"type": "integer"},
+                "medication": {"type": "string"},
+            },
+            "required": ["pat_id", "medication"],
+        },
+        "executor": f"{__name__}.update_meds",
+        "read_only": False,
+    }
+
+
+def test_requires_isolation_is_true():
+    env = DatabaseExecutableEnvironment.from_params(_params([_lookup_tool()]))
+    try:
+        assert env.requires_isolation() is True
+    finally:
+        env.close()
+
+
+def test_executes_read_tool_against_isolated_db():
+    env = DatabaseExecutableEnvironment.from_params(_params([_lookup_tool()]))
+    try:
+        [result] = env.step([("lookup", {"pat_id": 1})])
+        assert result.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()
+
+
+def test_uncommitted_write_visible_within_one_episode():
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_lookup_tool(), _update_tool()])
+    )
+    try:
+        env.step([("update", {"pat_id": 1, "medication": "statin"})])
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "statin"}
+    finally:
+        env.close()
+
+
+def test_close_rolls_back_so_a_fresh_env_starts_clean():
+    params = _params([_lookup_tool(), _update_tool()])
+    env = DatabaseExecutableEnvironment.from_params(params)
+    env.step([("update", {"pat_id": 1, "medication": "mutated"})])
+    env.close()  # rolls back; the inline-built DB is also discarded
+    fresh = DatabaseExecutableEnvironment.from_params(params)
+    try:
+        [seen] = fresh.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        fresh.close()
+
+
+def test_writes_do_not_leak_across_concurrent_rollouts():
+    params = _params([_lookup_tool(), _update_tool()])
+    # N rollouts of the same task; each builds its own inline DB.
+    envs = [DatabaseExecutableEnvironment.from_params(params) for _ in range(4)]
+    try:
+        for i, env in enumerate(envs):
+            env.step([("update", {"pat_id": 1, "medication": f"drug_{i}"})])
+        for i, env in enumerate(envs):
+            [seen] = env.step([("lookup", {"pat_id": 1})])
+            assert seen.output == {"name": "Bob", "meds": f"drug_{i}"}
+    finally:
+        for env in envs:
+            env.close()
+
+
+def test_shared_snapshot_is_never_mutated(tmp_path):
+    snapshot = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "shared.sqlite"
+    )
+    params = EnvironmentParams(
+        id="ehr",
+        name="ehr",
+        description="d",
+        env_type="database",
+        tools=[_lookup_tool(), _update_tool()],
+        env_kwargs={"db_path": str(snapshot)},
+    )
+    env = DatabaseExecutableEnvironment.from_params(params)
+    env.step([("update", {"pat_id": 1, "medication": "mutated"})])
+    env.close()  # rollback
+    # The shared snapshot file is untouched.
+    fresh = DatabaseExecutableEnvironment.from_params(params)
+    try:
+        [seen] = fresh.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        fresh.close()

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import sqlite3
 
+import pytest
+
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.database_executable_environment import (
@@ -45,6 +47,18 @@ def update_meds(arguments: dict, context: sqlite3.Connection) -> ToolResult:
         (arguments["medication"], arguments["pat_id"]),
     )
     return ToolResult(output={"updated_rows": cursor.rowcount})
+
+
+def write_meds_read_only(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    """A read_only-declared tool that (illegally) attempts a write."""
+    context.execute("UPDATE patients SET meds = 'sneaky' WHERE id = 1")
+    return ToolResult(output={})
+
+
+def write_then_raise(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    """Writes, then fails, so the call's savepoint must roll the write back."""
+    context.execute("UPDATE patients SET meds = 'partial' WHERE id = 1")
+    raise RuntimeError("boom")
 
 
 def _params(tools):
@@ -148,10 +162,8 @@ def test_writes_do_not_leak_across_concurrent_rollouts():
             env.close()
 
 
-def test_shared_snapshot_is_never_mutated(tmp_path):
-    snapshot = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "shared.sqlite"
-    )
+def test_shared_snapshot_is_never_mutated():
+    snapshot = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     params = EnvironmentParams(
         id="ehr",
         name="ehr",
@@ -172,10 +184,115 @@ def test_shared_snapshot_is_never_mutated(tmp_path):
         fresh.close()
 
 
+def _readonly_write_tool():
+    return {
+        "id": "ro_write",
+        "name": "ro_write",
+        "description": "a read-only tool that tries to write",
+        "parameters": {"type": "object"},
+        "executor": f"{__name__}.write_meds_read_only",
+        "read_only": True,
+    }
+
+
+def _boom_write_tool():
+    return {
+        "id": "boom",
+        "name": "boom",
+        "description": "writes then raises",
+        "parameters": {"type": "object"},
+        "executor": f"{__name__}.write_then_raise",
+        "read_only": False,
+    }
+
+
+def test_read_only_tool_cannot_write_then_pragma_resets():
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_readonly_write_tool(), _update_tool(), _lookup_tool()])
+    )
+    try:
+        # PRAGMA query_only=ON blocks the read-only tool's illegal write.
+        with pytest.raises(sqlite3.OperationalError):
+            env.step([("ro_write", {})])
+        # query_only was reset OFF, so a normal write still succeeds afterwards.
+        env.step([("update", {"pat_id": 1, "medication": "statin"})])
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "statin"}
+    finally:
+        env.close()
+
+
+def test_batch_rolls_back_all_writes_when_one_call_fails():
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_update_tool(), _boom_write_tool(), _lookup_tool()])
+    )
+    try:
+        with pytest.raises(RuntimeError):
+            env.step([("update", {"pat_id": 1, "medication": "first"}), ("boom", {})])
+        # The batch savepoint discarded the earlier update too.
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()
+
+
+def test_failing_call_discards_its_partial_write():
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_boom_write_tool(), _lookup_tool()])
+    )
+    try:
+        with pytest.raises(RuntimeError):
+            env.step([("boom", {})])
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize(
+    "env_kwargs",
+    [
+        {},  # neither db_path nor schema_sql
+        {"db_path": "nonexistent.sqlite", "schema_sql": _SCHEMA},  # both
+        {"seed_sql": _SEED},  # seed_sql without schema_sql
+    ],
+)
+def test_invalid_db_source_config_raises(env_kwargs):
+    params = EnvironmentParams(
+        id="ehr",
+        name="ehr",
+        description="d",
+        env_type="database",
+        tools=[_lookup_tool()],
+        env_kwargs=env_kwargs,
+    )
+    with pytest.raises(ValueError):
+        DatabaseExecutableEnvironment.from_params(params)
+
+
+def test_construction_failure_deletes_owned_snapshot(monkeypatch):
+    import oumi.environments.database_executable_environment as mod
+
+    created: list = []
+    real = mod.materialize_sqlite_snapshot
+
+    def _spy(**kwargs):
+        path = real(**kwargs)
+        created.append(path)
+        return path
+
+    monkeypatch.setattr(mod, "materialize_sqlite_snapshot", _spy)
+    bad_tool = dict(_lookup_tool(), executor="oumi.nonexistent.module.fn")
+    with pytest.raises(ValueError):
+        DatabaseExecutableEnvironment.from_params(_params([bad_tool]))
+    # The owned snapshot built before the failing constructor was cleaned up.
+    assert created and not created[0].exists()
+
+
 def run_raw_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
     try:
         context.execute(arguments["sql"])
-    except Exception as e:
+    except sqlite3.Error as e:
         return ToolResult(output={"error": str(e)})
     return ToolResult(output={"ok": True})
 

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -170,3 +170,43 @@ def test_shared_snapshot_is_never_mutated(tmp_path):
         assert seen.output == {"name": "Bob", "meds": "aspirin"}
     finally:
         fresh.close()
+
+
+def run_raw_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    try:
+        context.execute(arguments["sql"])
+    except Exception as e:
+        return ToolResult(output={"error": str(e)})
+    return ToolResult(output={"ok": True})
+
+
+def _raw_tool():
+    return {
+        "id": "raw",
+        "name": "raw",
+        "description": "run raw sql",
+        "parameters": {
+            "type": "object",
+            "properties": {"sql": {"type": "string"}},
+            "required": ["sql"],
+        },
+        "executor": f"{__name__}.run_raw_sql",
+        "read_only": True,
+    }
+
+
+def test_model_sql_cannot_break_framework_savepoints():
+    # Model SQL runs on the env's own connection. A query issuing
+    # `RELEASE SAVEPOINT oumi_tool_call` must not free the framework's own
+    # savepoint and crash step() at cleanup: savepoint names are randomized, so
+    # the attack just returns a graceful error and the env stays usable.
+    env = DatabaseExecutableEnvironment.from_params(
+        _params([_raw_tool(), _lookup_tool()])
+    )
+    try:
+        [attack] = env.step([("raw", {"sql": "RELEASE SAVEPOINT oumi_tool_call"})])
+        assert "error" in attack.output  # graceful, not a crash
+        [seen] = env.step([("lookup", {"pat_id": 1})])
+        assert seen.output == {"name": "Bob", "meds": "aspirin"}
+    finally:
+        env.close()

--- a/tests/unit/environments/test_database_session.py
+++ b/tests/unit/environments/test_database_session.py
@@ -1,0 +1,107 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sqlite3
+
+from oumi.environments.database_session import (
+    DatabaseSession,
+    materialize_sqlite_snapshot,
+)
+
+_SCHEMA = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);"
+_SEED = "INSERT INTO t VALUES (1, 'a');"
+
+
+def test_materialize_builds_a_seeded_snapshot(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()
+
+
+def test_rollback_session_discards_uncommitted_writes(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    session = DatabaseSession(path)
+    # Write without committing; visible on this connection...
+    session.connection.execute("UPDATE t SET v = 'mutated' WHERE id = 1")
+    assert session.connection.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == (
+        "mutated"
+    )
+    session.close()  # rolls back + closes
+    # ...gone from the snapshot afterwards.
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()
+
+
+def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
+    tmp_path,
+):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    a = DatabaseSession(path)
+    b = DatabaseSession(path)
+    try:
+        a.connection.execute("UPDATE t SET v = 'from_a' WHERE id = 1")
+        # b never sees a's uncommitted write.
+        assert b.connection.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    finally:
+        a.close()
+        b.close()
+
+
+def test_leading_ddl_is_rolled_back(tmp_path):
+    # DDL as the first statement must still roll back. Legacy sqlite3 only opens
+    # an implicit transaction before DML, so without the explicit BEGIN a leading
+    # CREATE TABLE would run in autocommit and persist past close().
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    session = DatabaseSession(path)
+    session.connection.execute("CREATE TABLE leaked (x INTEGER)")
+    session.close()
+    conn = sqlite3.connect(path)
+    leaked = conn.execute(
+        "SELECT count(*) FROM sqlite_master WHERE name = 'leaked'"
+    ).fetchone()[0]
+    conn.close()
+    assert leaked == 0
+
+
+def test_owned_session_deletes_its_file_on_close(tmp_path):
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, dest=tmp_path / "owned.sqlite"
+    )
+    session = DatabaseSession(path, owns_file=True)
+    assert path.exists()
+    session.close()
+    assert not path.exists()
+
+
+def test_close_is_idempotent(tmp_path):
+    # A router may close the same session at build time and again explicitly;
+    # the second close must not raise on the already-closed connection.
+    path = materialize_sqlite_snapshot(
+        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
+    )
+    session = DatabaseSession(path)
+    session.close()
+    session.close()

--- a/tests/unit/environments/test_database_session.py
+++ b/tests/unit/environments/test_database_session.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import sqlite3
 
+import pytest
+
 from oumi.environments.database_session import (
     DatabaseSession,
     materialize_sqlite_snapshot,
@@ -25,19 +27,15 @@ _SCHEMA = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);"
 _SEED = "INSERT INTO t VALUES (1, 'a');"
 
 
-def test_materialize_builds_a_seeded_snapshot(tmp_path):
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
-    )
+def test_materialize_builds_a_seeded_snapshot():
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     conn = sqlite3.connect(path)
     assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
     conn.close()
 
 
-def test_rollback_session_discards_uncommitted_writes(tmp_path):
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
-    )
+def test_rollback_session_discards_uncommitted_writes():
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     session = DatabaseSession(path)
     # Write without committing; visible on this connection...
     session.connection.execute("UPDATE t SET v = 'mutated' WHERE id = 1")
@@ -51,12 +49,8 @@ def test_rollback_session_discards_uncommitted_writes(tmp_path):
     conn.close()
 
 
-def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
-    tmp_path,
-):
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
-    )
+def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes():
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     a = DatabaseSession(path)
     b = DatabaseSession(path)
     try:
@@ -68,13 +62,10 @@ def test_two_sessions_on_one_snapshot_do_not_see_each_others_uncommitted_writes(
         b.close()
 
 
-def test_leading_ddl_is_rolled_back(tmp_path):
-    # DDL as the first statement must still roll back. Legacy sqlite3 only opens
-    # an implicit transaction before DML, so without the explicit BEGIN a leading
-    # CREATE TABLE would run in autocommit and persist past close().
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
-    )
+def test_leading_ddl_is_rolled_back():
+    # Leading DDL must roll back too: without the explicit BEGIN a first CREATE
+    # TABLE runs in autocommit and persists past close().
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     session = DatabaseSession(path)
     session.connection.execute("CREATE TABLE leaked (x INTEGER)")
     session.close()
@@ -86,22 +77,34 @@ def test_leading_ddl_is_rolled_back(tmp_path):
     assert leaked == 0
 
 
-def test_owned_session_deletes_its_file_on_close(tmp_path):
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, dest=tmp_path / "owned.sqlite"
-    )
+def test_owned_session_deletes_its_file_on_close():
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA)
     session = DatabaseSession(path, owns_file=True)
     assert path.exists()
     session.close()
     assert not path.exists()
 
 
-def test_close_is_idempotent(tmp_path):
+def test_close_is_idempotent():
     # A router may close the same session at build time and again explicitly;
     # the second close must not raise on the already-closed connection.
-    path = materialize_sqlite_snapshot(
-        schema_sql=_SCHEMA, seed_sql=_SEED, dest=tmp_path / "seed.sqlite"
-    )
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
     session = DatabaseSession(path)
     session.close()
     session.close()
+
+
+def test_transaction_control_is_denied():
+    # An executor must not COMMIT and defeat rollback isolation; the authorizer
+    # denies it, and the session still rolls back on close.
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
+    session = DatabaseSession(path)
+    try:
+        with pytest.raises(sqlite3.DatabaseError):
+            session.connection.execute("COMMIT")
+        session.connection.execute("UPDATE t SET v = 'mutated' WHERE id = 1")
+    finally:
+        session.close()
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()


### PR DESCRIPTION
## What

`DatabaseExecutableEnvironment` — a concrete `ExecutableEnvironment` for NL2SQL / DB-agent SFT, plus the leak-prevention wiring that isolates rollouts.

- **Per-rollout isolation** via `DatabaseSession`: opens a connection that never commits and rolls back on close, so executor writes never persist (no cross-run leak). Executors must not `commit()`; the env owns the transaction.
- `db_path` → shared snapshot + per-rollout rollback; `schema_sql` → fresh per-rollout build.
- Leak-prevention wiring: `BaseEnvironment.close()` + `tool_router` / `conversation_synthesizer` release isolation envs after use so the DB snapshot is freed in the synthesis path.

## Why

Lets users bring their own database and train LLMs on NL2SQL / DB-agent tasks with isolated, reproducible rollouts.

## Scope

This PR is **implementation only**. The EHR example (executors + configs + end-to-end config test) now lives in the stacked PR **#2545**, keeping this one focused and reviewable. Tests here use minimal inline executors (the same pattern as `test_executable_environment.py`), so the implementation carries no example dependency.

## Base

#2527 (ExecutableEnvironment base) has merged, so this now targets `main` directly.

## Test

Impl + wiring suites pass (`test_database_executable_environment`, `test_database_session`, `test_tool_router`, `test_conversation_synthesizer`, `test_executable_environment`); ruff / ruff-format / pyright clean.

Deferred (known): copy/CoW for concurrent committed writes, verl GRPO wiring, Postgres/server backends.
