### PR TITLE
fix(launcher): reserve CPU/memory on Modal sandboxes from JobConfig resources

### DIFF
--- a/src/oumi/launcher/clients/modal_client.py
+++ b/src/oumi/launcher/clients/modal_client.py
@@ -20,11 +20,11 @@ beyond the calling Python process. ``ModalClient`` translates a
 ``JobConfig`` into a sandbox launch and exposes status/cancel/log
 primitives via the sandbox's opaque ``object_id``.
 
-Image, GPU, secrets, and a workspace-scoped HuggingFace cache volume
-are derived from the ``JobConfig`` at launch time. ``setup`` and
-``run`` are concatenated into a single shell script and executed
-together inside the sandbox so secrets injected via ``modal.Secret``
-are visible (image-build time has no secrets attached). Sandboxes are
+Image, GPU, CPU/memory reservations, secrets, and a workspace-scoped
+HuggingFace cache volume are derived from the ``JobConfig`` at launch
+time. ``setup`` and ``run`` are concatenated into a single shell script
+and executed together inside the sandbox so secrets injected via
+``modal.Secret`` are visible (image-build time has no secrets attached). Sandboxes are
 tagged with the caller's logical cluster name so ``ModalCluster.down()``
 can find and terminate them across worker restarts.
 """
@@ -140,6 +140,21 @@ def _build_secret(modal_lib: Any, envs: dict[str, str]) -> Any | None:
     return modal_lib.Secret.from_dict({k: str(v) for k, v in envs.items()})
 
 
+def _parse_resource_count(value: str | None) -> float | None:
+    """Parses a SkyPilot-style resource count ("16", "16+") to a float.
+
+    Returns None for absent or unparseable values so the caller falls
+    back to Modal's defaults rather than failing the launch.
+    """
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return float(str(value).strip().rstrip("+"))
+    except ValueError:
+        logger.warning(f"Ignoring unparseable Modal resource request: {value!r}")
+        return None
+
+
 _LAUNCHER_APP_NAME = "oumi-launcher"
 
 #: Tag key applied to every sandbox at launch time. Used by
@@ -210,6 +225,13 @@ class ModalClient:
         gpu = job.resources.accelerators
         timeout = int(kwargs.get("timeout", _DEFAULT_TIMEOUT_S))
 
+        # Without an explicit reservation Modal grants only a burstable CPU
+        # sliver (nproc=1 observed), so dependency install and S3 transfer
+        # speed depend on host contention — minutes on an idle host, hours
+        # on a busy one.
+        cpu = _parse_resource_count(job.resources.cpus)
+        memory_gib = _parse_resource_count(job.resources.memory)
+
         # ``setup`` runs inside the sandbox (not at image-build time) so
         # secrets injected via ``modal.Secret`` are visible.
         cleaned_setup = _strip_sudo(job.setup) if job.setup else ""
@@ -235,6 +257,8 @@ class ModalClient:
             app=app,
             image=image,
             gpu=gpu,
+            cpu=cpu,
+            memory=int(memory_gib * 1024) if memory_gib else None,
             secrets=[secret] if secret else [],
             timeout=timeout,
             volumes={_HF_CACHE_MOUNT_PATH: hf_cache_volume},

--- a/tests/unit/launcher/clients/test_modal_client.py
+++ b/tests/unit/launcher/clients/test_modal_client.py
@@ -25,6 +25,8 @@ def _job(cloud: str = "modal", **overrides) -> JobConfig:
         cloud=cloud,
         accelerators=overrides.pop("accelerators", "H100:8"),
         image_id=overrides.pop("image_id", None),
+        cpus=overrides.pop("cpus", None),
+        memory=overrides.pop("memory", None),
     )
     return JobConfig(
         name=overrides.pop("name", "myjob"),
@@ -105,6 +107,29 @@ def test_launch_mounts_hf_cache_volume(fake_modal):
     )
     _, kwargs = fake_modal.Sandbox.create.call_args
     assert "/root/.cache/huggingface" in kwargs["volumes"]
+
+
+def test_launch_reserves_cpu_and_memory_from_resources(fake_modal):
+    """CPU/memory requests flow through so the sandbox isn't left on Modal's
+    burstable-sliver default (SkyPilot-style "+" modifiers are accepted)."""
+    with patch(
+        "oumi.launcher.clients.modal_client._import_modal", return_value=fake_modal
+    ):
+        ModalClient().launch(_job(cpus="16+", memory="64"))
+    _, kwargs = fake_modal.Sandbox.create.call_args
+    assert kwargs["cpu"] == 16.0
+    assert kwargs["memory"] == 64 * 1024
+
+
+def test_launch_leaves_cpu_and_memory_unset_when_absent(fake_modal):
+    """Absent or unparseable requests fall back to Modal's defaults."""
+    with patch(
+        "oumi.launcher.clients.modal_client._import_modal", return_value=fake_modal
+    ):
+        ModalClient().launch(_job(cpus="not-a-number"))
+    _, kwargs = fake_modal.Sandbox.create.call_args
+    assert kwargs["cpu"] is None
+    assert kwargs["memory"] is None
 
 
 def test_launch_default_image_is_cuda_devel_with_nvcc(fake_modal):


### PR DESCRIPTION
# Description

`ModalClient.launch` now passes `cpu`/`memory` from `job.resources` to `Sandbox.create`. SkyPilot-style `"16+"` modifiers are accepted; absent or unparseable values keep Modal's defaults, so existing callers are unchanged.

Without a reservation Modal grants only a burstable CPU sliver — a production-mirror sandbox reports `nproc=1` — so dependency install and S3 transfer speed depend on host contention: the identical setup script took ~2 minutes on an idle host and multiple hours on a contended one. With `cpu=16, memory=64GiB` the install is deterministic ~2 minutes.

## Related issues

Internal: LOU-3182.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?