### PR TITLE
feat(verl): OumiVerlTool — verl tool RL over any Oumi executable environment

### DIFF
--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -111,6 +111,8 @@ class ToolRouter:
         per-sample data (e.g. the database a single rollout should query). Shared
         envs are rejected because the override would silently apply to every sample.
         """
+        # Both checks run before the first build, so a rejected override can't
+        # strand envs already rebuilt in the loop (their teardown needs a router).
         overrides = env_kwargs_by_env or {}
         unknown_env_ids = overrides.keys() - self.env_by_id.keys()
         if unknown_env_ids:
@@ -118,15 +120,20 @@ class ToolRouter:
                 f"Per-sample env_kwargs target unknown environments: "
                 f"{sorted(unknown_env_ids)}. Known: {sorted(self.env_by_id)}"
             )
+        shared_env_ids = [
+            env_id
+            for env_id in overrides
+            if not self.env_by_id[env_id].requires_isolation()
+        ]
+        if shared_env_ids:
+            raise ValueError(
+                f"Environments {sorted(shared_env_ids)} are shared across samples, "
+                "so per-sample env_kwargs cannot be applied to them."
+            )
 
         env_by_id_new: dict[str, BaseEnvironment] = {}
         for env_id, parent_env in self.env_by_id.items():
             if not parent_env.requires_isolation():
-                if env_id in overrides:
-                    raise ValueError(
-                        f"Environment {env_id!r} is shared across samples, so "
-                        "per-sample env_kwargs cannot be applied to it."
-                    )
                 env_by_id_new[env_id] = parent_env
                 continue
             env_params = self.env_params_by_id[env_id]

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -97,7 +97,7 @@ class ToolRouter:
         )
 
     def for_sample(
-        self, env_kwargs_by_env: Mapping[str, Mapping[str, Any]] | None = None
+        self, env_kwargs_by_env_id: Mapping[str, Mapping[str, Any]] | None = None
     ) -> ToolRouter:
         """Return a router safe to use for one sample.
 
@@ -108,13 +108,13 @@ class ToolRouter:
         stateless ``SyntheticEnvironment``) are shared with the parent
         router to avoid the per-sample build + inference-engine attach cost.
 
-        ``env_kwargs_by_env`` replaces ``env_kwargs`` on the rebuilt envs with
+        ``env_kwargs_by_env_id`` replaces ``env_kwargs`` on the rebuilt envs with
         per-sample data (e.g. the database a single rollout should query). Shared
         envs are rejected because the override would silently apply to every sample.
         """
         # Both checks run before the first build, so a rejected override can't
         # strand envs already rebuilt in the loop (their teardown needs a router).
-        overrides = env_kwargs_by_env or {}
+        overrides = env_kwargs_by_env_id or {}
         unknown_env_ids = overrides.keys() - self.env_by_id.keys()
         if unknown_env_ids:
             raise ValueError(
@@ -148,8 +148,9 @@ class ToolRouter:
                     self.on_env_built(fresh)
                 env_by_id_new[env_id] = fresh
         except BaseException:
-            # No router escapes to close these, so release them here. Shared envs
-            # aren't in `built_here` — they belong to the parent.
+            # Per-sample envs are normally closed through the returned router; on this
+            # path there is no return value, so nothing else can reach them. Shared
+            # envs aren't in `built_here` — they belong to the parent.
             for env in built_here:
                 with suppress(Exception):
                     env.close()

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -148,9 +148,8 @@ class ToolRouter:
                     self.on_env_built(fresh)
                 env_by_id_new[env_id] = fresh
         except BaseException:
-            # Per-sample envs are normally closed through the returned router; on this
-            # path there is no return value, so nothing else can reach them. Shared
-            # envs aren't in `built_here` — they belong to the parent.
+            # Raising without returning means no router will ever close these.
+            # `built_here` omits the parent's shared envs, which must stay open.
             for env in built_here:
                 with suppress(Exception):
                     env.close()

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Mapping
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -132,17 +133,27 @@ class ToolRouter:
             )
 
         env_by_id_new: dict[str, BaseEnvironment] = {}
-        for env_id, parent_env in self.env_by_id.items():
-            if not parent_env.requires_isolation():
-                env_by_id_new[env_id] = parent_env
-                continue
-            env_params = self.env_params_by_id[env_id]
-            if env_id in overrides:
-                env_params = replace(env_params, env_kwargs=dict(overrides[env_id]))
-            fresh = build_environment(env_params)
-            if self.on_env_built is not None:
-                self.on_env_built(fresh)
-            env_by_id_new[env_id] = fresh
+        built_here: list[BaseEnvironment] = []
+        try:
+            for env_id, parent_env in self.env_by_id.items():
+                if not parent_env.requires_isolation():
+                    env_by_id_new[env_id] = parent_env
+                    continue
+                env_params = self.env_params_by_id[env_id]
+                if env_id in overrides:
+                    env_params = replace(env_params, env_kwargs=dict(overrides[env_id]))
+                fresh = build_environment(env_params)
+                built_here.append(fresh)
+                if self.on_env_built is not None:
+                    self.on_env_built(fresh)
+                env_by_id_new[env_id] = fresh
+        except BaseException:
+            # No router escapes to close these, so release them here. Shared envs
+            # aren't in `built_here` — they belong to the parent.
+            for env in built_here:
+                with suppress(Exception):
+                    env.close()
+            raise
 
         return ToolRouter(
             tool_specs=self.tool_specs,

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
 from typing import Any
 
 from oumi.builders.environments import build_environment
@@ -95,7 +95,9 @@ class ToolRouter:
             on_env_built=on_env_built,
         )
 
-    def for_sample(self) -> ToolRouter:
+    def for_sample(
+        self, env_kwargs_by_env: Mapping[str, Mapping[str, Any]] | None = None
+    ) -> ToolRouter:
         """Return a router safe to use for one sample.
 
         Envs whose ``requires_isolation()`` returns ``True`` are rebuilt via
@@ -104,13 +106,33 @@ class ToolRouter:
         don't require isolation (e.g. ``DeterministicEnvironment`` and
         stateless ``SyntheticEnvironment``) are shared with the parent
         router to avoid the per-sample build + inference-engine attach cost.
+
+        ``env_kwargs_by_env`` replaces ``env_kwargs`` on the rebuilt envs with
+        per-sample data (e.g. the database a single rollout should query). Shared
+        envs are rejected because the override would silently apply to every sample.
         """
+        overrides = env_kwargs_by_env or {}
+        unknown_env_ids = overrides.keys() - self.env_by_id.keys()
+        if unknown_env_ids:
+            raise ValueError(
+                f"Per-sample env_kwargs target unknown environments: "
+                f"{sorted(unknown_env_ids)}. Known: {sorted(self.env_by_id)}"
+            )
+
         env_by_id_new: dict[str, BaseEnvironment] = {}
         for env_id, parent_env in self.env_by_id.items():
             if not parent_env.requires_isolation():
+                if env_id in overrides:
+                    raise ValueError(
+                        f"Environment {env_id!r} is shared across samples, so "
+                        "per-sample env_kwargs cannot be applied to it."
+                    )
                 env_by_id_new[env_id] = parent_env
                 continue
-            fresh = build_environment(self.env_params_by_id[env_id])
+            env_params = self.env_params_by_id[env_id]
+            if env_id in overrides:
+                env_params = replace(env_params, env_kwargs=dict(overrides[env_id]))
+            fresh = build_environment(env_params)
             if self.on_env_built is not None:
                 self.on_env_built(fresh)
             env_by_id_new[env_id] = fresh

--- a/src/oumi/core/trainers/verl_agentic/__init__.py
+++ b/src/oumi/core/trainers/verl_agentic/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic Oumi tool bridge for verl."""

--- a/src/oumi/core/trainers/verl_agentic/env_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/env_provider.py
@@ -54,15 +54,18 @@ def _rollout_env_kwargs(
             "Rollout create_kwargs contain unknown tool IDs: "
             f"{sorted(unknown_tool_ids)}"
         )
-    env_kwargs_by_env: dict[str, dict[str, Any]] = {}
+    env_kwargs_by_env_id: dict[str, dict[str, Any]] = {}
     for tool_id, create_kwargs in create_kwargs_by_tool.items():
         env_id = tool_env_map[tool_id]
-        if env_id in env_kwargs_by_env and env_kwargs_by_env[env_id] != create_kwargs:
+        if (
+            env_id in env_kwargs_by_env_id
+            and env_kwargs_by_env_id[env_id] != create_kwargs
+        ):
             raise ValueError(
                 f"Tools provide conflicting create_kwargs for environment {env_id!r}."
             )
-        env_kwargs_by_env[env_id] = create_kwargs
-    return env_kwargs_by_env
+        env_kwargs_by_env_id[env_id] = create_kwargs
+    return env_kwargs_by_env_id
 
 
 def _teardown(request_id: str) -> None:

--- a/src/oumi/core/trainers/verl_agentic/env_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/env_provider.py
@@ -1,0 +1,102 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-rollout Oumi environment resolution for the verl tool adapter."""
+
+from __future__ import annotations
+
+import weakref
+from collections.abc import Mapping
+from typing import Any, Protocol, TypedDict
+
+from oumi.core.synthesis.tool_router import ToolRouter
+
+# Routers stay module-local because their environment connections are not picklable.
+# Value is (id of the parent router, rollout clone) — see `get_or_build_router`.
+_ROUTERS: dict[str, tuple[int, ToolRouter]] = {}
+
+
+class _ToolKwargs(TypedDict, total=False):
+    create_kwargs: Mapping[str, Any]
+
+
+class _RolloutData(Protocol):
+    @property
+    def request_id(self) -> str: ...
+
+    @property
+    def tools_kwargs(self) -> Mapping[str, _ToolKwargs | None] | None: ...
+
+
+def _rollout_env_kwargs(
+    agent_data: _RolloutData, tool_env_map: Mapping[str, str]
+) -> dict[str, dict[str, Any]]:
+    """Regroup this rollout's per-tool `create_kwargs` by owning environment."""
+    create_kwargs_by_tool = {}
+    for tool_id, entry in (agent_data.tools_kwargs or {}).items():
+        if entry and (create_kwargs := entry.get("create_kwargs")):
+            create_kwargs_by_tool[tool_id] = dict(create_kwargs)
+
+    unknown_tool_ids = create_kwargs_by_tool.keys() - tool_env_map.keys()
+    if unknown_tool_ids:
+        raise ValueError(
+            "Rollout create_kwargs contain unknown tool IDs: "
+            f"{sorted(unknown_tool_ids)}"
+        )
+    env_kwargs_by_env: dict[str, dict[str, Any]] = {}
+    for tool_id, create_kwargs in create_kwargs_by_tool.items():
+        env_id = tool_env_map[tool_id]
+        if env_id in env_kwargs_by_env and env_kwargs_by_env[env_id] != create_kwargs:
+            raise ValueError(
+                f"Tools provide conflicting create_kwargs for environment {env_id!r}."
+            )
+        env_kwargs_by_env[env_id] = create_kwargs
+    return env_kwargs_by_env
+
+
+def _teardown(request_id: str) -> None:
+    entry = _ROUTERS.pop(request_id, None)
+    if entry is not None:
+        entry[1].close()
+
+
+def get_or_build_router(
+    agent_data: _RolloutData, parent_router: ToolRouter
+) -> ToolRouter:
+    """Return the rollout-scoped clone of the process-wide `parent_router`.
+
+    `request_id` must be unique per live rollout: teardown is tied to this
+    `agent_data`, so a reused id would close the router still held by the other owner.
+
+    Every Oumi tool in one rollout shares that rollout's router, so they must all
+    name the same environment config. One config already covers many environments
+    (`EnvironmentConfig.environments` is a list), so a second one is a mistake.
+    """
+    request_id = agent_data.request_id
+    entry = _ROUTERS.get(request_id)
+    if entry is not None:
+        # `parent_router` is cached per config path, so identity == same config.
+        if entry[0] != id(parent_router):
+            raise ValueError(
+                "Oumi tools in one rollout must share a single environment config; "
+                "found tools built from two different `oumi_env_config` files. "
+                "List every environment in one config instead."
+            )
+        return entry[1]
+    router = parent_router.for_sample(
+        _rollout_env_kwargs(agent_data, parent_router.tool_env_map)
+    )
+    _ROUTERS[request_id] = (id(parent_router), router)
+    weakref.finalize(agent_data, _teardown, request_id)
+    return router

--- a/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
+++ b/src/oumi/core/trainers/verl_agentic/oumi_verl_tool.py
@@ -1,0 +1,106 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""verl adapter backed by a rollout-scoped Oumi tool router."""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from typing import Any
+from uuid import uuid4
+
+from verl.tools.base_tool import BaseTool  # pyright: ignore[reportMissingImports]
+from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
+    OpenAIFunctionToolSchema,
+    ToolResponse,
+)
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.synthesis.tool_router import ToolRouter
+from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
+from oumi.utils.logging import logger
+from oumi.utils.packaging import is_verl_v0_7_or_later
+
+
+@cache
+def _load_env_config(path: str) -> EnvironmentConfig:
+    config = EnvironmentConfig.from_yaml(path)
+    config.finalize_and_validate()
+    return config
+
+
+@cache
+def _parent_router(path: str) -> ToolRouter:
+    """The process-wide template each rollout clones; its envs are built once."""
+    return ToolRouter.from_environment_config(_load_env_config(path))
+
+
+class OumiVerlTool(BaseTool):
+    """A verl tool backed by the router shared within a rollout."""
+
+    def __init__(
+        self,
+        config: dict,
+        tool_schema: OpenAIFunctionToolSchema,
+    ) -> None:
+        """Loads and validates the configured `EnvironmentConfig`."""
+        if not is_verl_v0_7_or_later():
+            raise RuntimeError("OumiVerlTool requires verl 0.7.0 or later.")
+        super().__init__(config, tool_schema)
+        self._tool_id = tool_schema.function.name
+        self._env_config_path = config["oumi_env_config"]
+        # Validate at construction: the tool name is spelled out in both the verl
+        # tool config and the env config, so a mismatch would otherwise surface as
+        # an unusable tool that fails every call of every rollout.
+        env_config = _load_env_config(self._env_config_path)
+        if self._tool_id not in env_config.tool_environment_map:
+            raise ValueError(
+                f"Tool '{self._tool_id}' is not defined in "
+                f"{self._env_config_path}. Known tools: "
+                f"{sorted(env_config.tool_environment_map)}"
+            )
+
+    async def create(
+        self, instance_id: str | None = None, **kwargs: Any
+    ) -> tuple[str, ToolResponse]:
+        """Mints an instance id; the router is created lazily in `execute`."""
+        return instance_id or uuid4().hex, ToolResponse()
+
+    async def execute(
+        self,
+        instance_id: str,
+        parameters: dict[str, Any],
+        agent_data: Any = None,
+        **kwargs: Any,
+    ) -> tuple[ToolResponse, float, dict]:
+        """Routes one tool call through this rollout's shared Oumi router."""
+        router = get_or_build_router(agent_data, _parent_router(self._env_config_path))
+        # verl emits `None` for unset optional args; drop them so the executor
+        # sees an absent key rather than an explicit null.
+        args = {k: v for k, v in (parameters or {}).items() if v is not None}
+        try:
+            result = router.route_batch([(self._tool_id, args)])[0]
+        except Exception as e:
+            # A bad tool call is an observation the policy can recover from, not a
+            # reason to kill the trajectory.
+            logger.warning(f"Tool '{self._tool_id}' call failed: {e}")
+            return ToolResponse(text=f"Tool error: {e}"), 0.0, {}
+        out = result.output
+        text = out if isinstance(out, str) else json.dumps(out)
+        return ToolResponse(text=text), 0.0, {}
+
+    async def release(self, instance_id: str, **kwargs: Any) -> None:
+        """No-op because router teardown occurs at the rollout boundary."""
+        return None

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -16,6 +16,7 @@
 
 import copy
 import inspect
+import json
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -26,6 +27,8 @@ from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
 from oumi.core.types.conversation import Conversation
+from oumi.core.types.conversation import Role as ConversationRole
+from oumi.utils.conversation_utils import create_list_of_message_json_dicts
 from oumi.utils.grpo_utils import (
     extract_prompt_images_completion_from_conversation,
 )
@@ -246,9 +249,93 @@ class VerlGrpoTrainer(BaseTrainer):
         return (prompt_messages, images, answer)
 
     @staticmethod
+    def _create_verl_data_entry_from_tool_agent_conversation(
+        conversation: Conversation,
+        ground_truth: str,
+        tools_kwargs: dict[str, Any],
+        ability: str,
+        idx: int,
+        data_source: str,
+        split: str,
+    ) -> dict:
+        """Build a verl row from a structured tool-agent prompt."""
+        if any(
+            message.count_content_items().image_items
+            for message in conversation.messages
+        ):
+            raise ValueError("Tool-agent conversations do not support images.")
+        if not conversation.messages or conversation.messages[-1].role not in (
+            ConversationRole.USER,
+            ConversationRole.TOOL,
+        ):
+            raise ValueError(
+                "Tool-agent conversation prompts must end with a user or tool message."
+            )
+
+        prompt_messages = create_list_of_message_json_dicts(
+            conversation.messages,
+            group_adjacent_same_role_turns=False,
+        )
+        return {
+            "data_source": data_source,
+            "prompt": prompt_messages,
+            "images": [],
+            "ability": ability,
+            "agent_name": "tool_agent",
+            "reward_model": {"style": "rule", "ground_truth": ground_truth},
+            "extra_info": {
+                "split": split,
+                "index": idx,
+                "need_tools_kwargs": True,
+                "tools_kwargs": tools_kwargs,
+            },
+        }
+
+    @staticmethod
     def _create_verl_data_entry_from_conversation(
         example: dict, idx: int, data_source: str, split: str
     ) -> dict:
+        # Peek at metadata off the raw JSON so only the branch that needs a
+        # `Conversation` pays for building one.
+        raw_conversation = example["conversation_json"]
+        metadata = json.loads(raw_conversation).get("metadata") or {}
+        if metadata.get("agent_name") == "tool_agent":
+            conversation = Conversation.from_json(raw_conversation)
+            ground_truth = metadata.get("ground_truth")
+            if not isinstance(ground_truth, str) or not ground_truth:
+                raise ValueError(
+                    "Tool-agent conversation metadata must include a non-empty "
+                    "string 'ground_truth'."
+                )
+            tools_kwargs = metadata.get("tools_kwargs")
+            tools_kwargs_error = (
+                "Tool-agent conversation metadata 'tools_kwargs' must be a "
+                "mapping of tool names to dictionaries."
+            )
+            if not isinstance(tools_kwargs, dict):
+                raise ValueError(
+                    f"{tools_kwargs_error} Got {type(tools_kwargs).__name__}."
+                )
+            for tool_name, tool_kwargs in tools_kwargs.items():
+                if not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict):
+                    raise ValueError(
+                        f"{tools_kwargs_error} Got {tool_name!r}: "
+                        f"{type(tool_kwargs).__name__}."
+                    )
+            ability = metadata.get("ability", "tool_agent")
+            if not isinstance(ability, str):
+                raise ValueError(
+                    "Tool-agent conversation metadata 'ability' must be a string."
+                )
+            return VerlGrpoTrainer._create_verl_data_entry_from_tool_agent_conversation(
+                conversation,
+                ground_truth,
+                tools_kwargs,
+                ability,
+                idx,
+                data_source,
+                split,
+            )
         prompt_messages, images, answer = (
             VerlGrpoTrainer._extract_prompt_images_answer_from_conversation(example)
         )

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -499,6 +499,34 @@ def test_for_sample_closes_envs_it_built_when_a_later_build_fails(monkeypatch):
     built[0].close.assert_called_once()
 
 
+def test_for_sample_closes_an_env_whose_on_env_built_fails(monkeypatch):
+    """An env is owned from the moment it's built, before on_env_built runs on it.
+
+    It never reaches `env_by_id_new` on this path, so only `built_here` can free it.
+    """
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_db_env_params()])
+    )
+    built = []
+
+    def build(_env_params):
+        env = Mock(spec=BaseEnvironment)
+        env.requires_isolation.return_value = True
+        built.append(env)
+        return env
+
+    monkeypatch.setattr("oumi.core.synthesis.tool_router.build_environment", build)
+    monkeypatch.setattr(
+        router, "on_env_built", Mock(side_effect=RuntimeError("attach failed"))
+    )
+
+    with pytest.raises(RuntimeError, match="attach failed"):
+        router.for_sample()
+
+    assert len(built) == 1
+    built[0].close.assert_called_once()
+
+
 def test_for_sample_env_kwargs_override_does_not_leak_into_later_samples():
     """One sample's override must not follow the parent into the next sample.
 

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -442,14 +442,7 @@ def test_for_sample_env_kwargs_override_rebuilds_isolated_env_with_sample_data()
         EnvironmentConfig(environments=[_db_env_params()])
     )
 
-    clone = router.for_sample(
-        {
-            "db": {
-                "schema_sql": _DB_SCHEMA,
-                "seed_sql": "INSERT INTO patients VALUES (1, 'Alice', 'ibuprofen');",
-            }
-        }
-    )
+    clone = router.for_sample({"db": _ALICE_KWARGS})
 
     [result] = clone.env_by_id["db"].step([("lookup", {"pat_id": 1})])
     assert result.output == {"name": "Alice", "meds": "ibuprofen"}
@@ -506,6 +499,68 @@ def test_for_sample_closes_envs_it_built_when_a_later_build_fails(monkeypatch):
     built[0].close.assert_called_once()
 
 
+def test_for_sample_env_kwargs_override_does_not_leak_into_later_samples():
+    """One sample's override must not follow the parent into the next sample.
+
+    The batch loop calls for_sample() off the same parent per sample, so an
+    override recorded on the parent's params would silently retarget the rest.
+    """
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_db_env_params()])
+    )
+
+    overridden = router.for_sample({"db": _ALICE_KWARGS})
+    plain = router.for_sample()
+
+    [from_override] = overridden.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+    [from_config] = plain.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+    assert from_override.output == {"name": "Alice", "meds": "ibuprofen"}
+    assert from_config.output == {"name": "Bob", "meds": "aspirin"}
+
+
+def test_for_sample_env_kwargs_override_leaves_sibling_isolated_envs_on_config():
+    """Overriding one env must not retarget the other isolating envs in the config."""
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(
+            environments=[
+                _db_env_params("db_a", tool_id="lookup_a"),
+                _db_env_params("db_b", tool_id="lookup_b"),
+            ]
+        )
+    )
+
+    clone = router.for_sample({"db_a": _ALICE_KWARGS})
+
+    [a] = clone.env_by_id["db_a"].step([("lookup_a", {"pat_id": 1})])
+    [b] = clone.env_by_id["db_b"].step([("lookup_b", {"pat_id": 1})])
+    assert a.output == {"name": "Alice", "meds": "ibuprofen"}
+    assert b.output == {"name": "Bob", "meds": "aspirin"}
+
+
+def test_for_sample_failed_build_leaves_the_parents_shared_envs_open(monkeypatch):
+    """Teardown closes only what the pass built; later samples need the shared envs."""
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(
+            environments=[
+                _det_env_params("det1", [_tool("t1")]),
+                _stateful_synth_env_params("stateful"),
+            ]
+        )
+    )
+    shared = router.env_by_id["det1"]
+    shared_close = Mock()
+    monkeypatch.setattr(shared, "close", shared_close)
+    monkeypatch.setattr(
+        "oumi.core.synthesis.tool_router.build_environment",
+        Mock(side_effect=RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        router.for_sample()
+
+    shared_close.assert_not_called()
+
+
 def test_for_sample_rejects_bad_override_before_building_anything(monkeypatch):
     """A rejected override must not strand envs built earlier in the loop.
 
@@ -534,6 +589,11 @@ def test_for_sample_rejects_bad_override_before_building_anything(monkeypatch):
 
 _DB_SCHEMA = "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT, meds TEXT);"
 _DB_SEED = "INSERT INTO patients VALUES (1, 'Bob', 'aspirin');"
+# A per-sample override: same schema, a different row than the config seeds.
+_ALICE_KWARGS = {
+    "schema_sql": _DB_SCHEMA,
+    "seed_sql": "INSERT INTO patients VALUES (1, 'Alice', 'ibuprofen');",
+}
 
 
 # Local executor so this suite doesn't depend on the EHR example.
@@ -544,7 +604,7 @@ def _db_lookup_patient(arguments: dict, context: sqlite3.Connection) -> ToolResu
     return ToolResult(output={"name": row[0], "meds": row[1]})
 
 
-def _db_env_params(env_id: str = "db") -> EnvironmentParams:
+def _db_env_params(env_id: str = "db", tool_id: str = "lookup") -> EnvironmentParams:
     """A database env; each build materializes an owned temp snapshot + session."""
     return EnvironmentParams(
         id=env_id,
@@ -553,8 +613,8 @@ def _db_env_params(env_id: str = "db") -> EnvironmentParams:
         env_type="database",
         tools=[
             {
-                "id": "lookup",
-                "name": "lookup",
+                "id": tool_id,
+                "name": tool_id,
                 "description": "look up a patient",
                 "parameters": {
                     "type": "object",

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -436,6 +436,48 @@ def test_for_sample_mutation_does_not_bleed_back_to_parent():
     assert router.env_by_id["env1"] is parent_env
 
 
+def test_for_sample_env_kwargs_override_rebuilds_isolated_env_with_sample_data():
+    """Per-sample env_kwargs replace the config's, without touching the parent."""
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_db_env_params()])
+    )
+
+    clone = router.for_sample(
+        {
+            "db": {
+                "schema_sql": _DB_SCHEMA,
+                "seed_sql": "INSERT INTO patients VALUES (1, 'Alice', 'ibuprofen');",
+            }
+        }
+    )
+
+    [result] = clone.env_by_id["db"].step([("lookup", {"pat_id": 1})])
+    assert result.output == {"name": "Alice", "meds": "ibuprofen"}
+    assert router.env_params_by_id["db"].env_kwargs == {
+        "schema_sql": _DB_SCHEMA,
+        "seed_sql": _DB_SEED,
+    }
+
+
+def test_for_sample_env_kwargs_override_rejects_shared_env():
+    """A shared env can't take per-sample kwargs; they'd apply to every sample."""
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_det_env_params("det1", [_tool("t1")])])
+    )
+
+    with pytest.raises(ValueError, match="shared across samples"):
+        router.for_sample({"det1": {"anything": 1}})
+
+
+def test_for_sample_env_kwargs_override_rejects_unknown_env():
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(environments=[_det_env_params("det1", [_tool("t1")])])
+    )
+
+    with pytest.raises(ValueError, match="unknown environments: \\['nope'\\]"):
+        router.for_sample({"nope": {"anything": 1}})
+
+
 # ---------- close ----------
 
 

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -478,6 +478,29 @@ def test_for_sample_env_kwargs_override_rejects_unknown_env():
         router.for_sample({"nope": {"anything": 1}})
 
 
+def test_for_sample_rejects_bad_override_before_building_anything(monkeypatch):
+    """A rejected override must not strand envs built earlier in the loop.
+
+    The isolating env is ordered first, so an in-loop rejection of the shared
+    env's override would leave its owned snapshot open with no router to close.
+    """
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(
+            environments=[_db_env_params(), _det_env_params("det1", [_tool("t1")])]
+        )
+    )
+    builds = []
+    monkeypatch.setattr(
+        "oumi.core.synthesis.tool_router.build_environment",
+        lambda params: builds.append(params.id),
+    )
+
+    with pytest.raises(ValueError, match="shared across samples"):
+        router.for_sample({"det1": {"anything": 1}})
+
+    assert builds == []
+
+
 # ---------- close ----------
 
 

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -478,6 +478,34 @@ def test_for_sample_env_kwargs_override_rejects_unknown_env():
         router.for_sample({"nope": {"anything": 1}})
 
 
+def test_for_sample_closes_envs_it_built_when_a_later_build_fails(monkeypatch):
+    """A failed build must not strand the envs already rebuilt in that pass."""
+    router = ToolRouter.from_environment_config(
+        EnvironmentConfig(
+            environments=[_db_env_params(), _stateful_synth_env_params("stateful")]
+        )
+    )
+    built = []
+
+    def flaky_build(env_params):
+        if env_params.id == "stateful":
+            raise RuntimeError("boom")
+        env = Mock(spec=BaseEnvironment)
+        env.requires_isolation.return_value = True
+        built.append(env)
+        return env
+
+    monkeypatch.setattr(
+        "oumi.core.synthesis.tool_router.build_environment", flaky_build
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        router.for_sample()
+
+    assert len(built) == 1
+    built[0].close.assert_called_once()
+
+
 def test_for_sample_rejects_bad_override_before_building_anything(monkeypatch):
     """A rejected override must not strand envs built earlier in the loop.
 

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import FunctionCall, ToolCall
 
 try:
     verl_import_failed = False
@@ -152,3 +154,74 @@ def test_init_with_multiple_reward_funcs():
             train_dataset=MagicMock(),
             eval_dataset=MagicMock(),
         )
+
+
+def test_create_verl_data_entry_tool_agent_carries_metadata():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You can call run_sql."),
+            Message(role=Role.USER, content="How many rows in t?"),
+        ],
+        metadata={
+            "agent_name": "tool_agent",
+            "ground_truth": "SELECT count(*) FROM t",
+            "tools_kwargs": {
+                "run_sql": {
+                    "create_kwargs": {"schema_sql": "CREATE TABLE t(x INTEGER);"}
+                }
+            },
+        },
+    )
+    row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "nl2sql", "train"
+    )
+    assert row["agent_name"] == "tool_agent"
+    assert row["reward_model"]["ground_truth"] == "SELECT count(*) FROM t"
+    assert row["extra_info"]["need_tools_kwargs"] is True
+    assert "run_sql" in row["extra_info"]["tools_kwargs"]
+    assert row["prompt"][-1]["role"] == "user"
+
+
+def test_create_verl_data_entry_tool_agent_preserves_structured_history():
+    tool_call = ToolCall(
+        id="call_1",
+        function=FunctionCall(
+            name="run_sql", arguments='{"query":"SELECT count(*) FROM t"}'
+        ),
+    )
+    convo = Conversation(
+        messages=[
+            Message(role=Role.USER, content="How many rows in t?"),
+            Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call]),
+            Message(role=Role.TOOL, content='{"rows":[[2]]}', tool_call_id="call_1"),
+        ],
+        metadata={
+            "agent_name": "tool_agent",
+            "ground_truth": "SELECT count(*) FROM t",
+            "tools_kwargs": {"run_sql": {}},
+        },
+    )
+
+    row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _example(convo), 0, "nl2sql", "train"
+    )
+
+    assert row["prompt"] == [
+        {"role": "user", "content": "How many rows in t?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "run_sql",
+                        "arguments": '{"query":"SELECT count(*) FROM t"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": '{"rows":[[2]]}', "tool_call_id": "call_1"},
+    ]
+    assert json.loads(json.dumps(row["prompt"])) == row["prompt"]

--- a/tests/unit/core/trainers/verl_agentic/test_env_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_env_provider.py
@@ -1,0 +1,228 @@
+import gc
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from oumi.core.configs.environment_config import EnvironmentConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
+from oumi.core.synthesis import tool_router
+from oumi.core.synthesis.tool_router import ToolRouter
+from oumi.core.trainers.verl_agentic.env_provider import get_or_build_router
+from oumi.core.types.tool_call import ToolResult
+
+
+def run_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    """Local SQL executor; keeps this test independent of the nl2sql example."""
+    cursor = context.execute(arguments["query"])
+    columns = [d[0] for d in cursor.description] if cursor.description else []
+    rows = [list(r) for r in cursor.fetchall()]
+    return ToolResult(output={"columns": columns, "rows": rows})
+
+
+BASE = EnvironmentConfig(
+    environments=[
+        EnvironmentParams(
+            id="db",
+            env_type="database",
+            env_kwargs={"schema_sql": "CREATE TABLE t(x);"},
+            tools=[
+                {
+                    "id": "run_sql",
+                    "name": "run_sql",
+                    "description": "run sql",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                    "executor": f"{__name__}.run_sql",
+                    "read_only": True,
+                }
+            ],
+        )
+    ]
+)
+
+
+def _parent(cfg: EnvironmentConfig = BASE) -> ToolRouter:
+    """The process-wide template router that rollouts clone."""
+    return ToolRouter.from_environment_config(cfg)
+
+
+class _FakeAgentData(SimpleNamespace):
+    """Subclass so instances support weakref.finalize (bare SimpleNamespace doesn't)."""
+
+    request_id: str
+    tools_kwargs: dict[str, Any]
+
+
+def _agent_data(request_id: str):
+    return _FakeAgentData(
+        request_id=request_id,
+        tools_kwargs={
+            "run_sql": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2);",
+                }
+            }
+        },
+    )
+
+
+def test_same_request_id_returns_same_router():
+    ad = _agent_data("same-1")
+    parent = _parent()
+    r1 = get_or_build_router(ad, parent)
+    r2 = get_or_build_router(ad, parent)
+    assert r1 is r2
+
+
+def test_router_closed_and_evicted_when_agent_data_is_collected(monkeypatch):
+    request_id = "collected-1"
+    ad = _agent_data(request_id)
+    parent = _parent()
+    router = get_or_build_router(ad, parent)
+    closed = []
+    original_close = router.close
+
+    def close_spy():
+        closed.append(True)
+        original_close()
+
+    monkeypatch.setattr(router, "close", close_spy)
+
+    del ad
+    gc.collect()
+
+    assert closed == [True]
+
+    replacement_ad = _agent_data(request_id)
+    replacement_router = get_or_build_router(replacement_ad, parent)
+    assert replacement_router is not router
+
+    del replacement_ad
+    gc.collect()
+
+
+def test_router_routes_run_sql():
+    ad = _agent_data("routes-1")
+    router = get_or_build_router(ad, _parent())
+    out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
+    assert out.output == {"columns": ["count(*)"], "rows": [[2]]}
+
+
+def test_different_request_id_gets_isolated_router():
+    ad1 = _agent_data("iso-a")
+    ad2 = _agent_data("iso-b")
+    ad2.tools_kwargs["run_sql"]["create_kwargs"]["seed_sql"] = (
+        "INSERT INTO t VALUES (1),(2),(3);"
+    )
+    parent = _parent()
+    r1 = get_or_build_router(ad1, parent)
+    r2 = get_or_build_router(ad2, parent)
+    assert r1 is not r2
+    c1 = r1.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
+    c2 = r2.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0].output
+    assert c1 == {"columns": ["count(*)"], "rows": [[2]]}
+    assert c2 == {"columns": ["count(*)"], "rows": [[3]]}
+
+
+def test_db_path_create_kwargs_overrides_placeholder_schema(tmp_path):
+    # create_kwargs must replace env_kwargs to avoid setting both database sources.
+    db = tmp_path / "shared.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (9);")
+    conn.commit()
+    conn.close()
+    ad = _FakeAgentData(
+        request_id="dbpath-1",
+        tools_kwargs={"run_sql": {"create_kwargs": {"db_path": str(db)}}},
+    )
+    router = get_or_build_router(ad, _parent())
+    out = router.route_batch([("run_sql", {"query": "SELECT count(*) FROM t"})])[0]
+    assert out.output == {"columns": ["count(*)"], "rows": [[1]]}
+
+
+def _db_env_spec(env_id: str, tool_id: str) -> EnvironmentParams:
+    return EnvironmentParams(
+        id=env_id,
+        env_type="database",
+        env_kwargs={
+            "schema_sql": "CREATE TABLE t(x INTEGER);",
+            "seed_sql": "INSERT INTO t VALUES (7);",
+        },
+        tools=[
+            {
+                "id": tool_id,
+                "name": tool_id,
+                "description": "run sql",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "executor": f"{__name__}.run_sql",
+                "read_only": True,
+            }
+        ],
+    )
+
+
+def test_create_kwargs_scoped_to_owning_env_only():
+    # Only db_a's tool carries create_kwargs; db_b must keep its own configuration.
+    cfg = EnvironmentConfig(
+        environments=[
+            _db_env_spec("db_a", "q_a"),
+            _db_env_spec("db_b", "q_b"),
+        ]
+    )
+    ad = _FakeAgentData(
+        request_id="scope-1",
+        tools_kwargs={
+            "q_a": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2),(3),(4),(5);",
+                }
+            }
+        },
+    )
+    router = get_or_build_router(ad, _parent(cfg))
+    a = router.route_batch([("q_a", {"query": "SELECT count(*) FROM t"})])[0].output
+    b = router.route_batch([("q_b", {"query": "SELECT count(*) FROM t"})])[0].output
+    assert a == {"columns": ["count(*)"], "rows": [[5]]}
+    assert b == {"columns": ["count(*)"], "rows": [[1]]}
+
+
+def test_two_env_configs_in_one_rollout_is_rejected():
+    """Tools sharing a rollout share its router, so they must share one config."""
+    ad = _agent_data("two-configs-1")
+    get_or_build_router(ad, _parent())
+
+    with pytest.raises(ValueError, match="must share a single environment config"):
+        get_or_build_router(ad, _parent())
+
+
+def test_each_rollout_builds_its_envs_exactly_once(monkeypatch):
+    """Rollouts clone one parent, so no env is built and thrown away per rollout."""
+    parent = _parent()
+    builds: list[str] = []
+    original_build = tool_router.build_environment
+
+    def counting_build(env_params):
+        builds.append(env_params.id)
+        return original_build(env_params)
+
+    monkeypatch.setattr(tool_router, "build_environment", counting_build)
+
+    ad1, ad2 = _agent_data("count-a"), _agent_data("count-b")
+    get_or_build_router(ad1, parent)
+    get_or_build_router(ad2, parent)
+
+    assert builds == ["db", "db"]
+
+    del ad1, ad2
+    gc.collect()

--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -1,0 +1,119 @@
+import asyncio
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from oumi.core.types.tool_call import ToolResult
+
+pytest.importorskip("verl")
+
+from verl.tools.schemas import (  # pyright: ignore[reportMissingImports]
+    OpenAIFunctionToolSchema,
+)
+
+from oumi.core.trainers.verl_agentic.oumi_verl_tool import OumiVerlTool
+
+
+def run_sql(arguments: dict, context: sqlite3.Connection) -> ToolResult:
+    """Local SQL executor; keeps this test independent of the nl2sql example."""
+    cursor = context.execute(arguments["query"])
+    columns = [d[0] for d in cursor.description] if cursor.description else []
+    rows = [list(r) for r in cursor.fetchall()]
+    return ToolResult(output={"columns": columns, "rows": rows})
+
+
+class _FakeAgentData(SimpleNamespace):
+    """A weak-referenceable agent data stub."""
+
+
+def _make_tool(tmp_path) -> OumiVerlTool:
+    cfg_path = tmp_path / "env.yaml"
+    cfg_path.write_text(
+        "environments:\n- id: db\n  name: db\n  description: test db\n"
+        "  env_type: database\n"
+        "  env_kwargs: {schema_sql: 'CREATE TABLE t(x);'}\n"
+        "  tools:\n  - {id: run_sql, name: run_sql, description: run,\n"
+        "     parameters: {type: object, properties: {query: {type: string}}, "
+        "required: [query]},\n"
+        f"     executor: {__name__}.run_sql, read_only: true}}\n"
+    )
+    schema = OpenAIFunctionToolSchema.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": "run_sql",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    )
+    return OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
+
+
+def _agent_data(request_id: str) -> _FakeAgentData:
+    return _FakeAgentData(
+        request_id=request_id,
+        extra_fields={},
+        tools_kwargs={
+            "run_sql": {
+                "create_kwargs": {
+                    "schema_sql": "CREATE TABLE t(x INTEGER);",
+                    "seed_sql": "INSERT INTO t VALUES (1),(2);",
+                }
+            }
+        },
+    )
+
+
+def test_execute_routes_into_shared_env(tmp_path):
+    tool = _make_tool(tmp_path)
+    ad = _agent_data("execute-routes-into-shared-env")
+
+    iid, _ = asyncio.run(tool.create())
+    resp, reward, _metrics = asyncio.run(
+        tool.execute(iid, {"query": "SELECT count(*) FROM t"}, agent_data=ad)
+    )
+    assert reward == 0.0
+    assert "2" in resp.text
+
+
+def test_invalid_env_config_is_rejected_at_construction(tmp_path):
+    """The config is validated when the tool is built, not mid-rollout."""
+    cfg_path = tmp_path / "env.yaml"
+    cfg_path.write_text(
+        "environments:\n- id: db\n  name: db\n  description: d\n  env_type: nope\n"
+    )
+    schema = OpenAIFunctionToolSchema.model_validate(
+        {"type": "function", "function": {"name": "run_sql"}}
+    )
+
+    with pytest.raises(ValueError, match="Unknown env_type 'nope'"):
+        OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
+
+
+def test_tool_name_missing_from_env_config_is_rejected_at_construction(tmp_path):
+    """The name is spelled out twice; a mismatch must not wait for the first call."""
+    tool = _make_tool(tmp_path)
+    schema = OpenAIFunctionToolSchema.model_validate(
+        {"type": "function", "function": {"name": "run_sqll"}}
+    )
+
+    with pytest.raises(ValueError, match="Known tools: \\['run_sql'\\]"):
+        OumiVerlTool(config=tool.config, tool_schema=schema)
+
+
+def test_failed_tool_call_becomes_an_observation(tmp_path):
+    """A bad tool call must not propagate and kill the rollout."""
+    tool = _make_tool(tmp_path)
+    ad = _agent_data("failed-tool-call-becomes-an-observation")
+
+    iid, _ = asyncio.run(tool.create())
+    resp, reward, _metrics = asyncio.run(
+        tool.execute(iid, {"query": "NOT VALID SQL"}, agent_data=ad)
+    )
+    assert reward == 0.0
+    assert resp.text.startswith("Tool error:")


### PR DESCRIPTION
## Review scope

@shanghongsim #2560 landed on this branch instead of main, so the two halves are folded back together here.

| Part | Files | Status |
| --- | --- | --- |
| verl adapter | `core/trainers/verl_agentic/*`, `verl_grpo_trainer.py` + tests | **approved** in #2560, squash-merged here as `c8378cd` |
| `for_sample(env_kwargs_by_env_id)` | `core/synthesis/tool_router.py` + `test_tool_router.py` | **needs review** — the piece you asked to split out |

Two files: commits `3c4503f`, `3d76881`, `35628a5`, plus round 2 below.

## Round 2 — your review

| Feedback | Commit |
| --- | --- |
| `env_kwargs_by_env` → `env_kwargs_by_env_id`, keyed by id not object | `9a6f8b2` |
| "What do you mean by *no router escapes to close these*?" — teardown comment reworded | `21fdbe9` |
| Enterprise dependency ⇒ higher testing bar | `b9d2873`, `d80da8a` |

On the enterprise question: the api worker's `synth_generate_dataset_activity` drives `ConversationSynthesizer`, which is the only existing `for_sample()` caller, and it calls the zero-arg form. So the path is reached but unchanged. Rather than rest on "additive default", the cross-sample invariants are now pinned (see test plan). Two of them were genuine holes: swapping the teardown loop to `env_by_id_new.values()`, or replacing `built_here` with a `requires_isolation()` filter, each passed the full suite before these tests.

## The part under review

A caller with per-sample environment data, the database one RL rollout should query, had no way in. `env_kwargs` lives on the config, so it had to deep-copy the whole `EnvironmentConfig` (every tool schema and inline lookup table), rewrite one env's kwargs, and build a fresh router per sample, discarding a freshly-built template env each time.

`for_sample()` now takes that data directly:

```python
router.for_sample({"nl2sql_db": {"db_path": row_db_path}})
```

Two guards, both raising rather than silently no-opping: unknown environment ids, and **shared** (non-isolating) envs, where an override would apply to every sample instead of one. Both run before the first build, so a rejected override can't strand an env this pass already rebuilt. On that path `for_sample` raises without returning, so no router would ever close it and a database env would leave its snapshot on disk. A mid-loop `build_environment` failure is handled the same way: whatever the pass built is closed on the way out.

Default is `None`, so `for_sample()` behaves exactly as before and the synthesizer is untouched.

## The approved part, for context

`OumiVerlTool` connects verl's tool-RL loop to any Oumi executable environment: the policy model makes a tool call, the call runs for real against a live environment, and the trajectory is scored into a training signal. Nothing in the adapter is tied to a particular tool or domain.

```
Policy model → verl ToolAgentLoop → OumiVerlTool.execute
  → env_provider.get_or_build_router (keyed by request_id)
  → ToolRouter.route_batch → ExecutableEnvironment.step → executor
```

- One `ToolRouter` per rollout, keyed by `request_id` in a module-level registry. The router holds live environment connections, which aren't picklable, so it stays off `agent_data` (the trajectory is serialized and shipped to a separate reward worker). Teardown runs on `weakref.finalize` at the rollout boundary.
- The parent router is built once per env-config path; every rollout is a `for_sample()` clone carrying its own `create_kwargs`. One env per isolating environment per rollout, so nothing is built and discarded, shared envs are never rebuilt, and the config is never copied.
- Rows tagged `agent_name: tool_agent` skip the usual conversation-to-verl converter: the branch packs the prompt inline, forwards `tools_kwargs`, and reads `ground_truth` from metadata. Any tool-agent dataset flows through it, so this PR carries no `grpo_utils` changes.

## Test plan

Full CPU suite green in CI (`static-checks` runs pre-commit plus `pytest`).

- `test_tool_router.py`: an override rebuilds the isolated env with the sample's data and leaves the parent's params intact; shared env and unknown env id are rejected; neither rejection builds anything; a failed build closes what the pass built. Round 2 adds the cross-sample invariants: an override doesn't leak into the next sample off the same parent, overriding one env doesn't retarget its sibling isolating envs, a failed build leaves the parent's shared envs open, and a failed `on_env_built` closes the env it fired on.
- `test_env_provider.py`: the same `request_id` shares a router; different `request_id`s get independently-seeded isolated envs; each rollout builds its envs exactly once (counts `build_environment` calls); two env configs in one rollout are rejected. Runs in CPU CI, since it doesn't import verl.
- `test_oumi_verl_tool.py`: the adapter routes a call through the rollout's shared router; an invalid env config and an unknown tool name are rejected at construction. Gated on `importorskip("verl")`, and verl sits in the `gpu` extra, so this skips in CPU CI and runs only where verl is installed (scheduled GPU job, or the cluster). Verified against a stubbed verl locally and end to end on the cluster.
- `test_verl_grpo_trainer.py::test_tool_agent_row_carries_agent_name_and_tools_kwargs`.

## Validation



Validated end to end on real Spider (Qwen2.5-3B-Instruct, 8×H100, verl 0.7.1, 100 GRPO steps over 6,997 train rows):

- **Training curve**, `sql_execution_match` on the **full 1,034-row dev set**: 0.394 → 0.696 → 0.681 → **0.716** (evals every 25 steps).
- **Independent evaluation of the saved checkpoint**: reloaded `global_step_100` in a fresh process across all 8 ranks and re-scored the full dev set → **0.735**. This is the load-bearing check: the improvement is in the weights, not in the training loop's own reporting.
- **Audited 200 validation generations**: every one produced a real query, and none of the scoring answers were literal value echoes, so the reward is not being gamed. 143 of 144 scoring trajectories used exactly one `run_sql` call.

Metrics are in the internal W&B project `oumi-nl2sql-verl` (runs `6zk6dwhp` for training, `hk65jihf` for the checkpoint evaluation and the generation table).

Caveats, stated up front:

- This is our execution-match reward, **not** the official Spider `evaluation.py` metric, so it is not comparable to published Spider numbers. It compares result sets on a single database instance, and 39.5% of dev golds return a single scalar, so a semantically wrong query can still score. Test-suite accuracy is the follow-up.
- **Single seed**, no confidence intervals. The last three evals (0.696 / 0.681 / 0.716) sit within the late-phase step-to-step reward noise (σ ≈ 0.05), so read this as a plateau around 0.68–0.73 rather than a converged figure.
- `actor/entropy` collapses 0.408 → 0.040 (`entropy_coeff: 0`, `use_kl_loss: false`), which is consistent with that plateau — more steps will not help without a KL or entropy term.
- No no-tool ablation, so this does **not** establish that the tool caused the gain.

It demonstrates that the integration trains end to end and the reward improves — not a benchmark result.

Tested stack (required): verl **0.7.1** (`<0.8`), vllm 0.14.0, ray 2.56.1, torch 2.9.1+cu128, **trl 0.19.1** — trl must be `<0.20` because verl 0.7.1 imports `trl.AutoModelForCausalLMWithValueHead`. Multi-GPU additionally requires `NCCL_NVLS_ENABLE=0` on hosts where NVLS multicast cannot bind.

## Follow-up

#2571 — `route_batch` runs synchronously inside `async execute`, so a slow environment blocks verl's agent-loop event loop. Deferred: `asyncio.to_thread` isn't a valid fix (the SQLite connection is thread-pinned), so it needs a per-router worker thread and its own cluster validation.

## Related — split of #2544

1. **#2569 (this)** — `for_sample(env_kwargs_by_env_id)`, plus the approved #2560 adapter merged in here.
2. #2561 — NL2SQL `run_sql` executor + `sql_execution_match` reward. Independent, base main.
3. #2562 — Spider demo configs + row builder. Merge last (its configs reference this PR and #2561).


