### PR TITLE
refactor(synth-env): rename SyntheticEnvironmentKwargs.system_prompt to tool_persona

### DIFF
--- a/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+++ b/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
@@ -48,7 +48,7 @@ environment_config:
       name: Docs Lookup
       description: MCP-style documentation lookup tools (LLM-simulated).
       env_kwargs:
-        system_prompt: |
+        tool_persona: |
           You are simulating an MCP-style documentation server that resolves
           library names to canonical IDs and returns documentation snippets
           and example code. Every response MUST be a JSON object that exactly

--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -236,7 +236,7 @@ environment_config:
       name: Support Backend
       description: Simulated support system with tickets and users
       type: synthetic
-      system_prompt: You manage a customer support system with tickets and users.
+      tool_persona: You manage a customer support system with tickets and users.
       state_params:
         state_schema:
           type: object
@@ -269,7 +269,7 @@ environment_config:
       name: FAQ Lookup
       description: Cached LLM-backed FAQ answers
       type: synthetic
-      system_prompt: Generate concise FAQ answers grounded in the tool contract.
+      tool_persona: Generate concise FAQ answers grounded in the tool contract.
       cache_by_input: true
       tools:
         - id: answer_faq

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -76,7 +76,7 @@ class SyntheticStateParams(BaseParams):
 class SyntheticEnvironmentKwargs(BaseParams):
     """Type-specific kwargs for SyntheticEnvironment."""
 
-    system_prompt: str = ""
+    tool_persona: str = ""
     state_params: SyntheticStateParams | None = None
     cache_by_input: bool = True
 
@@ -87,10 +87,8 @@ class SyntheticEnvironmentKwargs(BaseParams):
 
     def __finalize_and_validate__(self) -> None:
         """Finalize and validate the kwargs."""
-        if not self.system_prompt:
-            raise ValueError(
-                "SyntheticEnvironmentKwargs.system_prompt cannot be empty."
-            )
+        if not self.tool_persona:
+            raise ValueError("SyntheticEnvironmentKwargs.tool_persona cannot be empty.")
         if self.state_params is not None and self.cache_by_input:
             raise ValueError(
                 "SyntheticEnvironmentKwargs.cache_by_input must be False when "
@@ -431,7 +429,7 @@ class SyntheticEnvironment(BaseEnvironment):
     def _build_simulator_system_prompt(self, tool: ToolParams) -> str:
         """Compose the simulator system prompt: env persona + tool schema."""
         return (
-            f"{self._kwargs.system_prompt}\n\n"
+            f"{self._kwargs.tool_persona}\n\n"
             f"You are simulating the `{tool.id}` tool. Respond ONLY with a "
             f"JSON object matching the tool's output schema. Do NOT include "
             f"explanations, markdown, or surrounding prose.\n\n"

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -427,7 +427,7 @@ class SyntheticEnvironment(BaseEnvironment):
                 )
 
     def _build_simulator_system_prompt(self, tool: ToolParams) -> str:
-        """Compose the simulator system prompt: env persona + tool schema."""
+        """Compose the simulator system prompt: tool persona + tool schema."""
         return (
             f"{self._kwargs.tool_persona}\n\n"
             f"You are simulating the `{tool.id}` tool. Respond ONLY with a "

--- a/tests/unit/builders/test_environments.py
+++ b/tests/unit/builders/test_environments.py
@@ -61,7 +61,7 @@ def test_build_environment_dispatches_synthetic():
         description="FAQ tools",
         env_type="synthetic",
         tools=[ToolParams(id="answer", name="Answer", description="Answer.")],
-        env_kwargs={"system_prompt": "Answer FAQs."},
+        env_kwargs={"tool_persona": "Answer FAQs."},
     )
     env = build_environment(params)
     assert isinstance(env, SyntheticEnvironment)

--- a/tests/unit/core/configs/test_synthesis_config.py
+++ b/tests/unit/core/configs/test_synthesis_config.py
@@ -84,11 +84,11 @@ def _synthetic_env_params(
     env_id: str = "faq",
     name: str = "FAQ",
     description: str = "FAQ tools",
-    system_prompt: str = "Answer FAQs.",
+    tool_persona: str = "Answer FAQs.",
     tools: list[ToolParams] | None = None,
     extra_kwargs: dict | None = None,
 ) -> EnvironmentParams:
-    env_kwargs: dict = {"system_prompt": system_prompt}
+    env_kwargs: dict = {"tool_persona": tool_persona}
     if extra_kwargs:
         env_kwargs.update(extra_kwargs)
     return EnvironmentParams(
@@ -218,7 +218,7 @@ def test_synthesis_config_restricts_tools_to_selected_environments():
                 env_id="files",
                 name="Files",
                 description="File tools",
-                system_prompt="Manage files.",
+                tool_persona="Manage files.",
                 tools=[files_tool],
                 extra_kwargs={
                     "state_params": {},
@@ -260,7 +260,7 @@ def test_synthesis_config_resolves_all_tools_from_selected_environments():
                 env_id="files",
                 name="Files",
                 description="File tools",
-                system_prompt="Manage files.",
+                tool_persona="Manage files.",
                 tools=[files_tool],
                 extra_kwargs={
                     "state_params": {},

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2504,7 +2504,7 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
                 },
             )
         ],
-        env_kwargs={"system_prompt": "Simulate the lookup tool."},
+        env_kwargs={"tool_persona": "Simulate the lookup tool."},
     )
     env_config = EnvironmentConfig(environments=[env_params])
 

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -72,7 +72,7 @@ def _stateful_synth_env_params(env_id: str) -> EnvironmentParams:
         env_type="synthetic",
         tools=[],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": {"initial_state": {"rows": [{"id": "1"}]}},
             "cache_by_input": False,
         },
@@ -147,7 +147,7 @@ def test_from_environment_config_includes_grounding_only_envs():
         env_type="synthetic",
         tools=[],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": {"initial_state": {"rows": [{"id": "1"}]}},
             "cache_by_input": False,
         },

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -342,6 +342,7 @@ def test_build_call_conv_has_system_and_user_messages():
     assert conv.messages[0].role == Role.SYSTEM
     assert conv.messages[1].role == Role.USER
     assert "answer" in str(conv.messages[0].content)
+    assert "Answer FAQs as a JSON tool" in str(conv.messages[0].content)
     user_payload = str(conv.messages[1].content)
     assert '"tool"' in user_payload and '"answer"' in user_payload
 

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -62,7 +62,7 @@ def _make_params(**overrides) -> EnvironmentParams:
         description="FAQ tools",
         env_type="synthetic",
         tools=[_make_tool()],
-        env_kwargs={"system_prompt": "Answer FAQs."},
+        env_kwargs={"tool_persona": "Answer FAQs."},
     )
     defaults.update(overrides)
     return EnvironmentParams(**defaults)
@@ -79,7 +79,7 @@ def test_from_params_constructs_stateful():
     params = _make_params(
         tools=[_make_tool(executor=f"{__name__}._state_increment")],
         env_kwargs={
-            "system_prompt": "You manage a filesystem.",
+            "tool_persona": "You manage a filesystem.",
             "state_params": SyntheticStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
@@ -98,7 +98,7 @@ def test_stateful_mode_requires_executor_on_every_tool():
             _make_tool(id="without_exec"),
         ],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(initial_state={"counter": 0}),
             "cache_by_input": False,
         },
@@ -109,16 +109,16 @@ def test_stateful_mode_requires_executor_on_every_tool():
         SyntheticEnvironment.from_params(params)
 
 
-def test_empty_system_prompt_raises():
-    params = _make_params(env_kwargs={"system_prompt": ""})
-    with pytest.raises(ValueError, match="system_prompt cannot be empty"):
+def test_empty_tool_persona_raises():
+    params = _make_params(env_kwargs={"tool_persona": ""})
+    with pytest.raises(ValueError, match="tool_persona cannot be empty"):
         SyntheticEnvironment.from_params(params)
 
 
 def test_rejects_cache_when_stateful():
     params = _make_params(
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(),
             "cache_by_input": True,
         }
@@ -178,7 +178,7 @@ def _typed_params() -> EnvironmentParams:
         description="FAQ env",
         env_type="synthetic",
         tools=[_typed_tool()],
-        env_kwargs={"system_prompt": "Answer FAQs as a JSON tool."},
+        env_kwargs={"tool_persona": "Answer FAQs as a JSON tool."},
     )
 
 
@@ -302,7 +302,7 @@ def test_step_no_output_schema_accepts_any_object():
         description="FAQ env",
         env_type="synthetic",
         tools=[tool],
-        env_kwargs={"system_prompt": "Answer FAQs."},
+        env_kwargs={"tool_persona": "Answer FAQs."},
     )
     env = SyntheticEnvironment.from_params(params)
     mock_engine = Mock()
@@ -394,7 +394,7 @@ def test_stateful_executor_threads_state_and_mutates():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
@@ -420,7 +420,7 @@ def test_read_only_tool_rejected_when_executor_returns_state():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
@@ -444,7 +444,7 @@ def test_updated_state_validated_against_schema():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
@@ -480,7 +480,7 @@ def test_executor_returning_non_toolresult_raises():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
@@ -504,7 +504,7 @@ def test_state_grounding_projects_from_state_path():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema={"type": "object"},
                 initial_state={
@@ -543,7 +543,7 @@ def test_state_grounding_state_path_missing_raises_at_init():
     params = _make_params(
         tools=[tool],
         env_kwargs={
-            "system_prompt": "p",
+            "tool_persona": "p",
             "state_params": SyntheticStateParams(
                 state_schema={"type": "object"},
                 initial_state={"files": {"count": 0}},


### PR DESCRIPTION
## Summary

Renames the synthetic environment's env-level tool system-instruction field from `system_prompt` to `tool_persona`.

This is a piping rename that aligns OSS with the enterprise API (oumi-ai/api#5314), which already exposes this field as `tool_persona` on `SyntheticEnvironmentConfig`. The new name makes clear to users that this is a persona/instruction prepended to the simulator's system prompt — **not** decoding/generation instructions.

## What changed
- `SyntheticEnvironmentKwargs.system_prompt` → `tool_persona` (field, non-empty validation, error message, and its use in `_build_simulator_system_prompt`).
- Updated all call sites: unit tests, `configs/examples/synthesis/mcp_docs_lookup_synth.yaml`, and `docs/user_guides/synth.md`.

## ⚠️ Breaking change
This renames a public config field. Existing synthesis configs / persisted `env_kwargs` that use the old `system_prompt` key will fail fast: `SyntheticEnvironmentKwargs(**env_kwargs)` raises `TypeError: ... unexpected keyword argument 'system_prompt'`, naming the offending key. This is intentional — no back-compat alias is added; migrate configs to `tool_persona`. All in-repo configs and docs have been migrated (repo-wide YAML sweep confirms no synthetic-env `system_prompt` key remains; the only surviving `system_prompt` references are the unrelated inference-config field and the synthesizer's `output_system_prompt`).

## Scope
- **Env-level rename only.** `tool_persona` remains a single string shared across the env's tools.
- Field stays **required** (non-empty validation unchanged).
- Explicitly deferred (separate future decisions): per-tool personas, and making the persona optional.
- Untouched: the inference-config `system_prompt`, the synthesizer's `output_system_prompt`, and the `_build_simulator_system_prompt` method name (it builds the simulator's actual system prompt).

## Self-review (eng:pr-review)
Seven-analyzer pass; three findings surfaced, all addressed:
- Documented the breaking rename above (was undocumented).
- Added an assertion in `test_build_call_conv_has_system_and_user_messages` that the configured `tool_persona` text is actually injected into the composed simulator prompt — directly guards the renamed `_build_simulator_system_prompt` wiring.
- Aligned the `_build_simulator_system_prompt` docstring vocabulary ("env persona" → "tool persona") with the renamed field.

## Test
`pytest tests/unit/environments/test_synthetic_environment.py tests/unit/core/synthesis/ tests/unit/builders/test_environments.py tests/unit/core/configs/test_synthesis_config.py` — 326 passed.

Suggested reviewer: @wizeng23

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
