### PR TITLE
feat(synthesis): count multi-turn min/max_turns as rounds (user+assistant exchanges)

### DIFF
--- a/configs/examples/synthesis/README.md
+++ b/configs/examples/synthesis/README.md
@@ -334,10 +334,10 @@ oumi synth -c configs/examples/synthesis/dynamic_few_shot_synth.yaml
 
 **Purpose**: Generate dynamic, variable-length multi-turn conversations using `multiturn_attributes` with conversation planning and role-based turn generation.
 
-**What it does**: Creates realistic customer support conversations where the system first plans the conversation flow, then generates each turn sequentially with full conversation context. Unlike the chained approach in `conversation_synth.yaml`, this produces variable-length conversations (4-12 turns) with natural back-and-forth dialogue.
+**What it does**: Creates realistic customer support conversations where the system first plans the conversation flow, then generates each turn sequentially with full conversation context. Unlike the chained approach in `conversation_synth.yaml`, this produces variable-length conversations (2-6 rounds, i.e. 4-12 messages) with natural back-and-forth dialogue.
 
 **Key features**:
-- **Multi-turn conversation generation** with variable length (4-12 turns per conversation)
+- **Multi-turn conversation generation** with variable length (2-6 rounds / 4-12 messages per conversation)
 - **Conversation planning**: The system automatically generates a turn-by-turn plan before generating the conversation
 - **Role-based instructions**: Separate instruction templates for USER and ASSISTANT roles
 - **Generated context attributes**: Customer name, issue details, and opening message are generated before the conversation begins
@@ -351,7 +351,7 @@ oumi synth -c configs/examples/synthesis/dynamic_few_shot_synth.yaml
 | Feature | `conversation_synth.yaml` | `multiturn_conversation_synth.yaml` |
 |---|---|---|
 | Approach | Chained `generated_attributes` | `multiturn_attributes` |
-| Turn count | Fixed (4 messages) | Variable (4-12 turns) |
+| Turn count | Fixed (4 messages) | Variable (2-6 rounds / 4-12 messages) |
 | Context threading | Manual via attribute references | Automatic conversation history |
 | Conversation planning | None | Automatic turn-by-turn plan |
 | Output format | `transformed_attributes` (CHAT) | Native conversation object |
@@ -360,8 +360,8 @@ oumi synth -c configs/examples/synthesis/dynamic_few_shot_synth.yaml
 ```yaml
 multiturn_attributes:
   - id: "support_conversation"
-    min_turns: 4
-    max_turns: 12
+    min_turns: 2
+    max_turns: 6
 
     role_instruction_messages:
       USER: |
@@ -441,7 +441,7 @@ oumi synth -c configs/examples/synthesis/multiturn_conversation_synth.yaml
 - **Three patron personas**: `anxious_parent`, `enthusiastic_reader`, `busy_professional` — sampled per conversation.
 - **Persona-aware planner**: the conversation planner receives the persona description and matches plan length/style accordingly (terse personas get tighter plans).
 - **Catalog-grounded assistant prompt**: the assistant is explicitly forbidden from calling `lookup_book_status` with a `book_id` it hasn't seen in a recent `list_book_catalog` response — preventing fabricated lookups when patrons ask for off-catalog titles.
-- **Multi-turn dialog**: 4-6 turns per conversation with up to 6 tool-call rounds per turn.
+- **Multi-turn dialog**: 4-6 rounds (8-12 messages) per conversation, with up to 6 tool-call rounds within each assistant turn.
 
 **How it differs from `multiturn_conversation_synth.yaml`**:
 

--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -145,7 +145,7 @@ strategy_params:
           - Stay polite and helpful.
 
       conversation_planner: |
-        Plan a {target_turns}-turn conversation between {user_persona.name}
+        Plan the conversation between {user_persona.name}
         ({user_persona.description}) and LibBot. The dialog must require LibBot
         to call list_book_catalog at least once and lookup_book_status at least
         once across the conversation.

--- a/configs/examples/synthesis/multiturn_conversation_synth.yaml
+++ b/configs/examples/synthesis/multiturn_conversation_synth.yaml
@@ -281,8 +281,8 @@ strategy_params:
 
   multiturn_attributes:
     - id: "support_conversation"
-      min_turns: 4
-      max_turns: 12
+      min_turns: 2
+      max_turns: 6
 
       role_instruction_messages:
         USER: |

--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -192,8 +192,8 @@ For dynamic, variable-length conversations, use `multiturn_attributes`. Each tur
 ```yaml
 multiturn_attributes:
   - id: support_conversation
-    min_turns: 4
-    max_turns: 12
+    min_turns: 2
+    max_turns: 6
 
     role_instruction_messages:
       USER: |
@@ -403,13 +403,13 @@ generated_attributes:
 
 **Multi-Turn Attributes**: Dynamic, variable-length conversations generated turn-by-turn
 
-Unlike generated attributes which produce single values, multi-turn attributes generate full conversations where each turn is produced by the model with the complete conversation history as context. The system automatically plans the conversation, then generates each turn sequentially.
+Unlike generated attributes which produce single values, multi-turn attributes generate full conversations where each message is produced by the model with the complete conversation history as context. The system automatically plans the conversation, then generates each turn sequentially.
 
 ```yaml
 multiturn_attributes:
   - id: support_conversation
-    min_turns: 4
-    max_turns: 12
+    min_turns: 2
+    max_turns: 6
 
     role_instruction_messages:
       USER: |
@@ -780,7 +780,7 @@ Create multi-turn conversations by chaining generated responses.
 
 Generate dynamic, variable-length conversations using `multiturn_attributes`. The system plans the conversation, then generates each turn with full conversation context, producing natural back-and-forth dialogue.
 
-**Example**: See {gh}`configs/examples/synthesis/multiturn_conversation_synth.yaml` for a customer support conversation example using multi-turn attributes with conversation planning, role-based instructions, and variable-length conversations (4-12 turns).
+**Example**: See {gh}`configs/examples/synthesis/multiturn_conversation_synth.yaml` for a customer support conversation example using multi-turn attributes with conversation planning, role-based instructions, and variable-length conversations (2-6 rounds / 4-12 messages).
 
 ### Domain Adaptation
 

--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -430,7 +430,7 @@ multiturn_attributes:
 Key parameters:
 
 - **`id`**: Unique identifier for the attribute. The generated conversation is stored under this ID, and a conversation plan is automatically stored under `{id}_plan`.
-- **`min_turns`** / **`max_turns`**: Controls the conversation length range. Each turn is one message (user or assistant).
+- **`min_turns`** / **`max_turns`**: Controls the conversation length range. Each turn is one round -- a user message plus an assistant reply -- so `max_turns: 12` yields up to 12 exchanges (24 messages).
 - **`role_instruction_messages`**: Per-role instruction templates. Must define both `USER` and `ASSISTANT` roles. These templates can reference any previously defined attributes using `{placeholder}` syntax.
 - **`output_system_prompt`**: Optional system prompt prepended to the final output conversation.
 - **`conversation_planner`**: Optional custom instructions for the conversation planner that generates a turn-by-turn plan before the conversation begins.

--- a/src/oumi/core/configs/params/synthesis_params.py
+++ b/src/oumi/core/configs/params/synthesis_params.py
@@ -462,10 +462,12 @@ class MultiTurnAttribute:
     """Unique identifier for the attribute."""
 
     min_turns: int
-    """Minimum number of turns (messages) required for the attribute."""
+    """Minimum number of turns (rounds) -- one round is a user message plus an
+    assistant reply."""
 
     max_turns: int
-    """Maximum number of turns (messages) allowed for the attribute."""
+    """Maximum number of turns (rounds) -- one round is a user message plus an
+    assistant reply."""
 
     role_instruction_messages: dict[Role, str]
     """Per-role instruction template for generating a turn."""
@@ -805,8 +807,9 @@ class GeneralSynthesisParams(BaseParams):
             role: ASSISTANT
             system_prompt: "You are a helpful support agent."
 
-    The conversation length is controlled by min_turns and max_turns. The output
-    is a list of message dictionaries::
+    The conversation length is controlled by min_turns and max_turns, which count
+    rounds (user+assistant exchanges). The output is a list of message
+    dictionaries::
 
         [
             {"role": "user", "content": "I need help with my order."},

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -1170,10 +1170,8 @@ class ConversationSynthesizer:
     def _select_target_turns(
         self, multiturn_attribute: MultiTurnAttribute, turn_order: list[Role]
     ) -> int:
-        # min_turns/max_turns are configured in rounds (one user+assistant
-        # exchange). Return a message count so the generation loop and planner
-        # stay message-based: one round == one full pass through turn_order
-        # (== 2 for the default [USER, ASSISTANT]).
+        # min_turns/max_turns count rounds; return a message count (one round
+        # == one pass through turn_order) so the loop and planner stay message-based.
         target_rounds = random.randint(
             multiturn_attribute.min_turns, multiturn_attribute.max_turns
         )

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -1170,24 +1170,14 @@ class ConversationSynthesizer:
     def _select_target_turns(
         self, multiturn_attribute: MultiTurnAttribute, turn_order: list[Role]
     ) -> int:
-        min_turns = multiturn_attribute.min_turns
-        max_turns = multiturn_attribute.max_turns
-        target_turns = random.randint(min_turns, max_turns)
-        if Role.ASSISTANT not in turn_order:
-            return target_turns
-
-        def role_at(turn_count: int) -> Role:
-            return turn_order[(turn_count - 1) % len(turn_order)]
-
-        if role_at(target_turns) == Role.ASSISTANT:
-            return target_turns
-        for turn_count in range(target_turns + 1, max_turns + 1):
-            if role_at(turn_count) == Role.ASSISTANT:
-                return turn_count
-        for turn_count in range(target_turns - 1, min_turns - 1, -1):
-            if role_at(turn_count) == Role.ASSISTANT:
-                return turn_count
-        return target_turns
+        # min_turns/max_turns are configured in rounds (one user+assistant
+        # exchange). Return a message count so the generation loop and planner
+        # stay message-based: one round == one full pass through turn_order
+        # (== 2 for the default [USER, ASSISTANT]).
+        target_rounds = random.randint(
+            multiturn_attribute.min_turns, multiturn_attribute.max_turns
+        )
+        return target_rounds * len(turn_order)
 
     def _format_output_system_message(
         self,

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -177,8 +177,7 @@ def test_build_planner_prompts_selects_turns_without_inference(
     mock_inference_engine.infer.assert_not_called()
     for prompt, sample in zip(prompts, samples):
         assert isinstance(prompt, PlannerPrompt)
-        # target_turns is a message count: rounds * len(turn_order), where
-        # rounds is drawn from [min_turns, max_turns].
+        # target_turns is a message count: rounds * len(turn_order).
         turn_order_len = len(synthesizer._default_turn_order)
         target_turns = prompt.augmented_sample["target_turns"]
         assert mock_multiturn_attribute.min_turns * turn_order_len <= target_turns
@@ -718,8 +717,7 @@ def test_generate_plan_uses_planner_only_guided_decoding(
         [{"customer_type": "friendly", "issue": "product question"}],
         MultiTurnAttribute(
             id="test_conversation",
-            # 1 round == one USER+ASSISTANT exchange (2 messages); matches the
-            # 3 scripted infer results below (1 planner + 2 turn calls).
+            # 1 round (2 turns) matches the 3 scripted infer results below.
             min_turns=1,
             max_turns=1,
             role_instruction_messages={
@@ -1205,8 +1203,6 @@ def _turn_attr(min_turns: int, max_turns: int) -> MultiTurnAttribute:
 @pytest.mark.parametrize(
     ("min_turns", "max_turns", "turn_order", "drawn_rounds", "expected_messages"),
     [
-        # rounds are drawn from [min_turns, max_turns] then multiplied by the
-        # turn-order length to get a message count.
         (2, 5, [Role.USER, Role.ASSISTANT], 3, 6),
         (4, 4, [Role.USER, Role.ASSISTANT], 4, 8),  # min == max
         (1, 3, [Role.USER, Role.ASSISTANT], 1, 2),  # min == 1 -> single exchange
@@ -1233,7 +1229,6 @@ def test_select_target_turns_counts_rounds_as_messages(
     )
 
     assert result == expected_messages
-    # The draw is over rounds, i.e. the raw [min_turns, max_turns] range.
     mock_randint.assert_called_once_with(min_turns, max_turns)
 
 
@@ -1882,8 +1877,6 @@ def test_synthesize_attaches_tools_to_assistant_prompt(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        # One round == one USER+ASSISTANT exchange: exactly the two turn
-        # prompts this test inspects.
         min_turns=1,
         max_turns=1,
         role_instruction_messages={
@@ -2329,7 +2322,6 @@ def test_assistant_turn_loops_on_tool_calls(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        # One round == the single assistant turn whose tool loop this exercises.
         min_turns=1,
         max_turns=1,
         role_instruction_messages={
@@ -2438,8 +2430,6 @@ def test_assistant_turn_caps_at_max_consecutive_tool_turns_then_finalizes(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        # One round == one USER+ASSISTANT exchange (a single assistant turn), so
-        # the agentic tool loop runs exactly once.
         min_turns=1,
         max_turns=1,
         role_instruction_messages={
@@ -2547,8 +2537,6 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        # One round == one USER+ASSISTANT exchange (a single assistant turn), so
-        # the agentic tool loop runs exactly once.
         min_turns=1,
         max_turns=1,
         role_instruction_messages={

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1204,10 +1204,10 @@ def _turn_attr(min_turns: int, max_turns: int) -> MultiTurnAttribute:
     ("min_turns", "max_turns", "turn_order", "drawn_rounds", "expected_messages"),
     [
         (2, 5, [Role.USER, Role.ASSISTANT], 3, 6),
-        (4, 4, [Role.USER, Role.ASSISTANT], 4, 8),  # min == max
+        (4, 4, [Role.USER, Role.ASSISTANT], 4, 8),  # min == max (single value)
         (1, 3, [Role.USER, Role.ASSISTANT], 1, 2),  # min == 1 -> single exchange
         (2, 5, [Role.USER], 3, 3),  # ASSISTANT absent: still rounds * len
-        (2, 5, [Role.USER, Role.ASSISTANT, Role.USER], 3, 9),  # len(turn_order) == 3
+        (2, 5, [Role.USER, Role.ASSISTANT, Role.USER], 3, 9),  # 3-role turn_order
     ],
 )
 @patch("oumi.core.synthesis.conversation_synthesizer.random.randint")
@@ -1688,6 +1688,14 @@ def test_synthesize_invokes_attach_grounding_facts(
     assert "grounding_facts" in samples[0]
     assert len(samples[0]["grounding_facts"]) == 2
     assert len(result) == 1
+    # 2 rounds -> 4 messages ending on assistant, through the real turn loop.
+    record = result[0]
+    assert record is not None
+    conv = record["t"]
+    assert isinstance(conv, dict)
+    messages = conv["messages"]
+    assert len(messages) == 4
+    assert messages[-1]["role"] == "assistant"
 
 
 # --- {grounding_facts} placeholder misuse warning ---

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -177,9 +177,13 @@ def test_build_planner_prompts_selects_turns_without_inference(
     mock_inference_engine.infer.assert_not_called()
     for prompt, sample in zip(prompts, samples):
         assert isinstance(prompt, PlannerPrompt)
+        # target_turns is a message count: rounds * len(turn_order), where
+        # rounds is drawn from [min_turns, max_turns].
+        turn_order_len = len(synthesizer._default_turn_order)
         target_turns = prompt.augmented_sample["target_turns"]
-        assert mock_multiturn_attribute.min_turns <= target_turns
-        assert target_turns <= mock_multiturn_attribute.max_turns
+        assert mock_multiturn_attribute.min_turns * turn_order_len <= target_turns
+        assert target_turns <= mock_multiturn_attribute.max_turns * turn_order_len
+        assert target_turns % turn_order_len == 0
         assert prompt.augmented_sample["conversation_plan"] == ""
         assert prompt.augmented_sample["parsed_turn_plans"] == [""] * target_turns
         assert prompt.augmented_sample["issue"] == sample["issue"]
@@ -714,8 +718,10 @@ def test_generate_plan_uses_planner_only_guided_decoding(
         [{"customer_type": "friendly", "issue": "product question"}],
         MultiTurnAttribute(
             id="test_conversation",
-            min_turns=2,
-            max_turns=2,
+            # 1 round == one USER+ASSISTANT exchange (2 messages); matches the
+            # 3 scripted infer results below (1 planner + 2 turn calls).
+            min_turns=1,
+            max_turns=1,
             role_instruction_messages={
                 Role.USER: "You are a {customer_type} customer with issue: {issue}.",
                 Role.ASSISTANT: "You are a helpful support agent.",
@@ -1185,6 +1191,50 @@ def _make_synthesizer(mock_inference_config, environment_config=None):
             mock_inference_config,
             environment_config=environment_config,
         )
+
+
+def _turn_attr(min_turns: int, max_turns: int) -> MultiTurnAttribute:
+    return MultiTurnAttribute(
+        id="c",
+        min_turns=min_turns,
+        max_turns=max_turns,
+        role_instruction_messages={Role.USER: "u", Role.ASSISTANT: "a"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("min_turns", "max_turns", "turn_order", "drawn_rounds", "expected_messages"),
+    [
+        # rounds are drawn from [min_turns, max_turns] then multiplied by the
+        # turn-order length to get a message count.
+        (2, 5, [Role.USER, Role.ASSISTANT], 3, 6),
+        (4, 4, [Role.USER, Role.ASSISTANT], 4, 8),  # min == max
+        (1, 3, [Role.USER, Role.ASSISTANT], 1, 2),  # min == 1 -> single exchange
+        (2, 5, [Role.USER], 3, 3),  # ASSISTANT absent: still rounds * len
+        (2, 5, [Role.USER, Role.ASSISTANT, Role.USER], 3, 9),  # len(turn_order) == 3
+    ],
+)
+@patch("oumi.core.synthesis.conversation_synthesizer.random.randint")
+def test_select_target_turns_counts_rounds_as_messages(
+    mock_randint,
+    mock_inference_config,
+    min_turns,
+    max_turns,
+    turn_order,
+    drawn_rounds,
+    expected_messages,
+):
+    """min/max_turns are rounds; the method returns rounds * len(turn_order)."""
+    mock_randint.return_value = drawn_rounds
+    synthesizer = _make_synthesizer(mock_inference_config)
+
+    result = synthesizer._select_target_turns(
+        _turn_attr(min_turns, max_turns), turn_order
+    )
+
+    assert result == expected_messages
+    # The draw is over rounds, i.e. the raw [min_turns, max_turns] range.
+    mock_randint.assert_called_once_with(min_turns, max_turns)
 
 
 def _grounded_env_params(
@@ -1832,8 +1882,10 @@ def test_synthesize_attaches_tools_to_assistant_prompt(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        min_turns=2,
-        max_turns=2,
+        # One round == one USER+ASSISTANT exchange: exactly the two turn
+        # prompts this test inspects.
+        min_turns=1,
+        max_turns=1,
         role_instruction_messages={
             Role.USER: "user",
             Role.ASSISTANT: "assistant",
@@ -2277,8 +2329,9 @@ def test_assistant_turn_loops_on_tool_calls(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        min_turns=2,
-        max_turns=2,
+        # One round == the single assistant turn whose tool loop this exercises.
+        min_turns=1,
+        max_turns=1,
         role_instruction_messages={
             Role.USER: "user",
             Role.ASSISTANT: "assistant",
@@ -2385,8 +2438,10 @@ def test_assistant_turn_caps_at_max_consecutive_tool_turns_then_finalizes(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        min_turns=2,
-        max_turns=2,
+        # One round == one USER+ASSISTANT exchange (a single assistant turn), so
+        # the agentic tool loop runs exactly once.
+        min_turns=1,
+        max_turns=1,
         role_instruction_messages={
             Role.USER: "user",
             Role.ASSISTANT: "assistant",
@@ -2492,8 +2547,10 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
 
     multiturn_attr = MultiTurnAttribute(
         id="dialog",
-        min_turns=2,
-        max_turns=2,
+        # One round == one USER+ASSISTANT exchange (a single assistant turn), so
+        # the agentic tool loop runs exactly once.
+        min_turns=1,
+        max_turns=1,
         role_instruction_messages={
             Role.USER: "user",
             Role.ASSISTANT: "assistant",
@@ -2822,13 +2879,13 @@ def test_token_usage_accumulates_in_straggler_finalization(
 
     mock_engine.infer.side_effect = infer_side_effect
 
-    # min == max == 2 makes the turn order deterministic (USER then ASSISTANT);
+    # min == max == 1 is one round -- USER then ASSISTANT, deterministic;
     # max_consecutive_tool_turns=0 routes the ASSISTANT turn through
     # _finalize_stragglers instead of a tool round.
     multiturn_attr = MultiTurnAttribute(
         id="straggler_conversation",
-        min_turns=2,
-        max_turns=2,
+        min_turns=1,
+        max_turns=1,
         role_instruction_messages={
             Role.USER: "You are a user.",
             Role.ASSISTANT: "You are an assistant.",


### PR DESCRIPTION
## What & why

Changes the multi-turn synthesis "turn" convention from **message-based** to **exchange-based**: one turn is now one **round** = one user message + one assistant reply. `MultiTurnAttribute.min_turns`/`max_turns` previously counted individual messages; they now count rounds, unifying synthesis with the evals convention (**LOU-3097**).

## Design

The **internal representation stays message-based**, so the generation loop (`_synthesize_all_samples`) and the planner (`parsed_turn_plans`, `PLANNER_JSON_SCHEMA`, `_parse_plan`) are **unchanged**. The rounds→messages conversion (`× len(turn_order)`) lands in exactly one place:

```python
def _select_target_turns(self, multiturn_attribute, turn_order) -> int:
    target_rounds = random.randint(
        multiturn_attribute.min_turns, multiturn_attribute.max_turns
    )
    return target_rounds * len(turn_order)
```

For the production `turn_order = [USER, ASSISTANT]` this yields an even message count that always ends on an assistant turn (no dangling user turn), replacing the old within-`[min, max]` "end-on-assistant" normalization search — which is no longer needed, since a full round always ends on the last role.

## Changes

- `_select_target_turns` returns `rounds * len(turn_order)` (single conversion site).
- Docstrings for `min_turns`/`max_turns` + the `multiturn_attributes` field doc → rounds/exchanges. Validation unchanged semantically (`min_turns >= 1` = 1 round, `max_turns >= min_turns`).
- `docs/user_guides/synth.md` + `configs/examples/synthesis/README.md`: all conversation-length prose restated as "N rounds (2N messages)".
- Example configs migrated to preserve their original message-length behavior: `multiturn_conversation_synth.yaml` `min/max_turns` 4/12 → 2/6 (still 4–12 messages), and `library_tool_use_synth.yaml` drops a redundant `{target_turns}` interpolation from its custom planner prompt.
- Tests updated to the new semantics; single-exchange scenarios use `min_turns=max_turns=1`. Added a parametrized unit test of `_select_target_turns` (multiplier, `min==max`, `min==1`, `ASSISTANT`-absent and 3-role orders) and an end-to-end assertion that a 2-round conversation is 4 messages ending on assistant.

`pytest tests/unit/core/synthesis tests/unit/core/configs -q` → **1572 passed, 10 skipped**.

## Follow-up (not in this PR)

The equivalent enterprise-repo change is a separate follow-up after this merges.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
