### PR TITLE
fix(deps): bump pillow ceiling to <12.4 for security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "peft>=0.17,<0.20",
     "pexpect>=4.9,<4.10",      # Used by Polaris client
     "posthog>=7.0,<8.0",
-    "pillow>=11.3,<12.3",      # Used by image datasets
+    "pillow>=11.3,<12.4",      # Used by image datasets
     "protobuf>=6.32",
     "pycares<6.0.0",
     "pydantic>=2.11,<2.14",


### PR DESCRIPTION
# Description

pillow versions `<12.3.0` carry severity vulnerabilities: https://pillow.readthedocs.io/en/latest/releasenotes/12.2.0.html

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (N/A — dependency range change only)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
