### PR TITLE
feat(collators): add pad_to_multiple_of to TextCompletionsCollatorWithPadding

### DIFF
--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -113,10 +113,19 @@ class TextCompletionsCollatorWithPadding:
         # An all-ones mask carries no information, but its presence makes
         # transformers wrap attention in per-batch mask closures that compiled
         # attention backends cannot cache (torch.compile guards on closure
-        # identity). Dropping it keeps the pure-causal fast path.
+        # identity). Replace it with explicit sequential position_ids: models
+        # derive identical positions themselves, attention falls back to the
+        # pure-causal fast path, and TRL's token accounting accepts
+        # position_ids in lieu of a mask (its padding-free convention).
         mask = result.get("attention_mask")
         if mask is not None and bool(mask.all()):
             del result["attention_mask"]
+            batch_size = result[_INPUT_IDS_KEY].shape[0]
+            result["position_ids"] = (
+                torch.arange(target, dtype=torch.long)
+                .unsqueeze(0)
+                .repeat(batch_size, 1)
+            )
         return result
 
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -74,9 +74,14 @@ class TextCompletionsCollatorWithPadding:
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:
             raise RuntimeError("Tokenizer doesn't define `pad_token_id`.")
+        elif not isinstance(tokenizer.pad_token_id, int):
+            raise RuntimeError(
+                "Tokenizer's `pad_token_id` is not an integer. "
+                f"{tokenizer.pad_token_id}. Type: {type(tokenizer.pad_token_id)}"
+            )
 
         self._pad_to_multiple_of = pad_to_multiple_of
-        self._pad_token_id = int(tokenizer.pad_token_id)
+        self._pad_token_id = tokenizer.pad_token_id
         self._ignore_index = ignore_index
         self._debug = debug
         self._has_logged_example = False

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -79,6 +79,7 @@ class TextCompletionsCollatorWithPadding:
         self._pad_to_multiple_of = pad_to_multiple_of
         self._pad_token_id = tokenizer.pad_token_id
         self._ignore_index = ignore_index
+        self._padding_side = str(getattr(tokenizer, "padding_side", "right"))
         self._debug = debug
         self._has_logged_example = False
 
@@ -102,17 +103,20 @@ class TextCompletionsCollatorWithPadding:
             return torch.cat([tensor, tail], dim=1)
 
         result[_INPUT_IDS_KEY] = _extend(result[_INPUT_IDS_KEY], self._pad_token_id)
-        if "attention_mask" in result:
-            result["attention_mask"] = _extend(result["attention_mask"], 1)
         if "labels" in result:
             result["labels"] = _extend(result["labels"], self._ignore_index)
-        # An all-ones mask still forces transformers to build per-batch mask
-        # closures that break torch.compile caching and knock flex_attention
-        # off its fast path. Swap it for sequential position_ids — what the
-        # model derives anyway (identical numerics), which TRL accepts in lieu
-        # of a mask.
-        mask = result.get("attention_mask")
-        if mask is not None and bool(mask.all()):
+        if "attention_mask" not in result:
+            return result
+
+        # Any attention_mask — all-ones, or the [1..|0..|1..] of a mixed-length
+        # batch — forces transformers to build per-batch mask closures that
+        # break torch.compile caching and knock flex_attention off its fast
+        # path. With right padding we can drop it entirely for sequential
+        # position_ids: real tokens form a prefix, so they never attend padding
+        # and their positions equal ``arange`` (identical numerics), padding
+        # labels are ignore_index (no loss/grad), and TRL accepts position_ids
+        # in lieu of a mask. Left padding needs the mask, so keep it there.
+        if self._padding_side == "right":
             del result["attention_mask"]
             batch_size = result[_INPUT_IDS_KEY].shape[0]
             result["position_ids"] = (
@@ -120,6 +124,8 @@ class TextCompletionsCollatorWithPadding:
                 .unsqueeze(0)
                 .repeat(batch_size, 1)
             )
+        else:
+            result["attention_mask"] = _extend(result["attention_mask"], 1)
         return result
 
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -55,13 +55,9 @@ class TextCompletionsCollatorWithPadding:
             compiled attention kernels (e.g. ``flex_attention``, block size
             128) cannot compile sequences shorter than one block; padding to
             the block size keeps short samples trainable. The extra positions
-            carry ``attention_mask=1`` and ``labels=ignore_index``: with right
-            padding and causal attention no real token can attend a padding
-            position, and ignored labels contribute no loss or gradient, so
-            training is numerically unchanged — while the all-ones mask keeps
-            compiled attention backends on their fused fast path (a padding
-            mask forces per-batch mask closures that defeat ``torch.compile``
-            caching and silently degrade to the memory-unsafe eager kernel).
+            carry ``labels=ignore_index`` and, under causal attention, are
+            never attended by real tokens, so training is numerically
+            unchanged.
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
@@ -110,13 +106,11 @@ class TextCompletionsCollatorWithPadding:
             result["attention_mask"] = _extend(result["attention_mask"], 1)
         if "labels" in result:
             result["labels"] = _extend(result["labels"], self._ignore_index)
-        # An all-ones mask carries no information, but its presence makes
-        # transformers wrap attention in per-batch mask closures that compiled
-        # attention backends cannot cache (torch.compile guards on closure
-        # identity). Replace it with explicit sequential position_ids: models
-        # derive identical positions themselves, attention falls back to the
-        # pure-causal fast path, and TRL's token accounting accepts
-        # position_ids in lieu of a mask (its padding-free convention).
+        # An all-ones mask still forces transformers to build per-batch mask
+        # closures that break torch.compile caching and knock flex_attention
+        # off its fast path. Swap it for sequential position_ids — what the
+        # model derives anyway (identical numerics), which TRL accepts in lieu
+        # of a mask.
         mask = result.get("attention_mask")
         if mask is not None and bool(mask.all()):
             del result["attention_mask"]

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -105,6 +105,13 @@ class TextCompletionsCollatorWithPadding:
             result["attention_mask"] = _extend(result["attention_mask"], 1)
         if "labels" in result:
             result["labels"] = _extend(result["labels"], self._ignore_index)
+        # An all-ones mask carries no information, but its presence makes
+        # transformers wrap attention in per-batch mask closures that compiled
+        # attention backends cannot cache (torch.compile guards on closure
+        # identity). Dropping it keeps the pure-causal fast path.
+        mask = result.get("attention_mask")
+        if mask is not None and bool(mask.all()):
+            del result["attention_mask"]
         return result
 
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -33,6 +33,7 @@ class TextCompletionsCollatorWithPadding:
         debug: bool = False,
         end_of_turn_template: str | None = None,
         ignore_index: int = -100,
+        pad_to_multiple_of: int | None = None,
     ):
         """Custom collator for text LLM training.
 
@@ -47,6 +48,12 @@ class TextCompletionsCollatorWithPadding:
             Required for ``all_assistant_turns``.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
+        pad_to_multiple_of: If set, pad each batch up to a multiple of this
+            value instead of exactly the longest sequence in the batch. Some
+            compiled attention kernels (e.g. ``flex_attention``, block size
+            128) cannot compile sequences shorter than one block; padding to
+            the block size keeps short samples trainable. Padding positions
+            are excluded from attention and loss as usual.
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
@@ -55,6 +62,7 @@ class TextCompletionsCollatorWithPadding:
             train_target=train_target,
             end_of_turn_template=end_of_turn_template,
             ignore_index=ignore_index,
+            pad_to_multiple_of=pad_to_multiple_of,
         )
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -14,6 +14,8 @@
 
 from typing import Any
 
+import torch
+
 from oumi.core.collators.trl_data_collator_for_completion_only_lm import (
     DataCollatorForCompletionOnlyLM,
 )
@@ -52,8 +54,14 @@ class TextCompletionsCollatorWithPadding:
             value instead of exactly the longest sequence in the batch. Some
             compiled attention kernels (e.g. ``flex_attention``, block size
             128) cannot compile sequences shorter than one block; padding to
-            the block size keeps short samples trainable. Padding positions
-            are excluded from attention and loss as usual.
+            the block size keeps short samples trainable. The extra positions
+            carry ``attention_mask=1`` and ``labels=ignore_index``: with right
+            padding and causal attention no real token can attend a padding
+            position, and ignored labels contribute no loss or gradient, so
+            training is numerically unchanged — while the all-ones mask keeps
+            compiled attention backends on their fused fast path (a padding
+            mask forces per-batch mask closures that defeat ``torch.compile``
+            caching and silently degrade to the memory-unsafe eager kernel).
         """
         self._default_collator = DataCollatorForCompletionOnlyLM(
             tokenizer=tokenizer,
@@ -62,17 +70,41 @@ class TextCompletionsCollatorWithPadding:
             train_target=train_target,
             end_of_turn_template=end_of_turn_template,
             ignore_index=ignore_index,
-            pad_to_multiple_of=pad_to_multiple_of,
         )
 
         if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:
             raise RuntimeError("Tokenizer doesn't define `pad_token_id`.")
 
+        self._pad_to_multiple_of = pad_to_multiple_of
+        self._pad_token_id = int(tokenizer.pad_token_id)
+        self._ignore_index = ignore_index
         self._debug = debug
         self._has_logged_example = False
 
     def _collate(self, inputs: list[Any]) -> dict[str, Any]:
         result = self._default_collator(inputs)
+        if self._pad_to_multiple_of:
+            result = self._pad_batch_to_multiple(result)
+        return result
+
+    def _pad_batch_to_multiple(self, result: dict[str, Any]) -> dict[str, Any]:
+        multiple = self._pad_to_multiple_of
+        assert multiple is not None
+        seq_len = result[_INPUT_IDS_KEY].shape[1]
+        target = ((seq_len + multiple - 1) // multiple) * multiple
+        extra = target - seq_len
+        if extra == 0:
+            return result
+
+        def _extend(tensor: torch.Tensor, value: int) -> torch.Tensor:
+            tail = tensor.new_full((tensor.shape[0], extra), value)
+            return torch.cat([tensor, tail], dim=1)
+
+        result[_INPUT_IDS_KEY] = _extend(result[_INPUT_IDS_KEY], self._pad_token_id)
+        if "attention_mask" in result:
+            result["attention_mask"] = _extend(result["attention_mask"], 1)
+        if "labels" in result:
+            result["labels"] = _extend(result["labels"], self._ignore_index)
         return result
 
     def __call__(self, batch: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -286,6 +287,14 @@ def train(
 ) -> None | dict[str, Any]:
     """Trains a model using the provided configuration."""
     _START_TIME = time.time()
+
+    # torch exposes no env var for the dynamo recompile limit; compiled
+    # attention backends (flex_attention) on variable-shape data can need
+    # more than the default 8 before shapes go dynamic.
+    recompile_limit = os.environ.get("OUMI_DYNAMO_RECOMPILE_LIMIT")
+    if recompile_limit:
+        torch._dynamo.config.recompile_limit = int(recompile_limit)
+        torch._dynamo.config.cache_size_limit = int(recompile_limit)
 
     _create_training_dirs(config)
     _log_training_info(config)

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -278,6 +278,26 @@ def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
     _log_feedback_request()
 
 
+# flex_attention buckets variable-length batches into one compiled shape per
+# `pad_to_multiple_of` multiple, and its GLOBAL_STATE guards can churn on top of
+# that; either can exhaust torch dynamo's default recompile limit (8) and
+# silently degrade to the eager kernel (quadratic memory -> OOM at long
+# context). Torch has no env var for this, so we set it in code whenever a batch
+# is padded to a multiple. Override with OUMI_DYNAMO_RECOMPILE_LIMIT.
+_DEFAULT_DYNAMO_RECOMPILE_LIMIT = 64
+
+
+def _maybe_raise_dynamo_recompile_limit(config: TrainingConfig) -> None:
+    collator_kwargs = config.data.get_split(DatasetSplit.TRAIN).collator_kwargs or {}
+    if not collator_kwargs.get("pad_to_multiple_of"):
+        return
+    override = os.environ.get("OUMI_DYNAMO_RECOMPILE_LIMIT")
+    limit = int(override) if override else _DEFAULT_DYNAMO_RECOMPILE_LIMIT
+    torch._dynamo.config.recompile_limit = limit
+    torch._dynamo.config.cache_size_limit = limit
+    logger.info(f"Set torch dynamo recompile limit to {limit} (pad_to_multiple_of).")
+
+
 def train(
     config: TrainingConfig,
     additional_model_kwargs: dict[str, Any] | None = None,
@@ -288,13 +308,7 @@ def train(
     """Trains a model using the provided configuration."""
     _START_TIME = time.time()
 
-    # torch exposes no env var for the dynamo recompile limit; compiled
-    # attention backends (flex_attention) on variable-shape data can need
-    # more than the default 8 before shapes go dynamic.
-    recompile_limit = os.environ.get("OUMI_DYNAMO_RECOMPILE_LIMIT")
-    if recompile_limit:
-        torch._dynamo.config.recompile_limit = int(recompile_limit)
-        torch._dynamo.config.cache_size_limit = int(recompile_limit)
+    _maybe_raise_dynamo_recompile_limit(config)
 
     _create_training_dirs(config)
     _log_training_info(config)

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -565,8 +565,11 @@ def test_pad_to_multiple_of_rounds_batch_length_up():
     seq_len = batch["input_ids"].shape[1]
     assert seq_len == 128
     num_real = len(short_row["input_ids"])
-    # Padding positions are invisible to attention and loss.
-    assert batch["attention_mask"][0, num_real:].sum() == 0
+    # Alignment padding is attended (attention_mask=1): causal attention keeps
+    # real tokens from seeing forward positions, ignored labels keep the loss
+    # unchanged, and an all-ones mask keeps compiled attention on the fused
+    # path instead of per-batch padding-mask closures.
+    assert (batch["attention_mask"][0, num_real:] == 1).all()
     assert (batch["input_ids"][0, num_real:] == pad_token_id).all()
     assert (batch["labels"][0, num_real:] == IGNORE).all()
     # Real completion tokens keep their labels.

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -565,11 +565,12 @@ def test_pad_to_multiple_of_rounds_batch_length_up():
     seq_len = batch["input_ids"].shape[1]
     assert seq_len == 128
     num_real = len(short_row["input_ids"])
-    # Alignment padding is attended (attention_mask=1): causal attention keeps
-    # real tokens from seeing forward positions, ignored labels keep the loss
-    # unchanged, and an all-ones mask keeps compiled attention on the fused
-    # path instead of per-batch padding-mask closures.
-    assert (batch["attention_mask"][0, num_real:] == 1).all()
+    # Alignment padding is attended: causal attention keeps real tokens from
+    # seeing forward positions and ignored labels keep the loss unchanged. The
+    # resulting all-ones attention_mask is dropped so compiled attention
+    # backends keep the pure-causal fast path (a mask tensor forces per-batch
+    # mask closures that defeat torch.compile caching).
+    assert "attention_mask" not in batch
     assert (batch["input_ids"][0, num_real:] == pad_token_id).all()
     assert (batch["labels"][0, num_real:] == IGNORE).all()
     # Real completion tokens keep their labels.

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -565,12 +565,11 @@ def test_pad_to_multiple_of_rounds_batch_length_up():
     seq_len = batch["input_ids"].shape[1]
     assert seq_len == 128
     num_real = len(short_row["input_ids"])
-    # Alignment padding is attended: causal attention keeps real tokens from
-    # seeing forward positions and ignored labels keep the loss unchanged. The
-    # all-ones attention_mask is replaced by sequential position_ids so
-    # compiled attention backends keep the pure-causal fast path (a mask
-    # tensor forces per-batch closures that defeat torch.compile caching)
-    # while TRL's token accounting stays satisfied.
+    # The all-ones attention_mask is dropped for sequential position_ids so
+    # compiled attention backends keep the closure-free causal fast path (a
+    # mask tensor forces per-batch closures that defeat torch.compile caching;
+    # TRL's token accounting accepts position_ids in lieu of a mask). Padding
+    # adds no loss (ignore_index) and, under causal attention, is unattended.
     assert "attention_mask" not in batch
     assert (batch["position_ids"][0] == torch.arange(128)).all()
     assert (batch["input_ids"][0, num_real:] == pad_token_id).all()

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -535,3 +535,66 @@ def test_span_masking_with_leading_newline_content():
     content_start = len(resp_ids)
     content_region = labels[content_start : content_start + len(nl_ids) + len(content)]
     assert all(v != IGNORE for v in content_region)
+
+
+def test_pad_to_multiple_of_rounds_batch_length_up():
+    tokenizer, pad_token_id = create_test_tokenizer()
+
+    instruction_prefix = "ignore this and after me"
+    response_prefix = "ignore this but not after me"
+    instruction_prefix_tokens = tokenizer.encode(
+        instruction_prefix, add_special_tokens=False
+    )
+    response_prefix_tokens = tokenizer.encode(response_prefix, add_special_tokens=False)
+
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
+        train_target="_legacy_instruction_response",
+        pad_to_multiple_of=128,
+    )
+
+    short_row = {
+        "input_ids": (
+            instruction_prefix_tokens + response_prefix_tokens + [201, 202, 203]
+        )
+    }
+    batch = collator([short_row])
+
+    seq_len = batch["input_ids"].shape[1]
+    assert seq_len == 128
+    num_real = len(short_row["input_ids"])
+    # Padding positions are invisible to attention and loss.
+    assert batch["attention_mask"][0, num_real:].sum() == 0
+    assert (batch["input_ids"][0, num_real:] == pad_token_id).all()
+    assert (batch["labels"][0, num_real:] == IGNORE).all()
+    # Real completion tokens keep their labels.
+    expected_tail = torch.tensor([201, 202, 203])
+    assert (batch["labels"][0, num_real - 3 : num_real] == expected_tail).all()
+
+
+def test_pad_to_multiple_of_none_keeps_longest_in_batch():
+    tokenizer, _ = create_test_tokenizer()
+
+    response_prefix = "ignore this but not after me"
+    response_prefix_tokens = tokenizer.encode(response_prefix, add_special_tokens=False)
+
+    instruction_prefix = "ignore this and after me"
+    instruction_prefix_tokens = tokenizer.encode(
+        instruction_prefix, add_special_tokens=False
+    )
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
+        train_target="_legacy_instruction_response",
+    )
+
+    row = {
+        "input_ids": (
+            instruction_prefix_tokens + response_prefix_tokens + [201, 202, 203]
+        )
+    }
+    batch = collator([row])
+    assert batch["input_ids"].shape[1] == len(row["input_ids"])

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -579,6 +579,40 @@ def test_pad_to_multiple_of_rounds_batch_length_up():
     assert (batch["labels"][0, num_real - 3 : num_real] == expected_tail).all()
 
 
+def test_pad_to_multiple_of_drops_mask_for_mixed_length_batch():
+    tokenizer, _ = create_test_tokenizer()
+
+    instruction_prefix = "ignore this and after me"
+    response_prefix = "ignore this but not after me"
+    instruction_prefix_tokens = tokenizer.encode(
+        instruction_prefix, add_special_tokens=False
+    )
+    response_prefix_tokens = tokenizer.encode(response_prefix, add_special_tokens=False)
+    prefix = instruction_prefix_tokens + response_prefix_tokens
+
+    collator = TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        instruction_template=instruction_prefix,
+        response_template=response_prefix,
+        train_target="_legacy_instruction_response",
+        pad_to_multiple_of=128,
+    )
+
+    # Rows of different lengths: the default collator right-pads the short row,
+    # so the mask has real zeros and ``mask.all()`` is False. Under right
+    # padding the mask is still dropped for sequential position_ids, so mixed
+    # batches (not just batch_size=1) keep the compiled fast path.
+    batch = collator(
+        [
+            {"input_ids": prefix + list(range(201, 231))},
+            {"input_ids": prefix + [201, 202, 203]},
+        ]
+    )
+    assert batch["input_ids"].shape == (2, 128)
+    assert "attention_mask" not in batch
+    assert (batch["position_ids"] == torch.arange(128)).all()
+
+
 def test_pad_to_multiple_of_none_keeps_longest_in_batch():
     tokenizer, _ = create_test_tokenizer()
 

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -567,10 +567,12 @@ def test_pad_to_multiple_of_rounds_batch_length_up():
     num_real = len(short_row["input_ids"])
     # Alignment padding is attended: causal attention keeps real tokens from
     # seeing forward positions and ignored labels keep the loss unchanged. The
-    # resulting all-ones attention_mask is dropped so compiled attention
-    # backends keep the pure-causal fast path (a mask tensor forces per-batch
-    # mask closures that defeat torch.compile caching).
+    # all-ones attention_mask is replaced by sequential position_ids so
+    # compiled attention backends keep the pure-causal fast path (a mask
+    # tensor forces per-batch closures that defeat torch.compile caching)
+    # while TRL's token accounting stays satisfied.
     assert "attention_mask" not in batch
+    assert (batch["position_ids"][0] == torch.arange(128)).all()
     assert (batch["input_ids"][0, num_real:] == pad_token_id).all()
     assert (batch["labels"][0, num_real:] == IGNORE).all()
     # Real completion tokens keep their labels.

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -136,3 +136,77 @@ def test_train_function_passes_debug_flag_correctly(
 
     # Verify the debug flag came from the config
     assert debug_training_config.training.log_examples is True
+
+
+def _config_with_collator_kwargs(collator_kwargs):
+    return TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs=collator_kwargs,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(model_name="openai-community/gpt2"),
+        training=TrainingParams(),
+    )
+
+
+@pytest.fixture
+def restore_dynamo_limits():
+    """Save/restore global torch dynamo limits mutated by the helper under test."""
+    import torch
+
+    saved = (
+        torch._dynamo.config.recompile_limit,
+        torch._dynamo.config.cache_size_limit,
+    )
+    yield
+    torch._dynamo.config.recompile_limit, torch._dynamo.config.cache_size_limit = saved
+
+
+def test_recompile_limit_unset_without_pad_to_multiple_of(
+    monkeypatch, restore_dynamo_limits
+):
+    import torch
+
+    from oumi.train import _maybe_raise_dynamo_recompile_limit
+
+    monkeypatch.delenv("OUMI_DYNAMO_RECOMPILE_LIMIT", raising=False)
+    torch._dynamo.config.recompile_limit = 8
+    _maybe_raise_dynamo_recompile_limit(_config_with_collator_kwargs(None))
+    assert torch._dynamo.config.recompile_limit == 8
+    _maybe_raise_dynamo_recompile_limit(_config_with_collator_kwargs({}))
+    assert torch._dynamo.config.recompile_limit == 8
+
+
+def test_recompile_limit_self_set_with_pad_to_multiple_of(
+    monkeypatch, restore_dynamo_limits
+):
+    import torch
+
+    from oumi.train import (
+        _DEFAULT_DYNAMO_RECOMPILE_LIMIT,
+        _maybe_raise_dynamo_recompile_limit,
+    )
+
+    monkeypatch.delenv("OUMI_DYNAMO_RECOMPILE_LIMIT", raising=False)
+    torch._dynamo.config.recompile_limit = 8
+    _maybe_raise_dynamo_recompile_limit(
+        _config_with_collator_kwargs({"pad_to_multiple_of": 8192})
+    )
+    assert torch._dynamo.config.recompile_limit == _DEFAULT_DYNAMO_RECOMPILE_LIMIT
+    assert torch._dynamo.config.cache_size_limit == _DEFAULT_DYNAMO_RECOMPILE_LIMIT
+
+
+def test_recompile_limit_env_override_wins(monkeypatch, restore_dynamo_limits):
+    import torch
+
+    from oumi.train import _maybe_raise_dynamo_recompile_limit
+
+    monkeypatch.setenv("OUMI_DYNAMO_RECOMPILE_LIMIT", "128")
+    torch._dynamo.config.recompile_limit = 8
+    _maybe_raise_dynamo_recompile_limit(
+        _config_with_collator_kwargs({"pad_to_multiple_of": 8192})
+    )
+    assert torch._dynamo.config.recompile_limit == 128


### PR DESCRIPTION
## What

Add an optional `pad_to_multiple_of` to `TextCompletionsCollatorWithPadding` — pad each batch up to a multiple (e.g. `128`) instead of just the longest row. Set via `collator_kwargs`; default `None` keeps the existing pad-to-longest behavior.

## Why

torch `flex_attention` cannot compile a batch shorter than its 128-token block (`NoValidChoicesError`), so a long-context dataset that also contains very short rows crashes at the first short batch. Padding batches up to a block multiple keeps short rows trainable.

## How

Under right padding the collator drops the `attention_mask` and emits sequential `position_ids`. A mask — all-ones, or the `[1..|0..|1..]` of a mixed-length batch — forces transformers to build per-batch mask closures that defeat `torch.compile` caching and knock flex_attention off its fused fast path (silent fallback to the eager kernel → OOM at long context); dropping it keeps every batch on the compiled path. `train.py` also raises torch dynamo's recompile limit (default 8 → 64, overridable via `OUMI_DYNAMO_RECOMPILE_LIMIT`) when `pad_to_multiple_of` is set, so flex_attention's per-shape bucket compiles don't exhaust the limit.

Loss-neutral for right-padded causal LMs: real tokens form a prefix so they never attend padding, and padding labels are `ignore_index` (no loss/gradient). Left padding keeps the mask.

## Test

Unit tests cover single-row, mixed-length, and `pad_to_multiple_of=None` batches. Validated end-to-end in a gemma-4-E4B 64k FFT job (`attn_implementation=flex_attention`): an 8-step run over a dataset mixing ~60-token and ~62k-token rows completed 8/8 with zero dynamo recompile warnings and a clean save; without the option, short rows crash flex compile at the first step.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
