### PR TITLE
feat(examples): NL2SQL Spider tool-agent GRPO demo (configs + row builder)

### DIFF
--- a/configs/examples/grpo_verl_nl2sql/README.md
+++ b/configs/examples/grpo_verl_nl2sql/README.md
@@ -1,0 +1,17 @@
+# NL2SQL tool-agent GRPO
+
+This example trains a verl tool agent on Spider execution accuracy. Prepare the
+Spider JSON files and SQLite databases before launching training:
+
+```bash
+python scripts/datasets/build_spider_tool_agent.py \
+  --spider-root /path/to/spider \
+  --db-root /path/to/spider/database
+
+oumi train -c configs/examples/grpo_verl_nl2sql/train.yaml
+```
+
+The Spider root must contain `train_spider.json` and `dev.json`. The database
+root must contain `<db_id>/<db_id>.sqlite`. The builder writes the configured
+`data/grpo_verl_nl2sql/train.jsonl` and `val.jsonl` files without copying the
+database contents into each row.

--- a/configs/examples/grpo_verl_nl2sql/README.md
+++ b/configs/examples/grpo_verl_nl2sql/README.md
@@ -1,7 +1,20 @@
 # NL2SQL tool-agent GRPO
 
-This example trains a verl tool agent on Spider execution accuracy. Prepare the
-Spider JSON files and SQLite databases before launching training:
+This example trains a verl tool agent on [Spider](https://github.com/taoyds/spider),
+the cross-domain text-to-SQL benchmark of
+[Yu et al. (2018)](https://arxiv.org/abs/1809.08887). Spider scores predictions
+with exact-set match and with execution accuracy; this example optimizes
+execution accuracy — run the predicted and the gold SQL against the same
+database and compare the result sets (see the *Evaluation Metrics* discussion in
+the paper and the reference implementation in
+[`evaluation.py`](https://github.com/taoyds/spider/blob/master/evaluation.py)).
+The `sql_execution_match` reward implements that comparison, treating row order
+as significant only when the gold query has a top-level `ORDER BY`.
+
+Download the JSON files and SQLite databases from the
+[Spider site](https://yale-lily.github.io/spider) or the
+[`xlangai/spider`](https://huggingface.co/datasets/xlangai/spider) mirror, then
+prepare the rows and launch training:
 
 ```bash
 python scripts/datasets/build_spider_tool_agent.py \
@@ -11,7 +24,43 @@ python scripts/datasets/build_spider_tool_agent.py \
 oumi train -c configs/examples/grpo_verl_nl2sql/train.yaml
 ```
 
-The Spider root must contain `train_spider.json` and `dev.json`. The database
-root must contain `<db_id>/<db_id>.sqlite`. The builder writes the configured
-`data/grpo_verl_nl2sql/train.jsonl` and `val.jsonl` files without copying the
-database contents into each row.
+The Spider root must contain `train_spider.json` (7,000 examples) and `dev.json`
+(1,034). The database root must contain `<db_id>/<db_id>.sqlite`.
+
+## Prepared rows
+
+The builder writes `data/grpo_verl_nl2sql/train.jsonl` and `val.jsonl` in Oumi
+`Conversation` format — one row per question, referencing the database by path
+instead of copying its contents into the row:
+
+- `messages[0]` — system prompt carrying the DDL of every table in that row's DB.
+- `messages[1]` — the natural-language question.
+- `metadata.agent_name` — the verl agent loop to run (`tool_agent`).
+- `metadata.ground_truth` — the gold SQL, scored by `sql_execution_match`.
+- `metadata.tools_kwargs.run_sql.create_kwargs.db_path` — absolute path to the
+  SQLite file the `run_sql` tool opens for this rollout.
+
+An example row, with the schema abridged to two tables:
+
+````json
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a SQL assistant for a SQLite database with this schema:\nCREATE TABLE singer (\nSinger_ID int,\nName text,\nCountry text,\nSong_Name text,\nSong_release_year text,\nAge int,\nIs_male bool,\nPRIMARY KEY (Singer_ID)\n)\n\nCREATE TABLE stadium (\nStadium_ID int,\nLocation text,\nName text,\nCapacity int,\nHighest int,\nLowest int,\nAverage int,\nPRIMARY KEY (Stadium_ID)\n)\nYou may call the tool run_sql(query) to execute a SQL query and inspect results. When you are done, give your final answer as a single SQL query inside a ```sql code block."
+    },
+    { "role": "user", "content": "How many singers do we have?" }
+  ],
+  "metadata": {
+    "agent_name": "tool_agent",
+    "ground_truth": "SELECT count(*) FROM singer",
+    "tools_kwargs": {
+      "run_sql": {
+        "create_kwargs": {
+          "db_path": "/path/to/spider/database/concert_singer/concert_singer.sqlite"
+        }
+      }
+    }
+  }
+}
+````

--- a/configs/examples/grpo_verl_nl2sql/README.md
+++ b/configs/examples/grpo_verl_nl2sql/README.md
@@ -27,11 +27,18 @@ oumi train -c configs/examples/grpo_verl_nl2sql/train.yaml
 The Spider root must contain `train_spider.json` (7,000 examples) and `dev.json`
 (1,034). The database root must contain `<db_id>/<db_id>.sqlite`.
 
+A few Spider rows carry gold SQL that does not run against its own database. The
+builder drops them from both splits — an unscoreable gold aborts the reward
+mid-run — logging each one and a per-split kept/dropped count. Both splits
+therefore come out smaller than the counts above, so validation accuracy here is
+not directly comparable to a published Spider dev number without accounting for
+the dropped rows.
+
 ## Prepared rows
 
 The builder writes `data/grpo_verl_nl2sql/train.jsonl` and `val.jsonl` in Oumi
-`Conversation` format — one row per question, referencing the database by path
-instead of copying its contents into the row:
+`Conversation` format — one row per surviving question, referencing the database
+by path instead of copying its contents into the row:
 
 - `messages[0]` — system prompt carrying the DDL of every table in that row's DB.
 - `messages[1]` — the natural-language question.

--- a/configs/examples/grpo_verl_nl2sql/environment_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/environment_config.yaml
@@ -1,10 +1,21 @@
+# Oumi environment manifest for the NL2SQL example: the database environment and
+# the read-only run_sql tool the policy calls during a rollout.
+#
+# See Also:
+#   - Example README: configs/examples/grpo_verl_nl2sql/README.md
+#   - Config class: oumi.core.configs.EnvironmentConfig
+#   - Loaded by: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+
 environments:
   - id: nl2sql_db
     name: NL2SQL database
     description: NL2SQL database environment exposing a read-only run_sql tool.
     env_type: database
     env_kwargs:
-      schema_sql: "CREATE TABLE placeholder(x INTEGER);"  # overridden per-rollout
+      # Placeholder: every row supplies its own db_path via
+      # metadata.tools_kwargs.run_sql.create_kwargs, which replaces this. A row
+      # missing that key silently trains against this empty table instead.
+      schema_sql: "CREATE TABLE placeholder(x INTEGER);"
     tools:
       - id: run_sql
         name: run_sql

--- a/configs/examples/grpo_verl_nl2sql/environment_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/environment_config.yaml
@@ -1,0 +1,20 @@
+environments:
+  - id: nl2sql_db
+    name: NL2SQL database
+    description: NL2SQL database environment exposing a read-only run_sql tool.
+    env_type: database
+    env_kwargs:
+      schema_sql: "CREATE TABLE placeholder(x INTEGER);"  # overridden per-rollout
+    tools:
+      - id: run_sql
+        name: run_sql
+        description: Execute a read-only SQL query and return the result rows.
+        parameters:
+          type: object
+          properties:
+            query:
+              type: string
+              description: "A single SQL SELECT statement."
+          required: [query]
+        executor: oumi.environments.examples.nl2sql.run_sql
+        read_only: true

--- a/configs/examples/grpo_verl_nl2sql/environment_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/environment_config.yaml
@@ -12,9 +12,8 @@ environments:
     description: NL2SQL database environment exposing a read-only run_sql tool.
     env_type: database
     env_kwargs:
-      # Placeholder: every row supplies its own db_path via
-      # metadata.tools_kwargs.run_sql.create_kwargs, which replaces this. A row
-      # missing that key silently trains against this empty table instead.
+      # Replaced per-rollout by the row's metadata.tools_kwargs create_kwargs. A row
+      # missing those silently trains against this empty table instead.
       schema_sql: "CREATE TABLE placeholder(x INTEGER);"
     tools:
       - id: run_sql

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -1,0 +1,54 @@
+model:
+  model_name: "Qwen/Qwen2.5-3B-Instruct"
+
+data:
+  train:
+    datasets:
+      - dataset_name: "text_sft"
+        dataset_path: "data/grpo_verl_nl2sql/train.jsonl"
+        dataset_kwargs:
+          return_conversations: true
+  validation:
+    datasets:
+      - dataset_name: "text_sft"
+        dataset_path: "data/grpo_verl_nl2sql/val.jsonl"
+        dataset_kwargs:
+          return_conversations: true
+
+training:
+  trainer_type: "VERL_GRPO"
+  num_train_epochs: 1
+  save_steps: -1
+  eval_strategy: "steps"
+  eval_steps: 20
+  learning_rate: 1.0e-6
+  reward_functions: ["sql_execution_match"]
+  grpo:
+    max_completion_length: 1024
+    use_vllm: True
+    temperature: 1.0
+    vllm_gpu_memory_utilization: 0.5
+  verl_config_overrides:
+    data:
+      train_batch_size: 32
+      max_prompt_length: 4096
+      filter_overlong_prompts: True
+    actor_rollout_ref:
+      rollout:
+        name: vllm
+        mode: async
+        multi_turn:
+          enable: true
+          format: hermes
+          tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+        agent:
+          default_agent_loop: tool_agent
+        tensor_model_parallel_size: 2
+        n: 8
+    trainer:
+      n_gpus_per_node: 8
+      nnodes: 1
+      val_before_train: True
+  output_dir: "output/grpo_verl_nl2sql"
+  run_name: "grpo_verl_nl2sql"
+  enable_wandb: True

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -28,6 +28,9 @@ training:
     use_vllm: True
     temperature: 1.0
     vllm_gpu_memory_utilization: 0.5
+  # Rollout options are verl's; see
+  # https://github.com/verl-project/verl/blob/main/verl/trainer/config/rollout/rollout.yaml
+  # and https://github.com/verl-project/verl/blob/main/verl/workers/config/rollout.py
   verl_config_overrides:
     data:
       train_batch_size: 32
@@ -40,6 +43,9 @@ training:
         multi_turn:
           enable: true
           format: hermes
+          # Unset, tool_agent never caps turns: a rollout only ends when it stops
+          # calling run_sql or burns max_completion_length.
+          max_assistant_turns: 5
           tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
         agent:
           default_agent_loop: tool_agent

--- a/configs/examples/grpo_verl_nl2sql/train.yaml
+++ b/configs/examples/grpo_verl_nl2sql/train.yaml
@@ -1,3 +1,19 @@
+# verl GRPO training config for NL2SQL on Spider.
+#
+# Requirements:
+#   - Prepare rows first: python scripts/datasets/build_spider_tool_agent.py
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi train -c configs/examples/grpo_verl_nl2sql/train.yaml
+#
+# See Also:
+#   - Example README: configs/examples/grpo_verl_nl2sql/README.md
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/*train.yaml
+
 model:
   model_name: "Qwen/Qwen2.5-3B-Instruct"
 
@@ -28,9 +44,8 @@ training:
     use_vllm: True
     temperature: 1.0
     vllm_gpu_memory_utilization: 0.5
-  # Rollout options are verl's; see
-  # https://github.com/verl-project/verl/blob/main/verl/trainer/config/rollout/rollout.yaml
-  # and https://github.com/verl-project/verl/blob/main/verl/workers/config/rollout.py
+  # Rollout options below are verl's, not Oumi's; see
+  # https://github.com/verl-project/verl/blob/main/verl/workers/config/rollout.py
   verl_config_overrides:
     data:
       train_batch_size: 32
@@ -43,8 +58,8 @@ training:
         multi_turn:
           enable: true
           format: hermes
-          # Unset, tool_agent never caps turns: a rollout only ends when it stops
-          # calling run_sql or burns max_completion_length.
+          # Left unset (verl's default), a rollout would only end when the model
+          # stops calling run_sql or burns max_completion_length.
           max_assistant_turns: 5
           tool_config_path: configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
         agent:

--- a/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
@@ -1,7 +1,16 @@
+# verl tool manifest for the NL2SQL example: the schema verl renders into the
+# policy's tool list, and the dispatch to Oumi's run_sql environment.
+#
+# See Also:
+#   - Example README: configs/examples/grpo_verl_nl2sql/README.md
+#   - Referenced by: configs/examples/grpo_verl_nl2sql/train.yaml
+#
+# Keep the schema below in sync with the run_sql tool in environment_config.yaml.
+
 tools:
   - class_name: oumi.core.trainers.verl_agentic.oumi_verl_tool.OumiVerlTool
     config:
-      type: native   # verl ToolType — required by initialize_tools_from_config
+      type: native   # required by verl's tool loader
       oumi_env_config: configs/examples/grpo_verl_nl2sql/environment_config.yaml
     tool_schema:
       type: function
@@ -13,4 +22,5 @@ tools:
           properties:
             query:
               type: string
+              description: A single SQL SELECT statement.
           required: [query]

--- a/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
@@ -4,8 +4,6 @@
 # See Also:
 #   - Example README: configs/examples/grpo_verl_nl2sql/README.md
 #   - Referenced by: configs/examples/grpo_verl_nl2sql/train.yaml
-#
-# Keep the schema below in sync with the run_sql tool in environment_config.yaml.
 
 tools:
   - class_name: oumi.core.trainers.verl_agentic.oumi_verl_tool.OumiVerlTool

--- a/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
+++ b/configs/examples/grpo_verl_nl2sql/verl_tool_config.yaml
@@ -1,0 +1,16 @@
+tools:
+  - class_name: oumi.core.trainers.verl_agentic.oumi_verl_tool.OumiVerlTool
+    config:
+      type: native   # verl ToolType — required by initialize_tools_from_config
+      oumi_env_config: configs/examples/grpo_verl_nl2sql/environment_config.yaml
+    tool_schema:
+      type: function
+      function:
+        name: run_sql
+        description: Execute a read-only SQL query and return the result rows.
+        parameters:
+          type: object
+          properties:
+            query:
+              type: string
+          required: [query]

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -44,6 +44,23 @@ def _schema_ddl(db_path: Path) -> str:
     return "\n\n".join(row[0].strip() for row in rows)
 
 
+def _gold_executes(db_path: Path, sql: str) -> bool:
+    """Whether the gold query runs against its own DB (some Spider rows don't)."""
+    try:
+        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return False
+    try:
+        # Match the reward's decoding so we don't drop rows it could have scored.
+        connection.text_factory = lambda b: b.decode("utf-8", "replace")
+        connection.execute(sql).fetchall()
+        return True
+    except sqlite3.Error:
+        return False
+    finally:
+        connection.close()
+
+
 def _build_rows(
     examples: list[dict[str, Any]],
     db_root: Path,
@@ -56,12 +73,17 @@ def _build_rows(
 
     schemas: dict[str, str] = {}
     rows = []
+    dropped = 0
     for example in examples:
         db_id = example["db_id"]
         db_path = db_root / db_id / f"{db_id}.sqlite"
         if db_id not in schemas:
             schemas[db_id] = _schema_ddl(db_path)
         schema = schemas[db_id]
+        # An unscoreable gold makes the row untrainable and aborts the reward mid-run.
+        if not _gold_executes(db_path, example["query"]):
+            dropped += 1
+            continue
         rows.append(
             {
                 "messages": [
@@ -82,6 +104,8 @@ def _build_rows(
                 },
             }
         )
+    if dropped:
+        print(f"dropped {dropped} row(s) whose gold SQL does not execute")
     return rows
 
 

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -14,14 +14,16 @@
 
 """Build Spider NL2SQL tool-agent train/val rows in Oumi Conversation format."""
 
-from __future__ import annotations
-
 import argparse
+import functools
 import json
 import random
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import Any
+
+from oumi.utils.logging import logger
 
 _SYSTEM_PROMPT = (
     "You are a SQL assistant for a SQLite database with this schema:\n{schema}\n"
@@ -31,58 +33,57 @@ _SYSTEM_PROMPT = (
 )
 
 
-def _schema_ddl(db_path: Path) -> str:
+def _read_only(db_path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    try:
+    # Benchmark DBs carry non-UTF-8 text. Decode without raising, as the reward
+    # does, so we don't drop rows it could have scored; backslashreplace keeps the
+    # DDL we splice into the prompt JSON-encodable.
+    connection.text_factory = lambda b: b.decode("utf-8", "backslashreplace")
+    return connection
+
+
+@functools.cache
+def _schema_ddl(db_path: Path) -> str:
+    with closing(_read_only(db_path)) as connection:
         rows = connection.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL "
             "ORDER BY name"
         ).fetchall()
-    finally:
-        connection.close()
     return "\n\n".join(row[0].strip() for row in rows)
 
 
 def _gold_executes(db_path: Path, sql: str) -> bool:
     """Whether the gold query runs against its own DB (some Spider rows don't)."""
     try:
-        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    except sqlite3.Error:
-        return False
-    try:
-        # Match the reward's decoding so we don't drop rows it could have scored.
-        connection.text_factory = lambda b: b.decode("utf-8", "replace")
-        connection.execute(sql).fetchall()
+        with closing(_read_only(db_path)) as connection:
+            connection.execute(sql).fetchall()
         return True
     except sqlite3.Error:
         return False
-    finally:
-        connection.close()
 
 
 def _build_rows(
     examples: list[dict[str, Any]],
     db_root: Path,
     *,
+    split: str,
     limit: int,
     seed: int,
 ) -> list[dict[str, Any]]:
     if 0 < limit < len(examples):
         examples = random.Random(seed).sample(examples, limit)
 
-    schemas: dict[str, str] = {}
     rows = []
     dropped = 0
     for example in examples:
         db_id = example["db_id"]
         db_path = db_root / db_id / f"{db_id}.sqlite"
-        if db_id not in schemas:
-            schemas[db_id] = _schema_ddl(db_path)
-        schema = schemas[db_id]
+        schema = _schema_ddl(db_path)
         # An unscoreable gold makes the row untrainable and aborts the reward mid-run.
         if not _gold_executes(db_path, example["query"]):
             dropped += 1
+            logger.warning(f"{split}: dropped {db_id} gold {example['query']!r}")
             continue
         rows.append(
             {
@@ -104,8 +105,7 @@ def _build_rows(
                 },
             }
         )
-    if dropped:
-        print(f"dropped {dropped} row(s) whose gold SQL does not execute")
+    logger.info(f"{split}: kept {len(rows)} row(s), dropped {dropped} unscoreable")
     return rows
 
 
@@ -119,12 +119,39 @@ def _write_jsonl(rows: list[dict[str, Any]], path: Path) -> None:
 def main() -> None:
     """Build train and validation JSONL files from a Spider release."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--spider-root", type=Path, required=True)
-    parser.add_argument("--db-root", type=Path)
-    parser.add_argument("--out-dir", type=Path, default=Path("data/grpo_verl_nl2sql"))
-    parser.add_argument("--train-limit", type=int, default=0)
-    parser.add_argument("--val-limit", type=int, default=0)
-    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--spider-root",
+        type=Path,
+        required=True,
+        help="Spider release root holding train_spider.json and dev.json.",
+    )
+    parser.add_argument(
+        "--db-root",
+        type=Path,
+        help="Directory of <db_id>/<db_id>.sqlite files. Defaults to "
+        "<spider-root>/database.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("data/grpo_verl_nl2sql"),
+        help="Where train.jsonl and val.jsonl are written.",
+    )
+    parser.add_argument(
+        "--train-limit",
+        type=int,
+        default=0,
+        help="Sample this many train examples. Non-positive means all of them.",
+    )
+    parser.add_argument(
+        "--val-limit",
+        type=int,
+        default=0,
+        help="Sample this many dev examples. Non-positive means all of them.",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Seed for the two limit samples."
+    )
     args = parser.parse_args()
 
     db_root = args.db_root or args.spider_root / "database"
@@ -135,11 +162,19 @@ def main() -> None:
         (args.spider_root / "dev.json").read_text(encoding="utf-8")
     )
     _write_jsonl(
-        _build_rows(train_examples, db_root, limit=args.train_limit, seed=args.seed),
+        _build_rows(
+            train_examples,
+            db_root,
+            split="train",
+            limit=args.train_limit,
+            seed=args.seed,
+        ),
         args.out_dir / "train.jsonl",
     )
     _write_jsonl(
-        _build_rows(val_examples, db_root, limit=args.val_limit, seed=args.seed),
+        _build_rows(
+            val_examples, db_root, split="val", limit=args.val_limit, seed=args.seed
+        ),
         args.out_dir / "val.jsonl",
     )
 

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -1,0 +1,117 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build Spider NL2SQL tool-agent train/val rows in Oumi Conversation format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_SYSTEM_PROMPT = (
+    "You are a SQL assistant for a SQLite database with this schema:\n{schema}\n"
+    "You may call run_sql(query) to inspect results. Return the final SQL query "
+    "inside a ```sql code block."
+)
+
+
+def _schema_ddl(db_path: Path) -> str:
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = connection.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL "
+            "ORDER BY name"
+        ).fetchall()
+    finally:
+        connection.close()
+    return "\n\n".join(row[0].strip() for row in rows)
+
+
+def _build_rows(
+    examples: list[dict[str, Any]],
+    db_root: Path,
+    *,
+    limit: int,
+    seed: int,
+) -> list[dict[str, Any]]:
+    if 0 < limit < len(examples):
+        examples = random.Random(seed).sample(examples, limit)
+
+    schemas: dict[str, str] = {}
+    rows = []
+    for example in examples:
+        db_id = example["db_id"]
+        db_path = db_root / db_id / f"{db_id}.sqlite"
+        if db_id not in schemas:
+            schemas[db_id] = _schema_ddl(db_path)
+        schema = schemas[db_id]
+        rows.append(
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": _SYSTEM_PROMPT.format(schema=schema),
+                    },
+                    {"role": "user", "content": example["question"]},
+                ],
+                "metadata": {
+                    "agent_name": "tool_agent",
+                    "ground_truth": example["query"],
+                    "tools_kwargs": {
+                        "run_sql": {"create_kwargs": {"db_path": str(db_path)}}
+                    },
+                },
+            }
+        )
+    return rows
+
+
+def _write_jsonl(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as output:
+        for row in rows:
+            output.write(json.dumps(row) + "\n")
+
+
+def main() -> None:
+    """Build train and validation JSONL files from a Spider release."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spider-root", type=Path, required=True)
+    parser.add_argument("--db-root", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path("data/grpo_verl_nl2sql"))
+    parser.add_argument("--train-limit", type=int, default=0)
+    parser.add_argument("--val-limit", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    db_root = args.db_root or args.spider_root / "database"
+    train_examples = json.loads((args.spider_root / "train_spider.json").read_text())
+    val_examples = json.loads((args.spider_root / "dev.json").read_text())
+    _write_jsonl(
+        _build_rows(train_examples, db_root, limit=args.train_limit, seed=args.seed),
+        args.out_dir / "train.jsonl",
+    )
+    _write_jsonl(
+        _build_rows(val_examples, db_root, limit=args.val_limit, seed=args.seed),
+        args.out_dir / "val.jsonl",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -35,9 +35,8 @@ _SYSTEM_PROMPT = (
 
 def _read_only(db_path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    # Benchmark DBs carry non-UTF-8 text. Decode without raising, as the reward
-    # does, so we don't drop rows it could have scored; backslashreplace keeps the
-    # DDL we splice into the prompt JSON-encodable.
+    # Decode without raising, as the reward does, so we keep rows it could score;
+    # backslashreplace also keeps the DDL we splice into the prompt JSON-encodable.
     connection.text_factory = lambda b: b.decode("utf-8", "backslashreplace")
     return connection
 

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -25,7 +25,8 @@ from typing import Any
 
 _SYSTEM_PROMPT = (
     "You are a SQL assistant for a SQLite database with this schema:\n{schema}\n"
-    "You may call run_sql(query) to inspect results. Return the final SQL query "
+    "You may call the tool run_sql(query) to execute a SQL query and inspect "
+    "results. When you are done, give your final answer as a single SQL query "
     "inside a ```sql code block."
 )
 

--- a/scripts/datasets/build_spider_tool_agent.py
+++ b/scripts/datasets/build_spider_tool_agent.py
@@ -74,7 +74,9 @@ def _build_rows(
                     "agent_name": "tool_agent",
                     "ground_truth": example["query"],
                     "tools_kwargs": {
-                        "run_sql": {"create_kwargs": {"db_path": str(db_path)}}
+                        "run_sql": {
+                            "create_kwargs": {"db_path": str(db_path.absolute())}
+                        }
                     },
                 },
             }
@@ -84,7 +86,7 @@ def _build_rows(
 
 def _write_jsonl(rows: list[dict[str, Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as output:
+    with path.open("w", encoding="utf-8") as output:
         for row in rows:
             output.write(json.dumps(row) + "\n")
 
@@ -101,8 +103,12 @@ def main() -> None:
     args = parser.parse_args()
 
     db_root = args.db_root or args.spider_root / "database"
-    train_examples = json.loads((args.spider_root / "train_spider.json").read_text())
-    val_examples = json.loads((args.spider_root / "dev.json").read_text())
+    train_examples = json.loads(
+        (args.spider_root / "train_spider.json").read_text(encoding="utf-8")
+    )
+    val_examples = json.loads(
+        (args.spider_root / "dev.json").read_text(encoding="utf-8")
+    )
     _write_jsonl(
         _build_rows(train_examples, db_root, limit=args.train_limit, seed=args.seed),
         args.out_dir / "train.jsonl",

--- a/tests/unit/core/configs/test_nl2sql_example_manifests.py
+++ b/tests/unit/core/configs/test_nl2sql_example_manifests.py
@@ -1,0 +1,78 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for the two NL2SQL manifests test_parse_configs.py has to exclude.
+
+Neither is a `TrainingConfig`: one is an `EnvironmentConfig`, the other is
+verl-format. This pins their shape and the wiring between them instead.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+
+_EXAMPLE_DIR = Path(__file__).parents[4] / "configs" / "examples" / "grpo_verl_nl2sql"
+
+
+@pytest.fixture
+def environment_config() -> EnvironmentConfig:
+    return EnvironmentConfig.from_yaml(_EXAMPLE_DIR / "environment_config.yaml")
+
+
+@pytest.fixture
+def verl_tool_config() -> dict:
+    return yaml.safe_load((_EXAMPLE_DIR / "verl_tool_config.yaml").read_text())
+
+
+def test_environment_config_parses_and_declares_one_read_only_sql_tool(
+    environment_config,
+):
+    (environment,) = environment_config.environments
+    (tool,) = environment.tools
+    assert environment.env_type == "database"
+    assert tool.read_only is True
+    # Asserted as a string, not imported: the executor ships in the env/reward PR.
+    assert tool.executor == "oumi.environments.examples.nl2sql.run_sql"
+
+
+def test_verl_tool_config_dispatches_to_the_environment_config(verl_tool_config):
+    (tool,) = verl_tool_config["tools"]
+    assert tool["class_name"].endswith("oumi_verl_tool.OumiVerlTool")
+    assert tool["config"]["type"] == "native"
+    referenced = Path(tool["config"]["oumi_env_config"])
+    assert referenced.name == "environment_config.yaml"
+    assert (_EXAMPLE_DIR.parents[2] / referenced).is_file()
+
+
+def test_the_two_run_sql_declarations_do_not_drift(
+    environment_config, verl_tool_config
+):
+    (oumi_tool,) = environment_config.environments[0].tools
+    verl_function = verl_tool_config["tools"][0]["tool_schema"]["function"]
+    # OumiVerlTool refuses to construct when these names disagree.
+    assert verl_function["name"] == oumi_tool.id == oumi_tool.name
+    assert verl_function["description"] == oumi_tool.description
+    assert verl_function["parameters"] == oumi_tool.parameters
+
+
+def test_train_config_points_at_the_verl_tool_config():
+    train = yaml.safe_load((_EXAMPLE_DIR / "train.yaml").read_text())
+    multi_turn = train["training"]["verl_config_overrides"]["actor_rollout_ref"][
+        "rollout"
+    ]["multi_turn"]
+    assert Path(multi_turn["tool_config_path"]).name == "verl_tool_config.yaml"
+    assert train["training"]["reward_functions"] == ["sql_execution_match"]

--- a/tests/unit/core/configs/test_parse_configs.py
+++ b/tests/unit/core/configs/test_parse_configs.py
@@ -52,6 +52,8 @@ def _get_all_config_paths(exclude_yaml_suffixes: set[str] | None) -> list[str]:
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            "grpo_verl_nl2sql/environment_config.yaml",  # EnvironmentConfig
+            "grpo_verl_nl2sql/verl_tool_config.yaml",  # verl-format tool config
         }
     ),
 )
@@ -88,6 +90,8 @@ def test_parse_configs(config_path: str):
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            "grpo_verl_nl2sql/environment_config.yaml",  # EnvironmentConfig
+            "grpo_verl_nl2sql/verl_tool_config.yaml",  # verl-format tool config
         }
     ),
 )

--- a/tests/unit/scripts/test_build_spider_tool_agent.py
+++ b/tests/unit/scripts/test_build_spider_tool_agent.py
@@ -29,17 +29,19 @@ def test_builds_spider_tool_agent_rows(tmp_path):
     (spider_root / "dev.json").write_text(json.dumps([example]))
     output_dir = tmp_path / "prepared"
 
+    # Relative args + a different cwd: emitted db_path must still be absolute.
     result = subprocess.run(
         [
             sys.executable,
             str(script),
             "--spider-root",
-            str(spider_root),
+            "spider",
             "--db-root",
-            str(db_root),
+            "spider/database",
             "--out-dir",
-            str(output_dir),
+            "prepared",
         ],
+        cwd=tmp_path,
         capture_output=True,
         text=True,
     )

--- a/tests/unit/scripts/test_build_spider_tool_agent.py
+++ b/tests/unit/scripts/test_build_spider_tool_agent.py
@@ -4,13 +4,27 @@ import subprocess
 import sys
 from pathlib import Path
 
+_TRAIN_EXAMPLE = {
+    "db_id": "company",
+    "question": "How many employees are there?",
+    "query": "SELECT count(*) FROM employees",
+}
+_DEV_EXAMPLE = {
+    "db_id": "company",
+    "question": "Who works here?",
+    "query": "SELECT name FROM employees",
+}
+_UNSCOREABLE_EXAMPLE = {
+    "db_id": "company",
+    "question": "How many contractors are there?",
+    "query": "SELECT count(*) FROM contractors",
+}
 
-def test_builds_spider_tool_agent_rows(tmp_path):
-    repo_root = Path(__file__).parents[3]
-    script = repo_root / "scripts" / "datasets" / "build_spider_tool_agent.py"
+
+def _spider_release(tmp_path, *, train, dev):
+    """Lay out a minimal Spider release and return (spider_root, db_path)."""
     spider_root = tmp_path / "spider"
-    db_root = spider_root / "database"
-    database_dir = db_root / "company"
+    database_dir = spider_root / "database" / "company"
     database_dir.mkdir(parents=True)
     db_path = database_dir / "company.sqlite"
     with sqlite3.connect(db_path) as connection:
@@ -18,18 +32,19 @@ def test_builds_spider_tool_agent_rows(tmp_path):
             "CREATE TABLE employees(name TEXT);"
             "INSERT INTO employees VALUES ('Ada'), ('Bo');"
         )
+    (spider_root / "train_spider.json").write_text(json.dumps(train))
+    (spider_root / "dev.json").write_text(json.dumps(dev))
+    return spider_root, db_path
 
-    example = {
-        "db_id": "company",
-        "question": "How many employees are there?",
-        "query": "SELECT count(*) FROM employees",
-    }
-    spider_root.mkdir(exist_ok=True)
-    (spider_root / "train_spider.json").write_text(json.dumps([example]))
-    (spider_root / "dev.json").write_text(json.dumps([example]))
-    output_dir = tmp_path / "prepared"
 
-    # Relative args + a different cwd: emitted db_path must still be absolute.
+def _build(tmp_path):
+    """Run the builder with relative args from a different cwd."""
+    script = (
+        Path(__file__).parents[3]
+        / "scripts"
+        / "datasets"
+        / "build_spider_tool_agent.py"
+    )
     result = subprocess.run(
         [
             sys.executable,
@@ -45,17 +60,67 @@ def test_builds_spider_tool_agent_rows(tmp_path):
         capture_output=True,
         text=True,
     )
-
     assert result.returncode == 0, result.stderr
-    row = json.loads((output_dir / "train.jsonl").read_text())
+    return tmp_path / "prepared"
+
+
+def _rows(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_builds_spider_tool_agent_rows(tmp_path):
+    _, db_path = _spider_release(tmp_path, train=[_TRAIN_EXAMPLE], dev=[_DEV_EXAMPLE])
+    output_dir = _build(tmp_path)
+
+    (row,) = _rows(output_dir / "train.jsonl")
     assert row["messages"][-1] == {
         "role": "user",
         "content": "How many employees are there?",
     }
     assert "CREATE TABLE employees" in row["messages"][0]["content"]
+    # Relative args + a different cwd: the emitted db_path must still be absolute.
     assert row["metadata"] == {
         "agent_name": "tool_agent",
         "ground_truth": "SELECT count(*) FROM employees",
         "tools_kwargs": {"run_sql": {"create_kwargs": {"db_path": str(db_path)}}},
     }
-    assert (output_dir / "val.jsonl").is_file()
+
+
+def test_val_rows_come_from_dev_not_train(tmp_path):
+    _spider_release(tmp_path, train=[_TRAIN_EXAMPLE], dev=[_DEV_EXAMPLE])
+    output_dir = _build(tmp_path)
+
+    (row,) = _rows(output_dir / "val.jsonl")
+    assert row["messages"][-1]["content"] == "Who works here?"
+    assert row["metadata"]["ground_truth"] == "SELECT name FROM employees"
+
+
+def test_rows_whose_gold_does_not_execute_are_dropped(tmp_path):
+    _spider_release(
+        tmp_path,
+        train=[_TRAIN_EXAMPLE, _UNSCOREABLE_EXAMPLE],
+        dev=[_UNSCOREABLE_EXAMPLE],
+    )
+    output_dir = _build(tmp_path)
+
+    kept = _rows(output_dir / "train.jsonl")
+    assert [row["metadata"]["ground_truth"] for row in kept] == [
+        "SELECT count(*) FROM employees"
+    ]
+    assert (output_dir / "val.jsonl").read_text() == ""
+
+
+def test_gold_selecting_non_utf8_text_is_kept(tmp_path):
+    example = {
+        "db_id": "company",
+        "question": "Which names are on file?",
+        "query": "SELECT name FROM people",
+    }
+    _, db_path = _spider_release(tmp_path, train=[example], dev=[_TRAIN_EXAMPLE])
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE people(name TEXT)")
+        connection.execute("INSERT INTO people VALUES (CAST(x'636166e9' AS TEXT))")
+    output_dir = _build(tmp_path)
+
+    (row,) = _rows(output_dir / "train.jsonl")
+    assert row["metadata"]["ground_truth"] == "SELECT name FROM people"

--- a/tests/unit/scripts/test_build_spider_tool_agent.py
+++ b/tests/unit/scripts/test_build_spider_tool_agent.py
@@ -1,0 +1,59 @@
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_builds_spider_tool_agent_rows(tmp_path):
+    repo_root = Path(__file__).parents[3]
+    script = repo_root / "scripts" / "datasets" / "build_spider_tool_agent.py"
+    spider_root = tmp_path / "spider"
+    db_root = spider_root / "database"
+    database_dir = db_root / "company"
+    database_dir.mkdir(parents=True)
+    db_path = database_dir / "company.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            "CREATE TABLE employees(name TEXT);"
+            "INSERT INTO employees VALUES ('Ada'), ('Bo');"
+        )
+
+    example = {
+        "db_id": "company",
+        "question": "How many employees are there?",
+        "query": "SELECT count(*) FROM employees",
+    }
+    spider_root.mkdir(exist_ok=True)
+    (spider_root / "train_spider.json").write_text(json.dumps([example]))
+    (spider_root / "dev.json").write_text(json.dumps([example]))
+    output_dir = tmp_path / "prepared"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--spider-root",
+            str(spider_root),
+            "--db-root",
+            str(db_root),
+            "--out-dir",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    row = json.loads((output_dir / "train.jsonl").read_text())
+    assert row["messages"][-1] == {
+        "role": "user",
+        "content": "How many employees are there?",
+    }
+    assert "CREATE TABLE employees" in row["messages"][0]["content"]
+    assert row["metadata"] == {
+        "agent_name": "tool_agent",
+        "ground_truth": "SELECT count(*) FROM employees",
+        "tools_kwargs": {"run_sql": {"create_kwargs": {"db_path": str(db_path)}}},
+    }
+    assert (output_dir / "val.jsonl").is_file()


### PR DESCRIPTION
## What

The runnable Spider demo that wires the adapter and the NL2SQL env/reward together: the example configs and the script that builds tool-agent training rows.

- `scripts/datasets/build_spider_tool_agent.py` turns a Spider release into train/val JSONL in Oumi Conversation format. Each row carries the schema-primed system prompt, the question, and metadata (`agent_name: tool_agent`, `ground_truth`, and per-tool `create_kwargs` with the DB path).
- `configs/examples/grpo_verl_nl2sql/`: the GRPO `train.yaml`, the Oumi `environment_config.yaml` (the `run_sql` executor plus `read_only`), and the verl `verl_tool_config.yaml` (model-facing schema plus dispatch to `OumiVerlTool`).

Merge last: the configs reference `OumiVerlTool` (adapter PR) and the `run_sql` executor plus `sql_execution_match` reward (env/reward PR). The diff itself is self-contained and its parse test passes on `main` alone.

## Test plan

`pytest tests/unit/scripts/test_build_spider_tool_agent.py tests/unit/core/configs/test_parse_configs.py` — 1033 pass on `main`. `test_parse_configs` excludes the two non-`TrainingConfig` yamls (env config and verl tool config) and validates the rest.

## Reviewer notes (carried from #2544)

- **Colocated vs server:** colocated (hybrid engine). `mode: async` selects the rollout execution path (verl's in-process agent-loop `AsyncLLM` server, required for multi-turn tool calling), not GPU placement. Placement is still the default hybrid engine, so actor and vLLM share GPUs and `gpu_memory_utilization` carves out vLLM's slice.
- **`run_sql` declared twice** (verl schema here, Oumi executor in `environment_config.yaml`): the two can drift. Since `ToolParams` already carries name/description/parameters, this manifest is derivable from the env config. Tracked as a follow-up, eventually generated at trainer startup so this file disappears.

## Related — split of #2544

#2544 was split into three reviewable PRs (merge order):
1. #2560 — core `OumiVerlTool` adapter. Independent, base main.
2. #2561 — NL2SQL env + reward. Independent, base main.
3. **#2562 (this)** — Spider demo. Merge last (its configs reference #2560 and #2561).

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
