### PR TITLE
fix(quantize): repair CLI output_format and output_path defaults

### DIFF
--- a/src/oumi/cli/quantize.py
+++ b/src/oumi/cli/quantize.py
@@ -126,7 +126,10 @@ def quantize(
             parsed_config.model.model_name = model
         if method != "awq_q4_0":  # Only override if not default
             parsed_config.method = method
-        if output != "quantized_model.gguf":  # Only override if not default
+        # Compare against the real --output default; "quantized_model.gguf" was a
+        # stale sentinel, so this always fired and silently ignored the config's
+        # output_path.
+        if output != "quantized_model":
             parsed_config.output_path = output
 
         # Only safetensors is supported for now
@@ -139,10 +142,10 @@ def quantize(
             )
 
         # Determine appropriate output format based on method
-        if method.startswith("awq_"):
-            output_format = "pytorch"
-        elif method.startswith("bnb_"):
-            output_format = "pytorch"  # or "safetensors" depending on preference
+        if method.startswith(("awq_", "bnb_")):
+            # Only safetensors is supported (SUPPORTED_OUTPUT_FORMATS); "pytorch"
+            # failed finalize_and_validate(), so this path never worked.
+            output_format = "safetensors"
         else:
             raise ValueError(
                 f"Unsupported quantization method: {method}. "

--- a/tests/unit/cli/test_cli_quantize.py
+++ b/tests/unit/cli/test_cli_quantize.py
@@ -1,0 +1,105 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from oumi.cli.quantize import quantize
+from oumi.core.configs import QuantizationConfig
+from oumi.quantize.base import QuantizationResult
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def app():
+    fake_app = typer.Typer()
+    fake_app.command()(quantize)
+    yield fake_app
+
+
+@pytest.fixture
+def mock_quantize():
+    """Stubs the quantizer; the CLI formats these fields, so return real types."""
+    with patch("oumi.quantize") as mock:
+        mock.return_value = QuantizationResult(
+            quantized_size_bytes=1024,
+            output_path="/tmp/quantized",
+            quantization_method="bnb_4bit",
+            format_type="safetensors",
+        )
+        yield mock
+
+
+def _captured_config(mock_quantize) -> QuantizationConfig:
+    assert mock_quantize.call_count == 1
+    return mock_quantize.call_args.args[0]
+
+
+@pytest.mark.parametrize("method", ["awq_q4_0", "bnb_4bit"])
+def test_cli_path_uses_safetensors(app, mock_quantize, method):
+    """Without --config the CLI must emit a supported output_format.
+
+    Both branches previously set "pytorch", which is absent from
+    SUPPORTED_OUTPUT_FORMATS, so finalize_and_validate() rejected every
+    invocation of this path.
+    """
+    result = runner.invoke(
+        app, ["--model", "some/model", "--method", method, "--output", "out"]
+    )
+    assert result.exit_code == 0, result.output
+    assert _captured_config(mock_quantize).output_format == "safetensors"
+
+
+def test_config_output_path_survives_when_output_not_passed(app, mock_quantize):
+    """A config's output_path must not be clobbered by the --output default.
+
+    The guard compared against "quantized_model.gguf" while the option default
+    is "quantized_model", so it always fired and overwrote output_path.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        config_path = Path(tmp) / "quant.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  model_name: 'some/model'\n"
+            "method: 'bnb_4bit'\n"
+            "output_path: '/tmp/from_config'\n"
+            "output_format: 'safetensors'\n"
+        )
+        result = runner.invoke(app, ["--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+        assert _captured_config(mock_quantize).output_path == "/tmp/from_config"
+
+
+def test_explicit_output_still_overrides_config(app, mock_quantize):
+    """An explicit --output must still win over the config's output_path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        config_path = Path(tmp) / "quant.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  model_name: 'some/model'\n"
+            "method: 'bnb_4bit'\n"
+            "output_path: '/tmp/from_config'\n"
+            "output_format: 'safetensors'\n"
+        )
+        result = runner.invoke(
+            app, ["--config", str(config_path), "--output", "/tmp/from_cli"]
+        )
+        assert result.exit_code == 0, result.output
+        assert _captured_config(mock_quantize).output_path == "/tmp/from_cli"


### PR DESCRIPTION
## Summary

Two defects made `oumi quantize` unusable outside the `-c config.yaml` path.

**1. `output_format` hardcoded to `"pytorch"`**

Both branches of the no-config path set `output_format = "pytorch"`, but `SUPPORTED_OUTPUT_FORMATS` is `["safetensors"]`, so `finalize_and_validate()` rejected every invocation:

```
Error: Unsupported output format: pytorch. Must be one of: ['safetensors']
```

`oumi quantize --model X --method Y --output Z` therefore failed for all six methods.

**2. Stale `--output` sentinel**

The guard compared against `"quantized_model.gguf"` while the option's actual default is `"quantized_model"`. The condition was always true, so a config file's `output_path` was silently overwritten with the CLI default and the model was written to the CWD instead of the requested path.

## Tests

The CLI had no test module, which is why both survived. Adds `tests/unit/cli/test_cli_quantize.py`: no-config `output_format`, config `output_path` preservation, and explicit-override behaviour. Three of the four fail against the unfixed CLI.

## Found via

Running a post-training quantization sweep across five models; both defects blocked the no-config path entirely.
