### PR TITLE
fix(launcher): treat Slurm command timeout as ClusterUnreachableError

### DIFF
--- a/src/oumi/launcher/clients/slurm_client.py
+++ b/src/oumi/launcher/clients/slurm_client.py
@@ -36,6 +36,10 @@ _LOG_DIR = "$HOME/oumi_slurm_logs/{job_id}.out"
 # auth rejected) — as distinct from a command that ran and returned non-zero.
 _SSH_TRANSPORT_FAILURE_EXIT_CODE = 255
 
+# Synthetic exit code for a command that hit its timeout: an unresponsive
+# controller is treated as unreachable, same as a transport failure.
+_COMMAND_TIMEOUT_EXIT_CODE = 124
+
 
 class _SlurmAuthException(Exception):
     pass
@@ -231,8 +235,11 @@ class SlurmResponse:
 
 
 def _raise_if_unreachable(response: SlurmResponse, cluster_name: str) -> None:
-    """Raise ClusterUnreachableError if the SSH transport to the host failed."""
-    if response.exit_code == _SSH_TRANSPORT_FAILURE_EXIT_CODE:
+    """Raise ClusterUnreachableError if the SSH transport failed or timed out."""
+    if response.exit_code in (
+        _SSH_TRANSPORT_FAILURE_EXIT_CODE,
+        _COMMAND_TIMEOUT_EXIT_CODE,
+    ):
         raise ClusterUnreachableError(
             f"Could not reach the Slurm controller for cluster '{cluster_name}'."
         )
@@ -600,7 +607,7 @@ class SlurmClient:
             return SlurmResponse(
                 stdout="",
                 stderr=f"Timeout while running command: {new_cmd}",
-                exit_code=1,
+                exit_code=_COMMAND_TIMEOUT_EXIT_CODE,
             )
         except Exception:
             duration_str = _compute_duration_debug_str(start_time)

--- a/tests/unit/launcher/clients/test_slurm_client.py
+++ b/tests/unit/launcher/clients/test_slurm_client.py
@@ -560,6 +560,23 @@ def test_slurm_client_get_job_unreachable_raises(mock_subprocess):
         _ = client.get_job("100")
 
 
+def test_slurm_client_get_job_timeout_unreachable_raises(mock_subprocess):
+    # A command that hits its timeout is an unresponsive controller; get_job
+    # surfaces it as unreachable, not a generic RuntimeError.
+    mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
+    mock_subprocess.run.side_effect = [
+        _mock_refresh_creds_run(),
+        _mock_refresh_creds_run(),
+        subprocess.TimeoutExpired(cmd="ssh ... squeue", timeout=180),
+    ]
+
+    client = SlurmClient("user", "host", "cluster_name")
+    with pytest.raises(
+        ClusterUnreachableError, match="Could not reach the Slurm controller"
+    ):
+        _ = client.get_job("100")
+
+
 def test_slurm_client_list_jobs_unreachable_raises(mock_subprocess, mock_datetime):
     sacct_unreachable = Mock()
     sacct_unreachable.stdout = b""


### PR DESCRIPTION
## Summary

An ssh command to the Slurm controller that hangs until the subprocess timeout currently returns `exit_code=1`, so `_raise_if_unreachable` (which only checks the 255 transport-failure code) doesn't fire and `_list_active_jobs_squeue` / `list_jobs` raise a bare `RuntimeError`. An unresponsive controller is unreachable for our purposes, so it should map to `ClusterUnreachableError` like a transport failure — letting callers ride their retry / fall-through path instead of treating it as a hard error.

## Changes

- Stamp a synthetic `_COMMAND_TIMEOUT_EXIT_CODE = 124` on the `SlurmResponse` returned from the `run_commands` timeout branch.
- `_raise_if_unreachable` now raises `ClusterUnreachableError` for both the SSH transport-failure code (255) and the timeout code (124).
- Unit test: `get_job` on a squeue that times out raises `ClusterUnreachableError`.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
