### PR TITLE
fix(environments): DatabaseSession authorizer breaks rollback/close on Python 3.10

### DIFF
--- a/src/oumi/environments/database_session.py
+++ b/src/oumi/environments/database_session.py
@@ -50,6 +50,16 @@ def _enable_foreign_keys(connection: sqlite3.Connection) -> None:
         raise RuntimeError("Failed to enable SQLite foreign-key enforcement.")
 
 
+def _allow_all(
+    _action_code: int,
+    _arg1: str | None,
+    _arg2: str | None,
+    _database_name: str | None,
+    _trigger_name: str | None,
+) -> int:
+    return sqlite3.SQLITE_OK
+
+
 def _deny_transaction_control(
     action_code: int,
     _arg1: str | None,
@@ -98,7 +108,9 @@ class DatabaseSession:
         if rollback:
             operations.extend(
                 (
-                    lambda: self.connection.set_authorizer(None),
+                    # set_authorizer(None) only clears on Python 3.11+; on 3.10 it
+                    # installs None as the callback, which denies everything.
+                    lambda: self.connection.set_authorizer(_allow_all),
                     self.connection.rollback,
                 )
             )


### PR DESCRIPTION
## Symptom

CI's `install-test` job (runs only on PRs touching `pyproject.toml`) fails deterministically on **3.10 / torch 2.8.0** with `sqlite3.DatabaseError: not authorized` across 18 tests in:
- `tests/unit/environments/test_database_executable_environment.py`
- `tests/unit/environments/test_database_session.py`
- `tests/unit/core/synthesis/test_tool_router.py`

The bug is latent on `main` (#2528 added no deps, so `install-test` never ran on it) and surfaces on any PR that edits `pyproject.toml` (#2529, #2546, #2548 all fail identically).

## Root cause

On Python 3.10, `sqlite3.Connection.set_authorizer(None)` does **not** clear the authorizer — support for `None` was only added in CPython 3.11. Instead it installs `None` as the callback; every subsequent authorizer check fails to call it and returns `SQLITE_DENY`, so **all** statements are denied. `DatabaseSession._cleanup` calls `set_authorizer(None)` and then `rollback()`, which is denied → `not authorized` → every test that closes a session fails.

(Not the savepoint action-code routing: verified with a debug authorizer that `SAVEPOINT`/`RELEASE`/`ROLLBACK TO` report `SQLITE_SAVEPOINT` (32) on 3.10 exactly as on 3.11+, and pass the deny-transaction-control authorizer fine.)

## Fix

Clear the authorizer by installing an allow-all callback (`_allow_all`) instead of `None`. Identical behavior on every supported Python version; the deny-model-transaction-control guarantee is untouched — `_deny_transaction_control` still denies `BEGIN`/`COMMIT`/`ROLLBACK` for the session's lifetime.

## Verification

- Fresh `uv` venv on **Python 3.10.19**: the 3 failing files reproduce **18 failed** pre-fix, **45 passed** post-fix; full `tests/unit/environments/` → **107 passed**.
- **Python 3.11** (conda): `tests/unit/environments/ tests/unit/core/synthesis/` → **382 passed, 10 skipped**.
- Security tests `test_transaction_control_is_denied` and `test_model_sql_cannot_break_framework_savepoints` pass on both versions.