### PR TITLE
Apply argument defaults in deterministic environments

### DIFF
--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -37,7 +37,10 @@ def _fill_argument_defaults(
     arguments: dict[str, Any],
     schema: dict[str, Any],
 ) -> dict[str, Any]:
-    """Return a copy of arguments with JSON Schema property defaults applied."""
+    """Return a copy of arguments with JSON Schema property defaults applied.
+
+    An absent object property is only created if it declares its own ``default``.
+    """
     result = dict(arguments)
     properties = schema.get("properties", {})
     if not isinstance(properties, dict):
@@ -108,8 +111,9 @@ class DeterministicEnvironment(BaseEnvironment):
         """Initialize a DeterministicEnvironment."""
         self._params = params
         self._kwargs = kwargs
-        self._tools_by_id = {tool.id: tool for tool in params.tools}
-        self._tool_ids = set(self._tools_by_id)
+        self._tools_by_id: dict[str, ToolParams] = {
+            tool.id: tool for tool in params.tools
+        }
         self._validate_lookup_table()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
@@ -117,15 +121,13 @@ class DeterministicEnvironment(BaseEnvironment):
         return [self._resolve_one(tool_id, args) for tool_id, args in calls]
 
     def _resolve_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        if tool_id not in self._tool_ids:
+        tool = self._tools_by_id.get(tool_id)
+        if tool is None:
             raise ValueError(
                 f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
-                f"Available tools: {sorted(self._tool_ids)}"
+                f"Available tools: {sorted(self._tools_by_id)}"
             )
-        arguments = _fill_argument_defaults(
-            arguments,
-            self._tools_by_id[tool_id].parameters,
-        )
+        arguments = _fill_argument_defaults(arguments, tool.parameters)
         entries = self._kwargs.lookup_table.get(tool_id, [])
         for entry in entries:
             if entry.matches(arguments):
@@ -192,10 +194,11 @@ class DeterministicEnvironment(BaseEnvironment):
         - Stale ``lookup_table`` keys (no matching tool): log a warning;
           entries are dormant.
         - Tools without entries: hard error.
+        - Entry inputs are normalized in place with schema defaults.
         - Duplicate inputs within a tool's entries: hard error.
         """
         for tool_id in self._kwargs.lookup_table:
-            if tool_id not in self._tool_ids:
+            if tool_id not in self._tools_by_id:
                 logger.warning(
                     "Environment '%s': lookup_table.'%s' references unknown "
                     "tool. Entries will be ignored.",

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -34,28 +34,133 @@ from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.utils import parse_env_kwargs
 from oumi.utils.logging import logger
 
+# Keywords whose value is a subschema, a list of them, or a map of them. Only
+# these are walked, so instance data never gets read as a declaration.
+# ``$defs``/``definitions`` are absent: inert until reached through a ``$ref``.
+_SUBSCHEMA = frozenset(
+    {
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+_SUBSCHEMA_LIST = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_SUBSCHEMA_MAP = frozenset({"dependentSchemas", "patternProperties", "properties"})
+
+
+def _resolve_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a local ``$ref`` against ``root``, with sibling keys winning.
+
+    Pydantic emits ``{"$ref": ..., "default": ...}`` for a nested model, so the
+    sibling ``default`` must override the target's. Non-local or dangling refs
+    are returned untouched — ``jsonschema`` still validates them, they just
+    contribute no defaults.
+    """
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#"):
+        return schema
+    target: Any = root
+    for part in ref[1:].split("/"):
+        if not part:  # Leading empty segment, or the whole-document ref "#".
+            continue
+        part = part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(target, dict) or part not in target:
+            return schema
+        target = target[part]
+    if not isinstance(target, dict):
+        return schema
+    return {**target, **{k: v for k, v in schema.items() if k != "$ref"}}
+
 
 def _fill_argument_defaults(
     arguments: dict[str, Any],
     schema: dict[str, Any],
+    root: dict[str, Any] | None = None,
+    seen: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Return a copy of arguments with JSON Schema property defaults applied.
 
     An absent object property is only created if it declares its own ``default``.
+    Local ``$ref``s are resolved so pydantic-generated schemas fill like inline
+    ones. Depth follows the arguments, except that a default is never inserted
+    through a ``$ref`` already on the path — a self-referential default would
+    otherwise expand forever.
     """
-    result = dict(arguments)
-    properties = schema.get("properties", {})
+    if root is None:
+        root = schema
+    result = copy.deepcopy(arguments)
+    properties = _resolve_ref(schema, root).get("properties", {})
     if not isinstance(properties, dict):
         return result
 
     for name, property_schema in properties.items():
         if not isinstance(property_schema, dict):
             continue
-        if name not in result and "default" in property_schema:
+        ref = property_schema.get("$ref")
+        property_schema = _resolve_ref(property_schema, root)
+        cyclic = isinstance(ref, str) and ref in seen
+        if name not in result and "default" in property_schema and not cyclic:
             result[name] = copy.deepcopy(property_schema["default"])
         if isinstance(result.get(name), dict):
-            result[name] = _fill_argument_defaults(result[name], property_schema)
+            result[name] = _fill_argument_defaults(
+                result[name],
+                property_schema,
+                root,
+                seen | {ref} if isinstance(ref, str) else seen,
+            )
     return result
+
+
+def _unfillable_default_paths(
+    node: Any,
+    path: str,
+    root: dict[str, Any],
+    reachable: bool = True,
+    seen: frozenset[tuple[str, bool]] = frozenset(),
+) -> list[str]:
+    """Find schema paths where a ``default`` would never be filled.
+
+    ``_fill_argument_defaults`` only descends ``properties`` chains (through
+    ``$ref``), so a ``default`` under ``items``/``anyOf``/``allOf`` is dead.
+    """
+    if not isinstance(node, dict):
+        return []
+
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        # Keyed on reachability too: one ``$ref`` can be reached both ways.
+        if (ref, reachable) in seen:
+            return []
+        node, seen = _resolve_ref(node, root), seen | {(ref, reachable)}
+
+    found: list[str] = []
+    if not reachable and "default" in node:
+        found.append(f"{path}.default")
+    for key, value in node.items():
+        if key in _SUBSCHEMA:
+            found += _unfillable_default_paths(
+                value, f"{path}.{key}", root, False, seen
+            )
+        elif key in _SUBSCHEMA_LIST and isinstance(value, list):
+            for index, item in enumerate(value):
+                found += _unfillable_default_paths(
+                    item, f"{path}.{key}[{index}]", root, False, seen
+                )
+        elif key in _SUBSCHEMA_MAP and isinstance(value, dict):
+            child_reachable = reachable and key == "properties"
+            for name, subschema in value.items():
+                found += _unfillable_default_paths(
+                    subschema, f"{path}.{key}.{name}", root, child_reachable, seen
+                )
+    return found
 
 
 @dataclass
@@ -198,8 +303,9 @@ class DeterministicEnvironment(BaseEnvironment):
         """Validate the env's lookup_table against its tool list.
 
         - Stale ``lookup_table`` keys (no matching tool): log a warning;
-          entries are dormant.
+          entries are dormant and are not normalized.
         - Tools without entries: hard error.
+        - Schema defaults that default-filling can never reach: hard error.
         - Entry inputs are normalized in place with schema defaults.
         - Duplicate inputs within a tool's entries: hard error.
         """
@@ -217,6 +323,16 @@ class DeterministicEnvironment(BaseEnvironment):
                 raise ValueError(
                     f"Tool '{tool.id}' has no entries in lookup_table for "
                     f"environment '{self._params.id}'."
+                )
+            unfillable = _unfillable_default_paths(
+                tool.parameters, "parameters", tool.parameters
+            )
+            if unfillable:
+                raise ValueError(
+                    f"Tool '{tool.id}' in environment '{self._params.id}' declares "
+                    f"schema defaults that are never applied, at "
+                    f"{sorted(unfillable)}. Defaults are only filled along "
+                    f"'properties' chains; move them onto a property."
                 )
             seen: set[str] = set()
             for entry in entries:

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import json
 import random
@@ -30,6 +31,26 @@ from oumi.core.registry import register_environment
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
+
+
+def _fill_argument_defaults(
+    arguments: dict[str, Any],
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a copy of arguments with JSON Schema property defaults applied."""
+    result = dict(arguments)
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return result
+
+    for name, property_schema in properties.items():
+        if not isinstance(property_schema, dict):
+            continue
+        if name not in result and "default" in property_schema:
+            result[name] = copy.deepcopy(property_schema["default"])
+        if isinstance(result.get(name), dict):
+            result[name] = _fill_argument_defaults(result[name], property_schema)
+    return result
 
 
 @dataclass
@@ -87,7 +108,8 @@ class DeterministicEnvironment(BaseEnvironment):
         """Initialize a DeterministicEnvironment."""
         self._params = params
         self._kwargs = kwargs
-        self._tool_ids = {tool.id for tool in params.tools}
+        self._tools_by_id = {tool.id: tool for tool in params.tools}
+        self._tool_ids = set(self._tools_by_id)
         self._validate_lookup_table()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
@@ -100,6 +122,10 @@ class DeterministicEnvironment(BaseEnvironment):
                 f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
                 f"Available tools: {sorted(self._tool_ids)}"
             )
+        arguments = _fill_argument_defaults(
+            arguments,
+            self._tools_by_id[tool_id].parameters,
+        )
         entries = self._kwargs.lookup_table.get(tool_id, [])
         for entry in entries:
             if entry.matches(arguments):
@@ -185,6 +211,7 @@ class DeterministicEnvironment(BaseEnvironment):
                 )
             seen: set[str] = set()
             for entry in entries:
+                entry.input = _fill_argument_defaults(entry.input, tool.parameters)
                 key = entry.input_key()
                 if key in seen:
                     raise ValueError(

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -34,9 +34,7 @@ from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.utils import parse_env_kwargs
 from oumi.utils.logging import logger
 
-# Keywords whose value is a subschema, a list of them, or a map of them. Only
-# these are walked, so instance data never gets read as a declaration.
-# ``$defs``/``definitions`` are absent: inert until reached through a ``$ref``.
+# JSON Schema keywords whose values contain subschemas.
 _SUBSCHEMA = frozenset(
     {
         "additionalItems",
@@ -57,19 +55,13 @@ _SUBSCHEMA_MAP = frozenset({"dependentSchemas", "patternProperties", "properties
 
 
 def _resolve_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
-    """Resolve a local ``$ref`` against ``root``, with sibling keys winning.
-
-    Pydantic emits ``{"$ref": ..., "default": ...}`` for a nested model, so the
-    sibling ``default`` must override the target's. Non-local or dangling refs
-    are returned untouched — ``jsonschema`` still validates them, they just
-    contribute no defaults.
-    """
+    """Resolve a local ``$ref``, preserving sibling overrides."""
     ref = schema.get("$ref")
     if not isinstance(ref, str) or not ref.startswith("#"):
         return schema
     target: Any = root
     for part in ref[1:].split("/"):
-        if not part:  # Leading empty segment, or the whole-document ref "#".
+        if not part:
             continue
         part = part.replace("~1", "/").replace("~0", "~")
         if not isinstance(target, dict) or part not in target:
@@ -86,14 +78,7 @@ def _fill_argument_defaults(
     root: dict[str, Any] | None = None,
     seen: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
-    """Return a copy of arguments with JSON Schema property defaults applied.
-
-    An absent object property is only created if it declares its own ``default``.
-    Local ``$ref``s are resolved so pydantic-generated schemas fill like inline
-    ones. Depth follows the arguments, except that a default is never inserted
-    through a ``$ref`` already on the path — a self-referential default would
-    otherwise expand forever.
-    """
+    """Return a copy of arguments with property defaults applied recursively."""
     if root is None:
         root = schema
     result = copy.deepcopy(arguments)
@@ -126,17 +111,12 @@ def _unfillable_default_paths(
     reachable: bool = True,
     seen: frozenset[tuple[str, bool]] = frozenset(),
 ) -> list[str]:
-    """Find schema paths where a ``default`` would never be filled.
-
-    ``_fill_argument_defaults`` only descends ``properties`` chains (through
-    ``$ref``), so a ``default`` under ``items``/``anyOf``/``allOf`` is dead.
-    """
+    """Find defaults outside ``properties`` chains."""
     if not isinstance(node, dict):
         return []
 
     ref = node.get("$ref")
     if isinstance(ref, str):
-        # Keyed on reachability too: one ``$ref`` can be reached both ways.
         if (ref, reachable) in seen:
             return []
         node, seen = _resolve_ref(node, root), seen | {(ref, reachable)}
@@ -300,15 +280,7 @@ class DeterministicEnvironment(BaseEnvironment):
         return cls(params, kwargs)
 
     def _validate_lookup_table(self) -> None:
-        """Validate the env's lookup_table against its tool list.
-
-        - Stale ``lookup_table`` keys (no matching tool): log a warning;
-          entries are dormant and are not normalized.
-        - Tools without entries: hard error.
-        - Schema defaults that default-filling can never reach: hard error.
-        - Entry inputs are normalized in place with schema defaults.
-        - Duplicate inputs within a tool's entries: hard error.
-        """
+        """Validate and normalize the lookup table."""
         for tool_id in self._kwargs.lookup_table:
             if tool_id not in self._tools_by_id:
                 logger.warning(
@@ -330,9 +302,9 @@ class DeterministicEnvironment(BaseEnvironment):
             if unfillable:
                 raise ValueError(
                     f"Tool '{tool.id}' in environment '{self._params.id}' declares "
-                    f"schema defaults that are never applied, at "
+                    "schema defaults that are never applied, at "
                     f"{sorted(unfillable)}. Defaults are only filled along "
-                    f"'properties' chains; move them onto a property."
+                    "'properties' chains; move them onto a property."
                 )
             seen: set[str] = set()
             for entry in entries:

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -157,11 +157,7 @@ def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
     tool = _make_tool(
         parameters={
             "type": "object",
-            "properties": {
-                "location": {"type": "string"},
-                "unit": {"type": "string", "default": "fahrenheit"},
-            },
-            "required": ["location"],
+            "properties": {"unit": {"type": "string", "default": "celsius"}},
         }
     )
 
@@ -171,108 +167,38 @@ def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
                 tools=[tool],
                 lookup_table={
                     "tool1": [
-                        ToolLookupEntry(
-                            input={"location": "sf"},
-                            output={"temperature": 65},
-                        ),
-                        ToolLookupEntry(
-                            input={"location": "sf", "unit": "fahrenheit"},
-                            output={"temperature": 65},
-                        ),
+                        ToolLookupEntry(input={}, output={"value": 1}),
+                        ToolLookupEntry(input={"unit": "celsius"}, output={"value": 2}),
                     ]
                 },
             )
         )
 
 
-# --- unreachable schema defaults ---
-
-
 @pytest.mark.parametrize(
-    "parameters,expected_path",
+    "keyword,subschema,path_suffix",
     [
-        pytest.param(
-            {
-                "type": "object",
-                "properties": {
-                    "unit": {
-                        "anyOf": [
-                            {"type": "string", "default": "fahrenheit"},
-                            {"type": "null"},
-                        ]
-                    }
-                },
-            },
-            "parameters.properties.unit.anyOf[0].default",
-            id="anyOf",
-        ),
-        pytest.param(
-            {
-                "type": "object",
-                "properties": {
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string", "default": "all"},
-                    }
-                },
-            },
-            "parameters.properties.tags.items.default",
-            id="items",
-        ),
-        pytest.param(
-            {
-                "$defs": {
-                    "Item": {
-                        "type": "object",
-                        "properties": {"enum": {"type": "string", "default": "x"}},
-                    }
-                },
-                "type": "object",
-                "properties": {
-                    "children": {"type": "array", "items": {"$ref": "#/$defs/Item"}}
-                },
-            },
-            "parameters.properties.children.items.properties.enum.default",
-            id="property-named-like-a-keyword",
-        ),
-        pytest.param(
-            # `list[Node]` on a recursive pydantic model: the same `$ref` is
-            # reached both fillably and not, so the cycle guard must key on both.
-            {
-                "$defs": {
-                    "Node": {
-                        "type": "object",
-                        "properties": {
-                            "label": {"type": "string", "default": "leaf"},
-                            "children": {
-                                "type": "array",
-                                "default": [],
-                                "items": {"$ref": "#/$defs/Node"},
-                            },
-                        },
-                    }
-                },
-                "type": "object",
-                "properties": {"root": {"$ref": "#/$defs/Node"}},
-            },
-            "parameters.properties.root.properties.children.items"
-            ".properties.label.default",
-            id="recursive-model-under-items",
-        ),
+        ("allOf", [{"type": "string", "default": "x"}], "allOf[0].default"),
+        ("anyOf", [{"type": "string", "default": "x"}], "anyOf[0].default"),
+        ("oneOf", [{"type": "string", "default": "x"}], "oneOf[0].default"),
+        ("items", {"type": "string", "default": "x"}, "items.default"),
     ],
 )
-def test_unreachable_schema_default_raises(parameters, expected_path):
-    """A default off the `properties` chain errors at construction, not at lookup."""
+def test_unreachable_schema_default_raises(keyword, subschema, path_suffix):
+    parameters = {
+        "type": "object",
+        "properties": {"value": {keyword: subschema}},
+    }
+
     with pytest.raises(ValueError, match="never applied") as excinfo:
         DeterministicEnvironment.from_params(
             _make_params(tools=[_make_tool(parameters=parameters)])
         )
-    assert expected_path in str(excinfo.value)
+    assert f"parameters.properties.value.{path_suffix}" in str(excinfo.value)
     assert "tool1" in str(excinfo.value)
 
 
 def test_combinator_without_defaults_is_accepted():
-    """Only a hidden default is an error; `anyOf` on its own stays usable."""
     tool = _make_tool(
         parameters={
             "type": "object",
@@ -285,277 +211,31 @@ def test_combinator_without_defaults_is_accepted():
     assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output={"msg": "ok"})]
 
 
-def test_pydantic_style_ref_schema_fills_nested_defaults():
-    """`model_json_schema()` emits `$ref` + `$defs`; defaults must still fill."""
+def test_defaults_are_filled_through_local_ref():
     tool = _make_tool(
         parameters={
             "type": "object",
             "$defs": {
                 "Opts": {
                     "type": "object",
-                    "properties": {"unit": {"type": "string", "default": "fahrenheit"}},
-                }
-            },
-            "properties": {
-                "location": {"type": "string"},
-                "opts": {"$ref": "#/$defs/Opts", "default": {"unit": "fahrenheit"}},
-            },
-            "required": ["location"],
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(input={"location": "sf"}, output={"msg": "ok"})
-                ]
-            },
-        )
-    )
-
-    # Both the absent `opts` and an explicit empty one resolve to the same row.
-    assert env.step([("tool1", {"location": "sf"})]) == [
-        ToolResult(output={"msg": "ok"})
-    ]
-    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
-        ToolResult(output={"msg": "ok"})
-    ]
-
-
-def test_ref_without_sibling_default_fills_through_target():
-    """A bare `$ref` parent fills from the target's own `default`."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "$defs": {
-                "Opts": {
-                    "type": "object",
-                    "default": {},
                     "properties": {"unit": {"type": "string", "default": "celsius"}},
                 }
             },
-            "properties": {"opts": {"$ref": "#/$defs/Opts"}},
+            "properties": {"opts": {"$ref": "#/$defs/Opts", "default": {}}},
         }
     )
+    entry = ToolLookupEntry(input={}, output={"msg": "ok"})
 
     env = DeterministicEnvironment.from_params(
         _make_params(
             tools=[tool],
-            lookup_table={"tool1": [ToolLookupEntry(input={}, output={"msg": "ok"})]},
+            lookup_table={"tool1": [entry]},
         )
     )
 
-    assert env._kwargs.lookup_table["tool1"][0].input == {"opts": {"unit": "celsius"}}
+    assert entry.input == {"opts": {"unit": "celsius"}}
     assert env.step([("tool1", {})]) == [ToolResult(output={"msg": "ok"})]
-
-
-def test_self_referential_ref_terminates():
-    """A cyclic `$ref` must not hang construction or lookup."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "$defs": {
-                "Node": {
-                    "type": "object",
-                    "properties": {
-                        "child": {"$ref": "#/$defs/Node"},
-                        "label": {"type": "string", "default": "leaf"},
-                    },
-                }
-            },
-            "properties": {"root": {"$ref": "#/$defs/Node"}},
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(input={"root": {"child": {}}}, output={"msg": "ok"})
-                ]
-            },
-        )
-    )
-
-    assert env._kwargs.lookup_table["tool1"][0].input == {
-        "root": {"label": "leaf", "child": {"label": "leaf"}}
-    }
-
-
-def test_dangling_ref_is_left_alone():
-    """An unresolvable `$ref` contributes no defaults and is not an error."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {"opts": {"$ref": "#/$defs/Missing"}},
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [ToolLookupEntry(input={"opts": {}}, output={"msg": "ok"})]
-            },
-        )
-    )
-
     assert env.step([("tool1", {"opts": {}})]) == [ToolResult(output={"msg": "ok"})]
-
-
-def test_default_value_containing_schema_keywords_is_not_flagged():
-    """A default's own value is data, so keywords inside it are not declarations."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "opts": {
-                    "type": "object",
-                    "default": {"$ref": "literal", "default": "literal"},
-                }
-            },
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={"opts": {"$ref": "literal", "default": "literal"}},
-                        output={"msg": "ok"},
-                    )
-                ]
-            },
-        )
-    )
-
-    assert env.step([("tool1", {})]) == [ToolResult(output={"msg": "ok"})]
-
-
-@pytest.mark.parametrize(
-    "parameters,arguments",
-    [
-        pytest.param(
-            {
-                "$defs": {
-                    "Item": {
-                        "type": "object",
-                        "properties": {"default": {"type": "string"}},
-                        "required": ["default"],
-                    }
-                },
-                "type": "object",
-                "properties": {
-                    "children": {"type": "array", "items": {"$ref": "#/$defs/Item"}}
-                },
-            },
-            {"children": [{"default": "given"}]},
-            id="property-named-default",
-        ),
-        pytest.param(
-            # What `Field(json_schema_extra={"example": ...})` emits.
-            {
-                "type": "object",
-                "properties": {
-                    "value": {"type": "string", "example": {"default": "data"}}
-                },
-            },
-            {"value": "ok"},
-            id="annotation-holding-data",
-        ),
-    ],
-)
-def test_non_subschema_positions_are_not_scanned(parameters, arguments):
-    """Only subschema positions are walked, so data never reads as a declaration."""
-    tool = _make_tool(parameters=parameters)
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [ToolLookupEntry(input=arguments, output={"msg": "ok"})]
-            },
-        )
-    )
-
-    assert env.step([("tool1", arguments)]) == [ToolResult(output={"msg": "ok"})]
-
-
-def test_self_referential_default_does_not_expand_forever():
-    """A `$ref` cycle whose recursive field defaults to `{}` must still terminate."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "$defs": {
-                "Node": {
-                    "type": "object",
-                    "properties": {"child": {"$ref": "#/$defs/Node", "default": {}}},
-                }
-            },
-            "properties": {"root": {"$ref": "#/$defs/Node"}},
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [ToolLookupEntry(input={"root": {}}, output={"msg": "ok"})]
-            },
-        )
-    )
-
-    # The default is dropped at the cycle rather than nested forever, and both
-    # sides of the match drop it identically.
-    assert env._kwargs.lookup_table["tool1"][0].input == {"root": {}}
-    assert env.step([("tool1", {"root": {}})]) == [ToolResult(output={"msg": "ok"})]
-
-
-def test_whole_document_ref_resolves():
-    """`{"$ref": "#"}` points at the root schema, not nowhere."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "label": {"type": "string", "default": "leaf"},
-                "child": {"$ref": "#"},
-            },
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [ToolLookupEntry(input={"child": {}}, output={"msg": "ok"})]
-            },
-        )
-    )
-
-    assert env._kwargs.lookup_table["tool1"][0].input == {
-        "label": "leaf",
-        "child": {"label": "leaf"},
-    }
-
-
-def test_unreferenced_defs_are_not_flagged():
-    """`$defs` entries nobody references are inert, not dead defaults."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "$defs": {"Unused": {"type": "object", "default": {"x": 1}}},
-            "properties": {"id": {"type": "string"}},
-        }
-    )
-
-    env = DeterministicEnvironment.from_params(_make_params(tools=[tool]))
-
-    assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output={"msg": "ok"})]
 
 
 # --- step ---
@@ -611,69 +291,34 @@ def test_step_unknown_tool_raises():
         env.step([("missing", {"id": "01"})])
 
 
-def test_step_matches_omitted_argument_to_explicit_default():
+def test_step_applies_defaults_to_calls_and_entries():
     tool = _make_tool(
         parameters={
             "type": "object",
             "properties": {
                 "location": {"type": "string"},
-                "unit": {"type": "string", "default": "fahrenheit"},
+                "unit": {"type": "string", "default": "celsius"},
             },
-            "required": ["location"],
         }
     )
+    entry = ToolLookupEntry(input={"location": "sf"}, output={"temperature": 18})
     env = DeterministicEnvironment.from_params(
         _make_params(
             tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={"location": "sf", "unit": "fahrenheit"},
-                        output={"temperature": 65},
-                    )
-                ]
-            },
+            lookup_table={"tool1": [entry]},
         )
     )
 
+    assert entry.input == {"location": "sf", "unit": "celsius"}
     assert env.step([("tool1", {"location": "sf"})]) == [
-        ToolResult(output={"temperature": 65})
+        ToolResult(output={"temperature": 18})
+    ]
+    assert env.step([("tool1", {"location": "sf", "unit": "celsius"})]) == [
+        ToolResult(output={"temperature": 18})
     ]
 
 
-def test_step_matches_explicit_argument_to_omitted_entry_default():
-    """The entry side is filled too, so terse lookup rows match verbose calls."""
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"},
-                "unit": {"type": "string", "default": "fahrenheit"},
-            },
-            "required": ["location"],
-        }
-    )
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={"location": "sf"},
-                        output={"temperature": 65},
-                    )
-                ]
-            },
-        )
-    )
-
-    assert env.step([("tool1", {"location": "sf", "unit": "fahrenheit"})]) == [
-        ToolResult(output={"temperature": 65})
-    ]
-
-
-def test_filled_list_default_is_not_aliased_to_schema():
-    """Filled defaults are deep-copied, so a filled entry can't corrupt the schema."""
+def test_default_filling_deep_copies_values():
     tool = _make_tool(
         parameters={
             "type": "object",
@@ -681,53 +326,15 @@ def test_filled_list_default_is_not_aliased_to_schema():
         }
     )
     entry = ToolLookupEntry(input={}, output={"ok": True})
-    DeterministicEnvironment.from_params(
+    env = DeterministicEnvironment.from_params(
         _make_params(tools=[tool], lookup_table={"tool1": [entry]})
     )
-    assert entry.input == {"tags": ["a"]}
+    arguments = {}
 
+    assert env.step([("tool1", arguments)]) == [ToolResult(output={"ok": True})]
+    assert arguments == {}
     entry.input["tags"].append("MUTATED")
-
     assert tool.parameters["properties"]["tags"]["default"] == ["a"]
-
-
-def test_step_recursively_fills_defaults_in_existing_object():
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"},
-                "opts": {
-                    "type": "object",
-                    "properties": {
-                        "unit": {"type": "string", "default": "fahrenheit"},
-                        "verbose": {"type": "boolean", "default": False},
-                    },
-                },
-            },
-            "required": ["location"],
-        }
-    )
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={
-                            "location": "sf",
-                            "opts": {"unit": "fahrenheit", "verbose": False},
-                        },
-                        output={"temperature": 65},
-                    )
-                ]
-            },
-        )
-    )
-
-    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
-        ToolResult(output={"temperature": 65})
-    ]
 
 
 def test_step_does_not_create_missing_object_without_default():
@@ -735,15 +342,11 @@ def test_step_does_not_create_missing_object_without_default():
         parameters={
             "type": "object",
             "properties": {
-                "location": {"type": "string"},
                 "opts": {
                     "type": "object",
-                    "properties": {
-                        "unit": {"type": "string", "default": "fahrenheit"},
-                    },
+                    "properties": {"unit": {"type": "string", "default": "celsius"}},
                 },
             },
-            "required": ["location"],
         }
     )
     env = DeterministicEnvironment.from_params(
@@ -751,15 +354,9 @@ def test_step_does_not_create_missing_object_without_default():
             tools=[tool],
             lookup_table={
                 "tool1": [
+                    ToolLookupEntry(input={}, output={"source": "no-opts"}),
                     ToolLookupEntry(
-                        input={"location": "sf"},
-                        output={"source": "no-opts"},
-                    ),
-                    ToolLookupEntry(
-                        input={
-                            "location": "sf",
-                            "opts": {"unit": "fahrenheit"},
-                        },
+                        input={"opts": {}},
                         output={"source": "opts"},
                     ),
                 ]
@@ -767,86 +364,10 @@ def test_step_does_not_create_missing_object_without_default():
         )
     )
 
-    assert env.step([("tool1", {"location": "sf"})]) == [
-        ToolResult(output={"source": "no-opts"})
-    ]
-    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+    assert env.step([("tool1", {})]) == [ToolResult(output={"source": "no-opts"})]
+    assert env.step([("tool1", {"opts": {}})]) == [
         ToolResult(output={"source": "opts"})
     ]
-
-
-def test_step_creates_and_fills_missing_object_with_default():
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"},
-                "opts": {
-                    "type": "object",
-                    "default": {},
-                    "properties": {
-                        "unit": {"type": "string", "default": "fahrenheit"},
-                        "verbose": {"type": "boolean", "default": False},
-                    },
-                },
-            },
-            "required": ["location"],
-        }
-    )
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={
-                            "location": "sf",
-                            "opts": {"unit": "fahrenheit", "verbose": False},
-                        },
-                        output={"temperature": 65},
-                    )
-                ]
-            },
-        )
-    )
-
-    assert env.step([("tool1", {"location": "sf"})]) == [
-        ToolResult(output={"temperature": 65})
-    ]
-
-
-def test_step_default_filling_does_not_mutate_call_arguments():
-    tool = _make_tool(
-        parameters={
-            "type": "object",
-            "properties": {
-                "opts": {
-                    "type": "object",
-                    "properties": {
-                        "verbose": {"type": "boolean", "default": False},
-                    },
-                }
-            },
-        }
-    )
-    env = DeterministicEnvironment.from_params(
-        _make_params(
-            tools=[tool],
-            lookup_table={
-                "tool1": [
-                    ToolLookupEntry(
-                        input={"opts": {"verbose": False}},
-                        output={"ok": True},
-                    )
-                ]
-            },
-        )
-    )
-    arguments = {"opts": {}}
-
-    env.step([("tool1", arguments)])
-
-    assert arguments == {"opts": {}}
 
 
 @pytest.mark.parametrize(
@@ -1001,15 +522,13 @@ def test_sample_grounding_merges_input_and_output():
 
 
 def test_sample_grounding_includes_filled_defaults():
-    """Entry inputs are normalized before projection, so defaults reach facts."""
     tool = _make_tool(
         "lookup",
         parameters={
             "type": "object",
             "properties": {
                 "id": {"type": "string"},
-                "unit": {"type": "string", "default": "fahrenheit"},
-                "locale": {"type": "string", "default": "en"},
+                "unit": {"type": "string", "default": "celsius"},
             },
         },
     )
@@ -1027,7 +546,7 @@ def test_sample_grounding_includes_filled_defaults():
     )
     facts = env.sample_grounding(n=1, rng=random.Random(0))
 
-    assert facts[0].data == {"id": "1", "unit": "fahrenheit", "title": "Dune"}
+    assert facts[0].data == {"id": "1", "unit": "celsius", "title": "Dune"}
 
 
 def test_grounding_key_collision_warns(caplog):

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -185,6 +185,379 @@ def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
         )
 
 
+# --- unreachable schema defaults ---
+
+
+@pytest.mark.parametrize(
+    "parameters,expected_path",
+    [
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "unit": {
+                        "anyOf": [
+                            {"type": "string", "default": "fahrenheit"},
+                            {"type": "null"},
+                        ]
+                    }
+                },
+            },
+            "parameters.properties.unit.anyOf[0].default",
+            id="anyOf",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string", "default": "all"},
+                    }
+                },
+            },
+            "parameters.properties.tags.items.default",
+            id="items",
+        ),
+        pytest.param(
+            {
+                "$defs": {
+                    "Item": {
+                        "type": "object",
+                        "properties": {"enum": {"type": "string", "default": "x"}},
+                    }
+                },
+                "type": "object",
+                "properties": {
+                    "children": {"type": "array", "items": {"$ref": "#/$defs/Item"}}
+                },
+            },
+            "parameters.properties.children.items.properties.enum.default",
+            id="property-named-like-a-keyword",
+        ),
+        pytest.param(
+            # `list[Node]` on a recursive pydantic model: the same `$ref` is
+            # reached both fillably and not, so the cycle guard must key on both.
+            {
+                "$defs": {
+                    "Node": {
+                        "type": "object",
+                        "properties": {
+                            "label": {"type": "string", "default": "leaf"},
+                            "children": {
+                                "type": "array",
+                                "default": [],
+                                "items": {"$ref": "#/$defs/Node"},
+                            },
+                        },
+                    }
+                },
+                "type": "object",
+                "properties": {"root": {"$ref": "#/$defs/Node"}},
+            },
+            "parameters.properties.root.properties.children.items"
+            ".properties.label.default",
+            id="recursive-model-under-items",
+        ),
+    ],
+)
+def test_unreachable_schema_default_raises(parameters, expected_path):
+    """A default off the `properties` chain errors at construction, not at lookup."""
+    with pytest.raises(ValueError, match="never applied") as excinfo:
+        DeterministicEnvironment.from_params(
+            _make_params(tools=[_make_tool(parameters=parameters)])
+        )
+    assert expected_path in str(excinfo.value)
+    assert "tool1" in str(excinfo.value)
+
+
+def test_combinator_without_defaults_is_accepted():
+    """Only a hidden default is an error; `anyOf` on its own stays usable."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {"id": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(_make_params(tools=[tool]))
+
+    assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output={"msg": "ok"})]
+
+
+def test_pydantic_style_ref_schema_fills_nested_defaults():
+    """`model_json_schema()` emits `$ref` + `$defs`; defaults must still fill."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "$defs": {
+                "Opts": {
+                    "type": "object",
+                    "properties": {"unit": {"type": "string", "default": "fahrenheit"}},
+                }
+            },
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {"$ref": "#/$defs/Opts", "default": {"unit": "fahrenheit"}},
+            },
+            "required": ["location"],
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(input={"location": "sf"}, output={"msg": "ok"})
+                ]
+            },
+        )
+    )
+
+    # Both the absent `opts` and an explicit empty one resolve to the same row.
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"msg": "ok"})
+    ]
+    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+        ToolResult(output={"msg": "ok"})
+    ]
+
+
+def test_ref_without_sibling_default_fills_through_target():
+    """A bare `$ref` parent fills from the target's own `default`."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "$defs": {
+                "Opts": {
+                    "type": "object",
+                    "default": {},
+                    "properties": {"unit": {"type": "string", "default": "celsius"}},
+                }
+            },
+            "properties": {"opts": {"$ref": "#/$defs/Opts"}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={"tool1": [ToolLookupEntry(input={}, output={"msg": "ok"})]},
+        )
+    )
+
+    assert env._kwargs.lookup_table["tool1"][0].input == {"opts": {"unit": "celsius"}}
+    assert env.step([("tool1", {})]) == [ToolResult(output={"msg": "ok"})]
+
+
+def test_self_referential_ref_terminates():
+    """A cyclic `$ref` must not hang construction or lookup."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "child": {"$ref": "#/$defs/Node"},
+                        "label": {"type": "string", "default": "leaf"},
+                    },
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(input={"root": {"child": {}}}, output={"msg": "ok"})
+                ]
+            },
+        )
+    )
+
+    assert env._kwargs.lookup_table["tool1"][0].input == {
+        "root": {"label": "leaf", "child": {"label": "leaf"}}
+    }
+
+
+def test_dangling_ref_is_left_alone():
+    """An unresolvable `$ref` contributes no defaults and is not an error."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {"opts": {"$ref": "#/$defs/Missing"}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [ToolLookupEntry(input={"opts": {}}, output={"msg": "ok"})]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"opts": {}})]) == [ToolResult(output={"msg": "ok"})]
+
+
+def test_default_value_containing_schema_keywords_is_not_flagged():
+    """A default's own value is data, so keywords inside it are not declarations."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "opts": {
+                    "type": "object",
+                    "default": {"$ref": "literal", "default": "literal"},
+                }
+            },
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"opts": {"$ref": "literal", "default": "literal"}},
+                        output={"msg": "ok"},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {})]) == [ToolResult(output={"msg": "ok"})]
+
+
+@pytest.mark.parametrize(
+    "parameters,arguments",
+    [
+        pytest.param(
+            {
+                "$defs": {
+                    "Item": {
+                        "type": "object",
+                        "properties": {"default": {"type": "string"}},
+                        "required": ["default"],
+                    }
+                },
+                "type": "object",
+                "properties": {
+                    "children": {"type": "array", "items": {"$ref": "#/$defs/Item"}}
+                },
+            },
+            {"children": [{"default": "given"}]},
+            id="property-named-default",
+        ),
+        pytest.param(
+            # What `Field(json_schema_extra={"example": ...})` emits.
+            {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "example": {"default": "data"}}
+                },
+            },
+            {"value": "ok"},
+            id="annotation-holding-data",
+        ),
+    ],
+)
+def test_non_subschema_positions_are_not_scanned(parameters, arguments):
+    """Only subschema positions are walked, so data never reads as a declaration."""
+    tool = _make_tool(parameters=parameters)
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [ToolLookupEntry(input=arguments, output={"msg": "ok"})]
+            },
+        )
+    )
+
+    assert env.step([("tool1", arguments)]) == [ToolResult(output={"msg": "ok"})]
+
+
+def test_self_referential_default_does_not_expand_forever():
+    """A `$ref` cycle whose recursive field defaults to `{}` must still terminate."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/$defs/Node", "default": {}}},
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [ToolLookupEntry(input={"root": {}}, output={"msg": "ok"})]
+            },
+        )
+    )
+
+    # The default is dropped at the cycle rather than nested forever, and both
+    # sides of the match drop it identically.
+    assert env._kwargs.lookup_table["tool1"][0].input == {"root": {}}
+    assert env.step([("tool1", {"root": {}})]) == [ToolResult(output={"msg": "ok"})]
+
+
+def test_whole_document_ref_resolves():
+    """`{"$ref": "#"}` points at the root schema, not nowhere."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "label": {"type": "string", "default": "leaf"},
+                "child": {"$ref": "#"},
+            },
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [ToolLookupEntry(input={"child": {}}, output={"msg": "ok"})]
+            },
+        )
+    )
+
+    assert env._kwargs.lookup_table["tool1"][0].input == {
+        "label": "leaf",
+        "child": {"label": "leaf"},
+    }
+
+
+def test_unreferenced_defs_are_not_flagged():
+    """`$defs` entries nobody references are inert, not dead defaults."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "$defs": {"Unused": {"type": "object", "default": {"x": 1}}},
+            "properties": {"id": {"type": "string"}},
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(_make_params(tools=[tool]))
+
+    assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output={"msg": "ok"})]
+
+
 # --- step ---
 
 

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -32,8 +32,16 @@ from oumi.environments.deterministic_environment import (
 )
 
 
-def _make_tool(tool_id: str = "tool1") -> ToolParams:
-    return ToolParams(id=tool_id, name=tool_id, description="A tool")
+def _make_tool(
+    tool_id: str = "tool1",
+    parameters: dict | None = None,
+) -> ToolParams:
+    return ToolParams(
+        id=tool_id,
+        name=tool_id,
+        description="A tool",
+        parameters=parameters if parameters is not None else {"type": "object"},
+    )
 
 
 def _make_params(
@@ -145,6 +153,38 @@ def test_duplicate_inputs_raises():
         )
 
 
+def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="duplicate input"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [
+                        ToolLookupEntry(
+                            input={"location": "sf"},
+                            output={"temperature": 65},
+                        ),
+                        ToolLookupEntry(
+                            input={"location": "sf", "unit": "fahrenheit"},
+                            output={"temperature": 65},
+                        ),
+                    ]
+                },
+            )
+        )
+
+
 # --- step ---
 
 
@@ -196,6 +236,194 @@ def test_step_unknown_tool_raises():
     env = DeterministicEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
         env.step([("missing", {"id": "01"})])
+
+
+def test_step_matches_omitted_argument_to_explicit_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf", "unit": "fahrenheit"},
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_recursively_fills_defaults_in_existing_object():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit", "verbose": False},
+                        },
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_does_not_create_missing_object_without_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf"},
+                        output={"source": "no-opts"},
+                    ),
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit"},
+                        },
+                        output={"source": "opts"},
+                    ),
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"source": "no-opts"})
+    ]
+    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+        ToolResult(output={"source": "opts"})
+    ]
+
+
+def test_step_creates_and_fills_missing_object_with_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit", "verbose": False},
+                        },
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_default_filling_does_not_mutate_call_arguments():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                }
+            },
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"opts": {"verbose": False}},
+                        output={"ok": True},
+                    )
+                ]
+            },
+        )
+    )
+    arguments = {"opts": {}}
+
+    env.step([("tool1", arguments)])
+
+    assert arguments == {"opts": {}}
 
 
 # --- sample_grounding ---

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -613,6 +613,36 @@ def test_sample_grounding_merges_input_and_output():
     assert facts[0].data == {"id": "1", "note": "output-note", "title": "Dune"}
 
 
+def test_sample_grounding_includes_filled_defaults():
+    """Entry inputs are normalized before projection, so defaults reach facts."""
+    tool = _make_tool(
+        "lookup",
+        parameters={
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+                "locale": {"type": "string", "default": "en"},
+            },
+        },
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "lookup": [ToolLookupEntry(input={"id": "1"}, output={"title": "Dune"})]
+            },
+            grounding=GroundingConfig(
+                sample_size=1,
+                tools={"lookup": ToolGroundingConfig(fields=["id", "unit", "title"])},
+            ),
+        )
+    )
+    facts = env.sample_grounding(n=1, rng=random.Random(0))
+
+    assert facts[0].data == {"id": "1", "unit": "fahrenheit", "title": "Dune"}
+
+
 def test_sample_grounding_seeded_is_reproducible():
     env = _grounded_env(n_entries=20)
     a = env.sample_grounding(n=4, rng=random.Random(42))

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -268,6 +268,56 @@ def test_step_matches_omitted_argument_to_explicit_default():
     ]
 
 
+def test_step_matches_explicit_argument_to_omitted_entry_default():
+    """The entry side is filled too, so terse lookup rows match verbose calls."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf"},
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf", "unit": "fahrenheit"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_filled_list_default_is_not_aliased_to_schema():
+    """Filled defaults are deep-copied, so a filled entry can't corrupt the schema."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {"tags": {"type": "array", "default": ["a"]}},
+        }
+    )
+    entry = ToolLookupEntry(input={}, output={"ok": True})
+    DeterministicEnvironment.from_params(
+        _make_params(tools=[tool], lookup_table={"tool1": [entry]})
+    )
+    assert entry.input == {"tags": ["a"]}
+
+    entry.input["tags"].append("MUTATED")
+
+    assert tool.parameters["properties"]["tags"]["default"] == ["a"]
+
+
 def test_step_recursively_fills_defaults_in_existing_object():
     tool = _make_tool(
         parameters={


### PR DESCRIPTION
## Summary
- apply JSON Schema defaults to deterministic lookup rows and incoming tool calls
- recursively fill defaults in existing or explicitly defaulted nested objects
- reject lookup rows that become duplicates after normalization

Follows the `_fill` shape agreed in Slack: fill a missing property only when it declares its own `default`, then descend into any object value. So with an `opts` object that has no `default` of its own, `{location: sf}` stays distinct from `{location: sf, opts: {}}` and `{location: sf, opts: {unit: fahrenheit}}`, and those latter two are equivalent.

## Notes for review
- `_validate_lookup_table` normalizes `entry.input` in place, so `sample_grounding` now projects filled defaults too — a row configured as `{location: sf}` emits the fact `{location: sf, unit: fahrenheit, ...}` when `unit` is whitelisted. Intended, and pinned by `test_sample_grounding_includes_filled_defaults`.
- An explicit `null` counts as present and is not replaced by the default.

## Unreachable defaults (addresses review comment 1)

Filling walks `properties` chains only, so a `default` anywhere else would be silently dropped. Two changes close that:

- **Local `$ref`s are resolved**, so a pydantic `model_json_schema()` tool schema fills exactly like the equivalent inline one. Sibling keys win over the target's (pydantic emits `{"$ref": ..., "default": ...}`). Non-local and dangling refs are left alone — `jsonschema` still validates them, they just contribute no defaults.
- **Everything still unreachable is a hard error at construction**, naming the tool and the JSON path — a `default` under `items`, `anyOf`/`oneOf`/`allOf`, `additionalProperties`, and so on. So `Optional[NestedModel]`, `list[NestedModel]`, and `dict[str, NestedModel]` schemas whose nested model has a defaulted field are now rejected rather than silently mismatching later. No config under `configs/` is affected.

The scan walks only subschema positions, so instance data is never read as a declaration: a property literally named `default`, or a `json_schema_extra` annotation holding `{"default": ...}`, is not flagged. Its cycle guard is keyed on reachability, so a `$ref` reached both fillably and not is checked both ways. Filling never inserts a default through a `$ref` already on the path, so a self-referential default terminates instead of recursing forever.

Known gap: a hand-written `$ref` with sibling `properties` merges shallowly rather than applying both schemas per JSON Schema 2020-12. Pydantic never emits that shape.

## Follow-up (not in this PR)
`SyntheticEnvironment._cache_key` keys `cache_by_input` on the raw `json.dumps(arguments, sort_keys=True)`, so it has the same equivalence gap this PR closes for deterministic envs: `{location: sf}` and `{location: sf, unit: fahrenheit}` are two cache entries and can produce two different simulated outputs for the same semantic call. Left out to keep this PR scoped to its title.

## Test Plan
- `PYTHONPATH=src pytest tests/unit/environments tests/unit/core/synthesis/test_tool_router.py -q`
- `uvx ruff@0.15.0 check src/oumi/environments/deterministic_environment.py tests/unit/environments/test_deterministic_environment.py`
- `uvx ruff@0.15.0 format --check src/oumi/environments/deterministic_environment.py tests/unit/environments/test_deterministic_environment.py`
- `pyright src/oumi/environments/deterministic_environment.py tests/unit/environments/test_deterministic_environment.py --pythonpath "$(command -v python)"`

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->

