### PR TITLE
feat(grpo): conversation LLM-judge reward

### DIFF
--- a/src/oumi/datasets/grpo/rewards/__init__.py
+++ b/src/oumi/datasets/grpo/rewards/__init__.py
@@ -18,6 +18,9 @@ from oumi.datasets.grpo.rewards.completion_length_rewards import (
     compute_sharp_target_token_length_reward,
     compute_soft_target_token_length_reward,
 )
+from oumi.datasets.grpo.rewards.conversation_judge_reward import (
+    conversation_llm_judge_reward,
+)
 from oumi.datasets.grpo.rewards.count_letters_rewards import compute_letter_count_reward
 from oumi.datasets.grpo.rewards.countdown_rewards import countdown_reward
 from oumi.datasets.grpo.rewards.gsm8k_reward import gsm8k_reward
@@ -26,6 +29,7 @@ __all__ = [
     "compute_letter_count_reward",
     "compute_soft_target_token_length_reward",
     "compute_sharp_target_token_length_reward",
+    "conversation_llm_judge_reward",
     "countdown_reward",
     "gsm8k_reward",
 ]

--- a/src/oumi/datasets/grpo/rewards/conversation_judge_reward.py
+++ b/src/oumi/datasets/grpo/rewards/conversation_judge_reward.py
@@ -1,0 +1,51 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM-judge reward for conversational GRPO rollouts (wraps SimpleJudge)."""
+
+import functools
+import os
+
+from oumi.core.configs.judge_config import JudgeConfig
+from oumi.core.registry import RegistryType, register
+from oumi.judges.simple_judge import SimpleJudge
+
+
+@functools.lru_cache(maxsize=8)
+def _get_judge(judge_config_path: str) -> SimpleJudge:
+    return SimpleJudge(JudgeConfig.from_path(judge_config_path))
+
+
+@register("conversation_llm_judge", RegistryType.REWARD_FUNCTION)
+def conversation_llm_judge_reward(
+    data_source, solution_str, ground_truth, extra_info, judge_config_path=None
+) -> float:
+    """Scores a conversation against its goal with an LLM judge."""
+    path = (
+        judge_config_path
+        or (extra_info or {}).get("judge_config_path")
+        or os.environ.get("OUMI_JUDGE_CONFIG_PATH")
+    )
+    if not path:
+        raise ValueError(
+            "conversation_llm_judge needs 'judge_config_path' (arg, extra_info, "
+            "or the OUMI_JUDGE_CONFIG_PATH env var)."
+        )
+    judge = _get_judge(path)
+    result = judge.judge([{"conversation": solution_str, "goal": ground_truth or ""}])[
+        0
+    ]
+    scores = result.field_scores or {}
+    value = scores.get("judgment")
+    return float(value) if value is not None else 0.0

--- a/tests/unit/datasets/grpo/rewards/test_conversation_judge_reward.py
+++ b/tests/unit/datasets/grpo/rewards/test_conversation_judge_reward.py
@@ -1,0 +1,61 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import oumi.datasets.grpo.rewards.conversation_judge_reward as rew
+
+
+class _StubOutput:
+    def __init__(self, scores):
+        self.field_scores = scores
+
+
+class _StubJudge:
+    def __init__(self, scores):
+        self._scores = scores
+        self.seen = None
+
+    def judge(self, inputs):
+        self.seen = inputs
+        return [_StubOutput(self._scores)]
+
+
+def test_reward_reads_judgment_score(monkeypatch):
+    stub = _StubJudge({"judgment": 1.0})
+    monkeypatch.setattr(rew, "_get_judge", lambda path: stub)
+    score = rew.conversation_llm_judge_reward(
+        "src",
+        "USER: hi\nAGENT: resolved",
+        "get a refund",
+        {"judge_config_path": "j.yaml"},
+    )
+    assert score == 1.0
+    expected_seen = [
+        {"conversation": "USER: hi\nAGENT: resolved", "goal": "get a refund"}
+    ]
+    assert stub.seen == expected_seen
+
+
+def test_reward_defaults_to_zero_when_no_score(monkeypatch):
+    monkeypatch.setattr(rew, "_get_judge", lambda path: _StubJudge({"judgment": None}))
+    score = rew.conversation_llm_judge_reward(
+        "src", "x", "g", {"judge_config_path": "j.yaml"}
+    )
+    assert score == 0.0
+
+
+def test_reward_requires_config_path():
+    with pytest.raises(ValueError):
+        rew.conversation_llm_judge_reward("src", "x", "g", {})


### PR DESCRIPTION
## What

`conversation_llm_judge_reward`: an LLM-as-judge reward for conversational GRPO. It scores a finished conversation with a judge model and maps the verdict to a scalar, registered under the GRPO reward registry.

Independent of the interaction adapter — the reward scores a trajectory and doesn't import the rollout machinery. Base: main.

Heads-up: `rewards/__init__.py` here and in #2561 (`sql_execution_match`) both append to the same registry list, so whichever lands second hits a one-line merge conflict.

## Test plan

`pytest tests/unit/datasets/grpo/rewards/test_conversation_judge_reward.py` — 3 pass on main (judge mocked).

## Related — split of #2556

#2556 was split into four PRs (also rebased onto main — it was 13 commits behind):
1. #2563 — `OumiVerlInteraction` core. Independent, base main.
2. **#2564 (this)** — conversation LLM-judge reward. Independent, base main.
3. #2565 — customer-support demo configs. Merge last (references #2563 and #2564).
4. #2566 — unrelated Ray-CPU fix, split out. Independent, base main.
