### PR TITLE
fix(deploy): don't log false config.json error on Fireworks adapter upload

### DIFF
--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -661,9 +661,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         # config.json — the inventory is deliberately filtered to adapter files.
         # Only full-model uploads require config.json.
         expected_config = (
-            "adapter_config.json"
-            if model_type == ModelType.ADAPTER
-            else "config.json"
+            "adapter_config.json" if model_type == ModelType.ADAPTER else "config.json"
         )
         if expected_config in file_sizes:
             logger.info(

--- a/src/oumi/deploy/fireworks_client.py
+++ b/src/oumi/deploy/fireworks_client.py
@@ -623,6 +623,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             file_inventory,
             file_resolver,
             progress_callback,
+            model_type,
         )
         await self._wait_and_validate(model_name, progress_callback)
         return UploadedModel(
@@ -637,6 +638,7 @@ class FireworksDeploymentClient(BaseDeploymentClient):
         file_sizes: dict[str, int],
         file_resolver: FileResolver,
         progress_callback: ProgressCallback | None,
+        model_type: ModelType = ModelType.FULL,
     ) -> None:
         """Upload files using a resolver that provides each file on demand.
 
@@ -650,14 +652,27 @@ class FireworksDeploymentClient(BaseDeploymentClient):
             file_sizes: Mapping of relative filename to file size in bytes.
             file_resolver: Async context manager factory yielding a local Path.
             progress_callback: Optional async progress callback.
+            model_type: FULL or ADAPTER. Determines which config file is
+                expected in the inventory.
         """
         total_bytes = sum(file_sizes.values())
         _MB = 1024 * 1024
-        if "config.json" in file_sizes:
-            logger.info("config.json found (%d bytes)", file_sizes["config.json"])
+        # Adapter (PEFT addon) uploads ship adapter_config.json, never
+        # config.json — the inventory is deliberately filtered to adapter files.
+        # Only full-model uploads require config.json.
+        expected_config = (
+            "adapter_config.json"
+            if model_type == ModelType.ADAPTER
+            else "config.json"
+        )
+        if expected_config in file_sizes:
+            logger.info(
+                "%s found (%d bytes)", expected_config, file_sizes[expected_config]
+            )
         else:
             logger.error(
-                "config.json NOT found in model files: %s",
+                "%s NOT found in model files: %s",
+                expected_config,
                 list(file_sizes.keys()),
             )
         logger.info(

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -1264,3 +1264,54 @@ class TestUploadModelFromInventory:
         assert sorted(resolved) == ["config.json", "model.safetensors"]
         # Upload must be called for each resolved file
         assert len(uploaded) == 2
+
+    @pytest.mark.asyncio
+    async def test_adapter_upload_does_not_error_on_missing_config_json(
+        self, tmp_path, caplog
+    ):
+        """Adapter uploads ship adapter_config.json, never config.json; the
+        absence of config.json must not be logged as an error (would page)."""
+        client = self._make_client()
+        file_inventory = {"adapter_config.json": 10, "adapter_model.safetensors": 200}
+        with (
+            patch.object(
+                client,
+                "_get_signed_urls_ordered",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            caplog.at_level("INFO", logger="oumi.deploy.fireworks_client"),
+        ):
+            await client._upload_model_files_with_resolver(
+                model_id="my-adapter",
+                file_sizes=file_inventory,
+                file_resolver=None,
+                progress_callback=None,
+                model_type=ModelType.ADAPTER,
+            )
+        assert not [r for r in caplog.records if r.levelname == "ERROR"]
+        assert any("adapter_config.json found" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_full_upload_errors_on_missing_config_json(self, tmp_path, caplog):
+        """Full-model uploads still log an error when config.json is absent."""
+        client = self._make_client()
+        file_inventory = {"model.safetensors": 200}
+        with (
+            patch.object(
+                client,
+                "_get_signed_urls_ordered",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            caplog.at_level("INFO", logger="oumi.deploy.fireworks_client"),
+        ):
+            await client._upload_model_files_with_resolver(
+                model_id="my-model",
+                file_sizes=file_inventory,
+                file_resolver=None,
+                progress_callback=None,
+                model_type=ModelType.FULL,
+            )
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert any("config.json NOT found" in r.message for r in errors)

--- a/tests/unit/deploy/test_fireworks_client.py
+++ b/tests/unit/deploy/test_fireworks_client.py
@@ -1273,6 +1273,11 @@ class TestUploadModelFromInventory:
         absence of config.json must not be logged as an error (would page)."""
         client = self._make_client()
         file_inventory = {"adapter_config.json": 10, "adapter_model.safetensors": 200}
+
+        @asynccontextmanager
+        async def noop_resolver(filename: str):
+            yield tmp_path / filename
+
         with (
             patch.object(
                 client,
@@ -1285,7 +1290,7 @@ class TestUploadModelFromInventory:
             await client._upload_model_files_with_resolver(
                 model_id="my-adapter",
                 file_sizes=file_inventory,
-                file_resolver=None,
+                file_resolver=noop_resolver,
                 progress_callback=None,
                 model_type=ModelType.ADAPTER,
             )
@@ -1297,6 +1302,11 @@ class TestUploadModelFromInventory:
         """Full-model uploads still log an error when config.json is absent."""
         client = self._make_client()
         file_inventory = {"model.safetensors": 200}
+
+        @asynccontextmanager
+        async def noop_resolver(filename: str):
+            yield tmp_path / filename
+
         with (
             patch.object(
                 client,
@@ -1309,7 +1319,7 @@ class TestUploadModelFromInventory:
             await client._upload_model_files_with_resolver(
                 model_id="my-model",
                 file_sizes=file_inventory,
-                file_resolver=None,
+                file_resolver=noop_resolver,
                 progress_callback=None,
                 model_type=ModelType.FULL,
             )


### PR DESCRIPTION
# Description

Adapter (PEFT addon) uploads to Fireworks logged a false `config.json NOT found` error on every deployment: `_upload_model_files_with_resolver` checked unconditionally for `config.json`, but adapter uploads only ship `adapter_config.json` / `adapter_model.safetensors`. The log didn't raise (uploads succeeded), but surfaced as a false error in monitoring.

Fix: thread `model_type` through and make the check type-aware — adapters expect `adapter_config.json`, full models expect `config.json`. Adds two regression tests.

## Related issues

Fixes LOU-2953

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
