### PR TITLE
fix(train): guard torch._dynamo recompile_limit for torch 2.6 compatibility

### DIFF
--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -293,8 +293,12 @@ def _maybe_raise_dynamo_recompile_limit(config: TrainingConfig) -> None:
         return
     override = os.environ.get("OUMI_DYNAMO_RECOMPILE_LIMIT")
     limit = int(override) if override else _DEFAULT_DYNAMO_RECOMPILE_LIMIT
-    torch._dynamo.config.recompile_limit = limit
+    # `cache_size_limit` is the backward-compatible knob present in all supported
+    # torch versions. torch>=2.7 renamed it to `recompile_limit` (the two alias the
+    # same value); torch 2.6 has only `cache_size_limit`, so guard the newer name.
     torch._dynamo.config.cache_size_limit = limit
+    if hasattr(torch._dynamo.config, "recompile_limit"):
+        torch._dynamo.config.recompile_limit = limit
     logger.info(f"Set torch dynamo recompile limit to {limit} (pad_to_multiple_of).")
 
 

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -157,12 +157,11 @@ def restore_dynamo_limits():
     """Save/restore global torch dynamo limits mutated by the helper under test."""
     import torch
 
-    saved = (
-        torch._dynamo.config.recompile_limit,
-        torch._dynamo.config.cache_size_limit,
-    )
+    # `cache_size_limit` exists in all supported torch versions; torch>=2.7 aliases
+    # it to `recompile_limit`. Assert on `cache_size_limit` so tests work on both.
+    saved = torch._dynamo.config.cache_size_limit
     yield
-    torch._dynamo.config.recompile_limit, torch._dynamo.config.cache_size_limit = saved
+    torch._dynamo.config.cache_size_limit = saved
 
 
 def test_recompile_limit_unset_without_pad_to_multiple_of(
@@ -173,11 +172,11 @@ def test_recompile_limit_unset_without_pad_to_multiple_of(
     from oumi.train import _maybe_raise_dynamo_recompile_limit
 
     monkeypatch.delenv("OUMI_DYNAMO_RECOMPILE_LIMIT", raising=False)
-    torch._dynamo.config.recompile_limit = 8
+    torch._dynamo.config.cache_size_limit = 8
     _maybe_raise_dynamo_recompile_limit(_config_with_collator_kwargs(None))
-    assert torch._dynamo.config.recompile_limit == 8
+    assert torch._dynamo.config.cache_size_limit == 8
     _maybe_raise_dynamo_recompile_limit(_config_with_collator_kwargs({}))
-    assert torch._dynamo.config.recompile_limit == 8
+    assert torch._dynamo.config.cache_size_limit == 8
 
 
 def test_recompile_limit_self_set_with_pad_to_multiple_of(
@@ -191,11 +190,10 @@ def test_recompile_limit_self_set_with_pad_to_multiple_of(
     )
 
     monkeypatch.delenv("OUMI_DYNAMO_RECOMPILE_LIMIT", raising=False)
-    torch._dynamo.config.recompile_limit = 8
+    torch._dynamo.config.cache_size_limit = 8
     _maybe_raise_dynamo_recompile_limit(
         _config_with_collator_kwargs({"pad_to_multiple_of": 8192})
     )
-    assert torch._dynamo.config.recompile_limit == _DEFAULT_DYNAMO_RECOMPILE_LIMIT
     assert torch._dynamo.config.cache_size_limit == _DEFAULT_DYNAMO_RECOMPILE_LIMIT
 
 
@@ -205,8 +203,8 @@ def test_recompile_limit_env_override_wins(monkeypatch, restore_dynamo_limits):
     from oumi.train import _maybe_raise_dynamo_recompile_limit
 
     monkeypatch.setenv("OUMI_DYNAMO_RECOMPILE_LIMIT", "128")
-    torch._dynamo.config.recompile_limit = 8
+    torch._dynamo.config.cache_size_limit = 8
     _maybe_raise_dynamo_recompile_limit(
         _config_with_collator_kwargs({"pad_to_multiple_of": 8192})
     )
-    assert torch._dynamo.config.recompile_limit == 128
+    assert torch._dynamo.config.cache_size_limit == 128


### PR DESCRIPTION
# Description

`torch._dynamo.config.recompile_limit` was added in **torch 2.7** (a rename of `cache_size_limit`; the two alias the same underlying value in 2.7+). On **torch 2.6.0** — the low end of Oumi's supported `torch>=2.6,<2.13` range — only `cache_size_limit` exists, so `_maybe_raise_dynamo_recompile_limit` (in `src/oumi/train.py`) and its tests raised `AttributeError: torch._dynamo.config.recompile_limit does not exist`.

This surfaced as 3 errors in the `install-test (3.12, 2.6.0)` CI matrix cell (the job runs on `pyproject.toml` changes and was seen failing on #2548).

**Fix:** set the backward-compatible `cache_size_limit` unconditionally, and only touch `recompile_limit` behind a `hasattr` guard. Tests now assert on `cache_size_limit` (aliased to `recompile_limit` on 2.7+, so behavior is identically exercised there). No behavior change on newer torch.

## Related issues

N/A — pre-existing failure on `main` in the torch 2.6.0 CI cell, surfaced while validating a dependency bump (#2548).

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (Updated the 3 `recompile_limit` tests to work across the supported torch range.)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->


---

## CI proof

Dispatched the `Installation Test` workflow on this branch (`workflow_dispatch`). The `install-test (3.12, 2.6.0)` matrix cell — the one that failed on the pillow bump PR (#2548) with the 3 `recompile_limit` `AttributeError`s — now **passes**:

**→ https://github.com/oumi-ai/oumi/actions/runs/29859836739/job/88733437309** (conclusion: success)

(The workflow run's overall status is red only because of the unrelated `install-test (3.10)` cell, which is fixed by a separate PR.)
