### PR TITLE
fix(inference): use os.replace for atomic progress-file swap (Python 3.10)

### DIFF
--- a/src/oumi/core/inference/progress_reporter.py
+++ b/src/oumi/core/inference/progress_reporter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import threading
 import time
 from datetime import datetime, timezone
@@ -96,7 +97,10 @@ class ProgressFileReporter:
             # Write to a temp file in the same directory so the replace is atomic.
             with open(self._tmp_path, "w") as f:
                 json.dump(snapshot, f)
-            self._tmp_path.replace(self._path)
+            # Use os.replace (not Path.replace) for the atomic swap: on Python 3.10
+            # Path.replace does not route through os.replace, so tests that simulate
+            # a failing replace by patching os.replace would otherwise be bypassed.
+            os.replace(self._tmp_path, self._path)
         except Exception as e:
             if not self._warned:
                 logger.warning(f"Failed to write inference progress file: {e}")


### PR DESCRIPTION
# Description

`ProgressFileReporter._write_snapshot` (`src/oumi/core/inference/progress_reporter.py`) performed its atomic temp→final swap with `pathlib.Path.replace`. On **Python 3.10**, `Path.replace` does not route through `os.replace` (it uses a bound accessor captured at import), so the tests that simulate a failing swap via `patch("os.replace", side_effect=OSError)` were silently bypassed — the replace succeeded, the file got written, and no warning fired. This failed 2 tests on the `install-test (3.10, 2.8.0)` CI job while passing on 3.11+ (where `Path.replace` does call `os.replace`):

```
FAILED inference/test_progress_reporter.py::test_write_failure_never_raises - AssertionError: assert not True
FAILED inference/test_progress_reporter.py::test_write_failure_warns_once - AssertionError: assert 0 == 1
```

**Fix:** call `os.replace(self._tmp_path, self._path)` directly. This makes the atomic-swap intent explicit and exercises the failure path consistently across Python 3.10–3.14. No behavior change on the success path; tests unchanged.

## Related issues

N/A — pre-existing latent test bug on `main` (test coupled to a CPython 3.11 pathlib implementation detail), surfaced by the `pyproject.toml`-triggered install-test on #2548.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (Existing tests already cover this; they now pass on Python 3.10.)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
