### PR TITLE
test(inference): patch Path.replace in progress-reporter write-failure tests

### DIFF
--- a/tests/unit/inference/test_progress_reporter.py
+++ b/tests/unit/inference/test_progress_reporter.py
@@ -112,7 +112,9 @@ def test_creates_parent_directories(progress_path):
 
 def test_write_failure_never_raises(progress_path):
     reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
-    with patch("os.replace", side_effect=OSError("disk full")):
+    # Patch Path.replace (what _write_snapshot actually calls). Patching os.replace
+    # would miss the failure on Python 3.10, where Path.replace doesn't route through it.
+    with patch.object(Path, "replace", side_effect=OSError("disk full")):
         reporter.start()
         reporter.record_completed()
         reporter.record_failed()
@@ -124,7 +126,7 @@ def test_write_failure_never_raises(progress_path):
 def test_write_failure_warns_once(progress_path):
     reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
     with patch("oumi.core.inference.progress_reporter.logger.warning") as mock_warning:
-        with patch("os.replace", side_effect=OSError("disk full")):
+        with patch.object(Path, "replace", side_effect=OSError("disk full")):
             reporter.start()
             reporter.record_completed()
             reporter.finalize()
@@ -134,7 +136,7 @@ def test_write_failure_warns_once(progress_path):
 
 def test_recovers_after_transient_write_failure(progress_path):
     reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
-    with patch("os.replace", side_effect=OSError("disk full")):
+    with patch.object(Path, "replace", side_effect=OSError("disk full")):
         reporter.start()
     reporter.record_completed()
     reporter.finalize()

--- a/tests/unit/inference/test_progress_reporter.py
+++ b/tests/unit/inference/test_progress_reporter.py
@@ -112,8 +112,9 @@ def test_creates_parent_directories(progress_path):
 
 def test_write_failure_never_raises(progress_path):
     reporter = ProgressFileReporter(progress_path, total=2, min_write_interval=0.0)
-    # Patch Path.replace (what _write_snapshot actually calls). Patching os.replace
-    # would miss the failure on Python 3.10, where Path.replace doesn't route through it.
+    # Patch Path.replace (what _write_snapshot actually calls). Patching
+    # os.replace would miss the failure on Python 3.10, where Path.replace
+    # does not route through os.replace.
     with patch.object(Path, "replace", side_effect=OSError("disk full")):
         reporter.start()
         reporter.record_completed()


### PR DESCRIPTION
# Description

The `ProgressFileReporter` write-failure tests simulated a failing atomic swap by patching `os.replace`, but `ProgressFileReporter._write_snapshot` calls `pathlib.Path.replace`. On **Python 3.10**, `Path.replace` does not route through `os.replace`, so the patch was silently bypassed — the swap succeeded, the file was written, no warning fired — and `test_write_failure_never_raises` / `test_write_failure_warns_once` failed only on the `install-test (3.10, 2.8.0)` job (they passed on 3.11+, where `Path.replace` does call `os.replace`).

**Fix (test-only):** patch `Path.replace` directly (via `patch.object(Path, "replace", ...)`) so the tests target the call the code actually makes, consistently across Python 3.10–3.14. **Production code is unchanged** — `Path.replace` was correct; only the tests' mock target was wrong.

## Related issues

N/A — pre-existing latent test bug on `main` (test coupled to a CPython 3.11 pathlib implementation detail), surfaced by the `pyproject.toml`-triggered install-test on #2548.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed? (This PR fixes the tests; production code untouched.)

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
