### PR TITLE
fix(environments): secure rollback-isolation teardown for Python 3.10 SQLite

### DIFF
--- a/src/oumi/environments/database_session.py
+++ b/src/oumi/environments/database_session.py
@@ -96,12 +96,17 @@ class DatabaseSession:
     def _cleanup(self, *, rollback: bool, suppress_errors: bool = False) -> None:
         operations: list[Callable[[], object]] = []
         if rollback:
-            operations.extend(
-                (
-                    lambda: self.connection.set_authorizer(None),
-                    self.connection.rollback,
-                )
-            )
+            # Discard uncommitted writes by closing with the transaction still
+            # open: SQLite rolls back on close. We deliberately do NOT issue an
+            # explicit ``connection.rollback()``. The authorizer denies every
+            # SQLITE_TRANSACTION action (BEGIN/COMMIT/END/ROLLBACK), and on the
+            # SQLite bundled with CPython 3.10 (3.50.x) a denied ROLLBACK during
+            # the transaction makes the denial sticky for the rest of that
+            # transaction -- so a follow-up framework ``rollback()`` would raise
+            # "not authorized" even after ``set_authorizer(None)``. Clearing the
+            # authorizer and letting ``close()`` do the implicit rollback avoids
+            # that trap while still discarding all writes (verified 3.10-3.14).
+            operations.append(lambda: self.connection.set_authorizer(None))
         operations.append(self.connection.close)
         if self._owns_file:
             operations.append(lambda: self._path.unlink(missing_ok=True))

--- a/tests/unit/environments/test_database_session.py
+++ b/tests/unit/environments/test_database_session.py
@@ -108,3 +108,26 @@ def test_transaction_control_is_denied():
     conn = sqlite3.connect(path)
     assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
     conn.close()
+
+
+def test_model_rollback_cannot_escape_to_autocommit():
+    # Regression for the "allow ROLLBACK" escape: if the authorizer let the
+    # model issue ROLLBACK, the outer transaction would end and (with
+    # isolation_level=None) the connection would drop into SQLite autocommit,
+    # where subsequent DML commits straight to the shared file -- SQLite fires
+    # no SQLITE_TRANSACTION for the implicit auto-BEGIN/COMMIT wrapping a bare
+    # statement, so the authorizer can't catch it. ROLLBACK must stay denied so
+    # the outer transaction never ends and nothing model-issued persists.
+    path = materialize_sqlite_snapshot(schema_sql=_SCHEMA, seed_sql=_SEED)
+    session = DatabaseSession(path)
+    try:
+        with pytest.raises(sqlite3.DatabaseError):
+            session.connection.execute("ROLLBACK")
+        # Even after the (denied) ROLLBACK attempt, this write stays inside the
+        # never-committed outer transaction rather than auto-committing.
+        session.connection.execute("UPDATE t SET v = 'evil' WHERE id = 1")
+    finally:
+        session.close()
+    conn = sqlite3.connect(path)
+    assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    conn.close()


### PR DESCRIPTION
# Description

Fixes the 18 `sqlite3.DatabaseError: not authorized` failures on the `install-test (3.10, 2.8.0)` CI job (test_database_session, test_database_executable_environment, test_tool_router), which pass on Python 3.11+.

**Root cause:** `DatabaseSession` opens a connection with `isolation_level=None` + explicit `BEGIN`, then installs an authorizer that denies all `SQLITE_TRANSACTION` actions. On the SQLite bundled with CPython 3.10 (3.50.x), once the authorizer denies a `ROLLBACK` during the transaction, that denial becomes **sticky for the rest of the transaction — even after `set_authorizer(None)`** — so the framework's teardown `connection.rollback()` raised "not authorized". SQLite 3.51 (3.11+) doesn't have this behavior.

**Fix:** teardown now clears the authorizer and lets `connection.close()` perform SQLite's implicit rollback of the still-open transaction. This discards all uncommitted writes without issuing an explicit `rollback()`, so it never trips the sticky denial.

**The authorizer is unchanged** — it still denies *every* transaction-control action (BEGIN/COMMIT/END/ROLLBACK). This is deliberate and important: model-issued SQL can never end the outer transaction, so it can never drop into SQLite autocommit (where bare DML would auto-commit to the shared file), nor persist via SAVEPOINT/RELEASE (those stay inside the never-committed outer transaction). This closes the isolation hole that an earlier "allow ROLLBACK" approach would have introduced (thanks to the reviewer who caught it).

**Regression test:** adds `test_model_rollback_cannot_escape_to_autocommit`, which issues a (denied) model `ROLLBACK` followed by a write and asserts the write does not persist to a second connection. It fails against the allow-ROLLBACK approach and passes here.

## Verification

Standalone reproduction + full pytest suites on **Python 3.10.20 (SQLite 3.50.4)** and **3.11.14**: the 3 affected suites → 46 passed on both; `test_transaction_control_is_denied` and `test_model_sql_cannot_break_framework_savepoints` still pass. Confirmed on 3.10 that model ROLLBACK is denied, `close()` doesn't raise, and the model's write does not persist (`('a',)`, not `('evil',)`).

## Related issues

N/A — pre-existing `main` failure introduced with the `DatabaseExecutableEnvironment` feature (#2528), surfaced by the `pyproject.toml`-triggered install-test on #2548. (The Python 3.10 `test_progress_reporter` failures from the same CI cell are handled separately in #2554.)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (Added a regression test for the ROLLBACK-escape path.)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
