### PR TITLE
Validate deterministic env lookup_table rows against tool schemas

### DIFF
--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -37,7 +37,10 @@ def _fill_argument_defaults(
     arguments: dict[str, Any],
     schema: dict[str, Any],
 ) -> dict[str, Any]:
-    """Return a copy of arguments with JSON Schema property defaults applied."""
+    """Return a copy of arguments with JSON Schema property defaults applied.
+
+    An absent object property is only created if it declares its own ``default``.
+    """
     result = dict(arguments)
     properties = schema.get("properties", {})
     if not isinstance(properties, dict):
@@ -108,8 +111,9 @@ class DeterministicEnvironment(BaseEnvironment):
         """Initialize a DeterministicEnvironment."""
         self._params = params
         self._kwargs = kwargs
-        self._tools_by_id = {tool.id: tool for tool in params.tools}
-        self._tool_ids = set(self._tools_by_id)
+        self._tools_by_id: dict[str, ToolParams] = {
+            tool.id: tool for tool in params.tools
+        }
         self._validate_lookup_table()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
@@ -117,15 +121,13 @@ class DeterministicEnvironment(BaseEnvironment):
         return [self._resolve_one(tool_id, args) for tool_id, args in calls]
 
     def _resolve_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
-        if tool_id not in self._tool_ids:
+        tool = self._tools_by_id.get(tool_id)
+        if tool is None:
             raise ValueError(
                 f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
-                f"Available tools: {sorted(self._tool_ids)}"
+                f"Available tools: {sorted(self._tools_by_id)}"
             )
-        arguments = _fill_argument_defaults(
-            arguments,
-            self._tools_by_id[tool_id].parameters,
-        )
+        arguments = _fill_argument_defaults(arguments, tool.parameters)
         entries = self._kwargs.lookup_table.get(tool_id, [])
         for entry in entries:
             if entry.matches(arguments):
@@ -192,10 +194,11 @@ class DeterministicEnvironment(BaseEnvironment):
         - Stale ``lookup_table`` keys (no matching tool): log a warning;
           entries are dormant.
         - Tools without entries: hard error.
+        - Entry inputs are normalized in place with schema defaults.
         - Duplicate inputs within a tool's entries: hard error.
         """
         for tool_id in self._kwargs.lookup_table:
-            if tool_id not in self._tool_ids:
+            if tool_id not in self._tools_by_id:
                 logger.warning(
                     "Environment '%s': lookup_table.'%s' references unknown "
                     "tool. Entries will be ignored.",

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -207,7 +207,9 @@ class DeterministicEnvironment(BaseEnvironment):
           entries are dormant.
         - Tools without entries: hard error.
         - Entry inputs are normalized in place with schema defaults.
-        - Entry inputs and outputs must conform to the tool schemas.
+        - Entry inputs must conform to the tool's ``parameters``; outputs must
+          be JSON values, and conform to ``output_schema`` when the tool
+          declares one (it is optional).
         - Duplicate inputs within a tool's entries: hard error.
         """
         for tool_id in self._kwargs.lookup_table:

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import json
 import random
@@ -30,6 +31,26 @@ from oumi.core.registry import register_environment
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
 from oumi.utils.logging import logger
+
+
+def _fill_argument_defaults(
+    arguments: dict[str, Any],
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a copy of arguments with JSON Schema property defaults applied."""
+    result = dict(arguments)
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return result
+
+    for name, property_schema in properties.items():
+        if not isinstance(property_schema, dict):
+            continue
+        if name not in result and "default" in property_schema:
+            result[name] = copy.deepcopy(property_schema["default"])
+        if isinstance(result.get(name), dict):
+            result[name] = _fill_argument_defaults(result[name], property_schema)
+    return result
 
 
 @dataclass
@@ -87,7 +108,8 @@ class DeterministicEnvironment(BaseEnvironment):
         """Initialize a DeterministicEnvironment."""
         self._params = params
         self._kwargs = kwargs
-        self._tool_ids = {tool.id for tool in params.tools}
+        self._tools_by_id = {tool.id: tool for tool in params.tools}
+        self._tool_ids = set(self._tools_by_id)
         self._validate_lookup_table()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
@@ -100,6 +122,10 @@ class DeterministicEnvironment(BaseEnvironment):
                 f"Tool '{tool_id}' not found in environment '{self._params.id}'. "
                 f"Available tools: {sorted(self._tool_ids)}"
             )
+        arguments = _fill_argument_defaults(
+            arguments,
+            self._tools_by_id[tool_id].parameters,
+        )
         entries = self._kwargs.lookup_table.get(tool_id, [])
         for entry in entries:
             if entry.matches(arguments):
@@ -185,6 +211,7 @@ class DeterministicEnvironment(BaseEnvironment):
                 )
             seen: set[str] = set()
             for entry in entries:
+                entry.input = _fill_argument_defaults(entry.input, tool.parameters)
                 key = entry.input_key()
                 if key in seen:
                     raise ValueError(

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import jsonschema
 from pydantic import JsonValue
+from pydantic import ValidationError as PydanticValidationError
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
@@ -233,6 +234,15 @@ class DeterministicEnvironment(BaseEnvironment):
                     raise ValueError(
                         f"Tool '{tool.id}' has lookup_table entry with invalid "
                         f"input {entry.input}: {e}"
+                    ) from e
+                # jsonschema accepts non-JSON values a JsonValue output rejects
+                # (e.g. a dict with int keys), so check against the consumer first.
+                try:
+                    ToolResult(output=entry.output)
+                except PydanticValidationError as e:
+                    raise ValueError(
+                        f"Tool '{tool.id}' has lookup_table entry with non-JSON "
+                        f"output {entry.output} for input {entry.input}: {e}"
                     ) from e
                 if tool.output_schema is not None:
                     try:

--- a/src/oumi/environments/deterministic_environment.py
+++ b/src/oumi/environments/deterministic_environment.py
@@ -22,12 +22,17 @@ import random
 from dataclasses import dataclass, field
 from typing import Any
 
+import jsonschema
 from pydantic import JsonValue
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.grounding_params import GroundingFact
-from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
+from oumi.core.configs.params.tool_params import (
+    ToolArgumentError,
+    ToolLookupError,
+    ToolParams,
+)
 from oumi.core.registry import register_environment
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
@@ -201,6 +206,7 @@ class DeterministicEnvironment(BaseEnvironment):
           entries are dormant.
         - Tools without entries: hard error.
         - Entry inputs are normalized in place with schema defaults.
+        - Entry inputs and outputs must conform to the tool schemas.
         - Duplicate inputs within a tool's entries: hard error.
         """
         for tool_id in self._kwargs.lookup_table:
@@ -221,6 +227,21 @@ class DeterministicEnvironment(BaseEnvironment):
             seen: set[str] = set()
             for entry in entries:
                 entry.input = _fill_argument_defaults(entry.input, tool.parameters)
+                try:
+                    tool.validate_arguments(entry.input)
+                except ToolArgumentError as e:
+                    raise ValueError(
+                        f"Tool '{tool.id}' has lookup_table entry with invalid "
+                        f"input {entry.input}: {e}"
+                    ) from e
+                if tool.output_schema is not None:
+                    try:
+                        jsonschema.validate(entry.output, tool.output_schema)
+                    except jsonschema.ValidationError as e:
+                        raise ValueError(
+                            f"Tool '{tool.id}' has lookup_table entry with invalid "
+                            f"output {entry.output} for input {entry.input}: {e}"
+                        ) from e
                 key = entry.input_key()
                 if key in seen:
                     raise ValueError(

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -180,7 +180,10 @@ def _typed_tool(tool_id: str) -> ToolParams:
 
 
 def _router_with(*tools: ToolParams) -> ToolRouter:
-    env_config = EnvironmentConfig(environments=[_det_env_params("env1", list(tools))])
+    lookup = {tool.id: [{"input": {"q": "configured"}, "output": {}}] for tool in tools}
+    env_config = EnvironmentConfig(
+        environments=[_det_env_params("env1", list(tools), lookup=lookup)]
+    )
     return ToolRouter.from_environment_config(env_config)
 
 

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -300,6 +300,56 @@ def test_valid_entry_output_constructs():
     ]
 
 
+def test_non_json_output_raises():
+    # jsonschema accepts an int-keyed dict as an "object"; ToolResult does not,
+    # and YAML/OmegaConf preserves numeric keys all the way here.
+    tool = _make_tool(output_schema={"type": "object"})
+
+    with pytest.raises(ValueError, match="non-JSON output"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [
+                        ToolLookupEntry(input={}, output={1: "x"})  # type: ignore[arg-type]
+                    ]
+                },
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "output_schema,output",
+    [
+        ({"type": "string"}, "sunny"),
+        ({"type": "array", "items": {"type": "number"}}, [1, 2]),
+        ({"type": "boolean"}, True),
+        ({"type": "null"}, None),
+    ],
+)
+def test_non_dict_outputs_validate_against_schema(output_schema, output):
+    tool = _make_tool(output_schema=output_schema)
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={"tool1": [ToolLookupEntry(input={}, output=output)]},
+        )
+    )
+
+    assert env.step([("tool1", {})]) == [ToolResult(output=output)]
+
+    with pytest.raises(ValueError, match="invalid output"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [ToolLookupEntry(input={}, output={"wrong": "type"})]
+                },
+            )
+        )
+
+
 # --- step ---
 
 

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -35,12 +35,14 @@ from oumi.environments.deterministic_environment import (
 def _make_tool(
     tool_id: str = "tool1",
     parameters: dict | None = None,
+    output_schema: dict | None = None,
 ) -> ToolParams:
     return ToolParams(
         id=tool_id,
         name=tool_id,
         description="A tool",
         parameters=parameters if parameters is not None else {"type": "object"},
+        output_schema=output_schema,
     )
 
 
@@ -183,6 +185,119 @@ def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
                 },
             )
         )
+
+
+def test_invalid_entry_input_raises():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="invalid input.*locaton"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [
+                        ToolLookupEntry(
+                            input={"locaton": "sf"},
+                            output={"temperature": 65},
+                        )
+                    ]
+                },
+            )
+        )
+
+
+def test_entry_input_is_validated_after_defaults_are_filled():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius"],
+                            "default": "fahrenheit",
+                        }
+                    },
+                    "required": ["unit"],
+                }
+            },
+            "required": ["opts"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="invalid input.*fahrenheit.*not one of"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [ToolLookupEntry(input={"opts": {}}, output={"ok": True})]
+                },
+            )
+        )
+
+
+def test_invalid_entry_output_raises():
+    tool = _make_tool(
+        output_schema={
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+            "required": ["temperature"],
+            "additionalProperties": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="invalid output.*temprature"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [
+                        ToolLookupEntry(
+                            input={"location": "sf"},
+                            output={"temprature": 65},
+                        )
+                    ]
+                },
+            )
+        )
+
+
+def test_valid_entry_output_constructs():
+    tool = _make_tool(
+        output_schema={
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+            "required": ["temperature"],
+            "additionalProperties": False,
+        }
+    )
+
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf"},
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
 
 
 # --- step ---

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -32,8 +32,16 @@ from oumi.environments.deterministic_environment import (
 )
 
 
-def _make_tool(tool_id: str = "tool1") -> ToolParams:
-    return ToolParams(id=tool_id, name=tool_id, description="A tool")
+def _make_tool(
+    tool_id: str = "tool1",
+    parameters: dict | None = None,
+) -> ToolParams:
+    return ToolParams(
+        id=tool_id,
+        name=tool_id,
+        description="A tool",
+        parameters=parameters if parameters is not None else {"type": "object"},
+    )
 
 
 def _make_params(
@@ -145,6 +153,38 @@ def test_duplicate_inputs_raises():
         )
 
 
+def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="duplicate input"):
+        DeterministicEnvironment.from_params(
+            _make_params(
+                tools=[tool],
+                lookup_table={
+                    "tool1": [
+                        ToolLookupEntry(
+                            input={"location": "sf"},
+                            output={"temperature": 65},
+                        ),
+                        ToolLookupEntry(
+                            input={"location": "sf", "unit": "fahrenheit"},
+                            output={"temperature": 65},
+                        ),
+                    ]
+                },
+            )
+        )
+
+
 # --- step ---
 
 
@@ -196,6 +236,194 @@ def test_step_unknown_tool_raises():
     env = DeterministicEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
         env.step([("missing", {"id": "01"})])
+
+
+def test_step_matches_omitted_argument_to_explicit_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf", "unit": "fahrenheit"},
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_recursively_fills_defaults_in_existing_object():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit", "verbose": False},
+                        },
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_does_not_create_missing_object_without_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf"},
+                        output={"source": "no-opts"},
+                    ),
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit"},
+                        },
+                        output={"source": "opts"},
+                    ),
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"source": "no-opts"})
+    ]
+    assert env.step([("tool1", {"location": "sf", "opts": {}})]) == [
+        ToolResult(output={"source": "opts"})
+    ]
+
+
+def test_step_creates_and_fills_missing_object_with_default():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "opts": {
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "unit": {"type": "string", "default": "fahrenheit"},
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                },
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={
+                            "location": "sf",
+                            "opts": {"unit": "fahrenheit", "verbose": False},
+                        },
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_step_default_filling_does_not_mutate_call_arguments():
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "opts": {
+                    "type": "object",
+                    "properties": {
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                }
+            },
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"opts": {"verbose": False}},
+                        output={"ok": True},
+                    )
+                ]
+            },
+        )
+    )
+    arguments = {"opts": {}}
+
+    env.step([("tool1", arguments)])
+
+    assert arguments == {"opts": {}}
 
 
 # --- sample_grounding ---

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -613,6 +613,36 @@ def test_sample_grounding_merges_input_and_output():
     assert facts[0].data == {"id": "1", "note": "output-note", "title": "Dune"}
 
 
+def test_sample_grounding_includes_filled_defaults():
+    """Entry inputs are normalized before projection, so defaults reach facts."""
+    tool = _make_tool(
+        "lookup",
+        parameters={
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+                "locale": {"type": "string", "default": "en"},
+            },
+        },
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "lookup": [ToolLookupEntry(input={"id": "1"}, output={"title": "Dune"})]
+            },
+            grounding=GroundingConfig(
+                sample_size=1,
+                tools={"lookup": ToolGroundingConfig(fields=["id", "unit", "title"])},
+            ),
+        )
+    )
+    facts = env.sample_grounding(n=1, rng=random.Random(0))
+
+    assert facts[0].data == {"id": "1", "unit": "fahrenheit", "title": "Dune"}
+
+
 def test_sample_grounding_seeded_is_reproducible():
     env = _grounded_env(n_entries=20)
     a = env.sample_grounding(n=4, rng=random.Random(42))

--- a/tests/unit/environments/test_deterministic_environment.py
+++ b/tests/unit/environments/test_deterministic_environment.py
@@ -268,6 +268,56 @@ def test_step_matches_omitted_argument_to_explicit_default():
     ]
 
 
+def test_step_matches_explicit_argument_to_omitted_entry_default():
+    """The entry side is filled too, so terse lookup rows match verbose calls."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "default": "fahrenheit"},
+            },
+            "required": ["location"],
+        }
+    )
+    env = DeterministicEnvironment.from_params(
+        _make_params(
+            tools=[tool],
+            lookup_table={
+                "tool1": [
+                    ToolLookupEntry(
+                        input={"location": "sf"},
+                        output={"temperature": 65},
+                    )
+                ]
+            },
+        )
+    )
+
+    assert env.step([("tool1", {"location": "sf", "unit": "fahrenheit"})]) == [
+        ToolResult(output={"temperature": 65})
+    ]
+
+
+def test_filled_list_default_is_not_aliased_to_schema():
+    """Filled defaults are deep-copied, so a filled entry can't corrupt the schema."""
+    tool = _make_tool(
+        parameters={
+            "type": "object",
+            "properties": {"tags": {"type": "array", "default": ["a"]}},
+        }
+    )
+    entry = ToolLookupEntry(input={}, output={"ok": True})
+    DeterministicEnvironment.from_params(
+        _make_params(tools=[tool], lookup_table={"tool1": [entry]})
+    )
+    assert entry.input == {"tags": ["a"]}
+
+    entry.input["tags"].append("MUTATED")
+
+    assert tool.parameters["properties"]["tags"]["default"] == ["a"]
+
+
 def test_step_recursively_fills_defaults_in_existing_object():
     tool = _make_tool(
         parameters={


### PR DESCRIPTION
Stacked on #2573 — review that one first; this diff is only the last commit.

## Problem

`DeterministicEnvironment` never schema-validated its `lookup_table` rows.
`_validate_lookup_table` caught duplicate inputs and tools with no entries, but
nothing called `tool.validate_arguments(entry.input)`, and `output_schema` was
declared on `ToolParams` and never enforced anywhere.

So this env constructed fine:

```yaml
tools:
  - id: get_weather
    parameters:
      properties:
        location: {type: string}
      required: [location]
      additionalProperties: false
lookup_table:
  get_weather:
    - input: {locaton: "sf"}      # typo
      output: {temperature: 65}
```

The row is unreachable: `location` is required, so any valid call carries it and
never matches this input. You only found out mid-run via `ToolLookupError`. With
`additionalProperties: false` it's worse — those arguments also fail
`validate_arguments` in `ToolRouter`, so the model can never produce a matching
call at all. A guaranteed-dead config, silently accepted.

Credit to @wizeng23 for catching this while reviewing #2573.

## Change

Validate every row at construction, inside the existing per-entry loop in
`_validate_lookup_table`:

- **Inputs** via `tool.validate_arguments(entry.input)`.
- **Outputs** via `output_schema` when the tool declares one — a bad output is
  worse than a bad input, since it flows into generated data rather than erroring.
- `ToolArgumentError` is re-raised as `ValueError`, matching the other
  construction-time errors in that method. `ToolError` subclasses are for the
  LLM self-correction loop, not config validation.

Ordering matters: validation runs **after** `_fill_argument_defaults`, so a row
that is invalid raw but valid once filled (a nested `required` field satisfied by
a nested `default`) is accepted. `test_entry_input_is_validated_after_defaults_are_filled`
pins that ordering — it only fails if validation moves before the fill.

## Breaking change

Any existing config with a sloppy unreachable row now fails at construction
instead of at runtime. That is the check working as intended, but it is a
behavior change for configs that "worked" only because the dead row was never
hit.

`configs/examples/synthesis/library_tool_use_synth.yaml` is the only in-repo
config with a `lookup_table` (9 rows); verified it still constructs.

## Tests

- Invalid input (typo'd key) → `ValueError`
- Validation runs after defaults are filled (ordering pin)
- Invalid output vs `output_schema` → `ValueError`
- Valid output constructs and resolves through `step`

One `test_tool_router.py` fixture supplied a schema-invalid `{}` row and is
updated to a conforming one.

417 passed in `tests/unit/environments/` + `tests/unit/core/synthesis/`.

## Update: non-JSON outputs

`jsonschema` accepts Python values that `ToolResult.output` (`JsonValue`) rejects
— a dict with int keys passes `{"type": "object"}`, and YAML preserves numeric
mapping keys through OmegaConf. Such a row passed validation and then raised at
the first `step()` that resolved it, which is the mid-run failure this PR exists
to prevent. Each output is now checked against `ToolResult` — the actual consumer
— before schema validation. Verified end-to-end from a YAML config.
