### PR TITLE
Optional env name/description; emit tools on synthesized conversations

### DIFF
--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -31,12 +31,25 @@ class EnvironmentParams(BaseParams):
     """Pure-data description of an environment."""
 
     id: str = ""
-    name: str = ""
-    description: str = ""
+    """Reference key for the environment, unique within an ``EnvironmentConfig``."""
+
+    name: str | None = None
+    """Optional human-readable display label. Not used at runtime."""
+
+    description: str | None = None
+    """Optional human-readable description. Not used at runtime."""
+
     env_type: str = ""
+    """Registry key selecting the environment implementation, e.g. ``deterministic``."""
+
     tools: list[Any] = field(default_factory=list)
+    """Tools this environment serves, coerced to ``ToolParams`` in ``__post_init__``."""
+
     env_kwargs: dict[str, Any] | None = None
+    """Type-specific construction kwargs passed to the environment's ``from_params``."""
+
     grounding: GroundingConfig | None = None
+    """Optional grounding configuration for the environment's planner prompts."""
 
     def __post_init__(self) -> None:
         """Coerce raw tool dicts and grounding config."""
@@ -63,13 +76,7 @@ class EnvironmentParams(BaseParams):
         return getattr(env_cls, "tool_params_cls", None) if env_cls else None
 
     def __finalize_and_validate__(self) -> None:
-        """Validate common fields and registry membership.
-
-        ``name`` and ``description`` are optional human-readable labels; only
-        ``id`` (the reference key) and ``env_type`` (the registry key) are
-        required, so environments can be built programmatically without
-        fabricating cosmetic strings.
-        """
+        """Validate common fields and registry membership."""
         if not self.id:
             raise ValueError(f"{type(self).__name__}.id cannot be empty.")
         if not self.env_type:

--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -63,13 +63,15 @@ class EnvironmentParams(BaseParams):
         return getattr(env_cls, "tool_params_cls", None) if env_cls else None
 
     def __finalize_and_validate__(self) -> None:
-        """Validate common fields and registry membership."""
+        """Validate common fields and registry membership.
+
+        ``name`` and ``description`` are optional human-readable labels; only
+        ``id`` (the reference key) and ``env_type`` (the registry key) are
+        required, so environments can be built programmatically without
+        fabricating cosmetic strings.
+        """
         if not self.id:
             raise ValueError(f"{type(self).__name__}.id cannot be empty.")
-        if not self.name:
-            raise ValueError(f"{type(self).__name__}.name cannot be empty.")
-        if not self.description:
-            raise ValueError(f"{type(self).__name__}.description cannot be empty.")
         if not self.env_type:
             raise ValueError(f"{type(self).__name__}.env_type cannot be empty.")
         if self.env_kwargs is not None and not isinstance(self.env_kwargs, Mapping):

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -1012,7 +1012,9 @@ class ConversationSynthesizer:
             if output_message:
                 output_messages.append(output_message)
             output_messages.extend(history)
-            conversations.append(Conversation(messages=output_messages))
+            conversations.append(
+                Conversation(messages=output_messages, tools=assistant_tools)
+            )
 
         return conversations
 

--- a/tests/unit/core/configs/params/test_environment_params.py
+++ b/tests/unit/core/configs/params/test_environment_params.py
@@ -65,7 +65,7 @@ def test_finalize_and_validate_rejects_empty_required_field(field):
         p.finalize_and_validate()
 
 
-def test_finalize_and_validate_allows_empty_name_and_description():
+def test_finalize_and_validate_allows_omitted_name_and_description():
     """name and description are optional labels, not required fields."""
     p = EnvironmentParams(
         id="e1",
@@ -73,8 +73,8 @@ def test_finalize_and_validate_allows_empty_name_and_description():
         tools=[_make_tool()],
     )
     p.finalize_and_validate()
-    assert p.name == ""
-    assert p.description == ""
+    assert p.name is None
+    assert p.description is None
 
 
 def test_finalize_and_validate_rejects_duplicate_tool_ids():

--- a/tests/unit/core/configs/params/test_environment_params.py
+++ b/tests/unit/core/configs/params/test_environment_params.py
@@ -50,11 +50,8 @@ def test_finalize_and_validate_rejects_unknown_env_type():
         p.finalize_and_validate()
 
 
-@pytest.mark.parametrize(
-    "field,value",
-    [("id", ""), ("name", ""), ("description", ""), ("env_type", "")],
-)
-def test_finalize_and_validate_rejects_empty_required_field(field, value):
+@pytest.mark.parametrize("field", ["id", "env_type"])
+def test_finalize_and_validate_rejects_empty_required_field(field):
     base: dict[str, Any] = dict(
         id="e1",
         name="E1",
@@ -62,10 +59,22 @@ def test_finalize_and_validate_rejects_empty_required_field(field, value):
         env_type="deterministic",
         tools=[_make_tool()],
     )
-    base[field] = value
+    base[field] = ""
     p = EnvironmentParams(**base)
     with pytest.raises(ValueError, match=f"{field} cannot be empty"):
         p.finalize_and_validate()
+
+
+def test_finalize_and_validate_allows_empty_name_and_description():
+    """name and description are optional labels, not required fields."""
+    p = EnvironmentParams(
+        id="e1",
+        env_type="deterministic",
+        tools=[_make_tool()],
+    )
+    p.finalize_and_validate()
+    assert p.name == ""
+    assert p.description == ""
 
 
 def test_finalize_and_validate_rejects_duplicate_tool_ids():

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1916,6 +1916,73 @@ def test_synthesize_attaches_tools_to_assistant_prompt(
     assert assistant_prompt.tools[0].function.name == "lookup"
 
 
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_attaches_tools_to_output_conversation(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+):
+    """The emitted conversation carries the tool definitions available to it."""
+
+    def capturing_infer(prompts, inference_config=None):
+        return [
+            Conversation(messages=[Message(role=Role.ASSISTANT, content="ok")])
+            for _ in prompts
+        ]
+
+    mock_engine = Mock()
+    mock_engine.infer.side_effect = capturing_infer
+    mock_build_inference_engine.return_value = mock_engine
+    mock_build_environment.return_value = Mock()
+
+    env_config = MagicMock(spec=EnvironmentConfig)
+    env_config.all_tools = [ToolParams(id="lookup", name="lookup", description="x")]
+    env_config.environments = []
+    env_config.tool_environment_map = {}
+
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+
+    multiturn_attr = MultiTurnAttribute(
+        id="dialog",
+        min_turns=1,
+        max_turns=1,
+        role_instruction_messages={
+            Role.USER: "user",
+            Role.ASSISTANT: "assistant",
+        },
+    )
+
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+    with patch.object(
+        synth,
+        "_resolve_available_tools",
+        return_value=env_config.all_tools,
+    ):
+        result = synth.synthesize(
+            samples=[{"target_turns": 2, "parsed_turn_plans": []}],
+            multiturn_attributes=multiturn_attr,
+        )
+
+    record = result[0]
+    assert record is not None
+    conversation = record["dialog"]
+    assert isinstance(conversation, dict)
+    tools = conversation["tools"]
+    assert tools is not None
+    assert len(tools) == 1
+    assert tools[0]["function"]["name"] == "lookup"
+
+
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_synthesize_no_tools_when_env_has_none(
     mock_build_inference_engine,

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -1983,6 +1983,84 @@ def test_synthesize_attaches_tools_to_output_conversation(
     assert tools[0]["function"]["name"] == "lookup"
 
 
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_synthesize_emits_tools_for_unlabeled_environment(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+):
+    """An environment with no name/description still finalizes and emits tools.
+
+    Drives a real ``EnvironmentConfig`` (not a mock) whose environment omits the
+    optional ``name`` and ``description`` labels, proving the labels are truly
+    optional end-to-end and that its tools still reach the output conversation.
+    """
+
+    def capturing_infer(prompts, inference_config=None):
+        return [
+            Conversation(messages=[Message(role=Role.ASSISTANT, content="ok")])
+            for _ in prompts
+        ]
+
+    mock_engine = Mock()
+    mock_engine.infer.side_effect = capturing_infer
+    mock_build_inference_engine.return_value = mock_engine
+    mock_build_environment.return_value = Mock()
+
+    env_config = EnvironmentConfig(
+        environments=[
+            EnvironmentParams(
+                id="library",
+                env_type="deterministic",
+                tools=[ToolParams(id="lookup", name="lookup", description="x")],
+            )
+        ]
+    )
+    env_config.finalize_and_validate()
+
+    inference_config = InferenceConfig(
+        engine=InferenceEngineType.OPENAI,
+        model=Mock(spec=ModelParams),
+        remote_params=Mock(spec=RemoteParams),
+        generation=GenerationParams(),
+    )
+
+    multiturn_attr = MultiTurnAttribute(
+        id="dialog",
+        min_turns=1,
+        max_turns=1,
+        available_environments=["library"],
+        role_instruction_messages={
+            Role.USER: "user",
+            Role.ASSISTANT: "assistant",
+        },
+    )
+
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        inference_config,
+        environment_config=env_config,
+    )
+    with patch.object(
+        synth,
+        "_resolve_available_tools",
+        return_value=env_config.all_tools,
+    ):
+        result = synth.synthesize(
+            samples=[{"target_turns": 2, "parsed_turn_plans": []}],
+            multiturn_attributes=multiturn_attr,
+        )
+
+    record = result[0]
+    assert record is not None
+    conversation = record["dialog"]
+    assert isinstance(conversation, dict)
+    tools = conversation["tools"]
+    assert tools is not None
+    assert tools[0]["function"]["name"] == "lookup"
+
+
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
 def test_synthesize_no_tools_when_env_has_none(
     mock_build_inference_engine,


### PR DESCRIPTION
# Description

Two small, independent improvements to the agentic-synthesis path, each in its own commit:

1. **`EnvironmentParams.name`/`description` are now optional.** Only `id` (the reference key used by `MultiTurnAttribute.available_environments`) and `env_type` (the registry key) are required to build an environment. `name` and `description` are human-readable labels; requiring them non-empty forced programmatic callers to fabricate throwaway strings. Hand-authored configs that set them are unaffected.

2. **The multi-turn synthesizer now emits tool definitions on the output conversation.** It already attached the available tools to each assistant *inference prompt*, but not to the returned `Conversation` — so the tool schemas were absent from the synthesized dataset. Downstream tool-use SFT reads a conversation's top-level `tools`, so without this the model never sees the tool schemas it was trained to call. The emitted `Conversation` now carries `tools`.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
