### PR TITLE
feat(environments): resolve tool executors by registry name

### DIFF
--- a/src/oumi/core/registry/__init__.py
+++ b/src/oumi/core/registry/__init__.py
@@ -24,6 +24,7 @@ from oumi.core.registry.registry import (
     register_environment,
     register_evaluation_function,
     register_sample_analyzer,
+    register_tool_executor,
 )
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "register_environment",
     "register_evaluation_function",
     "register_sample_analyzer",
+    "register_tool_executor",
 ]

--- a/src/oumi/core/registry/registry.py
+++ b/src/oumi/core/registry/registry.py
@@ -38,6 +38,7 @@ class RegistryType(Enum):
     SAMPLE_ANALYZER = auto()
     RULE = auto()
     ENVIRONMENT = auto()
+    TOOL_EXECUTOR = auto()
 
 
 class RegistryKey(namedtuple("RegistryKey", ["name", "registry_type"])):
@@ -375,6 +376,26 @@ def register_environment(registry_name: str) -> Callable:
     def decorator_register(obj):
         """Decorator to register its target `obj`."""
         REGISTRY.register(name=registry_name, type=RegistryType.ENVIRONMENT, value=obj)
+        return obj
+
+    return decorator_register
+
+
+def register_tool_executor(registry_name: str) -> Callable:
+    """Returns function to register a tool executor in the Oumi global registry.
+
+    Args:
+        registry_name: The name to register the executor under.
+
+    Returns:
+        Decorator function to register the target executor callable.
+    """
+
+    def decorator_register(obj):
+        """Decorator to register its target `obj`."""
+        REGISTRY.register(
+            name=registry_name, type=RegistryType.TOOL_EXECUTOR, value=obj
+        )
         return obj
 
     return decorator_register

--- a/src/oumi/core/registry/registry.py
+++ b/src/oumi/core/registry/registry.py
@@ -147,6 +147,7 @@ class Registry:
             RegistryType.METRICS_FUNCTION,
             RegistryType.REWARD_FUNCTION,
             RegistryType.ROLLOUT_FUNCTION,
+            RegistryType.TOOL_EXECUTOR,
         ) and not callable(value):
             raise ValueError(f"Registry: `{name}` of `{type}` must be callable.")
 

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -34,11 +34,10 @@ class ExecutableEnvironment(BaseEnvironment):
 
     Each tool declares its executor as a registry name or dotted import path;
     the base resolves them into ``_executors`` at construction. Subclasses supply
-    the per-call
-    execution context (DB connection, HTTP client, FS root, ...) by
-    implementing ``_build_execution_context``. The base owns tool lookup,
-    argument and result validation, the ``_absorb_result`` post-hook, and the
-    ``close`` lifecycle. Executors are invoked as
+    the per-call execution context (DB connection, HTTP client, FS root, ...) by
+    implementing ``_build_execution_context``. The base owns tool lookup, argument
+    and result validation, the ``_absorb_result`` post-hook, and the ``close``
+    lifecycle. Executors are invoked as
     ``executor(arguments=<dict>, context=<ctx>)`` and must return a
     ``ToolResult``. Result validation runs inside the execution context so a
     transactional context manager sees a validation failure and can roll back;

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -26,14 +26,15 @@ from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.executable_tool import ExecutableTool
-from oumi.environments.utils import import_executor, validate_executor_result
+from oumi.environments.utils import resolve_executor, validate_executor_result
 
 
 class ExecutableEnvironment(BaseEnvironment):
     """Abstract base for envs that dispatch tool calls to Python executors.
 
-    Each tool declares its executor as a dotted import path; the base resolves
-    them into ``_executors`` at construction. Subclasses supply the per-call
+    Each tool declares its executor as a registry name or dotted import path;
+    the base resolves them into ``_executors`` at construction. Subclasses supply
+    the per-call
     execution context (DB connection, HTTP client, FS root, ...) by
     implementing ``_build_execution_context``. The base owns tool lookup,
     argument and result validation, the ``_absorb_result`` post-hook, and the
@@ -47,10 +48,10 @@ class ExecutableEnvironment(BaseEnvironment):
     tool_params_cls: type[ToolParams] = ExecutableTool
 
     def __init__(self, params: EnvironmentParams) -> None:
-        """Resolve each tool's dotted-path executor into ``_executors``."""
+        """Resolve each tool's executor (registry name or dotted path)."""
         self._params = params
         self._executors: dict[str, Callable[..., Any]] = {
-            tool.id: import_executor(tool.executor, tool.id) for tool in params.tools
+            tool.id: resolve_executor(tool.executor, tool.id) for tool in params.tools
         }
 
     @abstractmethod

--- a/src/oumi/environments/executable_environment.py
+++ b/src/oumi/environments/executable_environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Abstract base for envs backed by user-supplied dotted-path executors."""
+"""Abstract base for environments backed by user-supplied tool executors."""
 
 from __future__ import annotations
 

--- a/src/oumi/environments/executable_tool.py
+++ b/src/oumi/environments/executable_tool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tool params base for tools that declare a dotted-path executor."""
+"""Tool params for tools backed by a Python executor."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from oumi.core.configs.params.tool_params import ToolParams
 
 @dataclass
 class ExecutableTool(ToolParams):
-    """`ToolParams` variant for envs that take user-supplied dotted-path executors."""
+    """`ToolParams` variant for environments with user-supplied executors."""
 
     def __post_init__(self) -> None:
         """Validate inherited fields and enforce non-empty executor."""
@@ -31,5 +31,5 @@ class ExecutableTool(ToolParams):
         if not self.executor:
             raise ValueError(
                 f"{type(self).__name__} '{self.id}' must declare a non-empty "
-                f"executor (dotted import path)."
+                f"executor (registry name or dotted import path)."
             )

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -47,7 +47,7 @@ from oumi.core.registry import register_environment
 from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
-from oumi.environments.utils import import_executor, validate_executor_result
+from oumi.environments.utils import resolve_executor, validate_executor_result
 from oumi.utils.str_utils import extract_json
 
 if TYPE_CHECKING:
@@ -133,7 +133,7 @@ class SyntheticEnvironment(BaseEnvironment):
                 f"initial_state is required)."
             )
         self._executors: dict[str, Callable[..., Any]] = {
-            tool.id: import_executor(tool.executor, tool.id)
+            tool.id: resolve_executor(tool.executor, tool.id)
             for tool in params.tools
             if tool.executor
         }

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -28,6 +28,7 @@ from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
+from oumi.core.registry import REGISTRY, RegistryType
 from oumi.core.types.tool_call import ToolResult
 
 _KwargsT = TypeVar("_KwargsT", bound=BaseParams)
@@ -78,6 +79,19 @@ def import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
             f"Tool '{tool_id}': executor '{dotted}' resolved to a non-callable."
         )
     return executor
+
+
+def resolve_executor(name: str, tool_id: str) -> Callable[..., Any]:
+    """Resolve an executor by registry name, falling back to a dotted import path.
+
+    Names registered via ``register_tool_executor`` win; anything else is
+    treated as a dotted import path. Registered names (e.g. ``ehr.list_patients``)
+    and import paths (e.g. ``pkg.module.fn``) don't collide in practice.
+    """
+    executor = REGISTRY.get(name, RegistryType.TOOL_EXECUTOR)
+    if executor is not None:
+        return executor
+    return import_executor(name, tool_id)
 
 
 def validate_executor_result(tool: ToolParams, result: Any) -> ToolResult:

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -82,12 +82,7 @@ def import_executor(dotted: str, tool_id: str) -> Callable[..., Any]:
 
 
 def resolve_executor(name: str, tool_id: str) -> Callable[..., Any]:
-    """Resolve an executor by registry name, falling back to a dotted import path.
-
-    Names registered via ``register_tool_executor`` win; anything else is
-    treated as a dotted import path. Registered names (e.g. ``ehr.list_patients``)
-    and import paths (e.g. ``pkg.module.fn``) don't collide in practice.
-    """
+    """Resolve an executor: a registered name wins, else a dotted import path."""
     executor = REGISTRY.get(name, RegistryType.TOOL_EXECUTOR)
     if executor is not None:
         return executor

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -86,7 +86,15 @@ def resolve_executor(name: str, tool_id: str) -> Callable[..., Any]:
     executor = REGISTRY.get(name, RegistryType.TOOL_EXECUTOR)
     if executor is not None:
         return executor
-    return import_executor(name, tool_id)
+    try:
+        return import_executor(name, tool_id)
+    except ValueError as e:
+        registered = sorted(REGISTRY.get_all(RegistryType.TOOL_EXECUTOR))
+        raise ValueError(
+            f"Tool '{tool_id}': executor '{name}' is not a registered tool "
+            "executor and could not be imported as a dotted path. "
+            f"Registered tool executors: {registered}. Import error: {e}"
+        ) from e
 
 
 def validate_executor_result(tool: ToolParams, result: Any) -> ToolResult:

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -30,6 +30,7 @@ from oumi.core.configs.params.grounding_params import GroundingFact
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.registry import REGISTRY, RegistryType
 from oumi.core.types.tool_call import ToolResult
+from oumi.utils.logging import logger
 
 _KwargsT = TypeVar("_KwargsT", bound=BaseParams)
 
@@ -85,6 +86,15 @@ def resolve_executor(name: str, tool_id: str) -> Callable[..., Any]:
     """Resolve an executor: a registered name wins, else a dotted import path."""
     executor = REGISTRY.get(name, RegistryType.TOOL_EXECUTOR)
     if executor is not None:
+        try:
+            import_executor(name, tool_id)
+        except ValueError:
+            pass
+        else:
+            logger.warning(
+                f"Tool '{tool_id}': executor '{name}' is both a registered tool "
+                "executor and an importable dotted path; using the registered one."
+            )
         return executor
     try:
         return import_executor(name, tool_id)

--- a/src/oumi/environments/utils.py
+++ b/src/oumi/environments/utils.py
@@ -88,12 +88,14 @@ def resolve_executor(name: str, tool_id: str) -> Callable[..., Any]:
     if executor is not None:
         try:
             import_executor(name, tool_id)
-        except ValueError:
-            pass
+        except Exception:
+            pass  # Diagnostic only: never let a speculative import break resolution.
         else:
             logger.warning(
-                f"Tool '{tool_id}': executor '{name}' is both a registered tool "
-                "executor and an importable dotted path; using the registered one."
+                "Tool '%s': executor '%s' is both a registered tool executor and "
+                "an importable dotted path; using the registered one.",
+                tool_id,
+                name,
             )
         return executor
     try:

--- a/tests/unit/core/test_registry.py
+++ b/tests/unit/core/test_registry.py
@@ -192,7 +192,12 @@ def test_registry_function(registry_type: RegistryType):
 
 
 @pytest.mark.parametrize(
-    "registry_type", [RegistryType.METRICS_FUNCTION, RegistryType.REWARD_FUNCTION]
+    "registry_type",
+    [
+        RegistryType.METRICS_FUNCTION,
+        RegistryType.REWARD_FUNCTION,
+        RegistryType.TOOL_EXECUTOR,
+    ],
 )
 def test_registry_metrics_function_non_callable(registry_type: RegistryType):
     class FooNonCallable:

--- a/tests/unit/environments/test_executor_resolution.py
+++ b/tests/unit/environments/test_executor_resolution.py
@@ -78,6 +78,15 @@ def test_resolve_executor_warns_when_registry_name_shadows_dotted_path(caplog):
     assert "using the registered one" in caplog.text
 
 
+def test_resolve_executor_survives_raising_shadow_import(monkeypatch):
+    def _boom(name, tool_id):
+        raise RuntimeError("module blew up at import time")
+
+    register_tool_executor("res.registered")(_registered_executor)
+    monkeypatch.setattr("oumi.environments.utils.import_executor", _boom)
+    assert resolve_executor("res.registered", "t") is _registered_executor
+
+
 def test_resolve_executor_unknown_name_reports_registered_executors():
     register_tool_executor("res.registered")(_registered_executor)
     with pytest.raises(

--- a/tests/unit/environments/test_executor_resolution.py
+++ b/tests/unit/environments/test_executor_resolution.py
@@ -70,6 +70,14 @@ def test_resolve_executor_falls_back_to_dotted_path():
     assert resolved is _dotted_executor
 
 
+def test_resolve_executor_warns_when_registry_name_shadows_dotted_path(caplog):
+    dotted = f"{__name__}._dotted_executor"
+    register_tool_executor(dotted)(_registered_executor)
+    with caplog.at_level("WARNING"):
+        assert resolve_executor(dotted, "t") is _registered_executor
+    assert "using the registered one" in caplog.text
+
+
 def test_resolve_executor_unknown_name_reports_registered_executors():
     register_tool_executor("res.registered")(_registered_executor)
     with pytest.raises(

--- a/tests/unit/environments/test_executor_resolution.py
+++ b/tests/unit/environments/test_executor_resolution.py
@@ -70,9 +70,16 @@ def test_resolve_executor_falls_back_to_dotted_path():
     assert resolved is _dotted_executor
 
 
-def test_resolve_executor_unknown_name_raises():
-    with pytest.raises(ValueError, match="executor"):
+def test_resolve_executor_unknown_name_reports_registered_executors():
+    register_tool_executor("res.registered")(_registered_executor)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "not a registered tool executor and could not be imported as a dotted path"
+        ),
+    ) as exc_info:
         resolve_executor("res.never_registered", "t")
+    assert "res.registered" in str(exc_info.value)
 
 
 class _EchoExecEnv(ExecutableEnvironment):

--- a/tests/unit/environments/test_executor_resolution.py
+++ b/tests/unit/environments/test_executor_resolution.py
@@ -1,0 +1,103 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-name and dotted-path executor resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.registry import REGISTRY, Registry, RegistryType, register_tool_executor
+from oumi.core.types.tool_call import ToolResult
+from oumi.environments.executable_environment import ExecutableEnvironment
+from oumi.environments.executable_tool import ExecutableTool
+from oumi.environments.utils import resolve_executor
+
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    """Snapshot and restore the registry so registrations don't leak."""
+    snapshot = Registry()
+    for reg_type in RegistryType:
+        for key, value in REGISTRY.get_all(reg_type).items():
+            snapshot.register(key, reg_type, value)
+    yield
+    REGISTRY.clear()
+    REGISTRY._initialized = False
+    for reg_type in RegistryType:
+        for key, value in snapshot.get_all(reg_type).items():
+            REGISTRY.register(key, reg_type, value)
+
+
+def _registered_executor(arguments, context):
+    return ToolResult(output={"via": "registry", "args": arguments})
+
+
+# Module-level dotted-path target for the fallback test.
+def _dotted_executor(arguments, context):
+    return ToolResult(output={"via": "dotted"})
+
+
+def test_register_tool_executor_registers_under_tool_executor_type():
+    register_tool_executor("res.registered")(_registered_executor)
+    assert REGISTRY.get("res.registered", RegistryType.TOOL_EXECUTOR) is (
+        _registered_executor
+    )
+
+
+def test_resolve_executor_prefers_registry_name():
+    register_tool_executor("res.registered")(_registered_executor)
+    assert resolve_executor("res.registered", "t") is _registered_executor
+
+
+def test_resolve_executor_falls_back_to_dotted_path():
+    resolved = resolve_executor(f"{__name__}._dotted_executor", "t")
+    assert resolved is _dotted_executor
+
+
+def test_resolve_executor_unknown_name_raises():
+    with pytest.raises(ValueError, match="executor"):
+        resolve_executor("res.never_registered", "t")
+
+
+class _EchoExecEnv(ExecutableEnvironment):
+    @contextmanager
+    def _build_execution_context(
+        self, tool: ExecutableTool, arguments: dict[str, Any]
+    ) -> Iterator[Any]:
+        yield None
+
+
+def test_executable_environment_dispatches_registry_named_executor():
+    register_tool_executor("res.registered")(_registered_executor)
+    env = _EchoExecEnv(
+        EnvironmentParams(
+            id="e",
+            name="e",
+            description="d",
+            env_type="executable",
+            tools=[
+                ExecutableTool(
+                    id="t", name="t", description="d", executor="res.registered"
+                )
+            ],
+        )
+    )
+    [result] = env.step([("t", {"a": 1})])
+    assert result.output == {"via": "registry", "args": {"a": 1}}

--- a/tests/unit/environments/test_executor_resolution.py
+++ b/tests/unit/environments/test_executor_resolution.py
@@ -32,7 +32,6 @@ from oumi.environments.utils import resolve_executor
 
 @pytest.fixture(autouse=True)
 def restore_registry():
-    """Snapshot and restore the registry so registrations don't leak."""
     snapshot = Registry()
     for reg_type in RegistryType:
         for key, value in REGISTRY.get_all(reg_type).items():
@@ -49,7 +48,7 @@ def _registered_executor(arguments, context):
     return ToolResult(output={"via": "registry", "args": arguments})
 
 
-# Module-level dotted-path target for the fallback test.
+# Must stay module-level: the fallback test resolves it by dotted path.
 def _dotted_executor(arguments, context):
     return ToolResult(output={"via": "dotted"})
 


### PR DESCRIPTION
## What

Adds a registry-based way to reference tool executors, addressing @wizeng23's review on #2458 ("thoughts on using the registry pattern compared to the module path?").

- New `RegistryType.TOOL_EXECUTOR` + `register_tool_executor` decorator, matching the existing reward/metrics/environment registry pattern.
- New `resolve_executor(name, tool_id)` in `environments/utils.py`: **registered names win, dotted import path is the fallback.**
- Both `SyntheticEnvironment` and `ExecutableEnvironment` now resolve through it (they already shared the `import_executor` helper, so one seam covers both env families).

## Why

- **Consistency**: registry-by-name is the repo's blessed pattern for referencing user code from config; executors were the odd one out on dotted paths.
- **Notebook workflow**: a function defined + `@register`ed in a Colab cell can be referenced by name in config; dotted paths can't reach `__main__`-defined functions.
- **Move-proof**: names survive relocating example code (exactly the friction #2458 hit when moving executors out of `src/oumi/`).

## Compatibility

Fully additive. The dotted-path fallback keeps every existing config, the DB-env (#2528) tests, and executable-env tests working **unchanged** — those tests now also serve as fallback-path coverage. New tests cover registry-name resolution, the decorator, fallback, and end-to-end dispatch through `ExecutableEnvironment`.

## Stacking

#2458 (EHR stateful example) will stack on this and switch its config to registry names.

Test: `pytest tests/unit/environments/test_executor_resolution.py tests/unit/environments/test_executable_environment.py tests/unit/environments/test_database_executable_environment.py tests/unit/core/test_registry.py` → 71 passed.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
