### PR TITLE
feat(synthesis): expose ConversationSynthesizer building blocks for out-of-process multi-turn synthesis

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -456,22 +456,28 @@ class ConversationSynthesizer:
         user_persona = multiturn_attribute.role_instruction_messages[Role.USER]
         seeds: list[SeedConversation] = []
         for sample, opening in zip(samples, opening_turns):
+            # Personas may reference {current_turn}; the seed is turn 1, matching
+            # build_opening_turn_prompts. Rendered once and reused for every turn.
+            sample_with_turn = {**sample, "current_turn": 1}
             seed = Conversation(
                 messages=[
-                    self._format_persona(sample, assistant_persona, Role.ASSISTANT),
+                    self._format_persona(
+                        sample_with_turn, assistant_persona, Role.ASSISTANT
+                    ),
                     Message(role=Role.USER, content=opening),
                 ]
             )
-            output_system_prompt = None
-            if multiturn_attribute.output_system_prompt is not None:
-                output_system_prompt = self._formatter.format(
-                    sample, multiturn_attribute.output_system_prompt
-                )
+            output_message = self._format_output_system_message(
+                sample, multiturn_attribute.output_system_prompt
+            )
+            output_system_prompt = (
+                output_message.content if output_message is not None else None
+            )
             generation_state = {
                 "target_turns": sample["target_turns"],
                 "turn_plans": sample.get("parsed_turn_plans", []),
                 "user_persona": self._formatter.format(
-                    sample, user_persona, missing_values_allowed=False
+                    sample_with_turn, user_persona, missing_values_allowed=False
                 ),
                 "output_system_prompt": output_system_prompt,
             }

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -65,6 +65,32 @@ class PlannerPrompt:
     conversation: Conversation
 
 
+@dataclasses.dataclass
+class OpeningTurnPrompt:
+    """An augmented sample plus its opening-turn generation prompt.
+
+    ``augmented_sample`` carries ``target_turns`` and the parsed per-turn
+    ``parsed_turn_plans``; ``conversation`` generates the opening user turn.
+    """
+
+    augmented_sample: dict
+    conversation: Conversation
+
+
+@dataclasses.dataclass
+class SeedConversation:
+    """A seed conversation plus the state a turn-by-turn driver needs.
+
+    ``conversation`` is the assistant-persona SYSTEM message followed by the
+    opening USER turn. ``generation_state`` carries ``target_turns``,
+    ``turn_plans``, the ``user_persona`` for synthesizing later user turns, and
+    the ``output_system_prompt`` for the finished conversation.
+    """
+
+    conversation: Conversation
+    generation_state: dict
+
+
 class ConversationSynthesizer:
     """Synthesizes a conversation.
 
@@ -364,6 +390,115 @@ class ConversationSynthesizer:
                 )
             )
         return prompts
+
+    def build_opening_turn_prompts(
+        self,
+        samples: list[dict],
+        plans: list[str],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> list[OpeningTurnPrompt]:
+        """Parse plans and build the opening (turn 1, USER) generation prompts.
+
+        Pairs with :meth:`build_planner_prompts`: given the samples it returned
+        and the raw plan strings inferred from them, parse each plan into
+        per-turn instructions and render the prompt that generates the opening
+        user turn. Inference-free — run the returned conversations on the user
+        model, then hand the utterances to :meth:`build_seed_conversations`.
+
+        Args:
+            samples: The augmented samples from ``build_planner_prompts`` (each
+                carrying ``target_turns``).
+            plans: Raw planner output strings, aligned 1:1 with ``samples``.
+            multiturn_attribute: The multi-turn attribute defining conversation
+                rules.
+
+        Returns:
+            One :class:`OpeningTurnPrompt` per sample, in order. Each carries the
+            sample augmented with parsed ``parsed_turn_plans`` and its
+            opening-turn generation conversation.
+        """
+        self._validate_roles(multiturn_attribute)
+        opening_role = self._default_turn_order[0]
+        prompts: list[OpeningTurnPrompt] = []
+        for sample, plan in zip(samples, plans):
+            target_turns = sample["target_turns"]
+            parsed = self._parse_plan(plan, target_turns) or [""] * target_turns
+            augmented = {
+                **sample,
+                "conversation_plan": plan,
+                "parsed_turn_plans": parsed,
+            }
+            prompts.append(
+                OpeningTurnPrompt(
+                    augmented_sample=augmented,
+                    conversation=self._build_turn_prompt(
+                        augmented,
+                        multiturn_attribute,
+                        opening_role,
+                        current_turn=1,
+                        history=[],
+                    ),
+                )
+            )
+        return prompts
+
+    def build_seed_conversations(
+        self,
+        samples: list[dict],
+        opening_turns: list[str],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> list[SeedConversation]:
+        """Build seed conversations for out-of-process multi-turn generation.
+
+        Given the augmented samples from :meth:`build_opening_turn_prompts` and
+        the opening user utterances inferred from them, produce for each sample a
+        seed — the assistant persona as a SYSTEM message followed by the opening
+        USER turn — plus the ``generation_state`` a turn-by-turn driver needs:
+        the target turn count, per-turn instructions, the user persona for
+        synthesizing later user turns, and the output system prompt for the
+        finished conversation. Inference-free.
+
+        Args:
+            samples: The augmented samples (carrying ``target_turns`` and
+                ``parsed_turn_plans``) from ``build_opening_turn_prompts``.
+            opening_turns: The opening user utterances, aligned 1:1 with
+                ``samples``.
+            multiturn_attribute: The multi-turn attribute defining conversation
+                rules.
+
+        Returns:
+            One :class:`SeedConversation` per sample, in order.
+        """
+        self._validate_roles(multiturn_attribute)
+        assistant_persona = multiturn_attribute.role_instruction_messages[
+            Role.ASSISTANT
+        ]
+        user_persona = multiturn_attribute.role_instruction_messages[Role.USER]
+        seeds: list[SeedConversation] = []
+        for sample, opening in zip(samples, opening_turns):
+            seed = Conversation(
+                messages=[
+                    self._format_persona(sample, assistant_persona, Role.ASSISTANT),
+                    Message(role=Role.USER, content=opening),
+                ]
+            )
+            output_system_prompt = None
+            if multiturn_attribute.output_system_prompt is not None:
+                output_system_prompt = self._formatter.format(
+                    sample, multiturn_attribute.output_system_prompt
+                )
+            generation_state = {
+                "target_turns": sample["target_turns"],
+                "turn_plans": sample.get("parsed_turn_plans", []),
+                "user_persona": self._formatter.format(
+                    sample, user_persona, missing_values_allowed=False
+                ),
+                "output_system_prompt": output_system_prompt,
+            }
+            seeds.append(
+                SeedConversation(conversation=seed, generation_state=generation_state)
+            )
+        return seeds
 
     def _plan_samples(
         self,
@@ -727,6 +862,45 @@ class ConversationSynthesizer:
             ),
         )
 
+    def _build_turn_prompt(
+        self,
+        sample: dict,
+        multiturn_attribute: MultiTurnAttribute,
+        role: Role,
+        current_turn: int,
+        history: list[Message],
+    ) -> Conversation:
+        """Build one turn's generation prompt: persona + history + instruction.
+
+        Shared by the in-process turn loop and out-of-process opening-turn
+        generation so both render turns identically.
+        """
+        target_turns = sample["target_turns"]
+        parsed_turn_plans = sample.get("parsed_turn_plans", [])
+        turn_idx = current_turn - 1
+
+        turn_instruction = ""
+        if 0 <= turn_idx < len(parsed_turn_plans):
+            turn_instruction = parsed_turn_plans[turn_idx]
+
+        sample_with_turn = {**sample, "current_turn": current_turn}
+        persona = multiturn_attribute.role_instruction_messages[role]
+        messages: list[Message] = [
+            self._format_persona(sample_with_turn, persona, role)
+        ]
+        messages.extend(history)
+
+        turn_info = (
+            f"You are generating turn {current_turn} of {target_turns} "
+            f"as the {role.value.upper()}.\n\n"
+        )
+        if turn_instruction:
+            turn_info += f"For this turn: {turn_instruction}\n\n"
+        turn_info += "Generate ONLY your response for this turn. Stay in character."
+        messages.append(Message(role=Role.USER, content=turn_info))
+
+        return Conversation(messages=messages)
+
     def _synthesize_all_samples(
         self,
         samples: list[dict],
@@ -770,35 +944,11 @@ class ConversationSynthesizer:
                 role = turn_order[turn_idx % len(turn_order)]
                 roles_for_turn.append(role)
 
-                prompt_messages: list[Message] = []
-                sample_with_turn = {**sample, "current_turn": current_turn}
-
-                persona = multiturn_attribute.role_instruction_messages[role]
-                formatted_persona = self._format_persona(
-                    sample_with_turn, persona, role
+                prompts.append(
+                    self._build_turn_prompt(
+                        sample, multiturn_attribute, role, current_turn, histories[i]
+                    )
                 )
-                prompt_messages.append(formatted_persona)
-                prompt_messages.extend(histories[i])
-
-                target_turns = sample["target_turns"]
-                parsed_turn_plans = sample.get("parsed_turn_plans", [])
-
-                turn_instruction = ""
-                if turn_idx < len(parsed_turn_plans):
-                    turn_instruction = parsed_turn_plans[turn_idx]
-
-                turn_info = (
-                    f"You are generating turn {current_turn} of {target_turns} "
-                    f"as the {role.value.upper()}.\n\n"
-                )
-                if turn_instruction:
-                    turn_info += f"For this turn: {turn_instruction}\n\n"
-                turn_info += (
-                    "Generate ONLY your response for this turn. Stay in character."
-                )
-                prompt_messages.append(Message(role=Role.USER, content=turn_info))
-
-                prompts.append(Conversation(messages=prompt_messages))
                 sample_indices.append(i)
 
             if not prompts:

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -59,13 +59,7 @@ _STRAGGLER_NUDGE = (
 
 @dataclasses.dataclass
 class PlannerPrompt:
-    """A planner-prompt conversation and the augmented sample it was built from.
-
-    ``augmented_sample`` carries the original sample plus the runtime planning
-    fields (``target_turns`` and the empty ``conversation_plan`` /
-    ``parsed_turn_plans`` placeholders). ``conversation`` is the ready-to-infer
-    planner prompt for that sample.
-    """
+    """A planner-prompt conversation and the augmented sample it was built from."""
 
     augmented_sample: dict
     conversation: Conversation
@@ -325,12 +319,9 @@ class ConversationSynthesizer:
     ) -> list[PlannerPrompt]:
         """Select target turns and build planner prompts, without inference.
 
-        The inference-free prefix of :meth:`_plan_samples`: picks a per-sample
-        turn count and renders each planner-prompt conversation, but does not
-        call the model. Callers that drive inference themselves (e.g. a workflow
-        that runs the planner as a separate stage) can run the returned
-        conversations under ``PLANNER_JSON_SCHEMA`` guided decoding and feed the
-        raw plan strings back through :meth:`_parse_plan`.
+        The inference-free prefix of :meth:`_plan_samples`, for callers that
+        drive the planner as a separate stage. ``target_turns`` is drawn
+        randomly here, so persist it if plans are inferred out-of-process.
 
         Args:
             samples: The samples to plan conversations for.
@@ -338,10 +329,7 @@ class ConversationSynthesizer:
                 rules.
 
         Returns:
-            One :class:`PlannerPrompt` per input sample, in order. Persist each
-            ``augmented_sample["target_turns"]`` if the plan strings are inferred
-            out-of-process — the turn count is drawn randomly here and cannot be
-            reconstructed downstream.
+            One :class:`PlannerPrompt` per input sample, in order.
         """
         self._validate_roles(multiturn_attribute)
         turn_order = self._default_turn_order

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -57,6 +57,20 @@ _STRAGGLER_NUDGE = (
 )
 
 
+@dataclasses.dataclass
+class PlannerPrompt:
+    """A planner-prompt conversation and the augmented sample it was built from.
+
+    ``augmented_sample`` carries the original sample plus the runtime planning
+    fields (``target_turns`` and the empty ``conversation_plan`` /
+    ``parsed_turn_plans`` placeholders). ``conversation`` is the ready-to-infer
+    planner prompt for that sample.
+    """
+
+    augmented_sample: dict
+    conversation: Conversation
+
+
 class ConversationSynthesizer:
     """Synthesizes a conversation.
 
@@ -304,6 +318,53 @@ class ConversationSynthesizer:
 
         return records
 
+    def build_planner_prompts(
+        self,
+        samples: list[dict],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> list[PlannerPrompt]:
+        """Select target turns and build planner prompts, without inference.
+
+        The inference-free prefix of :meth:`_plan_samples`: picks a per-sample
+        turn count and renders each planner-prompt conversation, but does not
+        call the model. Callers that drive inference themselves (e.g. a workflow
+        that runs the planner as a separate stage) can run the returned
+        conversations under ``PLANNER_JSON_SCHEMA`` guided decoding and feed the
+        raw plan strings back through :meth:`_parse_plan`.
+
+        Args:
+            samples: The samples to plan conversations for.
+            multiturn_attribute: The multi-turn attribute defining conversation
+                rules.
+
+        Returns:
+            One :class:`PlannerPrompt` per input sample, in order. Persist each
+            ``augmented_sample["target_turns"]`` if the plan strings are inferred
+            out-of-process — the turn count is drawn randomly here and cannot be
+            reconstructed downstream.
+        """
+        self._validate_roles(multiturn_attribute)
+        turn_order = self._default_turn_order
+        prompts: list[PlannerPrompt] = []
+        for sample in samples:
+            target_turns = self._select_target_turns(multiturn_attribute, turn_order)
+            augmented_sample = {
+                **sample,
+                "target_turns": target_turns,
+                "conversation_plan": "",
+                "parsed_turn_plans": [""] * target_turns,
+            }
+            logger.debug(f"Planning conversation with {target_turns} turns")
+            prompts.append(
+                PlannerPrompt(
+                    augmented_sample=augmented_sample,
+                    conversation=self._create_planner_prompt(
+                        multiturn_attribute, augmented_sample
+                    ),
+                )
+            )
+        return prompts
+
     def _plan_samples(
         self,
         samples: list[dict],
@@ -321,19 +382,9 @@ class ConversationSynthesizer:
             A list of sample dicts augmented with runtime fields
             (target_turns, conversation_plan, parsed_turn_plans).
         """
-        turn_order = self._default_turn_order
-
-        augmented_samples: list[dict] = []
-        for sample in samples:
-            target_turns = self._select_target_turns(multiturn_attributes, turn_order)
-            augmented_sample = {
-                **sample,
-                "target_turns": target_turns,
-                "conversation_plan": "",
-                "parsed_turn_plans": [""] * target_turns,
-            }
-            augmented_samples.append(augmented_sample)
-            logger.debug(f"Planning conversation with {target_turns} turns")
+        planner_prompts = self.build_planner_prompts(samples, multiturn_attributes)
+        augmented_samples = [prompt.augmented_sample for prompt in planner_prompts]
+        planner_conversations = [prompt.conversation for prompt in planner_prompts]
 
         indices_to_process = list(range(len(augmented_samples)))
 
@@ -341,15 +392,9 @@ class ConversationSynthesizer:
             if not indices_to_process:
                 break
 
-            planner_conversations = [
-                self._create_planner_prompt(
-                    multiturn_attributes,
-                    augmented_samples[i],
-                )
-                for i in indices_to_process
-            ]
-
-            plans = self._generate_plan(planner_conversations)
+            plans = self._generate_plan(
+                [planner_conversations[i] for i in indices_to_process]
+            )
 
             failed_indices: list[int] = []
             for idx, plan in zip(indices_to_process, plans):

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -361,6 +361,7 @@ class ConversationSynthesizer:
         """
         self._validate_roles(multiturn_attribute)
         self._prepare_sample_routers(len(samples))
+        self._warn_on_grounding_placeholder(multiturn_attribute)
         self._attach_grounding_facts(samples, multiturn_attribute)
         return self._render_planner_prompts(samples, multiturn_attribute)
 
@@ -369,7 +370,7 @@ class ConversationSynthesizer:
         samples: list[dict],
         multiturn_attribute: MultiTurnAttribute,
     ) -> list[PlannerPrompt]:
-        """Render planner prompts from samples that already carry grounding."""
+        """Render planner prompts, assuming grounding attachment has already run."""
         turn_order = self._default_turn_order
         prompts: list[PlannerPrompt] = []
         for sample in samples:

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -67,11 +67,7 @@ class PlannerPrompt:
 
 @dataclasses.dataclass
 class OpeningTurnPrompt:
-    """An augmented sample plus its opening-turn generation prompt.
-
-    ``augmented_sample`` carries ``target_turns`` and the parsed per-turn
-    ``parsed_turn_plans``; ``conversation`` generates the opening user turn.
-    """
+    """An augmented sample plus its opening-turn generation prompt."""
 
     augmented_sample: dict
     conversation: Conversation
@@ -79,13 +75,7 @@ class OpeningTurnPrompt:
 
 @dataclasses.dataclass
 class SeedConversation:
-    """A seed conversation plus the state a turn-by-turn driver needs.
-
-    ``conversation`` is the assistant-persona SYSTEM message followed by the
-    opening USER turn. ``generation_state`` carries ``target_turns``,
-    ``turn_plans``, the ``user_persona`` for synthesizing later user turns, and
-    the ``output_system_prompt`` for the finished conversation.
-    """
+    """A seed conversation plus the ``generation_state`` a turn driver needs."""
 
     conversation: Conversation
     generation_state: dict
@@ -346,10 +336,9 @@ class ConversationSynthesizer:
         """Attach grounding and build planner prompts, without inference.
 
         Self-contained inference-free entrypoint for callers that drive the
-        planner as a separate stage: prepares per-sample routers and attaches
-        grounding facts (the setup :meth:`synthesize` does before planning),
-        then renders one planner prompt per sample. ``target_turns`` is drawn
-        randomly, so persist it if plans are inferred out-of-process.
+        planner as a separate stage: prepares routers, attaches grounding, and
+        renders one prompt per sample. ``target_turns`` is drawn randomly, so
+        persist it if plans are inferred out-of-process.
 
         Args:
             samples: The samples to plan conversations for.
@@ -400,23 +389,18 @@ class ConversationSynthesizer:
     ) -> list[OpeningTurnPrompt]:
         """Parse plans and build the opening (turn 1, USER) generation prompts.
 
-        Pairs with :meth:`build_planner_prompts`: given the samples it returned
-        and the raw plan strings inferred from them, parse each plan into
-        per-turn instructions and render the prompt that generates the opening
-        user turn. Inference-free — run the returned conversations on the user
-        model, then hand the utterances to :meth:`build_seed_conversations`.
+        Inference-free stage after :meth:`build_planner_prompts`: parses each
+        plan into per-turn instructions and renders the opening-turn prompt.
 
         Args:
-            samples: The augmented samples from ``build_planner_prompts`` (each
+            samples: Augmented samples from ``build_planner_prompts`` (each
                 carrying ``target_turns``).
             plans: Raw planner output strings, aligned 1:1 with ``samples``.
             multiturn_attribute: The multi-turn attribute defining conversation
                 rules.
 
         Returns:
-            One :class:`OpeningTurnPrompt` per sample, in order. Each carries the
-            sample augmented with parsed ``parsed_turn_plans`` and its
-            opening-turn generation conversation.
+            One :class:`OpeningTurnPrompt` per sample, in order.
         """
         self._validate_roles(multiturn_attribute)
         opening_role = self._default_turn_order[0]
@@ -451,16 +435,11 @@ class ConversationSynthesizer:
     ) -> list[SeedConversation]:
         """Build seed conversations for out-of-process multi-turn generation.
 
-        Given the augmented samples from :meth:`build_opening_turn_prompts` and
-        the opening user utterances inferred from them, produce for each sample a
-        seed — the assistant persona as a SYSTEM message followed by the opening
-        USER turn — plus the ``generation_state`` a turn-by-turn driver needs:
-        the target turn count, per-turn instructions, the user persona for
-        synthesizing later user turns, and the output system prompt for the
-        finished conversation. Inference-free.
+        Inference-free stage after :meth:`build_opening_turn_prompts`: pairs each
+        opening user utterance with its seed conversation and generation state.
 
         Args:
-            samples: The augmented samples (carrying ``target_turns`` and
+            samples: Augmented samples (carrying ``target_turns`` and
                 ``parsed_turn_plans``) from ``build_opening_turn_prompts``.
             opening_turns: The opening user utterances, aligned 1:1 with
                 ``samples``.

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -317,11 +317,13 @@ class ConversationSynthesizer:
         samples: list[dict],
         multiturn_attribute: MultiTurnAttribute,
     ) -> list[PlannerPrompt]:
-        """Select target turns and build planner prompts, without inference.
+        """Attach grounding and build planner prompts, without inference.
 
-        The inference-free prefix of :meth:`_plan_samples`, for callers that
-        drive the planner as a separate stage. ``target_turns`` is drawn
-        randomly here, so persist it if plans are inferred out-of-process.
+        Self-contained inference-free entrypoint for callers that drive the
+        planner as a separate stage: prepares per-sample routers and attaches
+        grounding facts (the setup :meth:`synthesize` does before planning),
+        then renders one planner prompt per sample. ``target_turns`` is drawn
+        randomly, so persist it if plans are inferred out-of-process.
 
         Args:
             samples: The samples to plan conversations for.
@@ -332,6 +334,16 @@ class ConversationSynthesizer:
             One :class:`PlannerPrompt` per input sample, in order.
         """
         self._validate_roles(multiturn_attribute)
+        self._prepare_sample_routers(len(samples))
+        self._attach_grounding_facts(samples, multiturn_attribute)
+        return self._render_planner_prompts(samples, multiturn_attribute)
+
+    def _render_planner_prompts(
+        self,
+        samples: list[dict],
+        multiturn_attribute: MultiTurnAttribute,
+    ) -> list[PlannerPrompt]:
+        """Render planner prompts from samples that already carry grounding."""
         turn_order = self._default_turn_order
         prompts: list[PlannerPrompt] = []
         for sample in samples:
@@ -370,7 +382,7 @@ class ConversationSynthesizer:
             A list of sample dicts augmented with runtime fields
             (target_turns, conversation_plan, parsed_turn_plans).
         """
-        planner_prompts = self.build_planner_prompts(samples, multiturn_attributes)
+        planner_prompts = self._render_planner_prompts(samples, multiturn_attributes)
         augmented_samples = [prompt.augmented_sample for prompt in planner_prompts]
         planner_conversations = [prompt.conversation for prompt in planner_prompts]
 

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -22,6 +22,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from oumi.core.launcher import JobState, JobStatus
@@ -700,9 +701,6 @@ class SlurmClient:
         response_format = "JobId%-30,JobName%30,User%30,State%30,Reason%30"
         # Get current date and subtract one month.
         # Otherwise completed jobs older than ~24 hours may not be listed.
-
-        from datetime import datetime, timedelta
-
         current_date = datetime.now()
         one_month_ago = current_date - timedelta(days=30)
         start_date = one_month_ago.strftime("%Y-%m-%d")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -258,7 +258,7 @@ def test_build_opening_turn_prompts_parses_plan_and_builds_prompt(
     # Opening prompt: turn-1 generation, USER role, carrying turn_plans[0].
     assert prompt.conversation.messages[0].role == Role.SYSTEM
     assert prompt.conversation.messages[-1].role == Role.USER
-    assert "explain the billing issue" in prompt.conversation.messages[-1].content
+    assert "explain the billing issue" in str(prompt.conversation.messages[-1].content)
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -172,7 +172,6 @@ def test_build_planner_prompts_selects_turns_without_inference(
     prompts = synthesizer.build_planner_prompts(samples, mock_multiturn_attribute)
 
     assert len(prompts) == len(samples)
-    # The whole point of the split: prompt-building does not touch the model.
     mock_inference_engine.infer.assert_not_called()
     for prompt, sample in zip(prompts, samples):
         assert isinstance(prompt, PlannerPrompt)
@@ -181,9 +180,7 @@ def test_build_planner_prompts_selects_turns_without_inference(
         assert target_turns <= mock_multiturn_attribute.max_turns
         assert prompt.augmented_sample["conversation_plan"] == ""
         assert prompt.augmented_sample["parsed_turn_plans"] == [""] * target_turns
-        # Original attributes survive onto the augmented sample.
         assert prompt.augmented_sample["issue"] == sample["issue"]
-        # The real planner ask is the final USER turn, with placeholders resolved.
         assert prompt.conversation.messages[-1].role == Role.USER
         assert sample["issue"] in prompt.conversation.messages[-1].content
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -186,6 +186,31 @@ def test_build_planner_prompts_selects_turns_without_inference(
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_planner_prompts_attaches_grounding(
+    mock_build_inference_engine, mock_inference_config
+):
+    """build_planner_prompts grounds prompts for grounded envs, without inference."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+    env_config = _grounded_env_config(n_entries=10, sample_size=2, seed=5)
+    synthesizer = ConversationSynthesizer(
+        GeneralSynthesisParams(),
+        mock_inference_config,
+        environment_config=env_config,
+    )
+
+    prompts = synthesizer.build_planner_prompts(
+        [{}], _grounding_attr(available_envs=["env1"], available_tools=["lookup"])
+    )
+
+    mock_inference_engine.infer.assert_not_called()
+    assert len(prompts[0].augmented_sample["grounding_facts"]) == 2
+    assert "Ground this plan in these specific entities" in str(
+        prompts[0].conversation.messages[-1].content
+    )
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_synthesize_with_empty_samples(
     mock_build_inference_engine,
     mock_general_synthesis_params,

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -34,7 +34,10 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttributeValue,
 )
 from oumi.core.configs.params.tool_params import ToolParams
-from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
+from oumi.core.synthesis.conversation_synthesizer import (
+    ConversationSynthesizer,
+    PlannerPrompt,
+)
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
     Conversation,
@@ -144,6 +147,45 @@ def test_synthesize_returns_list_of_dicts(
         assert isinstance(item, dict)
         assert mock_multiturn_attribute.id in item
         assert plan_key in item
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_planner_prompts_selects_turns_without_inference(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+    mock_inference_config,
+):
+    """build_planner_prompts renders prompts and picks turns, but never infers."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    samples = [
+        {"customer_type": "frustrated", "issue": "billing problem"},
+        {"customer_type": "friendly", "issue": "product question"},
+    ]
+    prompts = synthesizer.build_planner_prompts(samples, mock_multiturn_attribute)
+
+    assert len(prompts) == len(samples)
+    # The whole point of the split: prompt-building does not touch the model.
+    mock_inference_engine.infer.assert_not_called()
+    for prompt, sample in zip(prompts, samples):
+        assert isinstance(prompt, PlannerPrompt)
+        target_turns = prompt.augmented_sample["target_turns"]
+        assert mock_multiturn_attribute.min_turns <= target_turns
+        assert target_turns <= mock_multiturn_attribute.max_turns
+        assert prompt.augmented_sample["conversation_plan"] == ""
+        assert prompt.augmented_sample["parsed_turn_plans"] == [""] * target_turns
+        # Original attributes survive onto the augmented sample.
+        assert prompt.augmented_sample["issue"] == sample["issue"]
+        # The real planner ask is the final USER turn, with placeholders resolved.
+        assert prompt.conversation.messages[-1].role == Role.USER
+        assert sample["issue"] in prompt.conversation.messages[-1].content
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -182,7 +182,7 @@ def test_build_planner_prompts_selects_turns_without_inference(
         assert prompt.augmented_sample["parsed_turn_plans"] == [""] * target_turns
         assert prompt.augmented_sample["issue"] == sample["issue"]
         assert prompt.conversation.messages[-1].role == Role.USER
-        assert sample["issue"] in prompt.conversation.messages[-1].content
+        assert sample["issue"] in str(prompt.conversation.messages[-1].content)
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -212,6 +212,15 @@ def test_build_planner_prompts_attaches_grounding(
     )
 
 
+def test_build_planner_prompts_warns_on_grounding_placeholder(mock_inference_config):
+    """build_planner_prompts runs the placeholder-misuse check, like synthesize."""
+    synth = _make_synthesizer(mock_inference_config)
+    attr = _grounding_attr()
+    with patch.object(synth, "_warn_on_grounding_placeholder") as mock_warn:
+        synth.build_planner_prompts([{}], attr)
+    mock_warn.assert_called_once_with(attr)
+
+
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_build_opening_turn_prompts_parses_plan_and_builds_prompt(
     mock_build_inference_engine,

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -303,6 +303,44 @@ def test_build_seed_conversations_assembles_seed_and_state(
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_seed_conversations_renders_current_turn_personas(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_inference_config,
+):
+    """Personas referencing {current_turn} render (as turn 1), not crash.
+
+    current_turn is a reserved placeholder the in-process path injects per turn;
+    the seed builder renders once as turn 1 rather than raising on the missing key.
+    """
+    mock_build_inference_engine.return_value = Mock()
+    attr = MultiTurnAttribute(
+        id="conversation",
+        min_turns=2,
+        max_turns=4,
+        role_instruction_messages={
+            Role.USER: "You are the user on turn {current_turn}.",
+            Role.ASSISTANT: "You are the assistant on turn {current_turn}.",
+        },
+        conversation_planner="Plan a {target_turns}-turn conversation.",
+    )
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params, mock_inference_config
+    )
+
+    seeds = synthesizer.build_seed_conversations(
+        [{"target_turns": 3, "parsed_turn_plans": ["a", "b", "c"]}],
+        ["Hi."],
+        attr,
+    )
+
+    assert seeds[0].conversation.messages[0].content == (
+        "You are the assistant on turn 1."
+    )
+    assert seeds[0].generation_state["user_persona"] == "You are the user on turn 1."
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_synthesize_with_empty_samples(
     mock_build_inference_engine,
     mock_general_synthesis_params,

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -255,7 +255,6 @@ def test_build_opening_turn_prompts_parses_plan_and_builds_prompt(
         "acknowledge and resolve",
     ]
     assert prompt.augmented_sample["conversation_plan"] == plans[0]
-    # Opening prompt: turn-1 generation, USER role, carrying turn_plans[0].
     assert prompt.conversation.messages[0].role == Role.SYSTEM
     assert prompt.conversation.messages[-1].role == Role.USER
     assert "explain the billing issue" in str(prompt.conversation.messages[-1].content)
@@ -292,16 +291,13 @@ def test_build_seed_conversations_assembles_seed_and_state(
     assert len(seeds) == 1
     seed = seeds[0]
     assert isinstance(seed, SeedConversation)
-    # Seed = assistant-persona SYSTEM message + the opening USER turn.
     assert seed.conversation.messages[0].role == Role.SYSTEM
     assert seed.conversation.messages[1].role == Role.USER
     assert seed.conversation.messages[1].content == "Hi, my latest bill looks wrong."
     state = seed.generation_state
     assert state["target_turns"] == 3
     assert state["turn_plans"] == ["open", "answer", "close"]
-    # User persona is formatted against the sample (references {issue}).
     assert "billing" in state["user_persona"]
-    # output_system_prompt is formatted (the fixture references {issue}).
     assert state["output_system_prompt"] is not None
     assert "billing" in state["output_system_prompt"]
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -36,7 +36,9 @@ from oumi.core.configs.params.synthesis_params import (
 from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.synthesis.conversation_synthesizer import (
     ConversationSynthesizer,
+    OpeningTurnPrompt,
     PlannerPrompt,
+    SeedConversation,
 )
 from oumi.core.types.conversation import (
     PLANNER_JSON_SCHEMA,
@@ -208,6 +210,91 @@ def test_build_planner_prompts_attaches_grounding(
     assert "Ground this plan in these specific entities" in str(
         prompts[0].conversation.messages[-1].content
     )
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_opening_turn_prompts_parses_plan_and_builds_prompt(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+    mock_inference_config,
+):
+    """build_opening_turn_prompts parses the plan and renders the turn-1 prompt."""
+    mock_inference_engine = Mock()
+    mock_build_inference_engine.return_value = mock_inference_engine
+
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    samples = [{"customer_type": "frustrated", "issue": "billing", "target_turns": 2}]
+    plans = [
+        '{"turns": [{"turn": 1, "instruction": "explain the billing issue"}, '
+        '{"turn": 2, "instruction": "acknowledge and resolve"}]}'
+    ]
+    result = synthesizer.build_opening_turn_prompts(
+        samples, plans, mock_multiturn_attribute
+    )
+
+    assert len(result) == 1
+    mock_inference_engine.infer.assert_not_called()
+    prompt = result[0]
+    assert isinstance(prompt, OpeningTurnPrompt)
+    assert prompt.augmented_sample["parsed_turn_plans"] == [
+        "explain the billing issue",
+        "acknowledge and resolve",
+    ]
+    assert prompt.augmented_sample["conversation_plan"] == plans[0]
+    # Opening prompt: turn-1 generation, USER role, carrying turn_plans[0].
+    assert prompt.conversation.messages[0].role == Role.SYSTEM
+    assert prompt.conversation.messages[-1].role == Role.USER
+    assert "explain the billing issue" in prompt.conversation.messages[-1].content
+
+
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_build_seed_conversations_assembles_seed_and_state(
+    mock_build_inference_engine,
+    mock_general_synthesis_params,
+    mock_multiturn_attribute,
+    mock_inference_config,
+):
+    """build_seed_conversations builds the [assistant persona, opening user] seed."""
+    mock_build_inference_engine.return_value = Mock()
+
+    synthesizer = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        mock_inference_config,
+    )
+
+    samples = [
+        {
+            "customer_type": "frustrated",
+            "issue": "billing",
+            "target_turns": 3,
+            "parsed_turn_plans": ["open", "answer", "close"],
+        }
+    ]
+    openings = ["Hi, my latest bill looks wrong."]
+    seeds = synthesizer.build_seed_conversations(
+        samples, openings, mock_multiturn_attribute
+    )
+
+    assert len(seeds) == 1
+    seed = seeds[0]
+    assert isinstance(seed, SeedConversation)
+    # Seed = assistant-persona SYSTEM message + the opening USER turn.
+    assert seed.conversation.messages[0].role == Role.SYSTEM
+    assert seed.conversation.messages[1].role == Role.USER
+    assert seed.conversation.messages[1].content == "Hi, my latest bill looks wrong."
+    state = seed.generation_state
+    assert state["target_turns"] == 3
+    assert state["turn_plans"] == ["open", "answer", "close"]
+    # User persona is formatted against the sample (references {issue}).
+    assert "billing" in state["user_persona"]
+    # output_system_prompt is formatted (the fixture references {issue}).
+    assert state["output_system_prompt"] is not None
+    assert "billing" in state["output_system_prompt"]
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -1,7 +1,7 @@
 import signal
 import subprocess
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
@@ -11,15 +11,23 @@ from oumi.core.launcher import JobState
 from oumi.launcher.clients.slurm_client import SlurmClient
 
 _CTRL_PATH: str = "-S ~/.ssh/control-%h-%p-%r"
+# Frozen via the mock_datetime fixture: "now" is 2025-01-31, 30 days back.
 _SACCT_CMD = (
     "sacct --user=user --format='JobId%-30,JobName%30,User%30,State%30,Reason%30' "
-    f"-X --starttime {(datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')}"
+    "-X --starttime 2025-01-01"
 )
 
 
 #
 # Fixtures
 #
+@pytest.fixture
+def mock_datetime():
+    with patch("oumi.launcher.clients.slurm_client.datetime") as dt:
+        dt.now.return_value = datetime(2025, 1, 31)
+        yield dt
+
+
 @pytest.fixture
 def mock_subprocess_no_init():
     with patch("oumi.launcher.clients.slurm_client.subprocess") as sp:
@@ -300,7 +308,7 @@ def test_slurm_client_submit_job_retry_auth(mock_subprocess):
     assert result == "3141592653polaris-pbs-01"
 
 
-def test_slurm_client_list_jobs_success(mock_subprocess):
+def test_slurm_client_list_jobs_success(mock_subprocess, mock_datetime):
     mock_run = Mock()
     mock_subprocess.run.return_value = mock_run
     mock_run.stdout = _get_test_data("sacct.txt").encode("utf-8")
@@ -325,7 +333,7 @@ def test_slurm_client_list_jobs_success(mock_subprocess):
     assert job_ids == expected_ids
 
 
-def test_slurm_client_list_jobs_first_login_success(mock_subprocess):
+def test_slurm_client_list_jobs_first_login_success(mock_subprocess, mock_datetime):
     mock_run = Mock()
     mock_subprocess.run.return_value = mock_run
     mock_run.stdout = _get_test_data("sacct_full.txt").encode("utf-8")
@@ -374,7 +382,7 @@ def test_slurm_client_list_jobs_fails_missing_header(mock_subprocess):
         )
 
 
-def test_slurm_client_list_jobs_handles_empty_string(mock_subprocess):
+def test_slurm_client_list_jobs_handles_empty_string(mock_subprocess, mock_datetime):
     mock_run = Mock()
     mock_subprocess.run.return_value = mock_run
     mock_run.stdout = b""
@@ -394,7 +402,7 @@ def test_slurm_client_list_jobs_handles_empty_string(mock_subprocess):
     assert job_ids == expected_ids
 
 
-def test_slurm_client_list_jobs_failure(mock_subprocess):
+def test_slurm_client_list_jobs_failure(mock_subprocess, mock_datetime):
     mock_success_run = Mock()
     mock_success_run.stdout = b"out"
     mock_success_run.stderr = b"err"


### PR DESCRIPTION
## Summary

Exposes the inference-free stages of `ConversationSynthesizer`'s multi-turn pipeline as public methods, so a caller can drive the *inference* (planning, opening-turn, and turn-by-turn generation) on its own infrastructure instead of inside `synthesize()`. `synthesize()`'s behavior is unchanged; this is extract-and-expose plus new unit tests.

## Public building blocks

1. **`build_planner_prompts`** — select `target_turns`, prepare per-sample routers, attach grounding facts, and render one planner prompt per sample. Run the returned conversations under `PLANNER_JSON_SCHEMA` guided decoding, then feed the raw plan strings to the next stage.
2. **`build_opening_turn_prompts`** — parse the inferred plans into per-turn instructions and render the opening (turn 1, USER) generation prompt.
3. **`build_seed_conversations`** — assemble the seed (assistant-persona SYSTEM message + opening USER turn) plus the `generation_state` a turn-by-turn driver needs: `target_turns`, `turn_plans`, `user_persona`, `output_system_prompt`.

New dataclasses: `PlannerPrompt`, `OpeningTurnPrompt`, `SeedConversation`.

## Internal refactors (behavior-preserving)

- `_render_planner_prompts` split out of `build_planner_prompts` so `_plan_samples` reuses it without re-running router/grounding setup that `synthesize()` already did.
- `_build_turn_prompt` extracted from `_synthesize_all_samples` so the in-process loop and the opening-turn builder render turns identically.

## Notes

- `target_turns` is drawn randomly; callers inferring plans out-of-process must persist `augmented_sample["target_turns"]`.

## Testing

**E2E composition smoke** — chained the three builders as an out-of-process caller would (stubbed inference between stages, since these methods are inference-free): `build_planner_prompts` → *[planner infers plan]* → `build_opening_turn_prompts` → *[model infers opening]* → `build_seed_conversations`.

Example — given:

```python
sample  = {"customer_type": "frustrated", "issue": "billing"}
persona = {USER: "You are a {customer_type} customer.", ASSISTANT: "You are a support agent."}
# canned planner output: 3 turns (greet → diagnose → resolve); canned opening: "Hi, my latest bill looks wrong."
```

the chain produces a complete seed + generation_state:

```
seed.conversation:
  [system] You are a support agent.
  [user]   Hi, my latest bill looks wrong.
seed.generation_state:
  target_turns:         3
  turn_plans:           ['Greet and state the billing problem.',
                         'Agent diagnoses the overcharge.',
                         'Agent resolves and confirms refund.']
  user_persona:         You are a frustrated customer.
  output_system_prompt: Support conversation about billing.
```

Unit tests cover each builder in isolation (incl. a regression test for `{current_turn}` persona rendering). Full **integration E2E** against a live model is exercised downstream in the service that consumes these builders via the agentic inference workflow — out of scope here since these methods are inference-free.
