### PR TITLE
feat(models): add text_only opt-in for dual-mode checkpoints (e.g. Qwen3.5)

### DIFF
--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -365,9 +365,19 @@ def _get_transformers_model_class(config):
 
 
 def is_image_text_llm_using_model_name(
-    model_name: str, trust_remote_code: bool, revision: str | None = None
+    model_name: str,
+    trust_remote_code: bool,
+    revision: str | None = None,
+    *,
+    text_only: bool = False,
 ) -> bool:
-    """Determines whether the model is a basic image+text LLM."""
+    """Determines whether the model is a basic image+text LLM.
+
+    When ``text_only`` is True the model is treated as a language model regardless
+    of its registry entry (used to load a dual-mode checkpoint's text backbone).
+    """
+    if text_only:
+        return False
     model_config = find_internal_model_config_using_model_name(
         model_name, trust_remote_code=trust_remote_code, revision=revision
     )
@@ -380,6 +390,7 @@ def is_image_text_llm(model_params: ModelParams) -> bool:
         model_params.model_name,
         model_params.trust_remote_code,
         revision=model_params.model_revision,
+        text_only=model_params.text_only,
     )
 
 

--- a/src/oumi/builders/models.py
+++ b/src/oumi/builders/models.py
@@ -309,7 +309,9 @@ def build_huggingface_model(
     # Both functions instantiate a model from the config, but the main difference is
     # `load_pretrained_weights` also loads the weights, and `from_config` initializes
     # the weights from scratch based on the params in the config and the model class.
-    transformers_model_class = _get_transformers_model_class(hf_config)
+    transformers_model_class = _get_transformers_model_class(
+        hf_config, text_only=model_params.text_only
+    )
     # Pass in the parsed torch dtype, else pass in the stringified version (which
     # currently can only be "auto").
     torch_dtype = model_params.torch_dtype or model_params.torch_dtype_str
@@ -347,7 +349,15 @@ def build_huggingface_model(
     return model
 
 
-def _get_transformers_model_class(config):
+def _get_transformers_model_class(config, *, text_only: bool = False):
+    if text_only:
+        # Load a dual-mode checkpoint's text backbone; skip the vision tower.
+        logger.info(
+            "text_only=True: using transformers.AutoModelForCausalLM to load the "
+            "language backbone only."
+        )
+        return transformers.AutoModelForCausalLM
+
     llm_info = get_all_models_map().get(config.model_type, None)
 
     if llm_info is not None:

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -600,6 +600,20 @@ def get_all_models_map() -> Mapping[
             model_class=default_vlm_class,
             config=_create_qwen3_vl_vlm_config(),
         ),
+        # Qwen3.5 is dual-mode: it loads as a VLM by default here, and as its
+        # text-only backbone (Qwen3_5ForCausalLM) when ModelParams.text_only=True.
+        # The processor resolves to Qwen3VLProcessor, so the Qwen3-VL config
+        # (chat template, image features, pixel limits) applies unchanged.
+        _ModelTypeInfo(
+            model_type="qwen3_5",
+            model_class=default_vlm_class,
+            config=_create_qwen3_vl_vlm_config(),
+        ),
+        _ModelTypeInfo(
+            model_type="qwen3_5_moe",
+            model_class=default_vlm_class,
+            config=_create_qwen3_vl_vlm_config(),
+        ),
         _ModelTypeInfo(
             model_type="vipllava",
             model_class=default_vlm_class,

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -65,6 +65,10 @@ from collections.abc import Mapping
 from typing import Any, NamedTuple, cast
 
 import transformers
+from transformers.models.auto.modeling_auto import (
+    MODEL_FOR_CAUSAL_LM_MAPPING,
+    MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING,
+)
 
 from oumi.core.configs import ModelParams
 from oumi.core.configs.internal.internal_model_config import (
@@ -702,3 +706,39 @@ def find_internal_model_config(
         model_params.trust_remote_code,
         revision=model_params.model_revision,
     )
+
+
+def is_dual_mode_model_type(
+    hf_config: transformers.PretrainedConfig,
+) -> bool:
+    """Whether a checkpoint has a genuine text-only backbone alongside its VLM class.
+
+    A model is dual-mode iff ``AutoModelForCausalLM`` resolves its config class to a
+    class *distinct* from the one ``AutoModelForImageTextToText`` resolves it to. When
+    both mappings resolve to the same class (e.g. ``gemma3`` ->
+    ``Gemma3ForConditionalGeneration``), loading via ``AutoModelForCausalLM`` still
+    builds the full VLM, so it is NOT dual-mode. When there is no causal mapping
+    (e.g. ``qwen3_vl``), there is no text-only path at all.
+
+    Args:
+        hf_config: The HuggingFace ``PretrainedConfig`` for the model.
+
+    Returns:
+        True if a distinct text-only class exists, False otherwise.
+    """
+    cfg_cls = type(hf_config)
+    causal_cls = MODEL_FOR_CAUSAL_LM_MAPPING._model_mapping.get(cfg_cls)
+    vlm_cls = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING._model_mapping.get(cfg_cls)
+    return causal_cls is not None and vlm_cls is not None and causal_cls != vlm_cls
+
+
+def is_dual_mode_model_using_model_name(
+    model_name: str, trust_remote_code: bool, revision: str | None = None
+) -> bool:
+    """Whether the named model is dual-mode. See ``is_dual_mode_model_type``."""
+    if is_custom_model(model_name):
+        return False
+    hf_config = find_model_hf_config(
+        model_name, trust_remote_code=trust_remote_code, revision=revision
+    )
+    return is_dual_mode_model_type(hf_config)

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -756,3 +756,30 @@ def is_dual_mode_model_using_model_name(
         model_name, trust_remote_code=trust_remote_code, revision=revision
     )
     return is_dual_mode_model_type(hf_config)
+
+
+def is_vision_language_model_type(hf_config: transformers.PretrainedConfig) -> bool:
+    """Whether the checkpoint exposes any vision-language model class.
+
+    True when ``AutoModelForImageTextToText`` resolves the config to a model class,
+    i.e. the checkpoint has a vision tower. This is True for both vision-only models
+    (e.g. ``qwen3_vl``) and dual-mode models (e.g. ``qwen3_5``), and False for
+    plain text models (e.g. ``llama``).
+    """
+    cfg_cls = type(hf_config)
+    return MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING._model_mapping.get(cfg_cls) is not None
+
+
+def is_vision_language_model_using_model_name(
+    model_name: str, trust_remote_code: bool, revision: str | None = None
+) -> bool:
+    """Whether the named model has a vision tower.
+
+    See ``is_vision_language_model_type``.
+    """
+    if is_custom_model(model_name):
+        return False
+    hf_config = find_model_hf_config(
+        model_name, trust_remote_code=trust_remote_code, revision=revision
+    )
+    return is_vision_language_model_type(hf_config)

--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -220,6 +220,32 @@ class ModelParams(BaseParams):
     other parts fixed.
     """
 
+    text_only: bool = False
+    """Load a dual-mode checkpoint as its text-only backbone.
+
+    Some checkpoints are dual-mode: transformers exposes both a text-only class
+    (e.g. ``Qwen3_5ForCausalLM``) and a multimodal class
+    (e.g. ``Qwen3_5ForConditionalGeneration``) for the same weights. By default
+    (``text_only=False``) such models are loaded as vision-language models. Set
+    ``text_only=True`` to load only the language backbone, skipping the vision
+    tower — the processor, vision chat template, and image features are not used.
+
+    Only valid for genuinely dual-mode models (those whose ``AutoModelForCausalLM``
+    class differs from their vision-language class). Setting it on a vision-only
+    model (e.g. ``qwen3_vl``) or a pseudo-dual model whose causal class is the same
+    as its vision-language class (e.g. ``gemma3``) raises a config error. It is a
+    no-op for plain text models.
+
+    Supported execution paths (keep this list in sync as coverage changes):
+        - Training: supported.
+        - Native inference (``InferenceEngineType.NATIVE``): supported.
+        - Evaluation via LM Harness (native/hf backend): supported.
+        - SGLang inference: supported.
+        - vLLM inference and vLLM-backed evaluation: NOT supported. vLLM manages
+          model loading itself and currently exposes only the multimodal class for
+          these checkpoints, so ``text_only`` has no effect there.
+    """
+
     model_revision: str | None = None
     """The revision of the model to use.
 

--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -229,29 +229,16 @@ class ModelParams(BaseParams):
     """
 
     text_only: bool = False
-    """Load a dual-mode checkpoint as its text-only backbone.
+    """Whether to load a multimodal model as a text-only language model.
 
-    Some checkpoints are dual-mode: transformers exposes both a text-only class
-    (e.g. ``Qwen3_5ForCausalLM``) and a multimodal class
-    (e.g. ``Qwen3_5ForConditionalGeneration``) for the same weights. By default
-    (``text_only=False``) such models are loaded as vision-language models. Set
-    ``text_only=True`` to load only the language backbone, skipping the vision
-    tower — the processor, vision chat template, and image features are not used.
+    Some models (e.g. Qwen3.5) ship the same weights as both a vision-language
+    model and a text-only language model. If True, only the language backbone is
+    loaded and the vision tower is skipped, so image inputs are ignored.
 
-    Only valid for genuinely dual-mode models (those whose ``AutoModelForCausalLM``
-    class differs from their vision-language class). Setting it on a vision-only
-    model (e.g. ``qwen3_vl``) or a pseudo-dual model whose causal class is the same
-    as its vision-language class (e.g. ``gemma3``) raises a config error. It is a
-    no-op for plain text models.
+    Only applies to models that provide a text-only variant; setting it on a
+    vision-only model (e.g. Qwen3-VL) raises an error.
 
-    Supported execution paths (keep this list in sync as coverage changes):
-        - Training: supported.
-        - Native inference (``InferenceEngineType.NATIVE``): supported.
-        - Evaluation via LM Harness (native/hf backend): supported.
-        - SGLang inference: supported.
-        - vLLM inference and vLLM-backed evaluation: NOT supported. vLLM manages
-          model loading itself and currently exposes only the multimodal class for
-          these checkpoints, so ``text_only`` has no effect there.
+    Defaults to False.
     """
 
     model_revision: str | None = None

--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -31,11 +31,11 @@ from oumi.utils.torch_utils import get_torch_dtype
 
 # `oumi.core.configs.internal.supported_models` imports `ModelParams` from
 # `oumi.core.configs`, so importing it at the top of this module would create a
-# circular import. `is_custom_model` and `is_dual_mode_model_using_model_name`
-# are instead imported into this module's namespace lazily, inside
-# `__finalize_and_validate__`, the first time they are needed.
+# circular import. These helpers are instead imported into this module's namespace
+# lazily, inside `__finalize_and_validate__`, the first time they are needed.
 is_custom_model: Any = None
 is_dual_mode_model_using_model_name: Any = None
+is_vision_language_model_using_model_name: Any = None
 
 
 @dataclass
@@ -359,25 +359,42 @@ class ModelParams(BaseParams):
 
         if self.text_only:
             global is_custom_model, is_dual_mode_model_using_model_name
-            if is_custom_model is None or is_dual_mode_model_using_model_name is None:
+            global is_vision_language_model_using_model_name
+            if is_custom_model is None:
                 from oumi.core.configs.internal import supported_models
 
                 is_custom_model = supported_models.is_custom_model
                 is_dual_mode_model_using_model_name = (
                     supported_models.is_dual_mode_model_using_model_name
                 )
+                is_vision_language_model_using_model_name = (
+                    supported_models.is_vision_language_model_using_model_name
+                )
 
-        if self.text_only and not is_custom_model(self.model_name):
-            if not is_dual_mode_model_using_model_name(
-                self.model_name,
-                trust_remote_code=self.trust_remote_code,
-                revision=self.model_revision,
+            if not is_custom_model(self.model_name) and not (
+                is_dual_mode_model_using_model_name(
+                    self.model_name,
+                    trust_remote_code=self.trust_remote_code,
+                    revision=self.model_revision,
+                )
             ):
-                raise OumiConfigError(
-                    f"text_only=True is not valid for model '{self.model_name}'. "
-                    "It is only supported for dual-mode checkpoints whose text-only "
-                    "class differs from their vision-language class (e.g. Qwen3.5). "
-                    "Vision-only models (e.g. Qwen3-VL) and models whose causal class "
-                    "equals their vision-language class (e.g. Gemma 3) have no "
-                    "text-only load path. Remove text_only or use a dual-mode model."
+                if is_vision_language_model_using_model_name(
+                    self.model_name,
+                    trust_remote_code=self.trust_remote_code,
+                    revision=self.model_revision,
+                ):
+                    # Vision-only model (e.g. Qwen3-VL): no text-only load path.
+                    raise OumiConfigError(
+                        f"text_only=True is not valid for model "
+                        f"'{self.model_name}'. It is only supported for models that "
+                        "ship both a vision-language and a text-only variant of the "
+                        "same weights (e.g. Qwen3.5). This model is vision-only and "
+                        "has no text-only variant. Remove text_only or use a model "
+                        "that provides one."
+                    )
+                # Plain text model (e.g. Llama): already text-only, so the flag has
+                # nothing to skip. Accept it but warn that it has no effect.
+                logger.warning(
+                    f"text_only=True has no effect for model '{self.model_name}': "
+                    "it is already a text-only model."
                 )

--- a/src/oumi/core/configs/params/model_params.py
+++ b/src/oumi/core/configs/params/model_params.py
@@ -29,6 +29,14 @@ from oumi.exceptions import (
 from oumi.utils.logging import logger
 from oumi.utils.torch_utils import get_torch_dtype
 
+# `oumi.core.configs.internal.supported_models` imports `ModelParams` from
+# `oumi.core.configs`, so importing it at the top of this module would create a
+# circular import. `is_custom_model` and `is_dual_mode_model_using_model_name`
+# are instead imported into this module's namespace lazily, inside
+# `__finalize_and_validate__`, the first time they are needed.
+is_custom_model: Any = None
+is_dual_mode_model_using_model_name: Any = None
+
 
 @dataclass
 class ModelParams(BaseParams):
@@ -361,3 +369,28 @@ class ModelParams(BaseParams):
             raise OumiConfigError(
                 "model_max_length must be a positive integer or None."
             )
+
+        if self.text_only:
+            global is_custom_model, is_dual_mode_model_using_model_name
+            if is_custom_model is None or is_dual_mode_model_using_model_name is None:
+                from oumi.core.configs.internal import supported_models
+
+                is_custom_model = supported_models.is_custom_model
+                is_dual_mode_model_using_model_name = (
+                    supported_models.is_dual_mode_model_using_model_name
+                )
+
+        if self.text_only and not is_custom_model(self.model_name):
+            if not is_dual_mode_model_using_model_name(
+                self.model_name,
+                trust_remote_code=self.trust_remote_code,
+                revision=self.model_revision,
+            ):
+                raise OumiConfigError(
+                    f"text_only=True is not valid for model '{self.model_name}'. "
+                    "It is only supported for dual-mode checkpoints whose text-only "
+                    "class differs from their vision-language class (e.g. Qwen3.5). "
+                    "Vision-only models (e.g. Qwen3-VL) and models whose causal class "
+                    "equals their vision-language class (e.g. Gemma 3) have no "
+                    "text-only load path. Remove text_only or use a dual-mode model."
+                )

--- a/src/oumi/core/evaluation/backends/lm_harness.py
+++ b/src/oumi/core/evaluation/backends/lm_harness.py
@@ -285,6 +285,7 @@ def evaluate(
         model_name=config.model.model_name,
         trust_remote_code=config.model.trust_remote_code,
         revision=config.model.model_revision,
+        text_only=config.model.text_only,
     )
 
     # Identify the proper LM Harness model (`lm_harness_model`) to use.

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
@@ -388,3 +389,26 @@ def test_build_oumi_model_invalid_model_type_raises(tmp_path):
 
     with pytest.raises(ValueError, match="does not contain a valid 'model_type'"):
         build_oumi_model(params)
+
+
+def test_is_image_text_llm_false_when_text_only():
+    params = ModelParams(model_name="Qwen/Qwen3.5-2B", text_only=True)
+    # Even if the registry says the model has a visual_config, text_only wins.
+    fake_config = mock.MagicMock()
+    fake_config.visual_config = object()
+    with mock.patch(
+        "oumi.builders.models.find_internal_model_config_using_model_name",
+        return_value=fake_config,
+    ):
+        assert is_image_text_llm(params) is False
+
+
+def test_is_image_text_llm_true_when_vision_default():
+    params = ModelParams(model_name="Qwen/Qwen3.5-2B")  # text_only defaults False
+    fake_config = mock.MagicMock()
+    fake_config.visual_config = object()
+    with mock.patch(
+        "oumi.builders.models.find_internal_model_config_using_model_name",
+        return_value=fake_config,
+    ):
+        assert is_image_text_llm(params) is True

--- a/tests/unit/builders/test_models.py
+++ b/tests/unit/builders/test_models.py
@@ -7,6 +7,7 @@ from torch import nn
 
 from oumi.builders.models import (
     _get_model_type,
+    _get_transformers_model_class,
     _patch_model_for_liger_kernel,
     build_chat_template,
     build_huggingface_model,
@@ -412,3 +413,28 @@ def test_is_image_text_llm_true_when_vision_default():
         return_value=fake_config,
     ):
         assert is_image_text_llm(params) is True
+
+
+def test_model_class_forces_causal_when_text_only():
+    import transformers
+
+    fake_config = mock.MagicMock()
+    fake_config.model_type = "qwen3_5"
+    cls = _get_transformers_model_class(fake_config, text_only=True)
+    assert cls is transformers.AutoModelForCausalLM
+
+
+def test_model_class_uses_registry_when_not_text_only():
+    import transformers
+
+    fake_info = mock.MagicMock()
+    fake_info.model_class = transformers.AutoModelForImageTextToText
+    fake_info.tested = True
+    fake_config = mock.MagicMock()
+    fake_config.model_type = "qwen3_5"
+    with mock.patch(
+        "oumi.builders.models.get_all_models_map",
+        return_value={"qwen3_5": fake_info},
+    ):
+        cls = _get_transformers_model_class(fake_config, text_only=False)
+    assert cls is transformers.AutoModelForImageTextToText

--- a/tests/unit/core/configs/internal/test_supported_models.py
+++ b/tests/unit/core/configs/internal/test_supported_models.py
@@ -6,6 +6,7 @@ from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
     find_internal_model_config_using_model_name,
     find_model_hf_config,
+    get_all_models_map,
     is_dual_mode_model_type,
 )
 from oumi.core.configs.params.model_params import ModelParams
@@ -84,3 +85,12 @@ def test_dual_mode_false_when_no_vlm_mapping():
     # plain text model: no ImageTextToText entry
     with _patch_mappings(causal_cls=type("Causal", (), {}), vlm_cls=None):
         assert is_dual_mode_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]
+
+
+def test_qwen3_5_registered_as_vlm():
+    models = get_all_models_map()
+    for mt in ("qwen3_5", "qwen3_5_moe"):
+        assert mt in models, f"{mt} missing from registry"
+        assert models[mt].config.visual_config is not None, (
+            f"{mt} should carry a visual_config (VLM by default)"
+        )

--- a/tests/unit/core/configs/internal/test_supported_models.py
+++ b/tests/unit/core/configs/internal/test_supported_models.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import pytest
 
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
     find_internal_model_config_using_model_name,
     find_model_hf_config,
+    is_dual_mode_model_type,
 )
 from oumi.core.configs.params.model_params import ModelParams
 
@@ -39,3 +42,45 @@ def test_common_vlm_models(model_name: str, trust_remote_code):
         )
         is not None
     ), debug_tag
+
+
+class _FakeConfig:
+    """Stand-in HF config whose class identity drives the mapping lookups."""
+
+
+def _patch_mappings(causal_cls, vlm_cls):
+    """Patch the two transformers auto-mappings to return the given classes."""
+    causal_map = mock.MagicMock()
+    causal_map._model_mapping.get.return_value = causal_cls
+    vlm_map = mock.MagicMock()
+    vlm_map._model_mapping.get.return_value = vlm_cls
+    return mock.patch.multiple(
+        "oumi.core.configs.internal.supported_models",
+        MODEL_FOR_CAUSAL_LM_MAPPING=causal_map,
+        MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING=vlm_map,
+    )
+
+
+def test_dual_mode_true_when_causal_class_distinct():
+    # qwen3_5: Qwen3_5ForCausalLM != Qwen3_5ForConditionalGeneration
+    with _patch_mappings(causal_cls=object, vlm_cls=type("VLM", (), {})):
+        assert is_dual_mode_model_type(_FakeConfig()) is True  # pyright: ignore[reportArgumentType]
+
+
+def test_dual_mode_false_when_same_class():
+    # gemma3: both mappings resolve to Gemma3ForConditionalGeneration
+    same = type("SameCls", (), {})
+    with _patch_mappings(causal_cls=same, vlm_cls=same):
+        assert is_dual_mode_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]
+
+
+def test_dual_mode_false_when_no_causal_mapping():
+    # qwen3_vl: no AutoModelForCausalLM entry
+    with _patch_mappings(causal_cls=None, vlm_cls=type("VLM", (), {})):
+        assert is_dual_mode_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]
+
+
+def test_dual_mode_false_when_no_vlm_mapping():
+    # plain text model: no ImageTextToText entry
+    with _patch_mappings(causal_cls=type("Causal", (), {}), vlm_cls=None):
+        assert is_dual_mode_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]

--- a/tests/unit/core/configs/internal/test_supported_models.py
+++ b/tests/unit/core/configs/internal/test_supported_models.py
@@ -8,6 +8,7 @@ from oumi.core.configs.internal.supported_models import (
     find_model_hf_config,
     get_all_models_map,
     is_dual_mode_model_type,
+    is_vision_language_model_type,
 )
 from oumi.core.configs.params.model_params import ModelParams
 
@@ -85,6 +86,18 @@ def test_dual_mode_false_when_no_vlm_mapping():
     # plain text model: no ImageTextToText entry
     with _patch_mappings(causal_cls=type("Causal", (), {}), vlm_cls=None):
         assert is_dual_mode_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]
+
+
+def test_vision_language_true_when_vlm_mapping_exists():
+    # Any model with an ImageTextToText class (vision-only or dual-mode).
+    with _patch_mappings(causal_cls=None, vlm_cls=type("VLM", (), {})):
+        assert is_vision_language_model_type(_FakeConfig()) is True  # pyright: ignore[reportArgumentType]
+
+
+def test_vision_language_false_when_no_vlm_mapping():
+    # Plain text model: no ImageTextToText class.
+    with _patch_mappings(causal_cls=type("Causal", (), {}), vlm_cls=None):
+        assert is_vision_language_model_type(_FakeConfig()) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_qwen3_5_registered_as_vlm():

--- a/tests/unit/core/configs/params/test_model_params.py
+++ b/tests/unit/core/configs/params/test_model_params.py
@@ -178,3 +178,13 @@ def test_adapter_config_invalid_json(tmp_path: Path):
 
     assert "line" in str(exc_info.value)
     assert "col" in str(exc_info.value)
+
+
+def test_text_only_defaults_to_false():
+    params = ModelParams(model_name="gpt2")
+    assert params.text_only is False
+
+
+def test_text_only_can_be_set_true():
+    params = ModelParams(model_name="Qwen/Qwen3.5-2B", text_only=True)
+    assert params.text_only is True

--- a/tests/unit/core/configs/params/test_model_params.py
+++ b/tests/unit/core/configs/params/test_model_params.py
@@ -1,5 +1,6 @@
 import dataclasses
 from pathlib import Path
+from unittest import mock
 from unittest.mock import call, patch
 
 import pytest
@@ -188,3 +189,43 @@ def test_text_only_defaults_to_false():
 def test_text_only_can_be_set_true():
     params = ModelParams(model_name="Qwen/Qwen3.5-2B", text_only=True)
     assert params.text_only is True
+
+
+def test_text_only_true_on_non_dual_mode_raises():
+    params = ModelParams(model_name="Qwen/Qwen3-VL-2B", text_only=True)
+    with (
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_custom_model",
+            return_value=False,
+        ),
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_dual_mode_model_using_model_name",
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(OumiConfigError, match="text_only"):
+            params.__finalize_and_validate__()
+
+
+def test_text_only_true_on_dual_mode_ok():
+    params = ModelParams(model_name="Qwen/Qwen3.5-2B", text_only=True)
+    with (
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_custom_model",
+            return_value=False,
+        ),
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_dual_mode_model_using_model_name",
+            return_value=True,
+        ),
+    ):
+        params.__finalize_and_validate__()  # should not raise
+
+
+def test_text_only_false_skips_capability_check():
+    params = ModelParams(model_name="Qwen/Qwen3-VL-2B")  # text_only defaults False
+    with mock.patch(
+        "oumi.core.configs.params.model_params.is_dual_mode_model_using_model_name"
+    ) as m:
+        params.__finalize_and_validate__()
+        m.assert_not_called()

--- a/tests/unit/core/configs/params/test_model_params.py
+++ b/tests/unit/core/configs/params/test_model_params.py
@@ -191,7 +191,8 @@ def test_text_only_can_be_set_true():
     assert params.text_only is True
 
 
-def test_text_only_true_on_non_dual_mode_raises():
+def test_text_only_true_on_vision_only_model_raises():
+    # A vision-only model (has a VLM class, not dual-mode) has no text-only path.
     params = ModelParams(model_name="Qwen/Qwen3-VL-2B", text_only=True)
     with (
         mock.patch(
@@ -202,8 +203,12 @@ def test_text_only_true_on_non_dual_mode_raises():
             "oumi.core.configs.params.model_params.is_dual_mode_model_using_model_name",
             return_value=False,
         ),
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_vision_language_model_using_model_name",
+            return_value=True,
+        ),
     ):
-        with pytest.raises(OumiConfigError, match="text_only"):
+        with pytest.raises(OumiConfigError, match="vision-only"):
             params.__finalize_and_validate__()
 
 
@@ -220,6 +225,28 @@ def test_text_only_true_on_dual_mode_ok():
         ),
     ):
         params.__finalize_and_validate__()  # should not raise
+
+
+def test_text_only_true_on_plain_text_model_warns_but_ok(caplog):
+    # A plain text model (no VLM class) is already text-only: the flag is a no-op,
+    # accepted with a warning rather than an error.
+    params = ModelParams(model_name="meta-llama/Llama-3.1-8B", text_only=True)
+    with (
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_custom_model",
+            return_value=False,
+        ),
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_dual_mode_model_using_model_name",
+            return_value=False,
+        ),
+        mock.patch(
+            "oumi.core.configs.params.model_params.is_vision_language_model_using_model_name",
+            return_value=False,
+        ),
+    ):
+        params.__finalize_and_validate__()  # should not raise
+    assert "has no effect" in caplog.text
 
 
 def test_text_only_false_skips_capability_check():

--- a/tests/unit/core/evaluation/test_backend_lm_harness.py
+++ b/tests/unit/core/evaluation/test_backend_lm_harness.py
@@ -316,6 +316,7 @@ def test_evaluate(mock_patches_for_evaluate):
         model_name=evaluation_config.model.model_name,
         trust_remote_code=evaluation_config.model.trust_remote_code,
         revision=evaluation_config.model.model_revision,
+        text_only=evaluation_config.model.text_only,
     )
     mock_get_task_dict.assert_called_once_with(task_params)
     mock_generate_lm_harness_model_args.assert_called_once_with(
@@ -335,6 +336,80 @@ def test_evaluate(mock_patches_for_evaluate):
     assert args[1] == mock_task_dict  # task_dict
     assert kwargs["limit"] == 222
     assert not kwargs["apply_chat_template"]
+
+
+def test_evaluate_text_only_selects_hf_not_hf_multimodal(mock_patches_for_evaluate):
+    # A dual-mode model with text_only=True must route to the text harness model
+    # ("hf"), not the multimodal one ("hf-multimodal"), and must forward
+    # `text_only` to `is_image_text_llm_using_model_name`.
+    mock_cuda_is_available = mock_patches_for_evaluate["mock_cuda_is_available"]
+    mock_is_image_text_llm = mock_patches_for_evaluate["mock_is_image_text_llm"]
+    mock_get_task_dict = mock_patches_for_evaluate["mock_get_task_dict"]
+    mock_generate_lm_harness_model_args = mock_patches_for_evaluate[
+        "mock_generate_lm_harness_model_args"
+    ]
+    mock_lm_harness_get_model_class = mock_patches_for_evaluate[
+        "mock_lm_harness_get_model_class"
+    ]
+    mock_lm_harness_evaluate = mock_patches_for_evaluate["mock_lm_harness_evaluate"]
+    mock_is_world_process_zero = mock_patches_for_evaluate["mock_is_world_process_zero"]
+
+    task_params = LMHarnessTaskParams(
+        evaluation_backend="lm_harness",
+        task_name="mmlu",
+    )
+    evaluation_config = EvaluationConfig(
+        tasks=[task_params],
+        model=ModelParams(model_name="Qwen/Qwen3.5-2B", text_only=True),
+        generation=GenerationParams(),
+        inference_engine=InferenceEngineType.NATIVE,
+        inference_remote_params=None,
+        run_name="run_name",
+        enable_wandb=False,
+        output_dir="test_output",
+    )
+
+    # The real `is_image_text_llm_using_model_name` would return False when
+    # `text_only=True`, regardless of the model's own multimodal registry entry.
+    # We mock it here (it's the registry/HF-config resolution dependency), but
+    # assert below that the call site actually forwards `text_only` and that the
+    # resulting `is_multimodal` value drives `lm_harness_model` selection to "hf".
+    mock_cuda_is_available.return_value = True
+    mock_is_image_text_llm.return_value = False
+    mock_get_task_dict.return_value = {"mmlu": MagicMock()}
+    mock_generate_lm_harness_model_args.return_value = {"pretrained": "some_model"}
+    mock_lm_harness_get_model_class.return_value = MagicMock()
+    mock_lm_harness_evaluate.return_value = {
+        "results": {"mmlu": {"acc": 0.5}},
+        "configs": {},
+    }
+    mock_is_world_process_zero.return_value = True
+
+    _ = evaluate_lm_harness(
+        task_params=task_params,
+        config=evaluation_config,
+    )
+
+    # `text_only` must be forwarded with the real config value (not hardcoded).
+    mock_is_image_text_llm.assert_called_once_with(
+        model_name=evaluation_config.model.model_name,
+        trust_remote_code=evaluation_config.model.trust_remote_code,
+        revision=evaluation_config.model.model_revision,
+        text_only=evaluation_config.model.text_only,
+    )
+    assert evaluation_config.model.text_only is True
+
+    # Since `is_image_text_llm_using_model_name` returned False (as it would for
+    # text_only=True), the NATIVE engine must select "hf", not "hf-multimodal".
+    mock_generate_lm_harness_model_args.assert_called_once_with(
+        lm_harness_model="hf",
+        is_multimodal=False,
+        model_params=evaluation_config.model,
+        generation_params=evaluation_config.generation,
+        inference_engine_type=evaluation_config.inference_engine,
+        inference_remote_params=evaluation_config.inference_remote_params,
+    )
+    mock_lm_harness_get_model_class.assert_called_once_with("hf")
 
 
 def test_evaluate_failure_vLLM_without_CUDA(mock_patches_for_evaluate):


### PR DESCRIPTION
# Description

Some checkpoints are dual-mode: transformers exposes both a text-only class (e.g. `Qwen3_5ForCausalLM`) and a multimodal class (e.g. `Qwen3_5ForConditionalGeneration`) for the same weights. Oumi's registry maps one `model_type` to one model class, so it could not represent both modes — a dual-mode checkpoint was silently treated as text-only (falling back to `AutoModelForCausalLM`), which meant vision fine-tuning ran without a processor, VL chat template, or image features and produced no vision learning, with no error. This PR adds an opt-in so the same checkpoint can be loaded either way per run.

- **New config field**: `ModelParams.text_only: bool = False`. Default loads the vision-language model (unchanged behavior); `text_only=True` loads only the language backbone, skipping the vision tower.
- **Dual-mode capability check** (`is_dual_mode_model_type` in `supported_models.py`): computed from the transformers auto-mappings rather than a hardcoded list — a model is dual-mode iff `AutoModelForCausalLM` resolves it to a class distinct from its `AutoModelForImageTextToText` class. This correctly admits `qwen3_5`/`qwen3_5_moe`, and excludes both vision-only models (`qwen3_vl`, no causal class) and models whose causal class equals their VLM class (`gemma3`).
- **Validation**: `text_only=True` on a non-dual-mode model raises a clear `OumiConfigError` at config-finalization time, instead of surfacing later as a raw transformers `Unrecognized configuration class` error.
- **Threaded through both VLM-ness derivations**: `is_image_text_llm` (gates processor/collator/`remove_unused_columns`) and `_get_transformers_model_class` (selects the `Auto*` class) both honor the flag, so the model class and the data pipeline stay consistent.
- **Registry**: `qwen3_5` and `qwen3_5_moe` are registered as vision-language models (processor resolves to `Qwen3VLProcessor`; reuses the existing Qwen3-VL internal config).
- **Evaluation**: the LM Harness backend picks the text harness model (`hf`/`vllm`) over the multimodal one (`hf-multimodal`/`vllm-vlm`) when `text_only` is set.

Scope: the flag takes effect for training, native inference, LM Harness (native/hf) evaluation, and the SGLang processor path. It is a documented no-op for the vLLM engine, which manages its own model loading and currently exposes only the multimodal class for these checkpoints; the field docstring states this.

## Related issues

Towardsa OPE-2158

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
