### PR TITLE
Pinned nvidia-cutlass-dsl for FA4 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ flash_attn = [
     # Note: May require manual installation with: pip install flash-attn --no-build-isolation
     # This is kept separate to avoid breaking existing environments
     "flash-attn>=2.0.0",
+    # flash-attn >=2.8 ships flash_attn/cute (FA4) which uses cutlass without declaring
+    # it as a dependency, so pip can't pick a compatible version on its own.
+    "nvidia-cutlass-dsl==4.2.1",
 ]
 
 evaluation = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,9 +168,6 @@ flash_attn = [
     # Note: May require manual installation with: pip install flash-attn --no-build-isolation
     # This is kept separate to avoid breaking existing environments
     "flash-attn>=2.0.0",
-    # flash-attn >=2.8 ships flash_attn/cute (FA4) which uses cutlass without declaring
-    # it as a dependency, so pip can't pick a compatible version on its own.
-    "nvidia-cutlass-dsl==4.2.1",
 ]
 
 evaluation = [

--- a/tests/scripts/e2e_tests_job.yaml
+++ b/tests/scripts/e2e_tests_job.yaml
@@ -35,6 +35,8 @@ run: |
   source "./configs/examples/misc/sky_init.sh"
 
   pip install uv && uv pip install --system -e ".[ci_gpu]" hf_transfer
+  # flash-attn >=2.8 ships flash_attn/cute (FA4) which uses cutlass without declaring
+  # it as a dependency, so pip can't pick a compatible version on its own.
   pip install flash-attn==2.8.3.post1 --no-build-isolation
   pip install "nvidia-cutlass-dsl==4.2.1"
 

--- a/tests/scripts/e2e_tests_job.yaml
+++ b/tests/scripts/e2e_tests_job.yaml
@@ -35,7 +35,8 @@ run: |
   source "./configs/examples/misc/sky_init.sh"
 
   pip install uv && uv pip install --system -e ".[ci_gpu]" hf_transfer
-  pip install -U flash-attn --no-build-isolation
+  pip install flash-attn==2.8.3.post1 --no-build-isolation
+  pip install "nvidia-cutlass-dsl==4.2.1"
 
   echo "Node ${SKYPILOT_NODE_RANK} starting..."
   echo "Unit tests: ${ENABLE_OUMI_UNIT_TESTS}"


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
In the e2e test,GRPO training crashes at trainer construction with:

```
AttributeError: module 'cutlass.cute.core' has no attribute 'ThrMma'
```

This is due to conflicts in dependency versions. 

An imperfect guard in vLLM does not catch that FA4 is not usable:

   ```python
   try:
       from flash_attn.cute.interface import _flash_attn_fwd
       FA4_AVAILABLE = True
   except ImportError as e:          # AttributeError is not an ImportError
       FA4_AVAILABLE = False
   ```

So it thinks that FA4 is usable but FA4 needs:
- `cutlass.utils.ampere_helpers` (dropped in nvidia-cutlass-dsl 4.3.0)
- `cute.core.ThrMma` (dropped in nvidia-cutlass-dsl 4.6.0)
- flashinfer (via vllm) needs nvidia-cutlass-dsl >=4.2.1.

That leaves nvidia-cutlass-dsl 4.2.1 as the only version satisfying all three. However, `flash_attn` does not declare cutlass as a dependency. So cutlass is only installed as a transitive dependency of flashinfer (via vllm). With an unbounded ceiling and no competing constraint, pip resolves to the newest release (4.6.1) which does not have `cute.core.ThrMma` and thus breaks flash-attn.

Pinning nvidia-cutlass-dsl to 4.2.1 should resolve the issue. e2e tests are running now.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
