### PR TITLE
Add mandatory description field to fix verl tool schema tests

### DIFF
--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -27,6 +27,28 @@ class _FakeAgentData(SimpleNamespace):
     """A weak-referenceable agent data stub."""
 
 
+def _tool_schema(name: str = "run_sql") -> OpenAIFunctionToolSchema:
+    """Mirrors the run_sql tool entry written by _make_tool.
+
+    `description` is required by verl's schema, so it cannot be omitted even
+    where a test only cares about the tool name.
+    """
+    return OpenAIFunctionToolSchema.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "run",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    )
+
+
 def _make_tool(tmp_path) -> OumiVerlTool:
     cfg_path = tmp_path / "env.yaml"
     cfg_path.write_text(
@@ -38,20 +60,9 @@ def _make_tool(tmp_path) -> OumiVerlTool:
         "required: [query]},\n"
         f"     executor: {__name__}.run_sql, read_only: true}}\n"
     )
-    schema = OpenAIFunctionToolSchema.model_validate(
-        {
-            "type": "function",
-            "function": {
-                "name": "run_sql",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"query": {"type": "string"}},
-                    "required": ["query"],
-                },
-            },
-        }
+    return OumiVerlTool(
+        config={"oumi_env_config": str(cfg_path)}, tool_schema=_tool_schema()
     )
-    return OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
 
 
 def _agent_data(request_id: str) -> _FakeAgentData:
@@ -87,23 +98,18 @@ def test_invalid_env_config_is_rejected_at_construction(tmp_path):
     cfg_path.write_text(
         "environments:\n- id: db\n  name: db\n  description: d\n  env_type: nope\n"
     )
-    schema = OpenAIFunctionToolSchema.model_validate(
-        {"type": "function", "function": {"name": "run_sql"}}
-    )
-
     with pytest.raises(ValueError, match="Unknown env_type 'nope'"):
-        OumiVerlTool(config={"oumi_env_config": str(cfg_path)}, tool_schema=schema)
+        OumiVerlTool(
+            config={"oumi_env_config": str(cfg_path)}, tool_schema=_tool_schema()
+        )
 
 
 def test_tool_name_missing_from_env_config_is_rejected_at_construction(tmp_path):
     """The name is spelled out twice; a mismatch must not wait for the first call."""
     tool = _make_tool(tmp_path)
-    schema = OpenAIFunctionToolSchema.model_validate(
-        {"type": "function", "function": {"name": "run_sqll"}}
-    )
 
     with pytest.raises(ValueError, match="Known tools: \\['run_sql'\\]"):
-        OumiVerlTool(config=tool.config, tool_schema=schema)
+        OumiVerlTool(config=tool.config, tool_schema=_tool_schema("run_sqll"))
 
 
 def test_failed_tool_call_becomes_an_observation(tmp_path):


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
In verl, description is a required field with no default:

```
class OpenAIFunctionSchema(BaseModel):
    name: str
    description: str  
```

Test data did not include `description` field, hence the failing tests. 
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
