### PR TITLE
fix(inference): correct Anthropic model-version gating for round and dated model names

### DIFF
--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -71,6 +71,10 @@ _IMAGE_MAGIC_PREFIXES: tuple[tuple[bytes, str], ...] = (
     (b"GIF89a", "image/gif"),
 )
 
+# Model-name prefixes for Anthropic's reasoning-first families, which gate both
+# `output_config` support and sampling-param support below.
+_REASONING_FIRST_MODEL_PREFIXES: tuple[str, ...] = ("claude-fable", "claude-mythos")
+
 
 def _detect_image_media_type(data: bytes) -> str:
     """Sniffs an Anthropic-supported image media type from magic bytes.
@@ -1011,7 +1015,7 @@ def _convert_guided_decoding_config_to_api_input(
 
 
 def _parse_model_version(model_name: str) -> tuple[str, tuple[int, int]] | None:
-    """Returns (family, (major, minor)) for a versioned Claude model, else None.
+    """Returns (family, (major, minor)) for versioned Opus/Sonnet/Haiku, else None.
 
     Anthropic drops the minor component on round versions (`claude-opus-5`, not
     `claude-opus-5-0`); treat a missing minor as 0.
@@ -1027,21 +1031,22 @@ def _model_supports_output_config(model_name: str) -> bool:
     # Anthropic's `output_config` (structured outputs) is GA on Claude 4.5+ (Opus,
     # Sonnet, Haiku) and the Fable/Mythos families. Older models (Claude 3.x, 3.5)
     # reject the field.
-    if model_name.startswith(("claude-fable", "claude-mythos")):
+    if model_name.startswith(_REASONING_FIRST_MODEL_PREFIXES):
         return True
 
     parsed = _parse_model_version(model_name)
-    return parsed[1] >= (4, 5) if parsed else False
+    if parsed is None:
+        return False
+    _, version = parsed
+    return version >= (4, 5)
 
 
 def _model_supports_sampling_params(model_name: str) -> bool:
     """Returns True if the model accepts sampling params, False otherwise."""
     # Anthropic removed the sampling params (temperature/top_p/top_k) on its
-    # reasoning-first models: Claude Opus 4.7+, Sonnet 5+, and the Fable/Mythos
-    # families return HTTP 400 ("`temperature` is deprecated for this model.").
-    # Opus 4.6 and earlier, Sonnet 4.6 and earlier, all Haiku, and Claude 3.x
-    # still accept them.
-    if model_name.startswith(("claude-fable", "claude-mythos")):
+    # reasoning-first models, which return HTTP 400 ("`temperature` is deprecated
+    # for this model."). Everything else still accepts them.
+    if model_name.startswith(_REASONING_FIRST_MODEL_PREFIXES):
         return False
 
     parsed = _parse_model_version(model_name)

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -1010,6 +1010,18 @@ def _convert_guided_decoding_config_to_api_input(
     }
 
 
+def _parse_model_version(model_name: str) -> tuple[str, tuple[int, int]] | None:
+    """Returns (family, (major, minor)) for a versioned Claude model, else None.
+
+    Anthropic drops the minor component on round versions (`claude-opus-5`, not
+    `claude-opus-5-0`); treat a missing minor as 0.
+    """
+    match = re.match(r"^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d+))?", model_name)
+    if not match:
+        return None
+    return match[1], (int(match[2]), int(match[3] or 0))
+
+
 def _model_supports_output_config(model_name: str) -> bool:
     """Returns True if the model accepts the output_config field, False otherwise."""
     # Anthropic's `output_config` (structured outputs) is GA on Claude 4.5+ (Opus,
@@ -1017,20 +1029,26 @@ def _model_supports_output_config(model_name: str) -> bool:
     if model_name.startswith("claude-mythos"):
         return True
 
-    version_re = re.compile(r"^claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)")
-    match = version_re.match(model_name)
-    return (int(match[1]), int(match[2])) >= (4, 5) if match else False
+    parsed = _parse_model_version(model_name)
+    return parsed[1] >= (4, 5) if parsed else False
 
 
 def _model_supports_sampling_params(model_name: str) -> bool:
     """Returns True if the model accepts sampling params, False otherwise."""
     # Anthropic removed the sampling params (temperature/top_p/top_k) on its
-    # reasoning-first models: Claude Opus 4.7+ and the Fable/Mythos families return
-    # HTTP 400 ("`temperature` is deprecated for this model."). Opus 4.6 and earlier,
-    # all Sonnet and Haiku, and Claude 3.x still accept them.
+    # reasoning-first models: Claude Opus 4.7+, Sonnet 5+, and the Fable/Mythos
+    # families return HTTP 400 ("`temperature` is deprecated for this model.").
+    # Opus 4.6 and earlier, Sonnet 4.6 and earlier, all Haiku, and Claude 3.x
+    # still accept them.
     if model_name.startswith(("claude-fable", "claude-mythos")):
         return False
 
-    version_re = re.compile(r"^claude-opus-(\d+)-(\d+)")
-    match = version_re.match(model_name)
-    return (int(match[1]), int(match[2])) < (4, 7) if match else True
+    parsed = _parse_model_version(model_name)
+    if not parsed:
+        return True
+    family, version = parsed
+    if family == "opus":
+        return version < (4, 7)
+    if family == "sonnet":
+        return version < (5, 0)
+    return True

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -1025,8 +1025,9 @@ def _parse_model_version(model_name: str) -> tuple[str, tuple[int, int]] | None:
 def _model_supports_output_config(model_name: str) -> bool:
     """Returns True if the model accepts the output_config field, False otherwise."""
     # Anthropic's `output_config` (structured outputs) is GA on Claude 4.5+ (Opus,
-    # Sonnet, Haiku) and Mythos. Older models (Claude 3.x, 3.5) reject the field.
-    if model_name.startswith("claude-mythos"):
+    # Sonnet, Haiku) and the Fable/Mythos families. Older models (Claude 3.x, 3.5)
+    # reject the field.
+    if model_name.startswith(("claude-fable", "claude-mythos")):
         return True
 
     parsed = _parse_model_version(model_name)

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -16,7 +16,7 @@ import copy
 import itertools
 import json
 import re
-from typing import Any
+from typing import Any, Final, Literal, NamedTuple, cast
 
 import pydantic
 from typing_extensions import override
@@ -74,6 +74,33 @@ _IMAGE_MAGIC_PREFIXES: tuple[tuple[bytes, str], ...] = (
 # Model-name prefixes for Anthropic's reasoning-first families, which gate both
 # `output_config` support and sampling-param support below.
 _REASONING_FIRST_MODEL_PREFIXES: tuple[str, ...] = ("claude-fable", "claude-mythos")
+
+_OPUS_FAMILY: Final = "opus"
+_SONNET_FAMILY: Final = "sonnet"
+_HAIKU_FAMILY: Final = "haiku"
+_ClaudeFamily = Literal["opus", "sonnet", "haiku"]
+
+# A model name carries an optional minor component and an optional -YYYYMMDD
+# snapshot date. Bounding the minor to two digits keeps a date out of it, so
+# `claude-opus-4-20250514` reads as 4.0 rather than 4.20250514.
+_MODEL_VERSION_RE = re.compile(
+    rf"^claude-({_OPUS_FAMILY}|{_SONNET_FAMILY}|{_HAIKU_FAMILY})"
+    r"-(\d+)(?:-(\d{1,2})(?!\d))?"
+)
+
+# `output_config` (structured outputs) is GA from this version on.
+_OUTPUT_CONFIG_MIN_VERSION: tuple[int, int] = (4, 5)
+
+# First version in each family to reject temperature/top_p/top_k.
+_OPUS_SAMPLING_PARAMS_REMOVED_VERSION: tuple[int, int] = (4, 7)
+_SONNET_SAMPLING_PARAMS_REMOVED_VERSION: tuple[int, int] = (5, 0)
+
+
+class _ClaudeModelVersion(NamedTuple):
+    """A Claude model name parsed into its family and (major, minor) version."""
+
+    family: _ClaudeFamily
+    version: tuple[int, int]
 
 
 def _detect_image_media_type(data: bytes) -> str:
@@ -194,6 +221,16 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
                 model_params.model_name,
                 generation_params.temperature,
                 generation_params.top_p,
+            )
+        else:
+            # Dropping the default still diverges from the requested config:
+            # temperature 0.0 is greedy decoding, and omitting it hands sampling
+            # to Anthropic's own default.
+            logger.info(
+                "%r does not accept sampling params; omitting temperature=%s, "
+                "so generation uses Anthropic's default sampling.",
+                model_params.model_name,
+                generation_params.temperature,
             )
 
         if self._remote_params.user_id:
@@ -1014,16 +1051,18 @@ def _convert_guided_decoding_config_to_api_input(
     }
 
 
-def _parse_model_version(model_name: str) -> tuple[str, tuple[int, int]] | None:
-    """Returns (family, (major, minor)) for versioned Opus/Sonnet/Haiku, else None.
+def _parse_model_version(model_name: str) -> _ClaudeModelVersion | None:
+    """Returns the parsed family and version, or None for an unversioned name.
 
     Anthropic drops the minor component on round versions (`claude-opus-5`, not
-    `claude-opus-5-0`); treat a missing minor as 0.
+    `claude-opus-5-0`); treat a missing minor as 0. A trailing snapshot date
+    (`claude-opus-4-20250514`) is not a minor version.
     """
-    match = re.match(r"^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d+))?", model_name)
+    match = _MODEL_VERSION_RE.match(model_name)
     if not match:
         return None
-    return match[1], (int(match[2]), int(match[3] or 0))
+    family = cast(_ClaudeFamily, match[1])
+    return _ClaudeModelVersion(family, (int(match[2]), int(match[3] or 0)))
 
 
 def _model_supports_output_config(model_name: str) -> bool:
@@ -1037,8 +1076,7 @@ def _model_supports_output_config(model_name: str) -> bool:
     parsed = _parse_model_version(model_name)
     if parsed is None:
         return False
-    _, version = parsed
-    return version >= (4, 5)
+    return parsed.version >= _OUTPUT_CONFIG_MIN_VERSION
 
 
 def _model_supports_sampling_params(model_name: str) -> bool:
@@ -1050,11 +1088,12 @@ def _model_supports_sampling_params(model_name: str) -> bool:
         return False
 
     parsed = _parse_model_version(model_name)
-    if not parsed:
+    if parsed is None:
         return True
-    family, version = parsed
-    if family == "opus":
-        return version < (4, 7)
-    if family == "sonnet":
-        return version < (5, 0)
-    return True
+    if parsed.family == _OPUS_FAMILY:
+        return parsed.version < _OPUS_SAMPLING_PARAMS_REMOVED_VERSION
+    if parsed.family == _SONNET_FAMILY:
+        return parsed.version < _SONNET_SAMPLING_PARAMS_REMOVED_VERSION
+    if parsed.family == _HAIKU_FAMILY:
+        return True
+    raise NotImplementedError(f"unhandled Claude family: {parsed.family}")

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -17,6 +17,7 @@ from oumi.core.types.conversation import (
 from oumi.core.types.tool_call import ToolCall, ToolDefinition
 from oumi.inference.anthropic_inference_engine import (
     AnthropicInferenceEngine,
+    _model_supports_output_config,
     _model_supports_sampling_params,
 )
 from oumi.inference.remote_inference_engine import BatchInfo, BatchStatus
@@ -91,7 +92,9 @@ def test_convert_conversation_omits_metadata_without_user_id(anthropic_engine):
         ("claude-opus-4-7", False),
         ("claude-opus-4-8", False),
         ("claude-opus-4-9", False),  # future Opus stays gated
+        ("claude-opus-5", False),  # round version, no minor component
         ("claude-sonnet-4-6", True),
+        ("claude-sonnet-5", False),
         ("claude-haiku-4-5", True),
         ("claude-3-5-sonnet-20241022", True),
         ("claude-3", True),
@@ -102,6 +105,21 @@ def test_convert_conversation_omits_metadata_without_user_id(anthropic_engine):
 )
 def test_model_supports_sampling_params(model_name, supported):
     assert _model_supports_sampling_params(model_name) is supported
+
+
+@pytest.mark.parametrize(
+    ("model_name", "supported"),
+    [
+        ("claude-opus-4-5-20251101", True),
+        ("claude-opus-5", True),  # round version, no minor component
+        ("claude-sonnet-5", True),
+        ("claude-haiku-4-5", True),
+        ("claude-3-5-sonnet-20241022", False),
+        ("claude-mythos-5", True),
+    ],
+)
+def test_model_supports_output_config(model_name, supported):
+    assert _model_supports_output_config(model_name) is supported
 
 
 def test_convert_conversation_omits_sampling_params_for_reasoning_models():

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -115,6 +115,7 @@ def test_model_supports_sampling_params(model_name, supported):
         ("claude-sonnet-5", True),
         ("claude-haiku-4-5", True),
         ("claude-3-5-sonnet-20241022", False),
+        ("claude-fable-5", True),
         ("claude-mythos-5", True),
     ],
 )

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from oumi.core.configs import GenerationParams, ModelParams, RemoteParams
+from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.types.conversation import (
     ContentItem,
     Conversation,
@@ -93,6 +94,7 @@ def test_convert_conversation_omits_metadata_without_user_id(anthropic_engine):
         ("claude-opus-4-8", False),
         ("claude-opus-4-9", False),  # future Opus stays gated
         ("claude-opus-5", False),  # round version, no minor component
+        ("claude-opus-4-20250514", True),  # snapshot date is not a minor version
         ("claude-sonnet-4-6", True),
         ("claude-sonnet-5", False),
         ("claude-haiku-4-5", True),
@@ -114,6 +116,9 @@ def test_model_supports_sampling_params(model_name, supported):
         ("claude-opus-5", True),  # round version, no minor component
         ("claude-sonnet-5", True),
         ("claude-haiku-4-5", True),
+        ("claude-sonnet-4-0", False),  # parses, but below the 4.5 boundary
+        ("claude-opus-4-20250514", False),  # snapshot date is not a minor version
+        ("claude-sonnet-4-20250514", False),
         ("claude-3-5-sonnet-20241022", False),
         ("claude-fable-5", True),
         ("claude-mythos-5", True),
@@ -121,6 +126,67 @@ def test_model_supports_sampling_params(model_name, supported):
 )
 def test_model_supports_output_config(model_name, supported):
     assert _model_supports_output_config(model_name) is supported
+
+
+def test_convert_conversation_includes_output_config_for_supported_model():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-5"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+
+    result = engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(
+            max_new_tokens=100,
+            guided_decoding=GuidedDecodingParams(json=schema),
+        ),
+        engine._model_params,
+    )
+
+    assert result["output_config"]["format"]["type"] == "json_schema"
+    assert result["output_config"]["format"]["schema"]["required"] == ["answer"]
+
+
+def test_convert_conversation_omits_output_config_for_unsupported_model():
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-3-5-sonnet-20241022"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    result = engine._convert_conversation_to_api_input(
+        conversation,
+        GenerationParams(
+            max_new_tokens=100,
+            guided_decoding=GuidedDecodingParams(json={"type": "object"}),
+        ),
+        engine._model_params,
+    )
+
+    assert "output_config" not in result
+
+
+def test_convert_conversation_logs_when_dropping_default_sampling_params(caplog):
+    engine = AnthropicInferenceEngine(
+        model_params=ModelParams(model_name="claude-opus-5"),
+        remote_params=RemoteParams(api_key="test_api_key", api_url="<placeholder>"),
+    )
+    conversation = Conversation(messages=[Message(content="hi", role=Role.USER)])
+
+    with caplog.at_level(logging.INFO):
+        engine._convert_conversation_to_api_input(
+            conversation,
+            GenerationParams(max_new_tokens=100),
+            engine._model_params,
+        )
+
+    assert any("Anthropic's default sampling" in r.message for r in caplog.records)
 
 
 def test_convert_conversation_omits_sampling_params_for_reasoning_models():


### PR DESCRIPTION
## What
Claude Opus 5, Sonnet 5, and Fable 5 now work, and dated Claude 4.0 names are no longer misread as a far-future version.

## Why
Opus 5 and Sonnet 5 were rejected on every request. Fable 5 silently dropped the requested response format — plausible answer, no error. Separately, a name ending in a release date was read as if the date were the version.

## How
One shared version reader handles every naming shape Anthropic uses, with per-family rules instead of assuming the flagship line.

## Testing
All three new models ran against the live API, plain and structured, with production settings: every combination succeeded, where before two were rejected and one dropped the format silently. The dated-name fix is unit-tested only — those models aren't on our key. Standard lints clean.