### PR TITLE
fix(launcher): silence pyright reportAttributeAccessIssue on sky.clouds.Slurm

### DIFF
--- a/src/oumi/launcher/clients/sky_client.py
+++ b/src/oumi/launcher/clients/sky_client.py
@@ -49,7 +49,9 @@ def _get_sky_cloud_from_job(job: JobConfig) -> "sky.clouds.Cloud":
     elif job.resources.cloud == SkyClient.SupportedClouds.NEBIUS.value:
         return sky.clouds.Nebius()
     elif job.resources.cloud == SkyClient.SupportedClouds.SLURM.value:
-        return sky.clouds.Slurm()
+        # Slurm cloud support was added in skypilot 0.12; older stubs pyright may
+        # resolve against don't expose it, but Oumi pins skypilot>=0.12.
+        return sky.clouds.Slurm()  # pyright: ignore[reportAttributeAccessIssue]
     raise ValueError(f"Unsupported cloud: {job.resources.cloud}")
 
 

--- a/src/oumi/launcher/clouds/sky_cloud.py
+++ b/src/oumi/launcher/clouds/sky_cloud.py
@@ -95,7 +95,9 @@ class SkyCloud(BaseCloud):
         elif self._cloud_name == SkyClient.SupportedClouds.NEBIUS.value:
             return self._get_clusters_by_class(sky.clouds.Nebius)
         elif self._cloud_name == SkyClient.SupportedClouds.SLURM.value:
-            return self._get_clusters_by_class(sky.clouds.Slurm)
+            # Slurm cloud support was added in skypilot 0.12; older stubs pyright
+            # may resolve against don't expose it, but Oumi pins skypilot>=0.12.
+            return self._get_clusters_by_class(sky.clouds.Slurm)  # pyright: ignore[reportAttributeAccessIssue]
         raise ValueError(f"Unsupported cloud: {self._cloud_name}")
 
 


### PR DESCRIPTION
# Description

The `static-checks` (pyright) CI job fails on `main` with:

```
src/oumi/launcher/clients/sky_client.py:52 - error: "Slurm" is not a known attribute of module "sky.clouds"
src/oumi/launcher/clouds/sky_cloud.py:98  - error: "Slurm" is not a known attribute of module "sky.clouds"
```

`sky.clouds.Slurm` **exists at runtime** in skypilot `>=0.12` (which Oumi pins — `skypilot>=0.12,<0.13`; 0.12 added Slurm cloud support), so this is a type-resolution gap, not a real bug. Because pyright treats it as an error, the whole `static-checks` job goes red.

**Fix:** add a targeted `# pyright: ignore[reportAttributeAccessIssue]` on the two `sky.clouds.Slurm` call sites, matching the convention already used for other `sky.*` attributes in `sky_client.py`. No runtime behavior change.

## Related issues

N/A — pre-existing `static-checks` failure on `main`.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (N/A — type-annotation-only change.)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->


---

## CI proof

The `static-checks` (pyright) job — which was failing on `main` with the two `sky.clouds.Slurm` errors — now **passes** on this branch:

**→ https://github.com/oumi-ai/oumi/actions/runs/29934191149/job/88971367430** (static-checks: SUCCESS)
