### PR TITLE
build(deps): raise vLLM floor to >=0.19,<0.20 (both extras)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "skypilot>=0.12,<0.13", # 0.12 adds Slurm cloud support
     "tensorboard>=2.20,<2.21", # Optional, for monitoring training
     "tiktoken>=0.7,<1.0",
-    "torch>=2.6,<2.13.0",      # vllm only supports up to torch==2.7
+    "torch>=2.6,<2.13.0",      # vLLM 0.19 pins torch 2.10; upper bound gives headroom. torch 2.11+ (vLLM 0.21+) is the deferred CUDA-13 migration (OPE-2164).
     "torchao>=0.16,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
@@ -130,7 +130,10 @@ gpu = [
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.
     "verl>=0.5,<0.8; python_version >= '3.10'", # Used for the VERL_GRPO trainer
-    "vllm>=0.14,<0.22",                         # For VLLMInferenceEngine, and vLLM-powered GRPO training.
+    # For VLLMInferenceEngine, and vLLM-powered GRPO training.
+    # Pinned to the 0.19.x line: 0.19 first serves Gemma-4/nemotron_h; <0.20 holds
+    # torch 2.10/CUDA-12. Raising past 0.19 needs the CUDA-13 migration (OPE-2164).
+    "vllm>=0.19,<0.20",
     "kernels>=0.11,<0.15",                      # For compute kernel implementations (e.g., attn_implementation in gold trainer)
 ]
 
@@ -204,7 +207,7 @@ torchdata = ["torchdata>=0.9,<0.10.0"]
 # CI targets
 ci_cpu = [
     "oumi[dev,docs,gcp,mcp,synthesis,tune,torchdata,file_formats]",
-    "vllm>=0.14,<0.22",                            # For VLLMInferenceEngine
+    "vllm>=0.19,<0.20",                            # For VLLMInferenceEngine (must match [gpu] pin)
     "boto3",  # For bedrock inference engine tests
     # This may fail to install. As a temporary workaround, run:
     # CMAKE_ARGS="-DLLAVA_BUILD=OFF" pip install -U llama-cpp-python

--- a/tests/unit/utils/test_packaging.py
+++ b/tests/unit/utils/test_packaging.py
@@ -1,7 +1,11 @@
 import importlib.metadata
+import sys
+from pathlib import Path
 
 import pytest
 from packaging import version
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 from oumi.utils.packaging import (
     PackagePrerequisites,
@@ -187,3 +191,77 @@ def test_verify_trl_vllm_compatibility_fails_new_trl_old_vllm(monkeypatch):
     monkeypatch.setattr("importlib.metadata.version", mock_version)
     with pytest.raises(RuntimeError, match="vLLM >= 0.11.0"):
         verify_trl_vllm_compatibility("test")
+
+
+def _vllm_specifiers_by_extra() -> dict[str, str]:
+    """Return the vLLM version specifier for each optional-dependencies extra.
+
+    Parses the repo's pyproject.toml and walks `[project.optional-dependencies]`,
+    returning for each extra that pins vLLM the normalized specifier string
+    (`str(Requirement(dep).specifier)`) of the dep whose name is "vllm".
+
+    Scope is `[project.optional-dependencies]` ONLY. A vllm pin added to the base
+    `[project.dependencies]` list or a `[tool.uv]` override is intentionally out of
+    this helper's scope.
+    """
+    # tomllib is stdlib only on py3.11+; import lazily so this module still imports
+    # under py3.10 (the tests that call this are skipped there).
+    import tomllib
+
+    pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        pyproject = tomllib.load(f)
+
+    specifiers_by_extra: dict[str, str] = {}
+    optional_deps = pyproject["project"]["optional-dependencies"]
+    for extra, deps in optional_deps.items():
+        for dep in deps:
+            requirement = Requirement(dep)
+            if requirement.name == "vllm":
+                specifiers_by_extra[extra] = str(requirement.specifier)
+                break
+    return specifiers_by_extra
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is py3.11+; oumi supports 3.10, CI runs 3.11",
+)
+def test_vllm_pin_gpu_matches_ci_cpu():
+    """The `gpu` and `ci_cpu` extras resolve to an identical specifier set.
+
+    Compared as normalized specifier strings (not byte-identity), so semantically
+    equal pins written differently still pass while a real divergence fails.
+    """
+    specifiers = _vllm_specifiers_by_extra()
+    assert specifiers["gpu"] == specifiers["ci_cpu"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is py3.11+; oumi supports 3.10, CI runs 3.11",
+)
+def test_vllm_floor_at_least_0_19():
+    """Every pinned extra floors vLLM at >= 0.19 (0.19 first serves nemotron_h)."""
+    for extra, specifier_str in _vllm_specifiers_by_extra().items():
+        specifier = Requirement(f"vllm{specifier_str}").specifier
+        lower_bounds = [
+            Version(clause.version)
+            for clause in specifier
+            if clause.operator in (">=", ">")
+        ]
+        assert lower_bounds, f"extra `{extra}` has no vLLM lower bound"
+        assert min(lower_bounds) >= Version("0.19")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is py3.11+; oumi supports 3.10, CI runs 3.11",
+)
+def test_exactly_two_explicit_vllm_pins():
+    """Exactly two extras carry an explicit vLLM pin: `gpu` and `ci_cpu`.
+
+    `ci_gpu` pulls vLLM transitively via `oumi[...gpu...]` with no explicit pin;
+    a silent third explicit pin would fail this test.
+    """
+    assert set(_vllm_specifiers_by_extra()) == {"gpu", "ci_cpu"}


### PR DESCRIPTION
> 🚧 **DRAFT / BLOCKED — do not merge.** This pin bump alone is unsatisfiable; kept open to document the blocker. See the full analysis on OPE-2162.

## What this does

Raises the vLLM floor `>=0.14,<0.22` → `>=0.19,<0.20` in both the `[gpu]` and `[ci_cpu]` extras, fixes the stale torch comment, and adds three import-free `tomllib` packaging tests (pin-parity, floor ≥ 0.19, exactly-two-pins).

## ⛔ Why it's blocked

`oumi[gpu]` bundles `verl` (pins `numpy<2`) and `vllm`. Every `vllm >= 0.14.1` requires `opencv-python-headless>=4.13` → `numpy>=2`, so a modern vLLM and verl **cannot resolve together**. The old `>=0.14` floor resolved only to vLLM **0.14.0** (the last numpy<2-compatible vLLM) — which is the very bug OPE-2162 reports (0.14 can't serve `nemotron_h`). `gpu-tests` fails here on the resolution.

Empirically, vLLM 0.19.1 **does** serve an `nemotron_h` LoRA with stock (unpatched) vLLM — so the fix is real, but it requires **decoupling `verl` from the vLLM-serving extra**, a packaging-architecture change paused for team ratification.

Fixes OPE-2163.
Part of the vLLM bump feature (OPE-2162) — see that issue for the full blocker analysis and options.
