### PR TITLE
fix(launcher): raise ClusterUnreachableError when the Slurm controller is unreachable

### DIFF
--- a/src/oumi/core/launcher/__init__.py
+++ b/src/oumi/core/launcher/__init__.py
@@ -23,12 +23,17 @@ launchers for running machine learning jobs.
 
 from oumi.core.launcher.base_cloud import BaseCloud
 from oumi.core.launcher.base_cluster import BaseCluster, JobState, JobStatus
-from oumi.core.launcher.exceptions import ClusterNotFoundError, LauncherError
+from oumi.core.launcher.exceptions import (
+    ClusterNotFoundError,
+    ClusterUnreachableError,
+    LauncherError,
+)
 
 __all__ = [
     "BaseCloud",
     "BaseCluster",
     "ClusterNotFoundError",
+    "ClusterUnreachableError",
     "JobState",
     "JobStatus",
     "LauncherError",

--- a/src/oumi/core/launcher/exceptions.py
+++ b/src/oumi/core/launcher/exceptions.py
@@ -26,3 +26,13 @@ class LauncherError(Exception):
 
 class ClusterNotFoundError(LauncherError):
     """Raised when the requested cluster does not exist on the cloud."""
+
+
+class ClusterUnreachableError(LauncherError):
+    """Raised when the cluster exists but its controller cannot be reached.
+
+    Distinct from :class:`ClusterNotFoundError`: the cluster is expected to
+    exist, but the launcher could not communicate with it (e.g. the SSH
+    transport to a Slurm controller failed). Callers can retry or fall through
+    to another provider rather than treating the job as gone.
+    """

--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -25,12 +25,16 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from oumi.core.launcher import JobState, JobStatus
+from oumi.core.launcher import ClusterUnreachableError, JobState, JobStatus
 from oumi.utils.logging import logger
 
 _CTRL_PATH = "-S ~/.ssh/control-%h-%p-%r"
 
 _LOG_DIR = "$HOME/oumi_slurm_logs/{job_id}.out"
+
+# ssh exits 255 when the transport itself fails (host down, connection refused,
+# auth rejected) — as distinct from a command that ran and returned non-zero.
+_SSH_TRANSPORT_FAILURE_EXIT_CODE = 255
 
 
 class _SlurmAuthException(Exception):
@@ -224,6 +228,14 @@ class SlurmResponse:
     stdout: str
     stderr: str
     exit_code: int
+
+
+def _raise_if_unreachable(response: SlurmResponse, cluster_name: str) -> None:
+    """Raise ClusterUnreachableError if the SSH transport to the host failed."""
+    if response.exit_code == _SSH_TRANSPORT_FAILURE_EXIT_CODE:
+        raise ClusterUnreachableError(
+            f"Could not reach the Slurm controller for cluster '{cluster_name}'."
+        )
 
 
 def retry_auth(user_function: Callable) -> Callable:
@@ -495,8 +507,8 @@ class SlurmClient:
         if child.returncode != 0:
             output = child.stderr.decode("utf-8")
             logger.error(f"Credential error: {output}")
-            raise RuntimeError(
-                "Failed to refresh Slurm credentials "
+            raise ClusterUnreachableError(
+                "Failed to establish an SSH connection to the Slurm controller "
                 f"for {self._user}@{self._slurm_host}."
             )
         return SlurmResponse(
@@ -711,6 +723,7 @@ class SlurmClient:
         )
         result = self.run_commands([command])
         if result.exit_code != 0:
+            _raise_if_unreachable(result, self._cluster_name)
             raise RuntimeError(f"Failed to list jobs. stderr: {result.stderr}")
         # Parse STDOUT to retrieve job statuses.
         lines = result.stdout.strip().split("\n")
@@ -751,6 +764,7 @@ class SlurmClient:
         )
         result = self.run_commands([command])
         if result.exit_code != 0:
+            _raise_if_unreachable(result, self._cluster_name)
             raise RuntimeError(
                 f"Failed to list jobs via squeue. stderr: {result.stderr}"
             )

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
-from oumi.core.launcher import JobState
+from oumi.core.launcher import ClusterUnreachableError, JobState
 from oumi.launcher.clients.slurm_client import SlurmClient
 
 _CTRL_PATH: str = "-S ~/.ssh/control-%h-%p-%r"
@@ -534,6 +534,73 @@ def test_slurm_client_get_job_squeue_failure_raises(mock_subprocess):
     client = SlurmClient("user", "host", "cluster_name")
     with pytest.raises(RuntimeError, match="Failed to list jobs via squeue"):
         _ = client.get_job("100")
+
+
+def test_slurm_client_get_job_unreachable_raises(mock_subprocess):
+    # ssh exits 255 when the transport fails; get_job must surface it as an
+    # unreachable controller, not a generic RuntimeError, so callers can retry
+    # or fall through instead of treating the job as gone.
+    squeue_unreachable = Mock()
+    squeue_unreachable.stdout = b""
+    squeue_unreachable.stderr = (
+        b"ssh: connect to host host port 22: Connection refused\n"
+    )
+    squeue_unreachable.returncode = 255
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        squeue_unreachable,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    with pytest.raises(
+        ClusterUnreachableError, match="Could not reach the Slurm controller"
+    ):
+        _ = client.get_job("100")
+
+
+def test_slurm_client_list_jobs_unreachable_raises(mock_subprocess, mock_datetime):
+    sacct_unreachable = Mock()
+    sacct_unreachable.stdout = b""
+    sacct_unreachable.stderr = (
+        b"ssh: connect to host host port 22: Connection refused\n"
+    )
+    sacct_unreachable.returncode = 255
+
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        sacct_unreachable,
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    with pytest.raises(
+        ClusterUnreachableError, match="Could not reach the Slurm controller"
+    ):
+        _ = client.list_jobs()
+
+
+def test_slurm_client_init_unreachable_raises(mock_subprocess_no_init):
+    # -O check fails, then establishing the tunnel fails: the controller is
+    # unreachable at construction time.
+    mock_subprocess_no_init.TimeoutExpired = subprocess.TimeoutExpired
+    check_fail = Mock()
+    check_fail.stdout = b""
+    check_fail.stderr = b"channel closed"
+    check_fail.returncode = 255
+
+    tunnel_fail = Mock()
+    tunnel_fail.stdout = b""
+    tunnel_fail.stderr = b"ssh: connect to host host port 22: Connection refused"
+    tunnel_fail.returncode = 255
+
+    mock_subprocess_no_init.run.side_effect = [check_fail, tunnel_fail]
+
+    with pytest.raises(
+        ClusterUnreachableError, match="Failed to establish an SSH connection"
+    ):
+        _ = SlurmClient("user", "host", "cluster_name")
 
 
 def test_slurm_client_cancel_success(mock_subprocess):


### PR DESCRIPTION
# Description

`SlurmClient` surfaced SSH transport failures (a dead/unreachable controller) as a bare `RuntimeError` — the same type it raises for a command that ran and genuinely failed. Callers can't tell "couldn't reach the controller" from "the command errored," so they can't safely retry or fall through; they treat the job as gone.

This adds a typed `ClusterUnreachableError(LauncherError)` and raises it on the two transport-failure paths:
- `_refresh_creds` — establishing the SSH master connection fails.
- `list_jobs` / `_list_active_jobs_squeue` — `ssh` exits `255` (transport failure), distinct from a non-255 command error.

Behavior is otherwise unchanged: a command that runs and returns non-zero still raises `RuntimeError` as before.

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the contributor guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
