### PR TITLE
feat(verl): support multi-turn prompts in GRPO data path (supersedes #2533)

### DIFF
--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -231,17 +231,18 @@ class VerlGrpoTrainer(BaseTrainer):
         )
 
         if len(images) > 0:
-            if len(prompt_messages) != 1:
+            user_messages = [m for m in prompt_messages if m["role"] == "user"]
+            if len(user_messages) != 1:
                 raise ValueError(
                     "Images are only supported for single-turn conversations, "
-                    f"but got a multi-turn prompt with {len(prompt_messages)} "
-                    "messages. Please use a text-only multi-turn conversation."
+                    f"but the prompt has {len(user_messages)} user messages "
+                    "(multi-turn). Please use a text-only multi-turn conversation."
                 )
             # TODO: Generalize. This only works for QwenVL 2.5, which is the only
             # VLM supported by verl as of 2025-05-15.
-            content = prompt_messages[0]["content"]
+            content = user_messages[0]["content"]
             if not content.startswith("<image>"):
-                prompt_messages[0]["content"] = "<image>" + content
+                user_messages[0]["content"] = "<image>" + content
         return (prompt_messages, images, answer)
 
     @staticmethod

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -27,7 +27,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from oumi.core.types.conversation import Conversation
 from oumi.utils.grpo_utils import (
-    extract_prompt_images_completion_from_single_turn_conversation,
+    extract_prompt_images_completion_from_conversation,
 )
 
 try:
@@ -186,7 +186,7 @@ class VerlGrpoTrainer(BaseTrainer):
                 raise ValueError(
                     "Invalid conversation_json in training or validation dataset."
                 ) from e
-            return VerlGrpoTrainer._create_verl_data_entry_from_single_turn_conversation
+            return VerlGrpoTrainer._create_verl_data_entry_from_conversation
         return None
 
     @staticmethod
@@ -206,46 +206,54 @@ class VerlGrpoTrainer(BaseTrainer):
         return dataset_names[0]
 
     @staticmethod
-    def _extract_question_images_answer_from_single_turn_conversation(
+    def _extract_prompt_images_answer_from_conversation(
         example: dict,
-    ) -> tuple[str, list, str]:
-        """Finds question, answer, and optional images in a single-turn conversation.
+    ) -> tuple[list[dict], list, str]:
+        """Finds prompt, answer, and optional images in a conversation.
+
+        Supports both single-turn and multi-turn conversations. The prompt is
+        returned in verl's chat format (a list of ``{"role", "content"}`` dicts)
+        and the answer is the final assistant message's text (the ground truth).
 
         Args:
             example: A dictionary containing the conversation JSON.
 
         Returns:
-            A tuple containing the question, images, and answer.
+            A tuple containing the prompt messages, images, and answer.
             The list of images is empty for text-only conversations.
+
+        Raises:
+            ValueError: If the conversation contains images but is multi-turn.
+                Images are only supported for single-turn conversations.
         """
-        prompt, images, answer = (
-            extract_prompt_images_completion_from_single_turn_conversation(example)
+        prompt_messages, images, answer = (
+            extract_prompt_images_completion_from_conversation(example)
         )
 
         if len(images) > 0:
+            if len(prompt_messages) != 1:
+                raise ValueError(
+                    "Images are only supported for single-turn conversations, "
+                    f"but got a multi-turn prompt with {len(prompt_messages)} "
+                    "messages. Please use a text-only multi-turn conversation."
+                )
             # TODO: Generalize. This only works for QwenVL 2.5, which is the only
             # VLM supported by verl as of 2025-05-15.
-            if not prompt.startswith("<image>"):
-                prompt = "<image>" + prompt
-        return (prompt, images, answer)
+            content = prompt_messages[0]["content"]
+            if not content.startswith("<image>"):
+                prompt_messages[0]["content"] = "<image>" + content
+        return (prompt_messages, images, answer)
 
     @staticmethod
-    def _create_verl_data_entry_from_single_turn_conversation(
+    def _create_verl_data_entry_from_conversation(
         example: dict, idx: int, data_source: str, split: str
     ) -> dict:
-        prompt, images, answer = (
-            VerlGrpoTrainer._extract_question_images_answer_from_single_turn_conversation(
-                example
-            )
+        prompt_messages, images, answer = (
+            VerlGrpoTrainer._extract_prompt_images_answer_from_conversation(example)
         )
         data = {
             "data_source": data_source,
-            "prompt": [
-                {
-                    "role": "user",
-                    "content": prompt,
-                }
-            ],
+            "prompt": prompt_messages,
             "images": images,
             "ability": "math",
             "reward_model": {"style": "rule", "ground_truth": answer},
@@ -253,7 +261,6 @@ class VerlGrpoTrainer(BaseTrainer):
                 "split": split,
                 "index": idx,
                 "answer": answer,
-                "question": prompt,  # TODO: extract problem
             },
         }
         return data

--- a/src/oumi/utils/grpo_utils.py
+++ b/src/oumi/utils/grpo_utils.py
@@ -109,8 +109,7 @@ def extract_prompt_images_completion_from_conversation(
         raise ValueError("Conversation prompt cannot start with an assistant message.")
 
     prompt_has_content = any(
-        message.compute_flattened_text_content().strip()
-        or message.image_content_items
+        message.compute_flattened_text_content().strip() or message.image_content_items
         for message in prompt_source_messages
     )
     if not prompt_has_content:

--- a/src/oumi/utils/grpo_utils.py
+++ b/src/oumi/utils/grpo_utils.py
@@ -67,23 +67,22 @@ def extract_prompt_images_completion_from_conversation(
 
     The final message must be an assistant message; its text becomes the
     completion (ground truth). All preceding messages form the prompt, in
-    verl's chat format (a list of ``{"role": ..., "content": ...}`` dicts).
-    A single-turn conversation (one user + one assistant message) is just the
-    two-message special case.
+    verl's chat format. A single-turn conversation (one user + one assistant
+    message) is just the two-message special case.
 
     Args:
         example: A dictionary containing the conversation JSON.
 
     Returns:
-        A tuple ``(prompt_messages, images, completion)`` where ``prompt_messages``
-        is a list of chat-format message dicts, ``images`` is a list of image
-        dicts collected across the prompt messages (empty for text-only
-        conversations), and ``completion`` is the final assistant message's text.
+        A tuple ``(prompt_messages, images, completion)``: the prompt as a list of
+        chat-format message dicts, the images (empty for text-only conversations),
+        and the completion text.
 
     Raises:
         ValueError: If ``conversation_json`` is missing, the conversation has
-            fewer than 2 messages, or the final message is not an assistant
-            message.
+            fewer than 2 messages, the prompt starts with an assistant message,
+            the prompt or completion is empty, or the final message is not an
+            assistant message.
     """
     if "conversation_json" not in example:
         raise ValueError(
@@ -105,16 +104,28 @@ def extract_prompt_images_completion_from_conversation(
             f"(used as the ground truth), but got role '{messages[-1].role}'."
         )
 
+    prompt_source_messages = messages[:-1]
+    if prompt_source_messages[0].role == Role.ASSISTANT:
+        raise ValueError("Conversation prompt cannot start with an assistant message.")
+
+    prompt_has_content = any(
+        message.compute_flattened_text_content().strip()
+        or message.image_content_items
+        for message in prompt_source_messages
+    )
+    if not prompt_has_content:
+        raise ValueError("Conversation prompt must not be empty.")
+
+    completion = messages[-1].compute_flattened_text_content()
+    if not completion.strip():
+        raise ValueError("Conversation completion must not be empty.")
+
     prompt_messages: list[dict] = []
     images: list = []
-    for message in messages[:-1]:
-        text_items = message.text_content_items
-        content = text_items[-1].content or "" if text_items else ""
+    for message in prompt_source_messages:
+        content = message.compute_flattened_text_content()
         prompt_messages.append({"role": message.role.value, "content": content})
         images.extend({"bytes": item.binary} for item in message.image_content_items)
-
-    completion_items = messages[-1].text_content_items
-    completion: str = completion_items[-1].content or "" if completion_items else ""
 
     return (prompt_messages, images, completion)
 

--- a/src/oumi/utils/grpo_utils.py
+++ b/src/oumi/utils/grpo_utils.py
@@ -60,6 +60,65 @@ def extract_prompt_images_completion_from_single_turn_conversation(
     return (prompt, images, answer)
 
 
+def extract_prompt_images_completion_from_conversation(
+    example: dict,
+) -> tuple[list[dict], list, str]:
+    """Splits a (possibly multi-turn) conversation into prompt, images, completion.
+
+    The final message must be an assistant message; its text becomes the
+    completion (ground truth). All preceding messages form the prompt, in
+    verl's chat format (a list of ``{"role": ..., "content": ...}`` dicts).
+    A single-turn conversation (one user + one assistant message) is just the
+    two-message special case.
+
+    Args:
+        example: A dictionary containing the conversation JSON.
+
+    Returns:
+        A tuple ``(prompt_messages, images, completion)`` where ``prompt_messages``
+        is a list of chat-format message dicts, ``images`` is a list of image
+        dicts collected across the prompt messages (empty for text-only
+        conversations), and ``completion`` is the final assistant message's text.
+
+    Raises:
+        ValueError: If ``conversation_json`` is missing, the conversation has
+            fewer than 2 messages, or the final message is not an assistant
+            message.
+    """
+    if "conversation_json" not in example:
+        raise ValueError(
+            f"Example doesn't contain 'conversation_json' key. "
+            f"Available keys: {example.keys()}"
+        )
+
+    conversation = Conversation.from_json(example["conversation_json"])
+    messages = conversation.messages
+
+    if len(messages) < 2:
+        raise ValueError(
+            f"Conversation must have at least 2 messages (a prompt and a "
+            f"final assistant message), but got {len(messages)}."
+        )
+    if messages[-1].role != Role.ASSISTANT:
+        raise ValueError(
+            f"The final message of a conversation must be an assistant message "
+            f"(used as the ground truth), but got role '{messages[-1].role}'."
+        )
+
+    prompt_messages: list[dict] = []
+    images: list = []
+    for message in messages[:-1]:
+        text_items = message.text_content_items
+        content = text_items[-1].content or "" if text_items else ""
+        prompt_messages.append({"role": message.role.value, "content": content})
+        images.extend({"bytes": item.binary} for item in message.image_content_items)
+
+    completion_items = messages[-1].text_content_items
+    completion: str = completion_items[-1].content or "" if completion_items else ""
+
+    return (prompt_messages, images, completion)
+
+
 def try_prepare_trl_grpo_example(
     example: dict,
 ) -> dict:

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -97,6 +97,30 @@ def test_create_verl_data_entry_single_turn_image_prepends_marker():
     assert entry["images"] == [{"bytes": b"imgbytes"}]
 
 
+def test_create_verl_data_entry_single_turn_image_with_system():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You are helpful."),
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentItem(type=Type.IMAGE_BINARY, binary=b"imgbytes"),
+                    ContentItem(type=Type.TEXT, content="Describe this."),
+                ],
+            ),
+            Message(role=Role.ASSISTANT, content="A cat."),
+        ]
+    )
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "my_dataset", "train"
+    )
+    assert entry["prompt"] == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "<image>Describe this."},
+    ]
+    assert entry["images"] == [{"bytes": b"imgbytes"}]
+
+
 def test_create_verl_data_entry_multi_turn_with_images_raises():
     convo = Conversation(
         messages=[

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -3,12 +3,23 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
+from oumi.core.types.conversation import (
+    ContentItem,
+    Conversation,
+    Message,
+    Role,
+    Type,
+)
 
 try:
     verl_import_failed = False
     import verl  # pyright: ignore[reportMissingImports]  # noqa: F401
 except ModuleNotFoundError:
     verl_import_failed = True
+
+
+def _example(conversation: Conversation) -> dict:
+    return {"conversation_json": conversation.to_json()}
 
 
 @pytest.mark.skipif(verl_import_failed, reason="verl not available")
@@ -22,6 +33,89 @@ def test_init_without_verl():
                 train_dataset=MagicMock(),
                 eval_dataset=MagicMock(),
             )
+
+
+def test_create_verl_data_entry_single_turn():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="What is 2+2?"),
+            Message(role=Role.ASSISTANT, content="4"),
+        ]
+    )
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 7, "my_dataset", "train"
+    )
+    assert entry["data_source"] == "my_dataset"
+    assert entry["prompt"] == [{"role": "user", "content": "What is 2+2?"}]
+    assert entry["images"] == []
+    assert entry["reward_model"] == {"style": "rule", "ground_truth": "4"}
+    assert entry["extra_info"]["split"] == "train"
+    assert entry["extra_info"]["index"] == 7
+    assert entry["extra_info"]["answer"] == "4"
+
+
+def test_create_verl_data_entry_multi_turn():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You are helpful."),
+            Message(role=Role.USER, content="Hi"),
+            Message(role=Role.ASSISTANT, content="Hello!"),
+            Message(role=Role.USER, content="What is 2+2?"),
+            Message(role=Role.ASSISTANT, content="4"),
+        ]
+    )
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "my_dataset", "validation"
+    )
+    assert entry["prompt"] == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello!"},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    assert entry["images"] == []
+    assert entry["reward_model"]["ground_truth"] == "4"
+
+
+def test_create_verl_data_entry_single_turn_image_prepends_marker():
+    convo = Conversation(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentItem(type=Type.IMAGE_BINARY, binary=b"imgbytes"),
+                    ContentItem(type=Type.TEXT, content="Describe this."),
+                ],
+            ),
+            Message(role=Role.ASSISTANT, content="A cat."),
+        ]
+    )
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "my_dataset", "train"
+    )
+    assert entry["prompt"] == [{"role": "user", "content": "<image>Describe this."}]
+    assert entry["images"] == [{"bytes": b"imgbytes"}]
+
+
+def test_create_verl_data_entry_multi_turn_with_images_raises():
+    convo = Conversation(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentItem(type=Type.IMAGE_BINARY, binary=b"imgbytes"),
+                    ContentItem(type=Type.TEXT, content="Describe this."),
+                ],
+            ),
+            Message(role=Role.ASSISTANT, content="A cat."),
+            Message(role=Role.USER, content="And this one?"),
+            Message(role=Role.ASSISTANT, content="A dog."),
+        ]
+    )
+    with pytest.raises(ValueError, match="multi-turn"):
+        VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            _example(convo), 0, "my_dataset", "train"
+        )
 
 
 @pytest.mark.skipif(verl_import_failed, reason="verl not available")

--- a/tests/unit/utils/test_grpo_utils.py
+++ b/tests/unit/utils/test_grpo_utils.py
@@ -1,0 +1,116 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from oumi.core.types.conversation import (
+    ContentItem,
+    Conversation,
+    Message,
+    Role,
+    Type,
+)
+from oumi.utils.grpo_utils import (
+    extract_prompt_images_completion_from_conversation,
+)
+
+
+def _example(conversation: Conversation) -> dict:
+    return {"conversation_json": conversation.to_json()}
+
+
+def test_single_turn_conversation():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="What is 2+2?"),
+            Message(role=Role.ASSISTANT, content="4"),
+        ]
+    )
+    prompt, images, completion = extract_prompt_images_completion_from_conversation(
+        _example(convo)
+    )
+    assert prompt == [{"role": "user", "content": "What is 2+2?"}]
+    assert images == []
+    assert completion == "4"
+
+
+def test_multi_turn_conversation_includes_history():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You are helpful."),
+            Message(role=Role.USER, content="Hi"),
+            Message(role=Role.ASSISTANT, content="Hello!"),
+            Message(role=Role.USER, content="What is 2+2?"),
+            Message(role=Role.ASSISTANT, content="4"),
+        ]
+    )
+    prompt, images, completion = extract_prompt_images_completion_from_conversation(
+        _example(convo)
+    )
+    assert prompt == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello!"},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    assert images == []
+    assert completion == "4"
+
+
+def test_raises_when_last_message_not_assistant():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="Hi"),
+            Message(role=Role.ASSISTANT, content="Hello!"),
+            Message(role=Role.USER, content="Still there?"),
+        ]
+    )
+    with pytest.raises(ValueError, match="assistant"):
+        extract_prompt_images_completion_from_conversation(_example(convo))
+
+
+def test_raises_when_fewer_than_two_messages():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.ASSISTANT, content="Hello!"),
+        ]
+    )
+    with pytest.raises(ValueError, match="at least 2 messages"):
+        extract_prompt_images_completion_from_conversation(_example(convo))
+
+
+def test_raises_when_conversation_json_missing():
+    with pytest.raises(ValueError, match="conversation_json"):
+        extract_prompt_images_completion_from_conversation({"foo": "bar"})
+
+
+def test_collects_images_from_prompt():
+    convo = Conversation(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentItem(type=Type.IMAGE_BINARY, binary=b"imgbytes"),
+                    ContentItem(type=Type.TEXT, content="Describe this."),
+                ],
+            ),
+            Message(role=Role.ASSISTANT, content="A cat."),
+        ]
+    )
+    prompt, images, completion = extract_prompt_images_completion_from_conversation(
+        _example(convo)
+    )
+    assert prompt == [{"role": "user", "content": "Describe this."}]
+    assert images == [{"bytes": b"imgbytes"}]
+    assert completion == "A cat."

--- a/tests/unit/utils/test_grpo_utils.py
+++ b/tests/unit/utils/test_grpo_utils.py
@@ -90,6 +90,42 @@ def test_raises_when_fewer_than_two_messages():
         extract_prompt_images_completion_from_conversation(_example(convo))
 
 
+def test_raises_when_prompt_starts_with_assistant():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.ASSISTANT, content="Unprompted response"),
+            Message(role=Role.ASSISTANT, content="Ground truth"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cannot start with an assistant"):
+        extract_prompt_images_completion_from_conversation(_example(convo))
+
+
+def test_raises_when_prompt_is_empty():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="  "),
+            Message(role=Role.ASSISTANT, content="Ground truth"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="prompt must not be empty"):
+        extract_prompt_images_completion_from_conversation(_example(convo))
+
+
+def test_raises_when_completion_is_empty():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="Question"),
+            Message(role=Role.ASSISTANT, content="\n\t"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="completion must not be empty"):
+        extract_prompt_images_completion_from_conversation(_example(convo))
+
+
 def test_raises_when_conversation_json_missing():
     with pytest.raises(ValueError, match="conversation_json"):
         extract_prompt_images_completion_from_conversation({"foo": "bar"})


### PR DESCRIPTION
## What

Generalizes the verl GRPO data conversion so a conversation dataset can carry multi-turn history. The prompt becomes every message up to the final assistant turn (emitted in verl's chat-list format), and the final assistant message is the ground truth. Single-turn is the two-message special case and its output is unchanged.

## Why

Today the conversion collapses a conversation into exactly one user message (prompt) + one assistant message (ground truth). This unblocks reference-based GRPO on multi-turn conversational datasets, where the model is trained to produce the final assistant turn given the preceding history.

## How

- New pure helper `extract_prompt_images_completion_from_conversation` in `grpo_utils.py`: conversation dict → `(prompt_messages, images, completion)`. Turn-count-agnostic and testable without verl installed.
- `verl_grpo_trainer.py`: `_create_verl_data_entry_from_conversation` emits the multi-message prompt list instead of wrapping a single string.
- **Validation at the data-ingestion boundary** — raises on: fewer than 2 messages, a final message that isn't an assistant turn, a prompt that starts on an assistant turn, or an empty prompt/completion. Ambiguous-but-legal shapes are allowed silently.
- Text is flattened with `Message.compute_flattened_text_content()` (joins all text items) instead of taking only the last item, so multi-segment messages aren't silently truncated.
- Images stay single-turn only (verl's QwenVL 2.5 path); a multi-turn conversation that carries images raises a clear error.
- The existing single-turn TRL helper (`extract_prompt_images_completion_from_single_turn_conversation`) is left untouched — the TRL GRPO path depends on its string-prompt shape.

## Testing

- Unit tests: single-turn (output unchanged), multi-turn with system + history, every validation raise, image collection; plus trainer-level row building for single/multi-turn, the `<image>` marker prepend, and the multi-turn-with-images raise.
- `pytest` green (verl-dependent trainer tests skip when verl isn't installed); `pyright` and `ruff` clean.

## Scope / deferred

- **Tool-call / agentic multi-turn is intentionally out of scope.** An earlier draft on this branch serialized `tool_calls`/`tool_call_id` into the prompt; it was reverted because it was incomplete for a prompt-only PR — no `tools=` schema was propagated (malformed prompts for tool-calling models), heterogeneous row keys produced an unstable Arrow schema under the multiprocess dataset writer, and it was untested. Tool/agent conversations (tools schema, uniform row features, ground-truth-from-metadata, prompts ending on a user turn) belong to the multi-turn **rollout** work and will land in a follow-up PR.
- Behavior change worth noting: a single-turn conversation that includes a `system` message previously had it dropped; it is now included in the prompt.

## Relationship to #2533

Branched off #2533 and includes its data-path commit plus review hardening (validation, text-flattening reuse, and the tool-call revert). Base is `main`, so this PR is a superset of #2533 — recommend closing #2533 in favor of this once reviewed, or I can rebase this onto #2533 to keep them stacked if you'd prefer.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
