### PR TITLE
fix(analyze): allow consecutive tool results in alternation check

### DIFF
--- a/src/oumi/analyze/analyzers/quality.py
+++ b/src/oumi/analyze/analyzers/quality.py
@@ -53,8 +53,9 @@ class DataQualityMetrics(BaseModel):
 
     has_non_alternating_turns: bool = Field(
         description=(
-            "True if non-system messages do NOT strictly alternate between "
-            "user and assistant roles (i.e. consecutive same-role messages exist)"
+            "True if non-system messages contain a consecutive same-role pair "
+            "other than tool->tool (consecutive tool results from parallel tool "
+            "calls are valid)"
         )
     )
     has_no_user_message: bool = Field(
@@ -128,12 +129,16 @@ class DataQualityAnalyzer(ConversationAnalyzer[DataQualityMetrics]):
         """
         messages = conversation.messages
 
-        # 1. Non-alternating turns check (ignoring system messages)
+        # 1. Non-alternating turns check (ignoring system messages).
+        # Consecutive tool results are valid — an assistant step may issue
+        # parallel tool calls, each producing its own tool message — so
+        # tool->tool is exempt. Any other repeated role (user->user,
+        # assistant->assistant) is flagged.
         roles = [m.role.value for m in messages]
-        non_system = [r for r in roles if r != "system"]
+        non_system = [r for r in roles if r != Role.SYSTEM.value]
         has_non_alternating = False
         for i in range(1, len(non_system)):
-            if non_system[i] == non_system[i - 1]:
+            if non_system[i] == non_system[i - 1] != Role.TOOL.value:
                 has_non_alternating = True
                 break
 

--- a/tests/unit/analyze/test_quality_analyzer.py
+++ b/tests/unit/analyze/test_quality_analyzer.py
@@ -147,6 +147,21 @@ def test_tool_turn_breaks_alternation(analyzer):
     assert result.has_non_alternating_turns is False
 
 
+def test_parallel_tool_calls_not_flagged(analyzer):
+    """Consecutive tool results (parallel tool calls) are valid, not flagged."""
+    conversation = Conversation(
+        messages=[
+            Message(role=Role.USER, content="Find order ORD-1 and its shipment."),
+            Message(role=Role.ASSISTANT, content="Looking both up."),
+            Message(role=Role.TOOL, content='{"order": "ORD-1"}'),
+            Message(role=Role.TOOL, content='{"shipment": "SHP-1"}'),
+            Message(role=Role.ASSISTANT, content="Found both."),
+        ]
+    )
+    result = analyzer.analyze(conversation)
+    assert result.has_non_alternating_turns is False
+
+
 def test_empty_conversation_not_flagged(analyzer, empty_conversation):
     """Empty conversation is not flagged as non-alternating."""
     result = analyzer.analyze(empty_conversation)


### PR DESCRIPTION
# Description

`DataQualityAnalyzer.has_non_alternating_turns` flags a conversation when any two consecutive non-system messages share the same role. The intent is to catch malformed data like two user turns or two assistant turns in a row. But the rule breaks on valid tool-using conversations: when an assistant issues **parallel tool calls** in a single step, each call produces its own `tool` message, so the conversation legitimately contains back-to-back `tool` turns (`assistant → tool → tool → assistant`). Those valid trajectories were being flagged as non-alternating, producing false positives on any agentic/tool-use dataset that uses parallel tool calls.

This change makes the check tool-aware:

- **Exempts `tool → tool` from the alternation check** — consecutive tool results are a normal consequence of parallel tool calls, not a data-quality problem.
- **Still flags genuinely malformed sequences** — consecutive `user` or consecutive `assistant` turns continue to be flagged as before.
- **Updates the `has_non_alternating_turns` field description** to state the tool-result exemption, so the metric documents its own behavior.
- **Adds a regression test** covering the parallel-tool-call sequence; the existing single-tool and consecutive-user/assistant cases are unchanged.

Single-tool-call turns (`assistant → tool → assistant`) were already valid and remain so.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
