### PR TITLE
feat(verl): OumiVerlTool bridges verl tool RL to any Oumi executable environment (NL2SQL first consumer)

### DIFF
--- a/configs/examples/grpo_verl_nl2sql/README.md
+++ b/configs/examples/grpo_verl_nl2sql/README.md
@@ -1,0 +1,17 @@
+# NL2SQL tool-agent GRPO
+
+This example trains a verl tool agent on Spider execution accuracy. Prepare the
+Spider JSON files and SQLite databases before launching training:
+
+```bash
+python scripts/datasets/build_spider_tool_agent.py \
+  --spider-root /path/to/spider \
+  --db-root /path/to/spider/database
+
+oumi train -c configs/examples/grpo_verl_nl2sql/train.yaml
+```
+
+The Spider root must contain `train_spider.json` and `dev.json`. The database
+root must contain `<db_id>/<db_id>.sqlite`. The builder writes the configured
+`data/grpo_verl_nl2sql/train.jsonl` and `val.jsonl` files without copying the
+database contents into each row.

--- a/configs/examples/grpo_verl_nl2sql/environment_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/environment_config.yaml
@@ -3,14 +3,18 @@ environments:
     name: NL2SQL database
     description: NL2SQL database environment exposing a read-only run_sql tool.
     env_type: database
-    env_kwargs: { schema_sql: "CREATE TABLE placeholder(x INTEGER);" }  # overridden per-rollout
+    env_kwargs:
+      schema_sql: "CREATE TABLE placeholder(x INTEGER);"  # overridden per-rollout
     tools:
       - id: run_sql
         name: run_sql
         description: Execute a read-only SQL query and return the result rows.
         parameters:
           type: object
-          properties: { query: { type: string, description: "A single SQL SELECT statement." } }
+          properties:
+            query:
+              type: string
+              description: "A single SQL SELECT statement."
           required: [query]
         executor: oumi.environments.examples.nl2sql.run_sql
         read_only: true

--- a/configs/examples/grpo_verl_nl2sql/environment_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/environment_config.yaml
@@ -1,0 +1,16 @@
+environments:
+  - id: nl2sql_db
+    name: NL2SQL database
+    description: NL2SQL database environment exposing a read-only run_sql tool.
+    env_type: database
+    env_kwargs: { schema_sql: "CREATE TABLE placeholder(x INTEGER);" }  # overridden per-rollout
+    tools:
+      - id: run_sql
+        name: run_sql
+        description: Execute a read-only SQL query and return the result rows.
+        parameters:
+          type: object
+          properties: { query: { type: string, description: "A single SQL SELECT statement." } }
+          required: [query]
+        executor: oumi.environments.examples.nl2sql.run_sql
+        read_only: true

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -1,0 +1,30 @@
+model:
+  model_name: "Qwen/Qwen2.5-3B-Instruct"
+
+data:
+  train: { datasets: [ { dataset_name: "<nl2sql-tool-agent-dataset>", split: "train" } ] }
+  validation: { datasets: [ { dataset_name: "<nl2sql-tool-agent-dataset>", split: "validation" } ] }
+
+training:
+  trainer_type: "VERL_GRPO"
+  num_train_epochs: 1
+  save_steps: -1
+  eval_strategy: "steps"
+  eval_steps: 20
+  learning_rate: 1.0e-6
+  reward_functions: ["sql_execution_match"]
+  grpo: { max_completion_length: 1024, use_vllm: True, temperature: 1.0, vllm_gpu_memory_utilization: 0.5 }
+  verl_config_overrides:
+    data: { train_batch_size: 32, max_prompt_length: 4096, filter_overlong_prompts: True }
+    actor_rollout_ref:
+      rollout:
+        name: sglang
+        mode: async
+        multi_turn: { enable: true, format: hermes, tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml }
+        agent: { default_agent_loop: tool_agent }
+        tensor_model_parallel_size: 2
+        n: 8
+    trainer: { n_gpus_per_node: 8, nnodes: 1, val_before_train: True }
+  output_dir: "output/grpo_verl_nl2sql"
+  run_name: "grpo_verl_nl2sql"
+  enable_wandb: True

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -18,7 +18,7 @@ training:
     data: { train_batch_size: 32, max_prompt_length: 4096, filter_overlong_prompts: True }
     actor_rollout_ref:
       rollout:
-        name: sglang
+        name: vllm
         mode: async
         multi_turn: { enable: true, format: hermes, tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml }
         agent: { default_agent_loop: tool_agent }

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -2,8 +2,18 @@ model:
   model_name: "Qwen/Qwen2.5-3B-Instruct"
 
 data:
-  train: { datasets: [ { dataset_name: "<nl2sql-tool-agent-dataset>", split: "train" } ] }
-  validation: { datasets: [ { dataset_name: "<nl2sql-tool-agent-dataset>", split: "validation" } ] }
+  train:
+    datasets:
+      - dataset_name: "text_sft"
+        dataset_path: "data/grpo_verl_nl2sql/train.jsonl"
+        dataset_kwargs:
+          return_conversations: true
+  validation:
+    datasets:
+      - dataset_name: "text_sft"
+        dataset_path: "data/grpo_verl_nl2sql/val.jsonl"
+        dataset_kwargs:
+          return_conversations: true
 
 training:
   trainer_type: "VERL_GRPO"
@@ -13,18 +23,32 @@ training:
   eval_steps: 20
   learning_rate: 1.0e-6
   reward_functions: ["sql_execution_match"]
-  grpo: { max_completion_length: 1024, use_vllm: True, temperature: 1.0, vllm_gpu_memory_utilization: 0.5 }
+  grpo:
+    max_completion_length: 1024
+    use_vllm: True
+    temperature: 1.0
+    vllm_gpu_memory_utilization: 0.5
   verl_config_overrides:
-    data: { train_batch_size: 32, max_prompt_length: 4096, filter_overlong_prompts: True }
+    data:
+      train_batch_size: 32
+      max_prompt_length: 4096
+      filter_overlong_prompts: True
     actor_rollout_ref:
       rollout:
         name: vllm
         mode: async
-        multi_turn: { enable: true, format: hermes, tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml }
-        agent: { default_agent_loop: tool_agent }
+        multi_turn:
+          enable: true
+          format: hermes
+          tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+        agent:
+          default_agent_loop: tool_agent
         tensor_model_parallel_size: 2
         n: 8
-    trainer: { n_gpus_per_node: 8, nnodes: 1, val_before_train: True }
+    trainer:
+      n_gpus_per_node: 8
+      nnodes: 1
+      val_before_train: True
   output_dir: "output/grpo_verl_nl2sql"
   run_name: "grpo_verl_nl2sql"
   enable_wandb: True

--- a/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
@@ -10,5 +10,7 @@ tools:
         description: Execute a read-only SQL query and return the result rows.
         parameters:
           type: object
-          properties: { query: { type: string } }
+          properties:
+            query:
+              type: string
           required: [query]

--- a/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
@@ -1,0 +1,14 @@
+tools:
+  - class_name: oumi.core.trainers.verl_agentic.oumi_verl_tool.OumiVerlTool
+    config:
+      type: native   # verl ToolType — required by initialize_tools_from_config
+      oumi_env_config: configs/examples/grpo_verl_nl2sql/environment_config.yaml
+    tool_schema:
+      type: function
+      function:
+        name: run_sql
+        description: Execute a read-only SQL query and return the result rows.
+        parameters:
+          type: object
+          properties: { query: { type: string } }
+          required: [query]

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -1,0 +1,117 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build Spider NL2SQL tool-agent train and validation rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_SYSTEM_PROMPT = (
+    "You are a SQL assistant for a SQLite database with this schema:\n{schema}\n"
+    "You may call run_sql(query) to inspect results. Return the final SQL query "
+    "inside a ```sql code block."
+)
+
+
+def _schema_ddl(db_path: Path) -> str:
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = connection.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL "
+            "ORDER BY name"
+        ).fetchall()
+    finally:
+        connection.close()
+    return "\n\n".join(row[0].strip() for row in rows)
+
+
+def _build_rows(
+    examples: list[dict[str, Any]],
+    db_root: Path,
+    *,
+    limit: int,
+    seed: int,
+) -> list[dict[str, Any]]:
+    if 0 < limit < len(examples):
+        examples = random.Random(seed).sample(examples, limit)
+
+    schemas: dict[str, str] = {}
+    rows = []
+    for example in examples:
+        db_id = example["db_id"]
+        db_path = db_root / db_id / f"{db_id}.sqlite"
+        if db_id not in schemas:
+            schemas[db_id] = _schema_ddl(db_path)
+        schema = schemas[db_id]
+        rows.append(
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": _SYSTEM_PROMPT.format(schema=schema),
+                    },
+                    {"role": "user", "content": example["question"]},
+                ],
+                "metadata": {
+                    "agent_name": "tool_agent",
+                    "ground_truth": example["query"],
+                    "tools_kwargs": {
+                        "run_sql": {"create_kwargs": {"db_path": str(db_path)}}
+                    },
+                },
+            }
+        )
+    return rows
+
+
+def _write_jsonl(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as output:
+        for row in rows:
+            output.write(json.dumps(row) + "\n")
+
+
+def main() -> None:
+    """Build train and validation JSONL files from a Spider release."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spider-root", type=Path, required=True)
+    parser.add_argument("--db-root", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path("data/grpo_verl_nl2sql"))
+    parser.add_argument("--train-limit", type=int, default=0)
+    parser.add_argument("--val-limit", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    db_root = args.db_root or args.spider_root / "database"
+    train_examples = json.loads((args.spider_root / "train_spider.json").read_text())
+    val_examples = json.loads((args.spider_root / "dev.json").read_text())
+    _write_jsonl(
+        _build_rows(train_examples, db_root, limit=args.train_limit, seed=args.seed),
+        args.out_dir / "train.jsonl",
+    )
+    _write_jsonl(
+        _build_rows(val_examples, db_root, limit=args.val_limit, seed=args.seed),
+        args.out_dir / "val.jsonl",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/oumi/core/trainers/verl_agentic/__init__.py
+++ b/src/oumi/core/trainers/verl_agentic/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""verl-free core for the Oumi<->verl agentic tool bridge."""
+"""Agentic Oumi tool bridge for verl."""

--- a/src/oumi/core/trainers/verl_agentic/__init__.py
+++ b/src/oumi/core/trainers/verl_agentic/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""verl-free core for the Oumi<->verl agentic tool bridge."""

--- a/src/oumi/core/trainers/verl_agentic/env_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/env_provider.py
@@ -27,24 +27,34 @@ from oumi.core.synthesis.tool_router import ToolRouter
 _ROUTERS: dict[str, ToolRouter] = {}
 
 
-def _rollout_create_kwargs(agent_data: Any) -> dict[str, Any]:
-    """The per-rollout env spec: first tools_kwargs entry carrying create_kwargs."""
-    for entry in (agent_data.tools_kwargs or {}).values():
-        create_kwargs = (entry or {}).get("create_kwargs")
-        if create_kwargs:
-            return dict(create_kwargs)
-    return {}
+def _rollout_create_kwargs(agent_data: Any) -> dict[str, dict[str, Any]]:
+    """This rollout's create_kwargs, keyed by the tool id each belongs to."""
+    return {
+        tool_id: dict(entry["create_kwargs"])
+        for tool_id, entry in (agent_data.tools_kwargs or {}).items()
+        if entry and entry.get("create_kwargs")
+    }
 
 
 def _build_router(
-    base_env_config: EnvironmentConfig, create_kwargs: dict[str, Any]
+    base_env_config: EnvironmentConfig,
+    create_kwargs_by_tool: dict[str, dict[str, Any]],
 ) -> ToolRouter:
-    """Build this rollout's router with its own isolated env instance(s)."""
+    """Build this rollout's router with its own isolated env instance(s).
+
+    Each tool's create_kwargs replaces (not merges) the env_kwargs of the env
+    that backs it, so a second env in the config never receives another's spec.
+    """
     cfg = copy.deepcopy(base_env_config)
+    tool_env = cfg.tool_environment_map
+    env_kwargs_by_env = {
+        tool_env[tool_id]: ck
+        for tool_id, ck in create_kwargs_by_tool.items()
+        if tool_id in tool_env
+    }
     for env in cfg.environments:
-        # Replace not merge, so a stale placeholder can't collide with an incoming key.
-        if create_kwargs:
-            env.env_kwargs = dict(create_kwargs)
+        if env.id in env_kwargs_by_env:
+            env.env_kwargs = env_kwargs_by_env[env.id]
     return ToolRouter.from_environment_config(cfg).for_sample()
 
 

--- a/src/oumi/core/trainers/verl_agentic/env_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/env_provider.py
@@ -1,0 +1,69 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-rollout Oumi environment resolution for the verl tool adapter."""
+
+from __future__ import annotations
+
+import copy
+import weakref
+from typing import Any
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.synthesis.tool_router import ToolRouter
+
+# Module-level so it's never pickled onto agent_data (its DB connection is unpicklable).
+_ROUTERS: dict[str, ToolRouter] = {}
+
+
+def _rollout_create_kwargs(agent_data: Any) -> dict[str, Any]:
+    """The per-rollout env spec: first tools_kwargs entry carrying create_kwargs."""
+    for entry in (agent_data.tools_kwargs or {}).values():
+        create_kwargs = (entry or {}).get("create_kwargs")
+        if create_kwargs:
+            return dict(create_kwargs)
+    return {}
+
+
+def _build_router(
+    base_env_config: EnvironmentConfig, create_kwargs: dict[str, Any]
+) -> ToolRouter:
+    """Build this rollout's router with its own isolated env instance(s)."""
+    cfg = copy.deepcopy(base_env_config)
+    for env in cfg.environments:
+        # Replace not merge, so a stale placeholder can't collide with an incoming key.
+        if create_kwargs:
+            env.env_kwargs = dict(create_kwargs)
+    return ToolRouter.from_environment_config(cfg).for_sample()
+
+
+def _teardown(request_id: str) -> None:
+    """Pop and close the rollout's router (fired when its agent_data is GC'd)."""
+    router = _ROUTERS.pop(request_id, None)
+    if router is not None:
+        router.close()
+
+
+def get_or_build_router(
+    agent_data: Any, base_env_config: EnvironmentConfig
+) -> ToolRouter:
+    """Return this rollout's router, building it on the first tool call."""
+    request_id = agent_data.request_id
+    router = _ROUTERS.get(request_id)
+    if router is not None:
+        return router
+    router = _build_router(base_env_config, _rollout_create_kwargs(agent_data))
+    _ROUTERS[request_id] = router
+    weakref.finalize(agent_data, _teardown, request_id)
+    return router

--- a/src/oumi/core/trainers/verl_agentic/env_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/env_provider.py
@@ -18,40 +18,58 @@ from __future__ import annotations
 
 import copy
 import weakref
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Protocol, TypedDict
 
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.synthesis.tool_router import ToolRouter
 
-# Module-level so it's never pickled onto agent_data (its DB connection is unpicklable).
+# Routers stay module-local because their environment connections are not picklable.
 _ROUTERS: dict[str, ToolRouter] = {}
 
 
-def _rollout_create_kwargs(agent_data: Any) -> dict[str, dict[str, Any]]:
-    """This rollout's create_kwargs, keyed by the tool id each belongs to."""
-    return {
-        tool_id: dict(entry["create_kwargs"])
-        for tool_id, entry in (agent_data.tools_kwargs or {}).items()
-        if entry and entry.get("create_kwargs")
-    }
+class _ToolKwargs(TypedDict, total=False):
+    create_kwargs: Mapping[str, Any]
+
+
+class _RolloutData(Protocol):
+    @property
+    def request_id(self) -> str: ...
+
+    @property
+    def tools_kwargs(self) -> Mapping[str, _ToolKwargs | None] | None: ...
+
+
+def _rollout_create_kwargs(
+    agent_data: _RolloutData,
+) -> dict[str, dict[str, Any]]:
+    create_kwargs_by_tool = {}
+    for tool_id, entry in (agent_data.tools_kwargs or {}).items():
+        if entry and (create_kwargs := entry.get("create_kwargs")):
+            create_kwargs_by_tool[tool_id] = dict(create_kwargs)
+    return create_kwargs_by_tool
 
 
 def _build_router(
     base_env_config: EnvironmentConfig,
     create_kwargs_by_tool: dict[str, dict[str, Any]],
 ) -> ToolRouter:
-    """Build this rollout's router with its own isolated env instance(s).
-
-    Each tool's create_kwargs replaces (not merges) the env_kwargs of the env
-    that backs it, so a second env in the config never receives another's spec.
-    """
     cfg = copy.deepcopy(base_env_config)
     tool_env = cfg.tool_environment_map
-    env_kwargs_by_env = {
-        tool_env[tool_id]: ck
-        for tool_id, ck in create_kwargs_by_tool.items()
-        if tool_id in tool_env
-    }
+    unknown_tool_ids = create_kwargs_by_tool.keys() - tool_env.keys()
+    if unknown_tool_ids:
+        raise ValueError(
+            "Rollout create_kwargs contain unknown tool IDs: "
+            f"{sorted(unknown_tool_ids)}"
+        )
+    env_kwargs_by_env: dict[str, dict[str, Any]] = {}
+    for tool_id, create_kwargs in create_kwargs_by_tool.items():
+        env_id = tool_env[tool_id]
+        if env_id in env_kwargs_by_env and env_kwargs_by_env[env_id] != create_kwargs:
+            raise ValueError(
+                f"Tools provide conflicting create_kwargs for environment {env_id!r}."
+            )
+        env_kwargs_by_env[env_id] = create_kwargs
     for env in cfg.environments:
         if env.id in env_kwargs_by_env:
             env.env_kwargs = env_kwargs_by_env[env.id]
@@ -59,16 +77,15 @@ def _build_router(
 
 
 def _teardown(request_id: str) -> None:
-    """Pop and close the rollout's router (fired when its agent_data is GC'd)."""
     router = _ROUTERS.pop(request_id, None)
     if router is not None:
         router.close()
 
 
 def get_or_build_router(
-    agent_data: Any, base_env_config: EnvironmentConfig
+    agent_data: _RolloutData, base_env_config: EnvironmentConfig
 ) -> ToolRouter:
-    """Return this rollout's router, building it on the first tool call."""
+    """Return the rollout-scoped router."""
     request_id = agent_data.request_id
     router = _ROUTERS.get(request_id)
     if router is not None:

--- a/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
+++ b/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""verl `BaseTool` adapter that routes tool calls into one Oumi env per rollout."""
+"""verl adapter backed by a rollout-scoped Oumi tool router."""
 
 from __future__ import annotations
 
@@ -21,20 +21,15 @@ from functools import cache
 from typing import Any
 from uuid import uuid4
 
+from verl.tools.base_tool import BaseTool  # pyright: ignore[reportMissingImports]
+from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
+    OpenAIFunctionToolSchema,
+    ToolResponse,
+)
+
 from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
-
-# verl isn't importable off-cluster; fall back to stubs so this module still imports.
-try:
-    from verl.tools.base_tool import BaseTool  # pyright: ignore[reportMissingImports]
-    from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
-        OpenAIFunctionToolSchema,
-        ToolResponse,
-    )
-except ModuleNotFoundError:  # pragma: no cover - exercised only where verl is absent
-    BaseTool = object  # type: ignore[assignment,misc]
-    OpenAIFunctionToolSchema = Any  # type: ignore[assignment,misc]
-    ToolResponse = None  # type: ignore[assignment,misc]
+from oumi.utils.packaging import is_verl_v0_7_or_later
 
 
 @cache
@@ -42,32 +37,42 @@ def _load_env_config(path: str) -> EnvironmentConfig:
     return EnvironmentConfig.from_yaml(path)
 
 
-class OumiVerlTool(BaseTool):  # pyright: ignore[reportGeneralTypeIssues]
-    """One instance per Oumi tool; all instances of a rollout share one env."""
+class OumiVerlTool(BaseTool):
+    """A verl tool backed by the router shared within a rollout."""
 
     def __init__(
         self,
         config: dict,
-        tool_schema: OpenAIFunctionToolSchema,  # pyright: ignore[reportInvalidTypeForm]
-    ):
-        """Loads this tool's shared `EnvironmentConfig` from `config`."""
-        super().__init__(config, tool_schema)  # pyright: ignore[reportCallIssue]
+        tool_schema: OpenAIFunctionToolSchema,
+    ) -> None:
+        """Loads the configured `EnvironmentConfig`."""
+        if not is_verl_v0_7_or_later():
+            raise RuntimeError("OumiVerlTool requires verl 0.7.0 or later.")
+        super().__init__(config, tool_schema)
         self._tool_id = tool_schema.function.name
         self._env_config = _load_env_config(config["oumi_env_config"])
 
-    async def create(self, instance_id=None, **kwargs):
-        """Mints an instance id; the env itself is created lazily in `execute`."""
-        return instance_id or uuid4().hex, ToolResponse()  # pyright: ignore[reportOptionalCall]
+    async def create(
+        self, instance_id: str | None = None, **kwargs: Any
+    ) -> tuple[str, ToolResponse]:
+        """Mints an instance id; the router is created lazily in `execute`."""
+        return instance_id or uuid4().hex, ToolResponse()
 
-    async def execute(self, instance_id, parameters, agent_data=None, **kwargs):
-        """Routes one tool call into this rollout's shared Oumi env."""
+    async def execute(
+        self,
+        instance_id: str,
+        parameters: dict[str, Any],
+        agent_data: Any = None,
+        **kwargs: Any,
+    ) -> tuple[ToolResponse, float, dict]:
+        """Routes one tool call through this rollout's shared Oumi router."""
         router = get_or_build_router(agent_data, self._env_config)
         args = {k: v for k, v in (parameters or {}).items() if v is not None}
         result = router.route_batch([(self._tool_id, args)])[0]
         out = result.output
         text = out if isinstance(out, str) else json.dumps(out)
-        return ToolResponse(text=text), 0.0, {}  # pyright: ignore[reportOptionalCall]
+        return ToolResponse(text=text), 0.0, {}
 
-    async def release(self, instance_id, **kwargs):
-        """No-op: env teardown is rollout-scoped (see env_provider), not per-call."""
+    async def release(self, instance_id: str, **kwargs: Any) -> None:
+        """No-op because router teardown occurs at the rollout boundary."""
         return None

--- a/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
+++ b/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
@@ -1,0 +1,73 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""verl `BaseTool` adapter that routes tool calls into one Oumi env per rollout."""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from typing import Any
+from uuid import uuid4
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
+
+# verl isn't importable off-cluster; fall back to stubs so this module still imports.
+try:
+    from verl.tools.base_tool import BaseTool  # pyright: ignore[reportMissingImports]
+    from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
+        OpenAIFunctionToolSchema,
+        ToolResponse,
+    )
+except ModuleNotFoundError:  # pragma: no cover - exercised only where verl is absent
+    BaseTool = object  # type: ignore[assignment,misc]
+    OpenAIFunctionToolSchema = Any  # type: ignore[assignment,misc]
+    ToolResponse = None  # type: ignore[assignment,misc]
+
+
+@cache
+def _load_env_config(path: str) -> EnvironmentConfig:
+    return EnvironmentConfig.from_yaml(path)
+
+
+class OumiVerlTool(BaseTool):  # pyright: ignore[reportGeneralTypeIssues]
+    """One instance per Oumi tool; all instances of a rollout share one env."""
+
+    def __init__(
+        self,
+        config: dict,
+        tool_schema: OpenAIFunctionToolSchema,  # pyright: ignore[reportInvalidTypeForm]
+    ):
+        """Loads this tool's shared `EnvironmentConfig` from `config`."""
+        super().__init__(config, tool_schema)  # pyright: ignore[reportCallIssue]
+        self._tool_id = tool_schema.function.name
+        self._env_config = _load_env_config(config["oumi_env_config"])
+
+    async def create(self, instance_id=None, **kwargs):
+        """Mints an instance id; the env itself is created lazily in `execute`."""
+        return instance_id or uuid4().hex, ToolResponse()  # pyright: ignore[reportOptionalCall]
+
+    async def execute(self, instance_id, parameters, agent_data=None, **kwargs):
+        """Routes one tool call into this rollout's shared Oumi env."""
+        router = get_or_build_router(agent_data, self._env_config)
+        args = {k: v for k, v in (parameters or {}).items() if v is not None}
+        result = router.route_batch([(self._tool_id, args)])[0]
+        out = result.output
+        text = out if isinstance(out, str) else json.dumps(out)
+        return ToolResponse(text=text), 0.0, {}  # pyright: ignore[reportOptionalCall]
+
+    async def release(self, instance_id, **kwargs):
+        """No-op: env teardown is rollout-scoped (see env_provider), not per-call."""
+        return None

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -25,7 +25,7 @@ from typing import Any, cast
 from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
-from oumi.core.types.conversation import Conversation
+from oumi.core.types.conversation import Conversation, Message
 from oumi.utils.grpo_utils import (
     extract_prompt_images_completion_from_conversation,
 )
@@ -66,6 +66,13 @@ from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
 # 4. split name (train, validation, etc.)
 # Returns an example converted to verl format.
 _DatasetProcessFn = Callable[[dict, int, str, str], dict]
+
+
+def _last_text_content(message: Message) -> str:
+    """A message's last text content, or "" if it has none (e.g. tool-call-only)."""
+    if not message.text_content_items:
+        return ""
+    return message.text_content_items[-1].content or ""
 
 
 class VerlGrpoTrainer(BaseTrainer):
@@ -246,9 +253,43 @@ class VerlGrpoTrainer(BaseTrainer):
         return (prompt_messages, images, answer)
 
     @staticmethod
+    def _create_verl_data_entry_from_tool_agent_conversation(
+        conversation: Conversation,
+        metadata: dict,
+        idx: int,
+        data_source: str,
+        split: str,
+    ) -> dict:
+        """Build a verl row for a tool_agent conversation (whole convo = prompt)."""
+        prompt_messages = [
+            {"role": m.role.value, "content": _last_text_content(m)}
+            for m in conversation.messages
+        ]
+        return {
+            "data_source": data_source,
+            "prompt": prompt_messages,
+            "images": [],
+            "ability": metadata.get("ability", "tool_agent"),
+            "agent_name": metadata["agent_name"],
+            "reward_model": {"style": "rule", "ground_truth": metadata["ground_truth"]},
+            "extra_info": {
+                "split": split,
+                "index": idx,
+                "need_tools_kwargs": True,
+                "tools_kwargs": metadata["tools_kwargs"],
+            },
+        }
+
+    @staticmethod
     def _create_verl_data_entry_from_conversation(
         example: dict, idx: int, data_source: str, split: str
     ) -> dict:
+        conversation = Conversation.from_json(example["conversation_json"])
+        metadata = conversation.metadata or {}
+        if metadata.get("agent_name") == "tool_agent":
+            return VerlGrpoTrainer._create_verl_data_entry_from_tool_agent_conversation(
+                conversation, metadata, idx, data_source, split
+            )
         prompt_messages, images, answer = (
             VerlGrpoTrainer._extract_prompt_images_answer_from_conversation(example)
         )

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -25,7 +25,9 @@ from typing import Any, cast
 from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
-from oumi.core.types.conversation import Conversation, Message
+from oumi.core.types.conversation import Conversation
+from oumi.core.types.conversation import Role as ConversationRole
+from oumi.utils.conversation_utils import create_list_of_message_json_dicts
 from oumi.utils.grpo_utils import (
     extract_prompt_images_completion_from_conversation,
 )
@@ -66,13 +68,6 @@ from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
 # 4. split name (train, validation, etc.)
 # Returns an example converted to verl format.
 _DatasetProcessFn = Callable[[dict, int, str, str], dict]
-
-
-def _last_text_content(message: Message) -> str:
-    """A message's last text content, or "" if it has none (e.g. tool-call-only)."""
-    if not message.text_content_items:
-        return ""
-    return message.text_content_items[-1].content or ""
 
 
 class VerlGrpoTrainer(BaseTrainer):
@@ -255,28 +250,43 @@ class VerlGrpoTrainer(BaseTrainer):
     @staticmethod
     def _create_verl_data_entry_from_tool_agent_conversation(
         conversation: Conversation,
-        metadata: dict,
+        ground_truth: str,
+        tools_kwargs: dict[str, Any],
+        ability: str,
         idx: int,
         data_source: str,
         split: str,
     ) -> dict:
-        """Build a verl row for a tool_agent conversation (whole convo = prompt)."""
-        prompt_messages = [
-            {"role": m.role.value, "content": _last_text_content(m)}
-            for m in conversation.messages
-        ]
+        """Build a verl row from a structured tool-agent prompt."""
+        if any(
+            message.count_content_items().image_items
+            for message in conversation.messages
+        ):
+            raise ValueError("Tool-agent conversations do not support images.")
+        if not conversation.messages or conversation.messages[-1].role not in (
+            ConversationRole.USER,
+            ConversationRole.TOOL,
+        ):
+            raise ValueError(
+                "Tool-agent conversation prompts must end with a user or tool message."
+            )
+
+        prompt_messages = create_list_of_message_json_dicts(
+            conversation.messages,
+            group_adjacent_same_role_turns=False,
+        )
         return {
             "data_source": data_source,
             "prompt": prompt_messages,
             "images": [],
-            "ability": metadata.get("ability", "tool_agent"),
-            "agent_name": metadata["agent_name"],
-            "reward_model": {"style": "rule", "ground_truth": metadata["ground_truth"]},
+            "ability": ability,
+            "agent_name": "tool_agent",
+            "reward_model": {"style": "rule", "ground_truth": ground_truth},
             "extra_info": {
                 "split": split,
                 "index": idx,
                 "need_tools_kwargs": True,
-                "tools_kwargs": metadata["tools_kwargs"],
+                "tools_kwargs": tools_kwargs,
             },
         }
 
@@ -285,10 +295,36 @@ class VerlGrpoTrainer(BaseTrainer):
         example: dict, idx: int, data_source: str, split: str
     ) -> dict:
         conversation = Conversation.from_json(example["conversation_json"])
-        metadata = conversation.metadata or {}
+        metadata = conversation.metadata
         if metadata.get("agent_name") == "tool_agent":
+            ground_truth = metadata.get("ground_truth")
+            if not isinstance(ground_truth, str) or not ground_truth:
+                raise ValueError(
+                    "Tool-agent conversation metadata must include a non-empty "
+                    "string 'ground_truth'."
+                )
+            tools_kwargs = metadata.get("tools_kwargs")
+            if not isinstance(tools_kwargs, dict) or any(
+                not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict)
+                for tool_name, tool_kwargs in tools_kwargs.items()
+            ):
+                raise ValueError(
+                    "Tool-agent conversation metadata 'tools_kwargs' must be a "
+                    "mapping of tool names to dictionaries."
+                )
+            ability = metadata.get("ability", "tool_agent")
+            if not isinstance(ability, str):
+                raise ValueError(
+                    "Tool-agent conversation metadata 'ability' must be a string."
+                )
             return VerlGrpoTrainer._create_verl_data_entry_from_tool_agent_conversation(
-                conversation, metadata, idx, data_source, split
+                conversation,
+                ground_truth,
+                tools_kwargs,
+                ability,
+                idx,
+                data_source,
+                split,
             )
         prompt_messages, images, answer = (
             VerlGrpoTrainer._extract_prompt_images_answer_from_conversation(example)

--- a/src/oumi/datasets/grpo/rewards/__init__.py
+++ b/src/oumi/datasets/grpo/rewards/__init__.py
@@ -21,6 +21,7 @@ from oumi.datasets.grpo.rewards.completion_length_rewards import (
 from oumi.datasets.grpo.rewards.count_letters_rewards import compute_letter_count_reward
 from oumi.datasets.grpo.rewards.countdown_rewards import countdown_reward
 from oumi.datasets.grpo.rewards.gsm8k_reward import gsm8k_reward
+from oumi.datasets.grpo.rewards.sql_execution_match import sql_execution_match
 
 __all__ = [
     "compute_letter_count_reward",
@@ -28,4 +29,5 @@ __all__ = [
     "compute_sharp_target_token_length_reward",
     "countdown_reward",
     "gsm8k_reward",
+    "sql_execution_match",
 ]

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -61,6 +61,25 @@ def _db_spec(extra_info: dict[str, Any]) -> dict[str, Any]:
     return run_sql.get("create_kwargs") or {}
 
 
+def _has_top_level_order_by(sql: str) -> bool:
+    """True if the outer query orders rows (ORDER BY inside a subquery doesn't).
+
+    Drops parenthesized subqueries first, so a TOP-N gold like
+    ``... IN (SELECT ... ORDER BY ... LIMIT k)`` isn't treated as order-sensitive.
+    Heuristic: assumes balanced parens and no ORDER BY inside a string literal.
+    """
+    depth = 0
+    top: list[str] = []
+    for ch in sql:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            top.append(ch)
+    return "order by" in "".join(top).lower()
+
+
 @register("sql_execution_match", RegistryType.REWARD_FUNCTION)
 def sql_execution_match(
     data_source: str,
@@ -87,7 +106,7 @@ def sql_execution_match(
         )
         owns_file = True
     try:
-        ordered = "order by" in str(ground_truth).lower()
+        ordered = _has_top_level_order_by(str(ground_truth))
         pred_rows = _run_or_none(db_path, pred_sql, ordered)
         gold_rows = _run_or_none(db_path, ground_truth, ordered)
         if pred_rows is None or gold_rows is None:

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -1,0 +1,98 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution-match (EX) reward for NL2SQL: compare predicted vs gold result sets."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from oumi.core.registry import RegistryType, register
+from oumi.environments.database_session import materialize_sqlite_snapshot
+
+_SQL_FENCE = re.compile(r"```sql\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_sql(text: str) -> str:
+    """Extract the model's final SQL: last ```sql fence, else last non-empty line."""
+    fences = _SQL_FENCE.findall(text or "")
+    if fences:
+        return fences[-1].strip()
+    lines = [ln.strip() for ln in (text or "").splitlines() if ln.strip()]
+    return lines[-1] if lines else ""
+
+
+def _run(db_path: Path, sql: str, ordered: bool) -> list:
+    """Execute `sql` read-only and return its rows, sorted unless `ordered`."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(sql).fetchall()
+    finally:
+        conn.close()
+    return rows if ordered else sorted(str(row) for row in rows)
+
+
+def _run_or_none(db_path: Path, sql: str, ordered: bool) -> list | None:
+    """`_run`, but returns None instead of raising on invalid SQL."""
+    try:
+        return _run(db_path, sql, ordered)
+    except Exception:
+        return None
+
+
+def _db_spec(extra_info: dict[str, Any]) -> dict[str, Any]:
+    """The run_sql tool's per-rollout DB spec (db_path, or schema_sql[/seed_sql])."""
+    tools_kwargs = extra_info.get("tools_kwargs") or {}
+    run_sql = tools_kwargs.get("run_sql") or {}
+    return run_sql.get("create_kwargs") or {}
+
+
+@register("sql_execution_match", RegistryType.REWARD_FUNCTION)
+def sql_execution_match(
+    data_source: str,
+    solution_str: str,
+    ground_truth: str,
+    extra_info: dict[str, Any],
+) -> float:
+    """1.0 if the predicted SQL's result set matches the gold SQL's, else 0.0.
+
+    The DB comes from ``extra_info["tools_kwargs"]["run_sql"]["create_kwargs"]``:
+    a "db_path" to a pre-staged SQLite file, or "schema_sql" (+ optional "seed_sql").
+    """
+    pred_sql = _extract_sql(solution_str)
+    if not pred_sql:
+        return 0.0
+
+    db_spec = _db_spec(extra_info)
+    shared_db = db_spec.get("db_path")
+    if shared_db:
+        db_path, owns_file = Path(shared_db), False
+    else:
+        db_path = materialize_sqlite_snapshot(
+            schema_sql=db_spec["schema_sql"], seed_sql=db_spec.get("seed_sql")
+        )
+        owns_file = True
+    try:
+        ordered = "order by" in str(ground_truth).lower()
+        pred_rows = _run_or_none(db_path, pred_sql, ordered)
+        gold_rows = _run_or_none(db_path, ground_truth, ordered)
+        if pred_rows is None or gold_rows is None:
+            return 0.0  # invalid SQL (pred or gold) scores 0
+        return 1.0 if pred_rows == gold_rows else 0.0
+    finally:
+        if owns_file:
+            db_path.unlink(missing_ok=True)

--- a/src/oumi/datasets/grpo/rewards/sql_execution_match.py
+++ b/src/oumi/datasets/grpo/rewards/sql_execution_match.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -25,59 +26,127 @@ from oumi.core.registry import RegistryType, register
 from oumi.environments.database_session import materialize_sqlite_snapshot
 
 _SQL_FENCE = re.compile(r"```sql\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+_SQL_START = re.compile(r"(?im)^\s*select\b")
+_READ_ACTIONS = {
+    sqlite3.SQLITE_FUNCTION,
+    sqlite3.SQLITE_READ,
+    sqlite3.SQLITE_RECURSIVE,
+    sqlite3.SQLITE_SELECT,
+}
+
+
+@dataclass(frozen=True)
+class _PathDatabaseSpec:
+    db_path: Path
+
+
+@dataclass(frozen=True)
+class _InlineDatabaseSpec:
+    schema_sql: str
+    seed_sql: str | None
+
+
+_DatabaseSpec = _PathDatabaseSpec | _InlineDatabaseSpec
+_RowResult = list[tuple[Any, ...]] | list[str]
 
 
 def _extract_sql(text: str) -> str:
-    """Extract the model's final SQL: last ```sql fence, else last non-empty line."""
+    """Extract the model's final fenced or unfenced SQL query."""
     fences = _SQL_FENCE.findall(text or "")
     if fences:
         return fences[-1].strip()
-    lines = [ln.strip() for ln in (text or "").splitlines() if ln.strip()]
+    starts = list(_SQL_START.finditer(text or ""))
+    if starts:
+        return text[starts[-1].start() :].strip()
+    lines = [line.strip() for line in (text or "").splitlines() if line.strip()]
     return lines[-1] if lines else ""
 
 
-def _run(db_path: Path, sql: str, ordered: bool) -> list:
-    """Execute `sql` read-only and return its rows, sorted unless `ordered`."""
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    try:
-        rows = conn.execute(sql).fetchall()
-    finally:
-        conn.close()
+def _read_only_authorizer(
+    action: int,
+    _arg1: str | None,
+    _arg2: str | None,
+    _database: str | None,
+    _trigger: str | None,
+) -> int:
+    return sqlite3.SQLITE_OK if action in _READ_ACTIONS else sqlite3.SQLITE_DENY
+
+
+def _run(conn: sqlite3.Connection, sql: str, ordered: bool) -> _RowResult:
+    """Return raw ordered rows or sorted row representations from a read query."""
+    rows = conn.execute(sql).fetchall()
     return rows if ordered else sorted(str(row) for row in rows)
 
 
-def _run_or_none(db_path: Path, sql: str, ordered: bool) -> list | None:
-    """`_run`, but returns None instead of raising on invalid SQL."""
-    try:
-        return _run(db_path, sql, ordered)
-    except Exception:
-        return None
-
-
-def _db_spec(extra_info: dict[str, Any]) -> dict[str, Any]:
+def _db_spec(extra_info: dict[str, Any]) -> _DatabaseSpec:
     """The run_sql tool's per-rollout DB spec (db_path, or schema_sql[/seed_sql])."""
     tools_kwargs = extra_info.get("tools_kwargs") or {}
     run_sql = tools_kwargs.get("run_sql") or {}
-    return run_sql.get("create_kwargs") or {}
+    values = run_sql.get("create_kwargs") or {}
+    if not isinstance(values, dict):
+        raise ValueError("run_sql create_kwargs must be a mapping.")
+
+    db_path = values.get("db_path")
+    schema_sql = values.get("schema_sql")
+    seed_sql = values.get("seed_sql")
+    if db_path is not None and not isinstance(db_path, (str, Path)):
+        raise ValueError("db_path must be a path string.")
+    if schema_sql is not None and not isinstance(schema_sql, str):
+        raise ValueError("schema_sql must be a string.")
+    if seed_sql is not None and not isinstance(seed_sql, str):
+        raise ValueError("seed_sql must be a string.")
+    if seed_sql is not None and not schema_sql:
+        raise ValueError("seed_sql requires schema_sql.")
+    if db_path and schema_sql:
+        raise ValueError("Provide exactly one of db_path or schema_sql.")
+    if db_path:
+        return _PathDatabaseSpec(Path(db_path))
+    if not schema_sql:
+        raise ValueError("Provide exactly one of db_path or schema_sql.")
+    return _InlineDatabaseSpec(schema_sql, seed_sql)
 
 
 def _has_top_level_order_by(sql: str) -> bool:
-    """True if the outer query orders rows (ORDER BY inside a subquery doesn't).
-
-    Drops parenthesized subqueries first, so a TOP-N gold like
-    ``... IN (SELECT ... ORDER BY ... LIMIT k)`` isn't treated as order-sensitive.
-    Heuristic: assumes balanced parens and no ORDER BY inside a string literal.
-    """
+    """Return whether the outer query contains an ORDER BY clause."""
     depth = 0
-    top: list[str] = []
-    for ch in sql:
+    tokens: list[str] = []
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "-" and i + 1 < len(sql) and sql[i + 1] == "-":
+            i += 2
+            while i < len(sql) and sql[i] not in "\r\n":
+                i += 1
+            continue
+        if ch == "/" and i + 1 < len(sql) and sql[i + 1] == "*":
+            end = sql.find("*/", i + 2)
+            i = len(sql) if end == -1 else end + 2
+            continue
+        if ch in "'\"`[":
+            closing = "]" if ch == "[" else ch
+            i += 1
+            while i < len(sql):
+                if sql[i] == closing:
+                    if i + 1 < len(sql) and sql[i + 1] == closing:
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            continue
         if ch == "(":
             depth += 1
         elif ch == ")":
             depth = max(0, depth - 1)
-        elif depth == 0:
-            top.append(ch)
-    return "order by" in "".join(top).lower()
+        elif depth == 0 and (ch.isalpha() or ch == "_"):
+            start = i
+            i += 1
+            while i < len(sql) and (sql[i].isalnum() or sql[i] in "_$"):
+                i += 1
+            tokens.append(sql[start:i].lower())
+            continue
+        i += 1
+    return any(a == "order" and b == "by" for a, b in zip(tokens, tokens[1:]))
 
 
 @register("sql_execution_match", RegistryType.REWARD_FUNCTION)
@@ -97,21 +166,26 @@ def sql_execution_match(
         return 0.0
 
     db_spec = _db_spec(extra_info)
-    shared_db = db_spec.get("db_path")
-    if shared_db:
-        db_path, owns_file = Path(shared_db), False
+    if isinstance(db_spec, _PathDatabaseSpec):
+        db_path, owns_file = db_spec.db_path, False
     else:
         db_path = materialize_sqlite_snapshot(
-            schema_sql=db_spec["schema_sql"], seed_sql=db_spec.get("seed_sql")
+            schema_sql=db_spec.schema_sql, seed_sql=db_spec.seed_sql
         )
         owns_file = True
     try:
-        ordered = _has_top_level_order_by(str(ground_truth))
-        pred_rows = _run_or_none(db_path, pred_sql, ordered)
-        gold_rows = _run_or_none(db_path, ground_truth, ordered)
-        if pred_rows is None or gold_rows is None:
-            return 0.0  # invalid SQL (pred or gold) scores 0
-        return 1.0 if pred_rows == gold_rows else 0.0
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            conn.set_authorizer(_read_only_authorizer)
+            ordered = _has_top_level_order_by(ground_truth)
+            gold_rows = _run(conn, ground_truth, ordered)
+            try:
+                pred_rows = _run(conn, pred_sql, ordered)
+            except sqlite3.Error:
+                return 0.0
+            return 1.0 if pred_rows == gold_rows else 0.0
+        finally:
+            conn.close()
     finally:
         if owns_file:
             db_path.unlink(missing_ok=True)

--- a/src/oumi/environments/examples/nl2sql.py
+++ b/src/oumi/environments/examples/nl2sql.py
@@ -27,6 +27,6 @@ def run_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
         cursor = context.execute(arguments["query"])
         columns = [d[0] for d in cursor.description] if cursor.description else []
         rows = [list(r) for r in cursor.fetchall()]
-    except Exception as e:  # surface the error text back to the model
+    except sqlite3.Error as e:
         return ToolResult(output={"error": str(e)})
     return ToolResult(output={"columns": columns, "rows": rows})

--- a/src/oumi/environments/examples/nl2sql.py
+++ b/src/oumi/environments/examples/nl2sql.py
@@ -1,0 +1,32 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only `run_sql` tool executor for the database environment."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from oumi.core.types.tool_call import ToolResult
+
+
+def run_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    """Execute the ``query`` argument against the rollout's bound SQLite connection."""
+    try:
+        cursor = context.execute(arguments["query"])
+        columns = [d[0] for d in cursor.description] if cursor.description else []
+        rows = [list(r) for r in cursor.fetchall()]
+    except Exception as e:  # surface the error text back to the model
+        return ToolResult(output={"error": str(e)})
+    return ToolResult(output={"columns": columns, "rows": rows})

--- a/tests/unit/core/configs/test_parse_configs.py
+++ b/tests/unit/core/configs/test_parse_configs.py
@@ -52,6 +52,8 @@ def _get_all_config_paths(exclude_yaml_suffixes: set[str] | None) -> list[str]:
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            "grpo_verl_nl2sql/environment_config.yaml",  # EnvironmentConfig
+            "grpo_verl_nl2sql/verl_tool_config.yaml",  # verl-format tool config
         }
     ),
 )
@@ -88,6 +90,8 @@ def test_parse_configs(config_path: str):
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            "grpo_verl_nl2sql/environment_config.yaml",  # EnvironmentConfig
+            "grpo_verl_nl2sql/verl_tool_config.yaml",  # verl-format tool config
         }
     ),
 )

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -152,3 +152,29 @@ def test_init_with_multiple_reward_funcs():
             train_dataset=MagicMock(),
             eval_dataset=MagicMock(),
         )
+
+
+def test_create_verl_data_entry_tool_agent_carries_metadata():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You can call run_sql."),
+            Message(role=Role.USER, content="How many rows in t?"),
+        ],
+        metadata={
+            "agent_name": "tool_agent",
+            "ground_truth": "SELECT count(*) FROM t",
+            "tools_kwargs": {
+                "run_sql": {
+                    "create_kwargs": {"schema_sql": "CREATE TABLE t(x INTEGER);"}
+                }
+            },
+        },
+    )
+    row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "nl2sql", "train"
+    )
+    assert row["agent_name"] == "tool_agent"
+    assert row["reward_model"]["ground_truth"] == "SELECT count(*) FROM t"
+    assert row["extra_info"]["need_tools_kwargs"] is True
+    assert "run_sql" in row["extra_info"]["tools_kwargs"]
+    assert row["prompt"][-1]["role"] == "user"  # ends on user turn

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import FunctionCall, ToolCall
 
 try:
     verl_import_failed = False
@@ -177,4 +179,49 @@ def test_create_verl_data_entry_tool_agent_carries_metadata():
     assert row["reward_model"]["ground_truth"] == "SELECT count(*) FROM t"
     assert row["extra_info"]["need_tools_kwargs"] is True
     assert "run_sql" in row["extra_info"]["tools_kwargs"]
-    assert row["prompt"][-1]["role"] == "user"  # ends on user turn
+    assert row["prompt"][-1]["role"] == "user"
+
+
+def test_create_verl_data_entry_tool_agent_preserves_structured_history():
+    tool_call = ToolCall(
+        id="call_1",
+        function=FunctionCall(
+            name="run_sql", arguments='{"query":"SELECT count(*) FROM t"}'
+        ),
+    )
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="How many rows in t?"),
+            Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+            Message(role=Role.TOOL, content='{"rows":[[2]]}', tool_call_id="call_1"),
+        ],
+        metadata={
+            "agent_name": "tool_agent",
+            "ground_truth": "SELECT count(*) FROM t",
+            "tools_kwargs": {"run_sql": {}},
+        },
+    )
+
+    row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "nl2sql", "train"
+    )
+
+    assert row["prompt"] == [
+        {"role": "user", "content": "How many rows in t?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "run_sql",
+                        "arguments": '{"query":"SELECT count(*) FROM t"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": '{"rows":[[2]]}', "tool_call_id": "call_1"},
+    ]
+    assert json.loads(json.dumps(row["prompt"])) == row["prompt"]

--- a/tests/unit/core/trainers/verl_agentic/test_env_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_env_provider.py
@@ -1,0 +1,99 @@
+import sqlite3
+from types import SimpleNamespace
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
+
+BASE = EnvironmentConfig(
+    environments=[  # type: ignore[list-item]
+        {
+            "id": "db",
+            "env_type": "database",
+            "env_kwargs": {
+                "schema_sql": "CREATE TABLE t(x);"
+            },  # overridden per rollout
+            "tools": [
+                {
+                    "id": "run_sql",
+                    "name": "run_sql",
+                    "description": "run sql",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                    "executor": "oumi.environments.examples.nl2sql.run_sql",
+                    "read_only": True,
+                }
+            ],
+        }
+    ]
+)
+
+
+class _FakeAgentData(SimpleNamespace):
+    """Subclass so instances support weakref.finalize (bare SimpleNamespace doesn't)."""
+
+
+def _agent_data(request_id: str):
+    # request_id is the per-rollout key the provider registers the router under.
+    return _FakeAgentData(
+        request_id=request_id,
+        tools_kwargs={
+            "run_sql": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2);",
+                }
+            }
+        },
+    )
+
+
+def test_same_request_id_returns_same_router():
+    ad = _agent_data("same-1")
+    r1 = get_or_build_router(ad, BASE)
+    r2 = get_or_build_router(ad, BASE)
+    assert r1 is r2  # one env per rollout, shared across tool calls
+
+
+def test_router_routes_run_sql():
+    ad = _agent_data("routes-1")
+    router = get_or_build_router(ad, BASE)
+    out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
+    assert out.output == {"columns": ["count(*)"], "rows": [[2]]}
+
+
+def test_different_request_id_gets_isolated_router():
+    ad1 = _agent_data("iso-a")
+    ad2 = _agent_data("iso-b")
+    # Each rollout builds its own env from its own create_kwargs; rollout 2 seeds
+    # an extra row so the two DBs are provably independent.
+    ad2.tools_kwargs["run_sql"]["create_kwargs"]["seed_sql"] = (
+        "INSERT INTO t VALUES (1),(2),(3);"
+    )
+    r1 = get_or_build_router(ad1, BASE)
+    r2 = get_or_build_router(ad2, BASE)
+    assert r1 is not r2
+    c1 = r1.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
+    c2 = r2.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
+    assert c1 == {"columns": ["count(*)"], "rows": [[2]]}
+    assert c2 == {"columns": ["count(*)"], "rows": [[3]]}  # isolated: own seed_sql
+
+
+def test_db_path_create_kwargs_overrides_placeholder_schema(tmp_path):
+    # A db_path rollout against a schema_sql-placeholder config must not leave
+    # both keys set — that would fail "exactly one of db_path/schema_sql" on
+    # every tool call (create_kwargs replaces, rather than merges into, env_kwargs).
+    db = tmp_path / "shared.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (9);")
+    conn.commit()
+    conn.close()
+    ad = _FakeAgentData(
+        request_id="dbpath-1",
+        tools_kwargs={"run_sql": {"create_kwargs": {"db_path": str(db)}}},
+    )
+    router = get_or_build_router(ad, BASE)  # must not raise
+    out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
+    assert out.output == {"columns": ["count(*)"], "rows": [[1]]}

--- a/tests/unit/core/trainers/verl_agentic/test_env_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_env_provider.py
@@ -1,18 +1,19 @@
+import gc
 import sqlite3
 from types import SimpleNamespace
+from typing import Any
 
 from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
 
 BASE = EnvironmentConfig(
-    environments=[  # type: ignore[list-item]
-        {
-            "id": "db",
-            "env_type": "database",
-            "env_kwargs": {
-                "schema_sql": "CREATE TABLE t(x);"
-            },  # overridden per rollout
-            "tools": [
+    environments=[
+        EnvironmentParams(
+            id="db",
+            env_type="database",
+            env_kwargs={"schema_sql": "CREATE TABLE t(x);"},
+            tools=[
                 {
                     "id": "run_sql",
                     "name": "run_sql",
@@ -26,7 +27,7 @@ BASE = EnvironmentConfig(
                     "read_only": True,
                 }
             ],
-        }
+        )
     ]
 )
 
@@ -34,9 +35,11 @@ BASE = EnvironmentConfig(
 class _FakeAgentData(SimpleNamespace):
     """Subclass so instances support weakref.finalize (bare SimpleNamespace doesn't)."""
 
+    request_id: str
+    tools_kwargs: dict[str, Any]
+
 
 def _agent_data(request_id: str):
-    # request_id is the per-rollout key the provider registers the router under.
     return _FakeAgentData(
         request_id=request_id,
         tools_kwargs={
@@ -54,7 +57,34 @@ def test_same_request_id_returns_same_router():
     ad = _agent_data("same-1")
     r1 = get_or_build_router(ad, BASE)
     r2 = get_or_build_router(ad, BASE)
-    assert r1 is r2  # one env per rollout, shared across tool calls
+    assert r1 is r2
+
+
+def test_router_closed_and_evicted_when_agent_data_is_collected(monkeypatch):
+    request_id = "collected-1"
+    ad = _agent_data(request_id)
+    router = get_or_build_router(ad, BASE)
+    original_close = router.close
+    close_calls = 0
+
+    def close_spy():
+        nonlocal close_calls
+        close_calls += 1
+        original_close()
+
+    monkeypatch.setattr(router, "close", close_spy)
+
+    del ad
+    gc.collect()
+
+    assert close_calls == 1
+
+    replacement_ad = _agent_data(request_id)
+    replacement_router = get_or_build_router(replacement_ad, BASE)
+    assert replacement_router is not router
+
+    del replacement_ad
+    gc.collect()
 
 
 def test_router_routes_run_sql():
@@ -67,8 +97,6 @@ def test_router_routes_run_sql():
 def test_different_request_id_gets_isolated_router():
     ad1 = _agent_data("iso-a")
     ad2 = _agent_data("iso-b")
-    # Each rollout builds its own env from its own create_kwargs; rollout 2 seeds
-    # an extra row so the two DBs are provably independent.
     ad2.tools_kwargs["run_sql"]["create_kwargs"]["seed_sql"] = (
         "INSERT INTO t VALUES (1),(2),(3);"
     )
@@ -78,13 +106,11 @@ def test_different_request_id_gets_isolated_router():
     c1 = r1.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
     c2 = r2.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
     assert c1 == {"columns": ["count(*)"], "rows": [[2]]}
-    assert c2 == {"columns": ["count(*)"], "rows": [[3]]}  # isolated: own seed_sql
+    assert c2 == {"columns": ["count(*)"], "rows": [[3]]}
 
 
 def test_db_path_create_kwargs_overrides_placeholder_schema(tmp_path):
-    # A db_path rollout against a schema_sql-placeholder config must not leave
-    # both keys set — that would fail "exactly one of db_path/schema_sql" on
-    # every tool call (create_kwargs replaces, rather than merges into, env_kwargs).
+    # create_kwargs must replace env_kwargs to avoid setting both database sources.
     db = tmp_path / "shared.sqlite"
     conn = sqlite3.connect(db)
     conn.executescript("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (9);")
@@ -94,21 +120,20 @@ def test_db_path_create_kwargs_overrides_placeholder_schema(tmp_path):
         request_id="dbpath-1",
         tools_kwargs={"run_sql": {"create_kwargs": {"db_path": str(db)}}},
     )
-    router = get_or_build_router(ad, BASE)  # must not raise
+    router = get_or_build_router(ad, BASE)
     out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
     assert out.output == {"columns": ["count(*)"], "rows": [[1]]}
 
 
-def _db_env_spec(env_id: str, tool_id: str) -> dict:
-    # placeholder seeds exactly 1 row, so an un-overwritten env is distinguishable.
-    return {
-        "id": env_id,
-        "env_type": "database",
-        "env_kwargs": {
+def _db_env_spec(env_id: str, tool_id: str) -> EnvironmentParams:
+    return EnvironmentParams(
+        id=env_id,
+        env_type="database",
+        env_kwargs={
             "schema_sql": "CREATE TABLE t(x INTEGER);",
             "seed_sql": "INSERT INTO t VALUES (7);",
         },
-        "tools": [
+        tools=[
             {
                 "id": tool_id,
                 "name": tool_id,
@@ -122,14 +147,13 @@ def _db_env_spec(env_id: str, tool_id: str) -> dict:
                 "read_only": True,
             }
         ],
-    }
+    )
 
 
 def test_create_kwargs_scoped_to_owning_env_only():
-    # Two DB envs; only db_a's tool carries create_kwargs. db_b must keep its own
-    # placeholder (1 row), not receive db_a's spec (the multi-env overwrite guard).
+    # Only db_a's tool carries create_kwargs; db_b must keep its own configuration.
     cfg = EnvironmentConfig(
-        environments=[  # type: ignore[list-item]
+        environments=[
             _db_env_spec("db_a", "q_a"),
             _db_env_spec("db_b", "q_b"),
         ]
@@ -148,5 +172,5 @@ def test_create_kwargs_scoped_to_owning_env_only():
     router = get_or_build_router(ad, cfg)
     a = router.route_batch([("q_a", {"query": "SELECT count(*) FROM t"})])[0].output
     b = router.route_batch([("q_b", {"query": "SELECT count(*) FROM t"})])[0].output
-    assert a == {"columns": ["count(*)"], "rows": [[5]]}  # db_a used create_kwargs
-    assert b == {"columns": ["count(*)"], "rows": [[1]]}  # db_b kept its placeholder
+    assert a == {"columns": ["count(*)"], "rows": [[5]]}
+    assert b == {"columns": ["count(*)"], "rows": [[1]]}

--- a/tests/unit/core/trainers/verl_agentic/test_env_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_env_provider.py
@@ -97,3 +97,56 @@ def test_db_path_create_kwargs_overrides_placeholder_schema(tmp_path):
     router = get_or_build_router(ad, BASE)  # must not raise
     out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
     assert out.output == {"columns": ["count(*)"], "rows": [[1]]}
+
+
+def _db_env_spec(env_id: str, tool_id: str) -> dict:
+    # placeholder seeds exactly 1 row, so an un-overwritten env is distinguishable.
+    return {
+        "id": env_id,
+        "env_type": "database",
+        "env_kwargs": {
+            "schema_sql": "CREATE TABLE t(x INTEGER);",
+            "seed_sql": "INSERT INTO t VALUES (7);",
+        },
+        "tools": [
+            {
+                "id": tool_id,
+                "name": tool_id,
+                "description": "run sql",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "executor": "oumi.environments.examples.nl2sql.run_sql",
+                "read_only": True,
+            }
+        ],
+    }
+
+
+def test_create_kwargs_scoped_to_owning_env_only():
+    # Two DB envs; only db_a's tool carries create_kwargs. db_b must keep its own
+    # placeholder (1 row), not receive db_a's spec (the multi-env overwrite guard).
+    cfg = EnvironmentConfig(
+        environments=[  # type: ignore[list-item]
+            _db_env_spec("db_a", "q_a"),
+            _db_env_spec("db_b", "q_b"),
+        ]
+    )
+    ad = _FakeAgentData(
+        request_id="scope-1",
+        tools_kwargs={
+            "q_a": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2),(3),(4),(5);",
+                }
+            }
+        },
+    )
+    router = get_or_build_router(ad, cfg)
+    a = router.route_batch([("q_a", {"query": "SELECT count(*) FROM t"})])[0].output
+    b = router.route_batch([("q_b", {"query": "SELECT count(*) FROM t"})])[0].output
+    assert a == {"columns": ["count(*)"], "rows": [[5]]}  # db_a used create_kwargs
+    assert b == {"columns": ["count(*)"], "rows": [[1]]}  # db_b kept its placeholder

--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -1,0 +1,60 @@
+import pytest
+
+verl = pytest.importorskip("verl")  # skips locally; runs on the cluster
+
+
+def test_execute_routes_into_shared_env(tmp_path):
+    import asyncio
+    from types import SimpleNamespace
+
+    from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
+        OpenAIFunctionToolSchema,
+    )
+
+    from oumi.core.trainers.verl_agentic.oumi_verl_tool import OumiVerlTool
+
+    cfg_path = tmp_path / "env.yaml"
+    cfg_path.write_text(
+        "environments:\n- id: db\n  env_type: database\n"
+        "  env_kwargs: {schema_sql: 'CREATE TABLE t(x);'}\n"
+        "  tools:\n  - {id: run_sql, name: run_sql, description: run,\n"
+        "     parameters: {type: object, properties: {query: {type: string}}, "
+        "required: [query]},\n"
+        "     executor: oumi.environments.examples.nl2sql.run_sql, read_only: true}\n"
+    )
+    schema = OpenAIFunctionToolSchema.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": "run_sql",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    )
+    tool = OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
+
+    class _FakeAgentData(SimpleNamespace):
+        """Subclass so instances support weakref.finalize (SimpleNamespace can't)."""
+
+    ad = _FakeAgentData(
+        extra_fields={},
+        tools_kwargs={
+            "run_sql": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2);",
+                }
+            }
+        },
+    )
+
+    iid, _ = asyncio.run(tool.create())
+    resp, reward, _metrics = asyncio.run(
+        tool.execute(iid, {"query": "SELECT count(*) FROM t"}, agent_data=ad)
+    )
+    assert reward == 0.0
+    assert "2" in resp.text

--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -1,6 +1,6 @@
 import pytest
 
-verl = pytest.importorskip("verl")  # skips locally; runs on the cluster
+verl = pytest.importorskip("verl")
 
 
 def test_execute_routes_into_shared_env(tmp_path):
@@ -38,9 +38,10 @@ def test_execute_routes_into_shared_env(tmp_path):
     tool = OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
 
     class _FakeAgentData(SimpleNamespace):
-        """Subclass so instances support weakref.finalize (SimpleNamespace can't)."""
+        """A weak-referenceable agent data stub."""
 
     ad = _FakeAgentData(
+        request_id="execute-routes-into-shared-env",
         extra_fields={},
         tools_kwargs={
             "run_sql": {

--- a/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
+++ b/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
@@ -139,3 +139,28 @@ def test_db_path_write_pred_scores_zero_without_mutating(tmp_path):
     conn = sqlite3.connect(db)
     assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 3
     conn.close()
+
+
+def test_top_level_order_by_ignores_subqueries():
+    from oumi.datasets.grpo.rewards.sql_execution_match import _has_top_level_order_by
+
+    assert _has_top_level_order_by("SELECT x FROM t ORDER BY x") is True
+    # ORDER BY only inside a subquery -> outer result is an unordered set.
+    assert (
+        _has_top_level_order_by(
+            "SELECT x FROM t WHERE x IN (SELECT x FROM t ORDER BY x LIMIT 2)"
+        )
+        is False
+    )
+
+
+def test_subquery_order_by_does_not_force_positional_match():
+    # Gold's ORDER BY is inside a subquery, so the outer result is a set; a correct
+    # pred returning the same rows in a different order must still score 1.0.
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT x FROM t WHERE x < 3 ORDER BY x DESC\n```",
+        ground_truth="SELECT x FROM t WHERE x IN (SELECT x FROM t ORDER BY x LIMIT 2)",
+        extra_info=EXTRA,
+    )
+    assert r == 1.0

--- a/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
+++ b/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
@@ -1,0 +1,141 @@
+import sqlite3
+
+from oumi.datasets.grpo.rewards.sql_execution_match import sql_execution_match
+
+SCHEMA = "CREATE TABLE t(x INTEGER);"
+SEED = "INSERT INTO t VALUES (1),(2),(3);"
+
+
+def _extra(**create_kwargs):
+    """The DB spec as verl delivers it: run_sql's create_kwargs under tools_kwargs."""
+    return {"tools_kwargs": {"run_sql": {"create_kwargs": create_kwargs}}}
+
+
+EXTRA = _extra(schema_sql=SCHEMA, seed_sql=SEED)
+
+
+def test_matching_sql_scores_one():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="Here you go:\n```sql\nSELECT count(*) FROM t\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 1.0
+
+
+def test_wrong_sql_scores_zero():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT x FROM t WHERE x = 1\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 0.0
+
+
+def test_ordered_result_wrong_order_scores_zero():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT x FROM t ORDER BY x DESC\n```",
+        ground_truth="SELECT x FROM t ORDER BY x ASC",
+        extra_info=EXTRA,
+    )
+    assert r == 0.0
+
+
+def test_ordered_result_matches_in_row_order():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT x FROM t ORDER BY x ASC\n```",
+        ground_truth="SELECT x FROM t ORDER BY x ASC",
+        extra_info=EXTRA,
+    )
+    assert r == 1.0
+
+
+def test_no_predicted_sql_scores_zero():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 0.0
+
+
+def test_invalid_predicted_sql_scores_zero():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT this is not valid sql\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 0.0
+
+
+def test_invalid_gold_sql_scores_zero():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT count(*) FROM t\n```",
+        ground_truth="SELECT this is not valid sql",
+        extra_info=EXTRA,
+    )
+    assert r == 0.0
+
+
+def test_extracts_last_non_empty_line_when_no_fence():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="I think the query is:\nSELECT count(*) FROM t",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 1.0
+
+
+def _make_shared_db(tmp_path):
+    """A pre-staged SQLite file (Spider-style) referenced by db_path, not inlined."""
+    db = tmp_path / "shared.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(SCHEMA + SEED)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_db_path_matching_scores_one_and_keeps_file(tmp_path):
+    db = _make_shared_db(tmp_path)
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT count(*) FROM t\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=_extra(db_path=str(db)),
+    )
+    assert r == 1.0
+    assert db.exists()  # shared file must not be unlinked
+
+
+def test_db_path_wrong_scores_zero(tmp_path):
+    db = _make_shared_db(tmp_path)
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nSELECT x FROM t WHERE x = 1\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=_extra(db_path=str(db)),
+    )
+    assert r == 0.0
+
+
+def test_db_path_write_pred_scores_zero_without_mutating(tmp_path):
+    db = _make_shared_db(tmp_path)
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="```sql\nDELETE FROM t\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=_extra(db_path=str(db)),
+    )
+    assert r == 0.0  # read-only connection rejects the write
+    conn = sqlite3.connect(db)
+    assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 3
+    conn.close()

--- a/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
+++ b/tests/unit/datasets/grpo/rewards/test_sql_execution_match.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+import pytest
+
 from oumi.datasets.grpo.rewards.sql_execution_match import sql_execution_match
 
 SCHEMA = "CREATE TABLE t(x INTEGER);"
@@ -74,14 +76,24 @@ def test_invalid_predicted_sql_scores_zero():
     assert r == 0.0
 
 
-def test_invalid_gold_sql_scores_zero():
-    r = sql_execution_match(
-        data_source="nl2sql",
-        solution_str="```sql\nSELECT count(*) FROM t\n```",
-        ground_truth="SELECT this is not valid sql",
-        extra_info=EXTRA,
-    )
-    assert r == 0.0
+def test_invalid_gold_sql_raises():
+    with pytest.raises(sqlite3.Error):
+        sql_execution_match(
+            data_source="nl2sql",
+            solution_str="```sql\nSELECT count(*) FROM t\n```",
+            ground_truth="SELECT this is not valid sql",
+            extra_info=EXTRA,
+        )
+
+
+def test_invalid_gold_sql_raises_even_when_prediction_is_invalid():
+    with pytest.raises(sqlite3.Error):
+        sql_execution_match(
+            data_source="nl2sql",
+            solution_str="```sql\nSELECT this is also invalid sql\n```",
+            ground_truth="SELECT this is not valid sql",
+            extra_info=EXTRA,
+        )
 
 
 def test_extracts_last_non_empty_line_when_no_fence():
@@ -89,6 +101,16 @@ def test_extracts_last_non_empty_line_when_no_fence():
         data_source="nl2sql",
         solution_str="I think the query is:\nSELECT count(*) FROM t",
         ground_truth="SELECT count(*) FROM t",
+        extra_info=EXTRA,
+    )
+    assert r == 1.0
+
+
+def test_extracts_multiline_sql_without_fence():
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str="I think the query is:\nSELECT count(*)\nFROM t\nWHERE x > 0",
+        ground_truth="SELECT count(*) FROM t WHERE x > 0",
         extra_info=EXTRA,
     )
     assert r == 1.0
@@ -113,7 +135,7 @@ def test_db_path_matching_scores_one_and_keeps_file(tmp_path):
         extra_info=_extra(db_path=str(db)),
     )
     assert r == 1.0
-    assert db.exists()  # shared file must not be unlinked
+    assert db.exists()
 
 
 def test_db_path_wrong_scores_zero(tmp_path):
@@ -135,17 +157,29 @@ def test_db_path_write_pred_scores_zero_without_mutating(tmp_path):
         ground_truth="SELECT count(*) FROM t",
         extra_info=_extra(db_path=str(db)),
     )
-    assert r == 0.0  # read-only connection rejects the write
+    assert r == 0.0
     conn = sqlite3.connect(db)
     assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 3
     conn.close()
+
+
+def test_vacuum_into_scores_zero_without_creating_file(tmp_path):
+    db = _make_shared_db(tmp_path)
+    destination = tmp_path / "escaped.sqlite"
+    r = sql_execution_match(
+        data_source="nl2sql",
+        solution_str=f"```sql\nVACUUM INTO '{destination}'\n```",
+        ground_truth="SELECT count(*) FROM t",
+        extra_info=_extra(db_path=str(db)),
+    )
+    assert r == 0.0
+    assert not destination.exists()
 
 
 def test_top_level_order_by_ignores_subqueries():
     from oumi.datasets.grpo.rewards.sql_execution_match import _has_top_level_order_by
 
     assert _has_top_level_order_by("SELECT x FROM t ORDER BY x") is True
-    # ORDER BY only inside a subquery -> outer result is an unordered set.
     assert (
         _has_top_level_order_by(
             "SELECT x FROM t WHERE x IN (SELECT x FROM t ORDER BY x LIMIT 2)"
@@ -154,9 +188,24 @@ def test_top_level_order_by_ignores_subqueries():
     )
 
 
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("SELECT 'ORDER BY (x)' FROM t", False),
+        ('SELECT "ORDER BY" FROM t', False),
+        ("SELECT x FROM t -- ORDER BY (x)\n", False),
+        ("SELECT x FROM t /* ORDER BY (x) */", False),
+        ("SELECT x FROM t ORDER /* gap */ BY x", True),
+    ],
+)
+def test_top_level_order_by_ignores_quoted_text_and_comments(sql, expected):
+    from oumi.datasets.grpo.rewards.sql_execution_match import _has_top_level_order_by
+
+    assert _has_top_level_order_by(sql) is expected
+
+
 def test_subquery_order_by_does_not_force_positional_match():
-    # Gold's ORDER BY is inside a subquery, so the outer result is a set; a correct
-    # pred returning the same rows in a different order must still score 1.0.
+    # The outer results are equivalent despite their different row order.
     r = sql_execution_match(
         data_source="nl2sql",
         solution_str="```sql\nSELECT x FROM t WHERE x < 3 ORDER BY x DESC\n```",

--- a/tests/unit/environments/test_nl2sql_executor.py
+++ b/tests/unit/environments/test_nl2sql_executor.py
@@ -1,0 +1,20 @@
+import sqlite3
+
+from oumi.environments.examples.nl2sql import run_sql
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    c.executescript("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (1),(2),(3);")
+    return c
+
+
+def test_run_sql_returns_rows():
+    res = run_sql(arguments={"query": "SELECT count(*) AS n FROM t"}, context=_conn())
+    assert res.output == {"columns": ["n"], "rows": [[3]]}
+
+
+def test_run_sql_returns_error_on_bad_sql():
+    res = run_sql(arguments={"query": "SELECT * FROM no_such_table"}, context=_conn())
+    assert isinstance(res.output, dict)
+    assert "no_such_table" in str(res.output["error"])

--- a/tests/unit/scripts/test_build_spider_tool_agent.py
+++ b/tests/unit/scripts/test_build_spider_tool_agent.py
@@ -1,0 +1,59 @@
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_builds_spider_tool_agent_rows(tmp_path):
+    repo_root = Path(__file__).parents[3]
+    script = repo_root / "scripts" / "datasets" / "build_spider_tool_agent.py"
+    spider_root = tmp_path / "spider"
+    db_root = spider_root / "database"
+    database_dir = db_root / "company"
+    database_dir.mkdir(parents=True)
+    db_path = database_dir / "company.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            "CREATE TABLE employees(name TEXT);"
+            "INSERT INTO employees VALUES ('Ada'), ('Bo');"
+        )
+
+    example = {
+        "db_id": "company",
+        "question": "How many employees are there?",
+        "query": "SELECT count(*) FROM employees",
+    }
+    spider_root.mkdir(exist_ok=True)
+    (spider_root / "train_spider.json").write_text(json.dumps([example]))
+    (spider_root / "dev.json").write_text(json.dumps([example]))
+    output_dir = tmp_path / "prepared"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--spider-root",
+            str(spider_root),
+            "--db-root",
+            str(db_root),
+            "--out-dir",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    row = json.loads((output_dir / "train.jsonl").read_text())
+    assert row["messages"][-1] == {
+        "role": "user",
+        "content": "How many employees are there?",
+    }
+    assert "CREATE TABLE employees" in row["messages"][0]["content"]
+    assert row["metadata"] == {
+        "agent_name": "tool_agent",
+        "ground_truth": "SELECT count(*) FROM employees",
+        "tools_kwargs": {"run_sql": {"create_kwargs": {"db_path": str(db_path)}}},
+    }
+    assert (output_dir / "val.jsonl").is_file()


### PR DESCRIPTION
## What

`OumiVerlTool` connects verl's tool-RL loop to any Oumi executable environment. During a verl GRPO rollout the policy model makes a tool call, that call runs for real against a live environment, and the resulting trajectory gets scored into a training signal. Nothing in the bridge is specific to SQL or to any one tool. NL2SQL is just the first thing wired up on it.

The two systems model tools differently. verl expects one tool backed by one executor. Oumi has one environment that exposes many tools through a `ToolRouter`. `OumiVerlTool` sits in between:

```
Policy model → verl ToolAgentLoop → OumiVerlTool.execute
  → env_provider.get_or_build_router (keyed by request_id)
  → ToolRouter.route_batch → ExecutableEnvironment.step → executor
```

**The bridge**, reusable for any environment:

- One `ToolRouter` per rollout, keyed by `request_id` in a module-level registry. The router holds live environment connections, which aren't picklable. It stays off `agent_data` because the trajectory gets serialized and shipped to a separate reward worker. Teardown runs on `weakref.finalize` at the rollout boundary.
- A `tool_agent` branch in the data path. Rows tagged `agent_name: tool_agent` skip the usual conversation-to-verl converter: the branch packs the prompt inline, forwards `tools_kwargs`, and reads `ground_truth` from metadata. Any tool-agent dataset flows through it, so this PR carries no `grpo_utils` changes.

**First consumer**, NL2SQL on `DatabaseExecutableEnvironment` (#2528):

- `run_sql` turns a tool call into a rollback-isolated SQLite query. The environment enforces read-only with `PRAGMA query_only`, so a hallucinated write can't touch a shared benchmark file.
- The `sql_execution_match` reward runs the model's final SQL and the gold query against the same DB and returns 1.0 when the result sets match. Matching ignores row order unless the gold query has a top-level `ORDER BY`. It reads its DB spec from `tools_kwargs["run_sql"]["create_kwargs"]`.

## Scope & stacking

- **Base: #2528** (`DatabaseExecutableEnvironment`). The reward and the `run_sql` executor route into it, so review and merge #2528 first.
- **Independent of #2542** (the multi-turn data path). The `tool_agent` branch packs its own prompt and does not use the `grpo_utils` multi-turn converter, so this PR touches no `grpo_utils` code. The two can land in any order after #2528.
- **Excluded (follow-ups):** the datasets themselves and the smoke / spider / slurm sbatch runners. The Spider row-builder script (`build_spider_tool_agent.py`) is included here, since it's what produces the `tool_agent` rows.

## Validation

Real Spider (job 126, 1×H100, Qwen2.5-3B): val EX went from 0.367 to 0.684. The full tool rollout and reward on the vllm async agent-loop path ran end to end on-box.

## Test plan

`pytest` on the touched units. They pass against the #2528 base; the verl-gated tests skip locally.

- `test_sql_execution_match.py`: shared `db_path` match and mismatch, plus a read-only run that rejects a write without mutating the file.
- `test_env_provider.py`: the same `request_id` shares a router; different `request_id`s get independently-seeded isolated envs.
- `test_verl_grpo_trainer.py::test_tool_agent_row_carries_agent_name_and_tools_kwargs`, `test_nl2sql_executor.py`.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
