### PR TITLE
fix(train): cap Ray CPUs via OUMI_RAY_NUM_CPUS

### DIFF
--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -254,15 +254,20 @@ def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
         )
     if not ray.is_initialized():
         logger.info("Initializing Ray cluster...")
-        ray.init(
-            runtime_env={
+        ray_init_kwargs: dict = {
+            "runtime_env": {
                 "env_vars": {
                     "TOKENIZERS_PARALLELISM": "true",
                     "NCCL_DEBUG": "WARN",
                     "VLLM_LOGGING_LEVEL": "WARN",
                 }
             }
-        )
+        }
+        # Cap Ray when the container reports the host's CPU count.
+        ray_num_cpus = os.environ.get("OUMI_RAY_NUM_CPUS")
+        if ray_num_cpus:
+            ray_init_kwargs["num_cpus"] = int(ray_num_cpus)
+        ray.init(**ray_init_kwargs)
 
     # We define the remote function as a sub function so that the `@ray.remote`
     # decorator is only run if this function is run. This function should only be run


### PR DESCRIPTION
## What

Cap Ray's CPU count with a new `OUMI_RAY_NUM_CPUS` env var. On shared or containerized nodes `ray.init()` reads the host's CPU count rather than the container's and oversubscribes; setting `OUMI_RAY_NUM_CPUS` passes an explicit `num_cpus` to `ray.init()`.

Unrelated to conversational rollout — split out of #2556 so it can land on its own. Base: main.

## Test plan

No new tests: a single `ray.init()` kwarg gated on an env var. Behavior is unchanged when `OUMI_RAY_NUM_CPUS` is unset.

## Related — split of #2556

Split out of #2556 (this is the unrelated infra piece). The conversational-rollout work is in #2563 (core), #2564 (reward), and #2565 (demo).
