### PR TITLE
docs(environments): EHR example for DatabaseExecutableEnvironment

### DIFF
--- a/configs/examples/synthesis/ehr_database_agent/ehr_database_synth.yaml
+++ b/configs/examples/synthesis/ehr_database_agent/ehr_database_synth.yaml
@@ -1,0 +1,161 @@
+# EHR Agent — Database-Backed Tool-Use Conversation Synthesis
+#
+# Generates multi-turn conversations between a clinician (the user) and ChartBot
+# (the assistant), which answers using SQL tools over a patients table. Each
+# conversation runs against its own rollback-isolated SQLite snapshot:
+# DatabaseExecutableEnvironment requires isolation, so the router rebuilds a
+# fresh session per sample and writes never leak between conversations.
+#
+# The tools reference their executors by registry name (ehr_db.*). The executors
+# live in executors.py next to this config and register those names via
+# @register_tool_executor; OUMI_EXTRA_DEPS_FILE imports that module at startup.
+#
+# Swap schema_sql/seed_sql for `db_path: /path/to/your.sqlite` to bring your own
+# database; the session never commits, so your file is left unmodified.
+#
+# Requirements:
+#   - Set OPENAI_API_KEY, or change inference_config to another native
+#     tool-calling engine (see NATIVE_TOOL_CALLING_ENGINES in
+#     oumi/inference/native_tool_calling.py).
+#
+# Usage (run from the repo root):
+#   OUMI_EXTRA_DEPS_FILE=configs/examples/synthesis/ehr_database_agent/extra_deps.txt \
+#     oumi synth -c configs/examples/synthesis/ehr_database_agent/ehr_database_synth.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/synth.html
+#   - Executors: configs/examples/synthesis/ehr_database_agent/executors.py
+
+strategy: GENERAL
+num_samples: 100
+output_path: ehr_database_dataset.jsonl
+
+environment_config:
+  environments:
+    - id: ehr
+      name: ehr
+      description: A small EHR patients table with lookup and update tools.
+      env_type: database
+      env_kwargs:
+        schema_sql: "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT NOT NULL, meds TEXT);"
+        seed_sql: >
+          INSERT INTO patients (id, name, meds) VALUES
+            (1, 'Bob Martin', 'aspirin'),
+            (2, 'Alice Chen', 'ibuprofen'),
+            (3, 'Carol Diaz', NULL),
+            (4, 'David Okoye', 'metformin'),
+            (5, 'Eve Larsson', 'lisinopril'),
+            (6, 'Frank Wu', 'atorvastatin'),
+            (7, 'Grace Park', NULL),
+            (8, 'Hassan Ali', 'amoxicillin'),
+            (9, 'Ivy Nguyen', 'omeprazole'),
+            (10, 'Jack Brown', 'warfarin'),
+            (11, 'Karen Smith', 'levothyroxine'),
+            (12, 'Liam Murphy', NULL);
+      tools:
+        - id: list_patients
+          name: list_patients
+          description: List all patients with their id and name.
+          parameters: {type: object, properties: {}}
+          executor: ehr_db.list_patients
+          read_only: true
+        - id: lookup_patient
+          name: lookup_patient
+          description: Look up one patient's name and current medication by id.
+          parameters:
+            type: object
+            properties:
+              pat_id: {type: integer, description: Patient id from list_patients.}
+            required: [pat_id]
+          executor: ehr_db.lookup_patient
+          read_only: true
+        - id: update_meds
+          name: update_meds
+          description: Set a patient's medication by id.
+          parameters:
+            type: object
+            properties:
+              pat_id: {type: integer}
+              medication: {type: string}
+            required: [pat_id, medication]
+          executor: ehr_db.update_meds
+          read_only: false
+
+strategy_params:
+  sampled_attributes:
+    - id: clinician_persona
+      name: Clinician persona
+      description: The kind of clinician talking to ChartBot.
+      possible_values:
+        - id: charge_nurse
+          name: A charge nurse doing a medication round
+          description: Practical, time-pressed, double-checks before changing anything.
+        - id: attending_physician
+          name: An attending physician reviewing a patient
+          description: Precise, asks targeted questions, decisive about med changes.
+        - id: pharmacist
+          name: A pharmacist reconciling medications
+          description: Detail-oriented, cross-checks current meds, cautious about interactions.
+
+  multiturn_attributes:
+    - id: ehr_dialog
+      min_turns: 4
+      max_turns: 6
+      max_consecutive_tool_turns: 6
+      available_environments:
+        - ehr
+
+      role_instruction_messages:
+        USER: |
+          You are {clinician_persona.name}: {clinician_persona.description}
+
+          You are talking to ChartBot, an EHR assistant, to look up patients and
+          (sometimes) update a patient's medication.
+
+          Guidelines:
+          - Stay in character — match the persona's tone.
+          - Don't call tools yourself; only ChartBot has tools.
+          - Refer to patients by name; let ChartBot find the id.
+          - Follow the plan's direction for this turn but respond naturally.
+          - Keep responses concise. Output only your message, nothing else.
+
+        ASSISTANT: |
+          You are ChartBot, a careful EHR assistant with three tools:
+          - list_patients(): list all patients with ids and names.
+          - lookup_patient(pat_id): get a patient's name and current medication.
+          - update_meds(pat_id, medication): change a patient's medication.
+
+          Guidelines:
+          - Use tools for facts; never guess a patient id or current medication.
+          - Resolve a name to an id via list_patients before lookup or update.
+          - Before calling update_meds, confirm the patient and the new medication
+            with the clinician.
+          - When you have what you need, give a clear final answer in plain text.
+
+      conversation_planner: |
+        Plan a {target_turns}-turn conversation between {clinician_persona.name}
+        ({clinician_persona.description}) and ChartBot. The dialog must require
+        ChartBot to call list_patients at least once and lookup_patient at least
+        once; some conversations should also update a medication.
+
+        Match the plan to the persona's communication style. Be specific about
+        what each turn should accomplish.
+
+      output_system_prompt: |
+        This is a conversation between a clinician and ChartBot, a tool-using
+        EHR assistant.
+
+  passthrough_attributes:
+    - clinician_persona
+    - ehr_dialog
+    - ehr_dialog_plan
+
+inference_config:
+  engine: OPENAI
+  model:
+    model_name: gpt-4o-mini
+  generation:
+    max_new_tokens: 1024
+    temperature: 0.4
+  remote_params:
+    num_workers: 10

--- a/configs/examples/synthesis/ehr_database_agent/executors.py
+++ b/configs/examples/synthesis/ehr_database_agent/executors.py
@@ -1,0 +1,64 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool executors for the EHR database synthesis example.
+
+``DatabaseExecutableEnvironment`` passes each executor a live SQLite connection
+inside a savepoint rather than a copied state document, so writes are ordinary
+SQL. The environment owns the transaction: executors must never commit, and
+every write is rolled back when the episode ends.
+
+For tools over small state that fits in a JSON snapshot, use
+``SyntheticEnvironment`` instead; see ``../ehr_stateful_agent/executors.py``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from oumi.core.registry import register_tool_executor
+from oumi.core.types.tool_call import ToolResult
+
+
+@register_tool_executor("ehr_db.list_patients")
+def list_patients(arguments: dict[str, Any], context: sqlite3.Connection) -> ToolResult:
+    """List every patient's id and name."""
+    rows = context.execute("SELECT id, name FROM patients ORDER BY id").fetchall()
+    return ToolResult(
+        output={"patients": [{"id": row[0], "name": row[1]} for row in rows]}
+    )
+
+
+@register_tool_executor("ehr_db.lookup_patient")
+def lookup_patient(
+    arguments: dict[str, Any], context: sqlite3.Connection
+) -> ToolResult:
+    """Return one patient's name and meds by id, or an error if absent."""
+    row = context.execute(
+        "SELECT name, meds FROM patients WHERE id = ?", (arguments["pat_id"],)
+    ).fetchone()
+    if row is None:
+        return ToolResult(output={"error": "not found"})
+    return ToolResult(output={"name": row[0], "meds": row[1]})
+
+
+@register_tool_executor("ehr_db.update_meds")
+def update_meds(arguments: dict[str, Any], context: sqlite3.Connection) -> ToolResult:
+    """Set a patient's medication (uncommitted; rolled back at episode end)."""
+    cursor = context.execute(
+        "UPDATE patients SET meds = ? WHERE id = ?",
+        (arguments["medication"], arguments["pat_id"]),
+    )
+    return ToolResult(output={"updated_rows": cursor.rowcount})

--- a/configs/examples/synthesis/ehr_database_agent/extra_deps.txt
+++ b/configs/examples/synthesis/ehr_database_agent/extra_deps.txt
@@ -1,0 +1,4 @@
+# Modules Oumi imports at startup so their @register_tool_executor decorators
+# run. Point OUMI_EXTRA_DEPS_FILE at this file (paths are relative to the
+# directory you run `oumi` from — the repo root for this example).
+configs/examples/synthesis/ehr_database_agent/executors.py

--- a/tests/unit/examples/test_ehr_database_executors.py
+++ b/tests/unit/examples/test_ehr_database_executors.py
@@ -1,0 +1,104 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the EHR database synthesis example's tool executors."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from omegaconf import OmegaConf
+
+from oumi.builders.environments import build_environment
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.environments.database_executable_environment import (
+    DatabaseExecutableEnvironment,
+)
+from oumi.environments.utils import resolve_executor
+
+_EXAMPLE_DIR = (
+    Path(__file__).parents[3]
+    / "configs"
+    / "examples"
+    / "synthesis"
+    / "ehr_database_agent"
+)
+_CONFIG = _EXAMPLE_DIR / "ehr_database_synth.yaml"
+
+
+@pytest.fixture(scope="module")
+def ehr_db():
+    """Load the example's executors the way OUMI_EXTRA_DEPS_FILE does."""
+    spec = importlib.util.spec_from_file_location(
+        "ehr_database_example_executors", _EXAMPLE_DIR / "executors.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def env(ehr_db) -> Iterator[DatabaseExecutableEnvironment]:
+    """Build the example's environment from its config; ehr_db registers its tools."""
+    raw = cast(
+        "dict[str, Any]", OmegaConf.to_container(OmegaConf.load(_CONFIG), resolve=True)
+    )
+    params = EnvironmentParams(**raw["environment_config"]["environments"][0])
+    environment = build_environment(params)
+    assert isinstance(environment, DatabaseExecutableEnvironment)
+    try:
+        yield environment
+    finally:
+        environment.close()
+
+
+def test_config_executor_names_resolve_to_the_example_functions(ehr_db):
+    """Every ``executor:`` in the config must be a registered ``ehr_db.*`` name."""
+    names = re.findall(r"^\s*executor:\s*(\S+)", _CONFIG.read_text(), re.MULTILINE)
+    assert len(names) == 3
+    for name in names:
+        namespace, _, attr = name.partition(".")
+        assert namespace == "ehr_db"
+        assert resolve_executor(name, "t") is getattr(ehr_db, attr)
+
+
+def test_list_patients_returns_every_seeded_row(env):
+    [result] = env.step([("list_patients", {})])
+    assert isinstance(result.output, dict)
+    patients = result.output["patients"]
+    assert len(patients) == 12
+    assert patients[0] == {"id": 1, "name": "Bob Martin"}
+
+
+def test_lookup_patient_returns_name_and_meds(env):
+    [result] = env.step([("lookup_patient", {"pat_id": 2})])
+    assert result.output == {"name": "Alice Chen", "meds": "ibuprofen"}
+
+
+def test_lookup_patient_unknown_id_returns_error(env):
+    [result] = env.step([("lookup_patient", {"pat_id": 999})])
+    assert result.output == {"error": "not found"}
+
+
+def test_update_meds_is_visible_to_a_later_lookup(env):
+    [update] = env.step([("update_meds", {"pat_id": 1, "medication": "warfarin"})])
+    assert update.output == {"updated_rows": 1}
+    [lookup] = env.step([("lookup_patient", {"pat_id": 1})])
+    assert lookup.output == {"name": "Bob Martin", "meds": "warfarin"}


### PR DESCRIPTION
## What

The EHR example for `DatabaseExecutableEnvironment`, split out of #2528 so that PR stayed a focused implementation. Now rebased onto `main` and realigned with what has since landed:

- `configs/examples/synthesis/ehr_database_agent/` — synthesis config, `executors.py`, and `extra_deps.txt` in one directory, mirroring the `ehr_stateful_agent/` layout from #2458. Nothing is added under `src/`.
- Executors register `ehr_db.*` names via `@register_tool_executor` (#2555) instead of being resolved by dotted path.
- `tests/unit/examples/test_ehr_database_executors.py` — loads `executors.py` the way `OUMI_EXTRA_DEPS_FILE` does, asserts every `executor:` in the config resolves to the example's function, and drives all three tools end-to-end through `env.step` against real SQLite.

Dropped since the last revision: the bare `EnvironmentParams` YAML (`configs/examples/database_env/ehr_database_env.yaml`) and the two `test_parse_configs` exclusions it needed — it wasn't runnable by any `oumi` command, and the e2e test now builds the environment from the synthesis config's `environment_config`.

## Why

A runnable, copy-pasteable starting point for bring-your-own-database NL2SQL / DB-agent synthesis. Swapping `schema_sql`/`seed_sql` for `db_path: /path/to/your.sqlite` points it at a real database; the session never commits, so the file is left unmodified.

## Test

```
OUMI_EXTRA_DEPS_FILE=configs/examples/synthesis/ehr_database_agent/extra_deps.txt \
  oumi synth -c configs/examples/synthesis/ehr_database_agent/ehr_database_synth.yaml
```

`pytest tests/unit/examples tests/unit/environments tests/unit/core/configs/test_parse_configs.py` — 1190 passed. `pre-commit` (ruff, ruff-format, pyright) clean on the touched files.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
