### PR TITLE
Remove ceiling on transformers for uv override only

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -79,7 +79,11 @@ jobs:
 
       - name: Override PyTorch ${{ matrix.torch-version }}
         run: |
-          uv pip install --system torch==${{ matrix.torch-version }} torchvision torchaudio
+          # torchaudio declares no dependency on torch, so leaving it unpinned lets it
+          # float to a build compiled against a different CUDA major version. transformers
+          # >=5.12 imports torchaudio on every `import transformers`, which turns that
+          # mismatch into an OSError on a missing libcudart. Versions track torch 1:1.
+          uv pip install --system torch==${{ matrix.torch-version }} torchvision torchaudio==${{ matrix.torch-version }}
 
       - name: Verify installation
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,15 @@ oumi = ["LICENSE", "README.md", "*.jinja"]
 # explicitly pinned to one (e.g. omegaconf==2.4.0.dev4) or when no stable release
 # satisfies the requirement (e.g. opentelemetry-semantic-conventions, which only
 # ships beta versions on PyPI).
-# A constraint (not an override) so it only raises the floor: the ceiling stays
-# defined by the `transformers` entry in [project.dependencies], and bumping it
-# there is enough. An override would replace that spec instead of narrowing it.
+# This must stay an override rather than a constraint. A constraint applies to
+# every requirement in the graph, including vllm's `transformers<5`, which makes
+# the [gpu] extra unsatisfiable. An override only replaces oumi's own spec, so
+# vllm keeps its cap and the GPU extra still resolves. The ceiling is duplicated
+# from [project.dependencies] because an override replaces that spec outright;
+# bump both together.
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
-constraint-dependencies = ["transformers>=5.5"]
+override-dependencies = ["transformers>=5.5,<5.10"]
 
 [project]
 name = "oumi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ oumi = ["LICENSE", "README.md", "*.jinja"]
 # ships beta versions on PyPI).
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
-override-dependencies = ["transformers>=5.5,<5.8"]
+override-dependencies = ["transformers>=5.5"]
 
 [project]
 name = "oumi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,12 @@ oumi = ["LICENSE", "README.md", "*.jinja"]
 # explicitly pinned to one (e.g. omegaconf==2.4.0.dev4) or when no stable release
 # satisfies the requirement (e.g. opentelemetry-semantic-conventions, which only
 # ships beta versions on PyPI).
+# A constraint (not an override) so it only raises the floor: the ceiling stays
+# defined by the `transformers` entry in [project.dependencies], and bumping it
+# there is enough. An override would replace that spec instead of narrowing it.
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
-override-dependencies = ["transformers>=5.5"]
+constraint-dependencies = ["transformers>=5.5"]
 
 [project]
 name = "oumi"


### PR DESCRIPTION
# Description

The ceiling was stale. The uv override should just increase the floor, but the ceiling should stay defined by the main dependency specification.
