### PR TITLE
fix(types): narrow three Optional-access sites flagged by newer pyright

### DIFF
--- a/src/oumi/builders/training.py
+++ b/src/oumi/builders/training.py
@@ -62,13 +62,12 @@ def build_trainer(
         cls: type[transformers.Trainer],
     ) -> Callable[..., BaseTrainer]:
         def _init_hf_trainer(*args, **kwargs) -> BaseTrainer:
-            training_args = kwargs.pop("args", None)
+            training_args = cast(TrainingParams | None, kwargs.pop("args", None))
             training_config = kwargs.pop("training_config", None)
             callbacks = kwargs.pop("callbacks", [])
-            if training_args is not None:
-                # if set, convert to HuggingFace Trainer args format
-                training_args = cast(TrainingParams, training_args)
-                training_args.finalize_and_validate()
+            if training_args is None:
+                raise ValueError("Building a trainer requires `args` (TrainingParams).")
+            training_args.finalize_and_validate()
 
             hf_args = training_args.to_hf(training_config)
             if verbose and is_world_process_zero():

--- a/src/oumi/core/datasets/vision_language_dpo_dataset.py
+++ b/src/oumi/core/datasets/vision_language_dpo_dataset.py
@@ -169,8 +169,7 @@ class VisionLanguageDpoDataset(BaseDpoDataset):
         images = [images] if isinstance(images, dict) else images
 
         # Load and resize the images.
-        if images is not None:
-            images = [self._resize_image(self._load_image(image)) for image in images]
+        images = [self._resize_image(self._load_image(image)) for image in images]
 
         # Add the image turns to the prompt if not already present.
         if all(isinstance(turn["content"], str) for turn in prompt_chat):

--- a/src/oumi/core/tuners/optuna_tuner.py
+++ b/src/oumi/core/tuners/optuna_tuner.py
@@ -177,6 +177,7 @@ class OptunaTuner(BaseTuner):
             return metric_values[0] if len(metric_values) == 1 else metric_values
 
         # Run optimization
+        assert self._study  # populated by create_study() above
         self._study.optimize(_objective, n_trials=n_trials)
 
     def get_best_trials(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## What

Fixes the three `reportOptional*` errors currently failing `static-checks` on `main`:

| File:line | Error |
|---|---|
| `builders/training.py:73` | `to_hf` is not a known attribute of `None` |
| `core/datasets/vision_language_dpo_dataset.py:177` | Object of type `None` cannot be used as iterable |
| `core/tuners/optuna_tuner.py:180` | `optimize` is not a known attribute of `None` |

## Why these landed

None of these are new code — blame dates them to Aug/Nov 2025, and they merged **green**. The pyright hook runs unpinned:

```
entry: env PYRIGHT_PYTHON_PYLANCE_VERSION=latest-release pyright
```

so a newer pyright release (now `1.1.411`) tightened Optional-narrowing and began flagging code the older checker accepted — turning `static-checks` red with **no source change**. (Same class as #2187, *"fix pyright failure by removing warning"*.)

## The fixes

- **training.py** — `kwargs.pop("args", None)` is untyped, so pyright inferred `None`. Cast it to `TrainingParams | None` and require it: the `to_hf` call already assumed non-None, so `None` now raises a clear `ValueError` instead of a cryptic `AttributeError`.
- **vision_language_dpo_dataset.py** — `images = ... or []` already guarantees a list, so the `if images is not None` guard was dead — and its un-taken branch is exactly what reintroduced `None` at the downstream `for image in images`. Removed it.
- **optuna_tuner.py** — `create_study()` populates `self._study` via a side effect pyright can't track. Added `assert self._study`, matching the existing idiom in `save_study()`.

## Not included (deliberate)

This does **not** pin pyright — that's a policy call (pin-and-bump-deliberately vs. keep `latest-release` but make `static-checks` a required check). Happy to follow up whichever way maintainers prefer.

## Verification

- `pyright` on the three files: all three target errors gone.
- `ruff` + `ruff-format`: pass.
- `tests/unit/core/tuners/test_optuna_tuner.py`, `tests/unit/datasets/test_vision_dpo_jsonlines_dataset.py`, `tests/unit/datasets/test_base_dpo_dataset.py`: pass.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
