### PR TITLE
fix(inference): omit sampling params for Anthropic models that reject them

### DIFF
--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -172,13 +172,23 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             "model": model_params.model_name,
             "messages": self._messages_to_anthropic_blocks(messages),
             "max_tokens": generation_params.max_new_tokens,
-            "temperature": generation_params.temperature,
         }
 
-        # Only include top_p if it's explicitly set (Sonnet 4.5 requires only one of
-        # temperature or top_p to be set, not both)
-        if generation_params.top_p is not None:
-            body["top_p"] = generation_params.top_p
+        # Anthropic removed the sampling params (temperature/top_p/top_k) on its
+        # reasoning-first models (Claude Opus 4.7+, Fable/Mythos): sending them
+        # returns HTTP 400. Omit them there; every other Claude model keeps its
+        # configured values.
+        if _model_supports_sampling_params(model_params.model_name):
+            body["temperature"] = generation_params.temperature
+            # Only include top_p if it's explicitly set (Sonnet 4.5 requires only
+            # one of temperature or top_p to be set, not both).
+            if generation_params.top_p is not None:
+                body["top_p"] = generation_params.top_p
+        else:
+            logger.debug(
+                "%r does not accept sampling params; omitting temperature/top_p.",
+                model_params.model_name,
+            )
 
         if self._remote_params.user_id:
             body["metadata"] = {"user_id": self._remote_params.user_id}
@@ -1008,3 +1018,18 @@ def _model_supports_output_config(model_name: str) -> bool:
     version_re = re.compile(r"^claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)")
     match = version_re.match(model_name)
     return (int(match[1]), int(match[2])) >= (4, 5) if match else False
+
+
+def _model_supports_sampling_params(model_name: str) -> bool:
+    """Returns True if the model accepts sampling params (temperature/top_p)."""
+    # Anthropic removed the sampling params (temperature/top_p/top_k) on its
+    # reasoning-first models: Claude Opus 4.7+ and the Fable/Mythos families return
+    # HTTP 400 ("`temperature` is deprecated for this model."). Opus 4.6 and earlier,
+    # all Sonnet and Haiku, and Claude 3.x still accept them.
+    if model_name.startswith(("claude-fable", "claude-mythos")):
+        return False
+
+    match = re.match(r"^claude-opus-(\d+)-(\d+)", model_name)
+    if match:
+        return (int(match[1]), int(match[2])) < (4, 7)
+    return True

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -174,20 +174,22 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             "max_tokens": generation_params.max_new_tokens,
         }
 
-        # Anthropic removed the sampling params (temperature/top_p/top_k) on its
-        # reasoning-first models (Claude Opus 4.7+, Fable/Mythos): sending them
-        # returns HTTP 400. Omit them there; every other Claude model keeps its
-        # configured values.
         if _model_supports_sampling_params(model_params.model_name):
             body["temperature"] = generation_params.temperature
-            # Only include top_p if it's explicitly set (Sonnet 4.5 requires only
-            # one of temperature or top_p to be set, not both).
+            # Only include top_p if explicitly set — Claude 4+ rejects a request
+            # that sets both temperature and top_p.
             if generation_params.top_p is not None:
                 body["top_p"] = generation_params.top_p
-        else:
-            logger.debug(
-                "%r does not accept sampling params; omitting temperature/top_p.",
+        elif (
+            generation_params.temperature != 0.0 or generation_params.top_p is not None
+        ):
+            # Warn only when discarding a non-default value the user actually set.
+            logger.warning(
+                "%r does not accept sampling params; "
+                "omitting temperature=%s / top_p=%s.",
                 model_params.model_name,
+                generation_params.temperature,
+                generation_params.top_p,
             )
 
         if self._remote_params.user_id:
@@ -1021,7 +1023,7 @@ def _model_supports_output_config(model_name: str) -> bool:
 
 
 def _model_supports_sampling_params(model_name: str) -> bool:
-    """Returns True if the model accepts sampling params (temperature/top_p)."""
+    """Returns True if the model accepts sampling params, False otherwise."""
     # Anthropic removed the sampling params (temperature/top_p/top_k) on its
     # reasoning-first models: Claude Opus 4.7+ and the Fable/Mythos families return
     # HTTP 400 ("`temperature` is deprecated for this model."). Opus 4.6 and earlier,
@@ -1029,7 +1031,6 @@ def _model_supports_sampling_params(model_name: str) -> bool:
     if model_name.startswith(("claude-fable", "claude-mythos")):
         return False
 
-    match = re.match(r"^claude-opus-(\d+)-(\d+)", model_name)
-    if match:
-        return (int(match[1]), int(match[2])) < (4, 7)
-    return True
+    version_re = re.compile(r"^claude-opus-(\d+)-(\d+)")
+    match = version_re.match(model_name)
+    return (int(match[1]), int(match[2])) < (4, 7) if match else True

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -135,6 +136,59 @@ def test_convert_conversation_includes_sampling_params_for_supported_models():
 
     assert result["temperature"] == 0.3
     assert result["top_p"] == 0.9
+
+
+def test_convert_conversation_includes_temperature_omits_unset_top_p():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-4-6"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(max_new_tokens=100, temperature=0.3),
+        engine._model_params,
+    )
+
+    assert result["temperature"] == 0.3
+    assert "top_p" not in result
+
+
+def test_convert_conversation_warns_when_dropping_nondefault_sampling_params(caplog):
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-4-8"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    with caplog.at_level(logging.WARNING):
+        engine._convert_conversation_to_api_input(
+            conversation,
+            GenerationParams(max_new_tokens=100, temperature=0.7),
+            engine._model_params,
+        )
+
+    assert any("does not accept sampling params" in r.message for r in caplog.records)
+
+
+def test_convert_conversation_silent_when_dropping_default_sampling_params(caplog):
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-4-8"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    with caplog.at_level(logging.WARNING):
+        engine._convert_conversation_to_api_input(
+            conversation,
+            GenerationParams(max_new_tokens=100),
+            engine._model_params,
+        )
+
+    assert not any(
+        "does not accept sampling params" in r.message for r in caplog.records
+    )
 
 
 def test_convert_api_output_to_conversation(anthropic_engine):

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -14,7 +14,10 @@ from oumi.core.types.conversation import (
     Type,
 )
 from oumi.core.types.tool_call import ToolCall, ToolDefinition
-from oumi.inference.anthropic_inference_engine import AnthropicInferenceEngine
+from oumi.inference.anthropic_inference_engine import (
+    AnthropicInferenceEngine,
+    _model_supports_sampling_params,
+)
 from oumi.inference.remote_inference_engine import BatchInfo, BatchStatus
 
 
@@ -77,6 +80,61 @@ def test_convert_conversation_omits_metadata_without_user_id(anthropic_engine):
     )
 
     assert "metadata" not in result
+
+
+@pytest.mark.parametrize(
+    ("model_name", "supported"),
+    [
+        ("claude-opus-4-6", True),
+        ("claude-opus-4-5-20251101", True),
+        ("claude-opus-4-7", False),
+        ("claude-opus-4-8", False),
+        ("claude-opus-4-9", False),  # future Opus stays gated
+        ("claude-sonnet-4-6", True),
+        ("claude-haiku-4-5", True),
+        ("claude-3-5-sonnet-20241022", True),
+        ("claude-3", True),
+        ("claude-fable-5", False),
+        ("claude-mythos-5", False),
+        ("claude-mythos-preview", False),
+    ],
+)
+def test_model_supports_sampling_params(model_name, supported):
+    assert _model_supports_sampling_params(model_name) is supported
+
+
+def test_convert_conversation_omits_sampling_params_for_reasoning_models():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-4-8"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(max_new_tokens=100, temperature=0.0, top_p=0.9),
+        engine._model_params,
+    )
+
+    assert "temperature" not in result
+    assert "top_p" not in result
+
+
+def test_convert_conversation_includes_sampling_params_for_supported_models():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-4-6"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(max_new_tokens=100, temperature=0.3, top_p=0.9),
+        engine._model_params,
+    )
+
+    assert result["temperature"] == 0.3
+    assert result["top_p"] == 0.9
 
 
 def test_convert_api_output_to_conversation(anthropic_engine):


### PR DESCRIPTION
## Problem

Anthropic removed the sampling parameters (`temperature`, `top_p`, `top_k`) on its reasoning-first models — Claude **Opus 4.7+** and the **Fable / Mythos** families. Sending any of them now returns:

```
400 invalid_request_error: `temperature` is deprecated for this model.
```

`AnthropicInferenceEngine._convert_conversation_to_api_input` puts `temperature` in the request body **unconditionally**, and `GenerationParams.temperature` is a non-optional `float` defaulting to `0.0` — so every request to one of these models fails, and they can't be used through the Anthropic engine at all. Opus 4.6 and earlier, all Sonnet/Haiku, and Claude 3.x still accept the params.

Confirmed against the live API:

| Model | with `temperature` | without `temperature` |
|---|---|---|
| `claude-opus-4-8` | 400 (deprecated) | 200 |
| `claude-opus-4-7` | 400 (deprecated) | 200 |
| `claude-opus-4-6` | 200 | 200 |

## Fix

Add a per-model `_model_supports_sampling_params(model_name)` gate — mirroring the existing `_model_supports_output_config` helper in the same file — and only include `temperature` / `top_p` for models that accept them. Models that reject them get a request without those fields (plus a `debug` log); every other model keeps its configured values unchanged. The gate returns `False` for `claude-fable*` / `claude-mythos*` and `claude-opus-{>=4.7}` (version-tuple compare, so future Opus releases stay gated), `True` otherwise.

`top_p` was already conditional (only sent when explicitly set); it now shares the same per-model gate, since Anthropic removed the sampling params as a group.

## Tests

- `test_model_supports_sampling_params` — parametrized across Opus 4.5/4.6/4.7/4.8/4.9, Sonnet 4.6, Haiku 4.5, Claude 3.x, Fable 5, Mythos 5 / preview.
- `test_convert_conversation_omits_sampling_params_for_reasoning_models` — an Opus 4.8 body has no `temperature`/`top_p`.
- `test_convert_conversation_includes_sampling_params_for_supported_models` — an Opus 4.6 body keeps both.

`pytest tests/unit/inference/test_anthropic_inference_engine.py` → **51 passed**; `ruff` + `ruff-format` clean.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
