### PR TITLE
feat(det-env): allow any JSON value as deterministic lookup output

### DIFF
--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -25,7 +25,6 @@ keys at validation time would silently lose information that
 downstream code relies on.
 """
 
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 
@@ -177,8 +176,7 @@ class ToolCall(pydantic.BaseModel):
     """The function the model called."""
 
 
-@dataclass
-class ToolResult:
+class ToolResult(pydantic.BaseModel):
     """Result returned by an environment ``step()``.
 
     Runtime value (not an OpenAI wire-format type) — projected by the

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -36,9 +36,6 @@ JSONSchemaType = Literal[
     "object", "string", "number", "integer", "boolean", "array", "null"
 ]
 
-# Any JSON-serializable value.
-JsonValue = str | int | float | bool | list[Any] | dict[str, Any] | None
-
 
 class JSONSchema(pydantic.BaseModel):
     """A JSON Schema object describing the shape of a value.
@@ -190,5 +187,5 @@ class ToolResult:
     else is json-encoded at the message boundary.
     """
 
-    output: JsonValue
+    output: pydantic.JsonValue
     updated_state: dict[str, Any] | None = None

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -36,6 +36,9 @@ JSONSchemaType = Literal[
     "object", "string", "number", "integer", "boolean", "array", "null"
 ]
 
+# Any JSON-serializable value.
+JsonValue = str | int | float | bool | list[Any] | dict[str, Any] | None
+
 
 class JSONSchema(pydantic.BaseModel):
     """A JSON Schema object describing the shape of a value.
@@ -183,9 +186,9 @@ class ToolResult:
 
     Runtime value (not an OpenAI wire-format type) — projected by the
     synthesizer into ``Message(role=TOOL, content=...)`` before output.
-    ``output`` may be a string or a JSON-serializable dict; the
-    synthesizer json-encodes dicts at the message boundary.
+    ``output`` may be any JSON value — a string is used as-is, everything
+    else is json-encoded at the message boundary.
     """
 
-    output: str | dict[str, Any]
+    output: JsonValue
     updated_state: dict[str, Any] | None = None

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -28,7 +28,7 @@ downstream code relies on.
 from enum import Enum
 from typing import Any, Literal
 
-import pydantic
+from pydantic import BaseModel, ConfigDict, JsonValue
 
 # The seven primitive types defined by JSON Schema.
 JSONSchemaType = Literal[
@@ -36,7 +36,7 @@ JSONSchemaType = Literal[
 ]
 
 
-class JSONSchema(pydantic.BaseModel):
+class JSONSchema(BaseModel):
     """A JSON Schema object describing the shape of a value.
 
     Models the subset of JSON Schema commonly used in LLM tool
@@ -46,7 +46,7 @@ class JSONSchema(pydantic.BaseModel):
     module — see the module docstring for why round-tripping matters.
     """
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+    model_config = ConfigDict(frozen=True, extra="allow")
 
     type: JSONSchemaType | list[JSONSchemaType] | None = None
     """JSON type(s) of this value. A list expresses a union
@@ -89,10 +89,10 @@ class ToolType(str, Enum):
         return self.value
 
 
-class FunctionDefinition(pydantic.BaseModel):
+class FunctionDefinition(BaseModel):
     """Definition of a function that can be called by the model."""
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+    model_config = ConfigDict(frozen=True, extra="allow")
 
     name: str
     """The name of the function to be called.
@@ -124,10 +124,10 @@ class FunctionDefinition(pydantic.BaseModel):
     """
 
 
-class ToolDefinition(pydantic.BaseModel):
+class ToolDefinition(BaseModel):
     """Definition of a tool available to the model."""
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+    model_config = ConfigDict(frozen=True, extra="allow")
 
     type: ToolType = ToolType.FUNCTION
     """The type of the tool. Currently only ``function`` is supported.
@@ -140,10 +140,10 @@ class ToolDefinition(pydantic.BaseModel):
     """The function definition."""
 
 
-class FunctionCall(pydantic.BaseModel):
+class FunctionCall(BaseModel):
     """A function call made by the model."""
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+    model_config = ConfigDict(frozen=True, extra="allow")
 
     name: str
     """The name of the function being called."""
@@ -157,10 +157,10 @@ class FunctionCall(pydantic.BaseModel):
     """
 
 
-class ToolCall(pydantic.BaseModel):
+class ToolCall(BaseModel):
     """A tool call emitted by the model."""
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="allow")
+    model_config = ConfigDict(frozen=True, extra="allow")
 
     id: str
     """The ID of the tool call.
@@ -176,7 +176,7 @@ class ToolCall(pydantic.BaseModel):
     """The function the model called."""
 
 
-class ToolResult(pydantic.BaseModel):
+class ToolResult(BaseModel):
     """Result returned by an environment ``step()``.
 
     Runtime value (not an OpenAI wire-format type) — projected by the
@@ -185,5 +185,5 @@ class ToolResult(pydantic.BaseModel):
     else is json-encoded at the message boundary.
     """
 
-    output: pydantic.JsonValue
+    output: JsonValue
     updated_state: dict[str, Any] | None = None

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -94,6 +94,7 @@ class DeterministicEnvironment(BaseEnvironment):
         self._kwargs = kwargs
         self._tool_ids = {tool.id for tool in params.tools}
         self._validate_lookup_table()
+        self._warn_grounding_key_collisions()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
         """Resolve a batch of deterministic tool calls to their outputs."""
@@ -201,3 +202,31 @@ class DeterministicEnvironment(BaseEnvironment):
                         f"Tool '{tool.id}' has duplicate input entry: {entry.input}"
                     )
                 seen.add(key)
+
+    def _warn_grounding_key_collisions(self) -> None:
+        """Warn once when a dict output shadows a whitelisted input field.
+
+        In ``sample_grounding`` a dict output is merged over the input, so a
+        grounding field present in both takes the output value and the input
+        value is silently dropped. Surface it at construction so config
+        authors notice; only whitelisted fields matter since the rest never
+        reach a grounding fact.
+        """
+        grounding = self._params.grounding
+        if grounding is None or not grounding.tools:
+            return
+        for tool_id, tool_grounding in grounding.tools.items():
+            whitelist = set(tool_grounding.fields)
+            shadowed: set[str] = set()
+            for entry in self._kwargs.lookup_table.get(tool_id, []):
+                if isinstance(entry.output, dict):
+                    shadowed |= entry.input.keys() & entry.output.keys() & whitelist
+            if shadowed:
+                logger.warning(
+                    "Environment '%s': tool '%s' grounding field(s) %s appear "
+                    "in both input and output; the output value shadows the "
+                    "input in grounding facts.",
+                    self._params.id,
+                    tool_id,
+                    sorted(shadowed),
+                )

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -206,11 +206,8 @@ class DeterministicEnvironment(BaseEnvironment):
     def _warn_grounding_key_collisions(self) -> None:
         """Warn once when a dict output shadows a whitelisted input field.
 
-        In ``sample_grounding`` a dict output is merged over the input, so a
-        grounding field present in both takes the output value and the input
-        value is silently dropped. Surface it at construction so config
-        authors notice; only whitelisted fields matter since the rest never
-        reach a grounding fact.
+        Only whitelisted fields matter — a collision on any other key is
+        dropped by the projection and never reaches a grounding fact.
         """
         grounding = self._params.grounding
         if grounding is None or not grounding.tools:

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -27,17 +27,20 @@ from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.registry import register_environment
-from oumi.core.types.tool_call import ToolResult
+from oumi.core.types.tool_call import JsonValue, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
 
 
 @dataclass
 class ToolLookupEntry(BaseParams):
-    """One (input, output) pair in a deterministic env's lookup table."""
+    """One (input, output) pair in a deterministic env's lookup table.
+
+    ``output`` may be any JSON value (scalar, list, object, or null).
+    """
 
     input: dict[str, Any] = field(default_factory=dict)
-    output: dict[str, Any] = field(default_factory=dict)
+    output: JsonValue = None
 
     def input_key(self) -> str:
         """Canonical JSON form of ``input`` for matching and dedup."""
@@ -122,9 +125,10 @@ class DeterministicEnvironment(BaseEnvironment):
 
         Walks every tool that has a per-tool entry in
         ``params.grounding.tools``. Each entry in that tool's lookup table
-        is projected via ``{**input, **output}`` filtered through the
-        configured ``fields`` whitelist. Tools without a grounding entry
-        contribute nothing.
+        is projected via ``{**input, **output}`` (dict outputs only;
+        non-dict outputs ground on their input fields alone) filtered
+        through the configured ``fields`` whitelist. Tools without a
+        grounding entry contribute nothing.
         """
         grounding = self._params.grounding
         if grounding is None or not grounding.tools:
@@ -138,7 +142,12 @@ class DeterministicEnvironment(BaseEnvironment):
                 continue
             whitelist = set(tool_grounding.fields)
             for entry in self._kwargs.lookup_table.get(tool.id, []):
-                row = {**entry.input, **entry.output}
+                # Non-dict outputs (scalars/lists) have no named fields to
+                # project, so they ground on their input fields only; dict
+                # outputs merge both.
+                row = dict(entry.input)
+                if isinstance(entry.output, dict):
+                    row.update(entry.output)
                 projected = {
                     key: value for key, value in row.items() if key in whitelist
                 }

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -22,12 +22,14 @@ import random
 from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import JsonValue
+
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.registry import register_environment
-from oumi.core.types.tool_call import JsonValue, ToolResult
+from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
 

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -125,10 +125,9 @@ class DeterministicEnvironment(BaseEnvironment):
 
         Walks every tool that has a per-tool entry in
         ``params.grounding.tools``. Each entry in that tool's lookup table
-        is projected via ``{**input, **output}`` (dict outputs only;
-        non-dict outputs ground on their input fields alone) filtered
-        through the configured ``fields`` whitelist. Tools without a
-        grounding entry contribute nothing.
+        is projected to its ``input`` fields (merged with ``output`` when
+        the output is a dict), filtered through the configured ``fields``
+        whitelist. Tools without a grounding entry contribute nothing.
         """
         grounding = self._params.grounding
         if grounding is None or not grounding.tools:

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1975,6 +1975,55 @@ def test_dispatch_tool_calls_routes_through_env(
     fake_env.step.assert_called_once_with([("get_weather", {"city": "Paris"})])
 
 
+@pytest.mark.parametrize(
+    ("output", "expected_content"),
+    [
+        (None, "null"),
+        (191.23, "191.23"),
+        (["users", "orders"], '["users", "orders"]'),
+        (True, "true"),
+    ],
+)
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_dispatch_tool_calls_json_encodes_non_dict_output(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+    output,
+    expected_content,
+):
+    """Non-dict tool outputs are json-encoded at the TOOL message boundary."""
+    mock_build_inference_engine.return_value = Mock()
+
+    fake_env = Mock(spec=BaseEnvironment)
+    fake_env.step.return_value = [ToolResult(output=output)]
+    mock_build_environment.return_value = fake_env
+
+    env_config = _make_env_config("weather", "get_weather")
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+
+    tc = ToolCall(
+        id="call_1",
+        function=FunctionCall(name="get_weather", arguments='{"city": "Paris"}'),
+    )
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
+
+    assert msg.role == Role.TOOL
+    assert msg.content == expected_content
+
+
 @patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_dispatch_tool_calls_folds_same_env_calls_into_one_step(

--- a/tests/unit/environments/test_database_executable_environment.py
+++ b/tests/unit/environments/test_database_executable_environment.py
@@ -322,7 +322,7 @@ def test_model_sql_cannot_break_framework_savepoints():
     )
     try:
         [attack] = env.step([("raw", {"sql": "RELEASE SAVEPOINT oumi_tool_call"})])
-        assert "error" in attack.output  # graceful, not a crash
+        assert isinstance(attack.output, dict) and "error" in attack.output
         [seen] = env.step([("lookup", {"pat_id": 1})])
         assert seen.output == {"name": "Bob", "meds": "aspirin"}
     finally:

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -349,6 +349,57 @@ def test_sample_grounding_merges_input_and_output():
     assert facts[0].data == {"id": "1", "note": "output-note", "title": "Dune"}
 
 
+def test_grounding_key_collision_warns(caplog):
+    """Warn when a whitelisted grounding field is in both input and output."""
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[_make_tool("lookup")],
+                lookup_table={
+                    "lookup": [
+                        ToolLookupEntry(
+                            input={"id": "1", "note": "in"},
+                            output={"note": "out", "title": "Dune"},
+                        ),
+                    ]
+                },
+                grounding=GroundingConfig(
+                    sample_size=1,
+                    tools={
+                        "lookup": ToolGroundingConfig(fields=["id", "note", "title"]),
+                    },
+                ),
+            )
+        )
+    assert any(
+        "shadows the input" in rec.getMessage() and "note" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_grounding_key_collision_outside_whitelist_no_warn(caplog):
+    """A collision on a non-whitelisted key never reaches a fact, so no warning."""
+    with caplog.at_level(logging.WARNING, logger="oumi"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[_make_tool("lookup")],
+                lookup_table={
+                    "lookup": [
+                        ToolLookupEntry(
+                            input={"id": "1", "note": "in"},
+                            output={"note": "out"},
+                        ),
+                    ]
+                },
+                grounding=GroundingConfig(
+                    sample_size=1,
+                    tools={"lookup": ToolGroundingConfig(fields=["id"])},
+                ),
+            )
+        )
+    assert not any("shadows the input" in rec.getMessage() for rec in caplog.records)
+
+
 def test_sample_grounding_scalar_output_projects_input_only():
     """Non-dict outputs have no fields to project; ground on input alone."""
     env = DeterministicEnvironment.from_params(

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -198,6 +198,20 @@ def test_step_unknown_tool_raises():
         env.step([("missing", {"id": "01"})])
 
 
+@pytest.mark.parametrize(
+    "output",
+    [191.23, ["a", "b"], "text", True, None],
+)
+def test_step_returns_non_dict_output(output):
+    """Scalars, lists, and None round-trip through step() unchanged."""
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            lookup_table={"tool1": [ToolLookupEntry(input={"id": "01"}, output=output)]}
+        )
+    )
+    assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output=output)]
+
+
 # --- sample_grounding ---
 
 
@@ -333,6 +347,30 @@ def test_sample_grounding_merges_input_and_output():
     )
     facts = env.sample_grounding(n=1, rng=random.Random(0))
     assert facts[0].data == {"id": "1", "note": "output-note", "title": "Dune"}
+
+
+def test_sample_grounding_scalar_output_projects_input_only():
+    """Non-dict outputs have no fields to project; ground on input alone."""
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[_make_tool("price")],
+            lookup_table={
+                "price": [
+                    ToolLookupEntry(input={"id": "AAPL"}, output=191.23),
+                    ToolLookupEntry(input={"id": "GOOG"}, output=2801.5),
+                ]
+            },
+            grounding=GroundingConfig(
+                sample_size=10,
+                tools={"price": ToolGroundingConfig(fields=["id"])},
+            ),
+        )
+    )
+    facts = env.sample_grounding(n=10, rng=random.Random(0))
+    assert len(facts) == 2
+    assert sorted(f.data["id"] for f in facts) == ["AAPL", "GOOG"]
+    for fact in facts:
+        assert set(fact.data.keys()) == {"id"}
 
 
 def test_sample_grounding_seeded_is_reproducible():

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -200,7 +200,7 @@ def test_step_unknown_tool_raises():
 
 @pytest.mark.parametrize(
     "output",
-    [191.23, ["a", "b"], "text", True, None],
+    [191.23, 42, ["a", "b"], "text", True, None],
 )
 def test_step_returns_non_dict_output(output):
     """Scalars, lists, and None round-trip through step() unchanged."""


### PR DESCRIPTION
## What

Widen the deterministic environment's lookup-table `output` from "must be a dict" to **any JSON value** (string, number, boolean, array, object, or null), and adapt grounding so it still works.

Aligns OSS with the enterprise API ([oumi-ai/api#5314](https://github.com/oumi-ai/api/pull/5314)), whose `LookupEntry.output` is typed `JsonValue`. Many real tools return a scalar or list (e.g. `get_stock_price -> 191.23`, `list_tables -> ["users","orders"]`); forcing a `{value: ...}` wrapper is unnatural. OSS only forced dict because grounding needed named fields to project.

## Changes

- **`core/types/tool_call.py`**: add a `JsonValue` alias; retype `ToolResult.output` to `JsonValue`.
- **`environments/deterministic_environment.py`**: retype `ToolLookupEntry.output` to `JsonValue` (default `None`).
- **Grounding**: `sample_grounding` builds each fact row as a named-field projection. A non-dict output has no field names to project, so it now grounds on its **input fields only**; dict outputs still merge input+output (output wins on collision, unchanged).

No change needed in `conversation_synthesizer._tool_message` — it already `json.dumps`es non-str output, so lists/scalars/None serialize correctly. The synthetic env's `_parse_and_validate` still (correctly) requires dict for LLM-simulated output — separate constraint, left alone.

### Why grounding projects input-only for non-dict outputs

Grounding is a **named-field projection**: `grounding.tools[tool_id].fields` is a whitelist of field *names*, and each `GroundingFact` renders as `name=value` in the planner prompt. Only a dict exposes named fields; a bare scalar/list has no name to match against the whitelist. The tool *input* is always a dict, so it always projects — but a non-dict *output* contributes nothing.

Example — a `get_stock_price` tool grounded on `fields=["ticker", "price"]`:

| lookup entry | projected grounding fact |
| --- | --- |
| `input={"ticker":"AAPL"}, output={"price":191.23}` (dict) | `ticker=AAPL`, `price=191.23` |
| `input={"ticker":"AAPL"}, output=191.23` (scalar) | `ticker=AAPL` only |

The scalar `191.23` isn't rejected — it just can't answer "what is the `price` field?", so it contributes only its input fields.

## Tests

- Non-dict outputs (`float`, `int`, `list`, `str`, `bool`, `None`) round-trip through `step()`.
- Non-dict `ToolResult` output is json-encoded at the TOOL message boundary (`None`→`"null"`, `191.23`→`"191.23"`, list, `bool`).
- Scalar-output grounded tool projects input fields only (no output field, no crash).
- All existing grounding tests (dict-output merge path, output-wins-on-collision) still pass.

`tests/unit/environments/test_deterministic_environment.py`, `test_conversation_synthesizer.py`, and `tests/unit/core/types/` all green (192 passed).

> **CI note:** the red `static-checks` (pyright) check is **pre-existing on `main`** — 3 `reportOptional*` errors in `builders/training.py`, `core/datasets/vision_language_dpo_dataset.py`, and `core/tuners/optuna_tuner.py`, none of which this PR touches. Not introduced by this change.

Suggested reviewer: @wizeng23

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
