### PR TITLE
[Synth Env] Make guided decoding optional for synthetic tool simulation

### DIFF
--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -225,6 +225,7 @@ At the config level:
 - Tools do not declare an `environment` field. The parent environment owns the binding.
 - `deterministic_outputs` is only used for tools in `deterministic` environments.
 - `read_only` is only meaningful for tools in stateful `synthetic` environments.
+- `env_kwargs.guided_decoding` (default `true`) constrains simulated tool output to each tool's `output_schema`. Set it to `false` when a schema is too large for the provider's grammar compiler, or when constrained decoding is too slow — output is still validated against `output_schema` after generation, so an off-schema response raises a tool error instead of being silently accepted. Individual tools can override the env default with their own `guided_decoding` field.
 - Multiturn attributes reference environments (not individual tools) to select which tools are available.
 
 Example:

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -80,8 +80,9 @@ class ToolParams(BaseParams):
     guided_decoding: bool | None = None
     """Per-tool override of the synthetic env's ``guided_decoding`` default.
 
-    ``None`` inherits ``SyntheticEnvironmentKwargs.guided_decoding``. Ignored by
-    environments that don't LLM-simulate tool output.
+    ``None`` inherits ``SyntheticEnvironmentKwargs.guided_decoding``. Inert when the
+    tool has no ``output_schema`` (nothing to constrain), and in environments that
+    don't LLM-simulate tool output.
     """
 
     @classmethod

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -77,6 +77,12 @@ class ToolParams(BaseParams):
     ``SyntheticEnvironment``, ``context`` for an ``ExecutableEnvironment`` — and
     must return a ``ToolResult``.
     """
+    guided_decoding: bool | None = None
+    """Per-tool override of the synthetic env's ``guided_decoding`` default.
+
+    ``None`` inherits ``SyntheticEnvironmentKwargs.guided_decoding``. Ignored by
+    environments that don't LLM-simulate tool output.
+    """
 
     @classmethod
     def create(cls, raw: Any) -> ToolParams:
@@ -98,6 +104,7 @@ class ToolParams(BaseParams):
                 else None
             ),
             read_only=raw.get("read_only", True),
+            guided_decoding=raw.get("guided_decoding"),
             executor=raw.get("executor", ""),
         )
 

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -79,6 +79,14 @@ class SyntheticEnvironmentKwargs(BaseParams):
     tool_persona: str = ""
     state_params: SyntheticStateParams | None = None
     cache_by_input: bool = True
+    guided_decoding: bool = True
+    """Constrain simulator output to each tool's ``output_schema``.
+
+    Set to ``False`` to generate freely and rely on the ``jsonschema``
+    post-validation instead: large ``output_schema`` values can exceed a
+    provider's grammar-compiler limits or make constrained decoding several
+    times slower.
+    """
 
     def __post_init__(self) -> None:
         """Coerce state_params dict into SyntheticStateParams if needed."""
@@ -415,14 +423,23 @@ class SyntheticEnvironment(BaseEnvironment):
     def _simulator_inference_config(self, tool: ToolParams) -> InferenceConfig:
         """Overlay guided decoding for the tool's output_schema onto base_config.
 
-        Tools without ``output_schema`` get the permissive ``{"type": "object"}``
-        constraint. Mirrors ``ConversationSynthesizer._planner_inference_config``.
+        No constraint is sent when the tool has no ``output_schema`` (nothing to
+        constrain) or when ``guided_decoding`` is off (env default, or the tool's
+        own override), leaving ``_parse_and_validate`` as the only schema check.
         """
         assert self._base_inference_config is not None
-        schema = tool.output_schema or {"type": "object"}
+        use_guided = (
+            self._kwargs.guided_decoding
+            if tool.guided_decoding is None
+            else tool.guided_decoding
+        )
+        guided = (
+            GuidedDecodingParams(json=tool.output_schema)
+            if use_guided and tool.output_schema
+            else None
+        )
         sim_gen = dataclasses.replace(
-            self._base_inference_config.generation,
-            guided_decoding=GuidedDecodingParams(json=schema),
+            self._base_inference_config.generation, guided_decoding=guided
         )
         return dataclasses.replace(self._base_inference_config, generation=sim_gen)
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -33,7 +33,7 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttribute,
     SampledAttributeValue,
 )
-from oumi.core.configs.params.tool_params import ToolError, ToolParams
+from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.synthesis.conversation_synthesizer import (
     ConversationSynthesizer,
     OpeningTurnPrompt,
@@ -48,6 +48,7 @@ from oumi.core.types.conversation import (
 )
 from oumi.core.types.tool_call import FunctionCall, ToolCall, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
+from oumi.environments.synthetic_environment import SyntheticEnvironment
 
 
 @pytest.fixture
@@ -2265,18 +2266,57 @@ def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
 
 @patch("oumi.core.synthesis.tool_router.build_environment")
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_dispatch_tool_calls_recovers_from_schema_validation_tool_error(
+def test_dispatch_tool_calls_recovers_from_unguided_schema_drift(
     mock_build_inference_engine,
     mock_build_environment,
     mock_general_synthesis_params,
 ):
-    """Unguided simulator drift must surface as a tool error, not kill the sample."""
-    mock_build_inference_engine.return_value = Mock()
-    fake_env = Mock(spec=BaseEnvironment)
-    fake_env.step.side_effect = ToolError(
-        "Simulator output for 't' failed schema validation: 1 is not of type 'string'"
+    """End-to-end: guidance off → off-schema simulator output → recoverable tool error.
+
+    Drives a real ``SyntheticEnvironment`` so the assertions cover the whole path:
+    no constraint reaches the engine, and the resulting ``ToolError`` becomes a
+    ``TOOL`` message instead of killing the sample.
+    """
+    tool = ToolParams(
+        id="answer",
+        name="Answer",
+        description="Answer.",
+        parameters={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        },
     )
-    mock_build_environment.return_value = fake_env
+    env_params = EnvironmentParams(
+        id="faq",
+        name="FAQ",
+        description="FAQ env",
+        env_type="synthetic",
+        tools=[tool],
+        env_kwargs={"tool_persona": "Answer FAQs.", "guided_decoding": False},
+    )
+    mock_build_environment.return_value = SyntheticEnvironment.from_params(env_params)
+
+    mock_engine = Mock()
+    mock_engine.infer = Mock(
+        side_effect=lambda convs, _cfg: [
+            Conversation(
+                messages=[*c.messages, Message(role=Role.ASSISTANT, content='{"a": 1}')]
+            )
+            for c in convs
+        ]
+    )
+    mock_build_inference_engine.return_value = mock_engine
+
+    env_config = MagicMock(spec=EnvironmentConfig)
+    env_config.environments = [env_params]
+    env_config.all_tools = [tool]
+    env_config.tool_environment_map = {"answer": "faq"}
 
     synth = ConversationSynthesizer(
         mock_general_synthesis_params,
@@ -2286,12 +2326,14 @@ def test_dispatch_tool_calls_recovers_from_schema_validation_tool_error(
             remote_params=Mock(spec=RemoteParams),
             generation=GenerationParams(),
         ),
-        environment_config=_make_env_config("e", "t"),
+        environment_config=env_config,
     )
 
-    tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="{}"))
+    tc = ToolCall(id="c", function=FunctionCall(name="answer", arguments='{"q": "x"}'))
     synth._prepare_sample_routers(1)
     [msg] = synth._dispatch_tool_calls([tc], 0)
+
+    assert mock_engine.infer.call_args[0][1].generation.guided_decoding is None
     assert msg.role == Role.TOOL
     assert "failed schema validation" in str(msg.content)
 

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -33,7 +33,7 @@ from oumi.core.configs.params.synthesis_params import (
     SampledAttribute,
     SampledAttributeValue,
 )
-from oumi.core.configs.params.tool_params import ToolParams
+from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.synthesis.conversation_synthesizer import (
     ConversationSynthesizer,
     OpeningTurnPrompt,
@@ -2261,6 +2261,39 @@ def test_dispatch_tool_calls_handles_env_exception_with_per_call_fallback(
     [msg] = synth._dispatch_tool_calls([tc], 0)
     assert msg.role == Role.TOOL
     assert "Tool 't' raised: boom" in str(msg.content)
+
+
+@patch("oumi.core.synthesis.tool_router.build_environment")
+@patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
+def test_dispatch_tool_calls_recovers_from_schema_validation_tool_error(
+    mock_build_inference_engine,
+    mock_build_environment,
+    mock_general_synthesis_params,
+):
+    """Unguided simulator drift must surface as a tool error, not kill the sample."""
+    mock_build_inference_engine.return_value = Mock()
+    fake_env = Mock(spec=BaseEnvironment)
+    fake_env.step.side_effect = ToolError(
+        "Simulator output for 't' failed schema validation: 1 is not of type 'string'"
+    )
+    mock_build_environment.return_value = fake_env
+
+    synth = ConversationSynthesizer(
+        mock_general_synthesis_params,
+        InferenceConfig(
+            engine=InferenceEngineType.OPENAI,
+            model=Mock(spec=ModelParams),
+            remote_params=Mock(spec=RemoteParams),
+            generation=GenerationParams(),
+        ),
+        environment_config=_make_env_config("e", "t"),
+    )
+
+    tc = ToolCall(id="c", function=FunctionCall(name="t", arguments="{}"))
+    synth._prepare_sample_routers(1)
+    [msg] = synth._dispatch_tool_calls([tc], 0)
+    assert msg.role == Role.TOOL
+    assert "failed schema validation" in str(msg.content)
 
 
 @patch("oumi.core.synthesis.tool_router.build_environment")

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import random
 from unittest.mock import Mock
 
@@ -182,14 +183,21 @@ def _typed_params() -> EnvironmentParams:
     )
 
 
-def _attached_env(infer_returns: list[str]) -> tuple[SyntheticEnvironment, Mock]:
+def _attached_env(
+    infer_returns: list[str],
+    params: EnvironmentParams | None = None,
+    **kwargs_overrides,
+) -> tuple[SyntheticEnvironment, Mock]:
     """Build an env with a mock engine that drains ``infer_returns`` in order.
 
     Each call consumed by the simulator pops the next element from the queue,
     so a single ``infer_returns`` list spans multiple ``env.step`` invocations
-    and multiple within-batch calls.
+    and multiple within-batch calls. ``kwargs_overrides`` are merged into
+    ``env_kwargs``.
     """
-    env = SyntheticEnvironment.from_params(_typed_params())
+    params = params or _typed_params()
+    params.env_kwargs = {**(params.env_kwargs or {}), **kwargs_overrides}
+    env = SyntheticEnvironment.from_params(params)
     mock_engine = Mock()
     queue = list(infer_returns)
 
@@ -332,6 +340,55 @@ def test_simulator_inference_config_overlays_guided_decoding():
     assert cfg.generation is not None
     assert cfg.generation.guided_decoding is not None
     assert cfg.generation.guided_decoding.json == tool.output_schema
+
+
+def test_simulator_inference_config_omits_guided_decoding_when_disabled():
+    env, _ = _attached_env(['{"a": "x"}'], guided_decoding=False)
+    cfg = env._simulator_inference_config(env._lookup_tool("answer"))
+    assert cfg.generation.guided_decoding is None
+
+
+@pytest.mark.parametrize(
+    "env_default,tool_override,expect_guided",
+    [
+        (True, None, True),
+        (True, False, False),
+        (False, None, False),
+        (False, True, True),
+    ],
+)
+def test_tool_guided_decoding_overrides_env_default(
+    env_default, tool_override, expect_guided
+):
+    params = _typed_params()
+    params.tools = [_typed_tool(guided_decoding=tool_override)]
+    env, _ = _attached_env(['{"a": "x"}'], params=params, guided_decoding=env_default)
+    cfg = env._simulator_inference_config(env._lookup_tool("answer"))
+    assert (cfg.generation.guided_decoding is not None) == expect_guided
+
+
+def test_simulator_inference_config_omits_guided_decoding_without_output_schema():
+    """A bare ``{"type": "object"}`` constraint means ``{}``-only under strict mode."""
+    params = _typed_params()
+    params.tools = [_typed_tool(output_schema=None)]
+    env, _ = _attached_env(['{"a": "x"}'], params=params)
+    cfg = env._simulator_inference_config(env._lookup_tool("answer"))
+    assert cfg.generation.guided_decoding is None
+
+
+def test_system_prompt_carries_output_schema_when_guidance_disabled():
+    """Free generation leans on the prompt, so the full schema must stay in it."""
+    env, _ = _attached_env(['{"a": "x"}'], guided_decoding=False)
+    tool = env._lookup_tool("answer")
+    prompt = str(env.build_call_conversation("answer", {"q": "hi"}).messages[0].content)
+    assert json.dumps(tool.to_llm_schema(), indent=2) in prompt
+    assert "output_schema" in prompt
+
+
+def test_step_without_guided_decoding_still_validates_output_schema():
+    env, _ = _attached_env(['{"a": 1}'], guided_decoding=False)
+    with pytest.raises(ToolError, match="failed schema validation"):
+        env.step([("answer", {"q": "x"})])
 
 
 def test_build_call_conv_has_system_and_user_messages():


### PR DESCRIPTION
# Description

`SyntheticEnvironment` unconditionally constrained simulator output to each tool's
`output_schema` via guided decoding, with no way to opt out short of monkeypatching the
inference engine.

That is a problem for large schemas. A provider compiles the schema into a grammar, and
past a certain size that compilation gets slow or fails outright — on Anthropic's
`output_config` path it fails to compile and surfaces upstream as request timeouts rather
than a legible error. Constrained decoding is also several times slower than free
generation on the same schema.

The guarantee guided decoding buys is narrower than it looks: `_parse_and_validate`
already validates every simulator response against `output_schema` after generation, and
`ConversationSynthesizer._dispatch_tool_calls` already turns a resulting `ToolError` into
a structured tool-error message the model can self-correct against. So the trade is
in-decode enforcement versus post-generation enforcement, not enforcement versus none.

This PR makes the in-decode half optional.

- `SyntheticEnvironmentKwargs.guided_decoding` (default `True`) sets the env-wide default.
- `ToolParams.guided_decoding` (`None` = inherit) overrides it per tool.
- `_simulator_inference_config` resolves tool override → env default → `True`, and sends
  no constraint when it resolves to off.

The library default stays `True`, so existing configs are unaffected.

Also drops the `{"type": "object"}` fallback for tools without an `output_schema`. Strict-mode
providers inject `additionalProperties: false` into every object schema, which narrows that
bare constraint to *only* the empty object — so a schemaless tool was silently forced to
simulate `{}`. There is nothing to constrain without a schema, and `_parse_and_validate` is
a no-op there, so the constraint is now omitted.

## Behavior change: schemaless tools

Dropping the fallback is not provider-neutral. `GuidedDecodingParams.strict` defaults to
`False`, and only the strict branch injects `additionalProperties: false`
(`remote_inference_engine.py:477`), while Anthropic injects it unconditionally
(`anthropic_inference_engine.py:1045`). So the bare `{"type": "object"}` constraint behaved
differently per provider, and for a tool with **no** `output_schema`:

| Provider | Before | After |
| --- | --- | --- |
| Anthropic | `additionalProperties: false` injected → only `{}` validated, silently forcing empty tool results | Correct — no constraint sent |
| OpenAI-compatible, Gemini/GCP | Non-strict `response_format` enforced a JSON object | No constraint sent |
| vLLM, SGLang | `guided_json` enforced a JSON object | No constraint sent |

Anthropic is fixed; the other four lose a JSON-object guarantee they did have. For those,
a schemaless tool's output correctness now rests on the system prompt plus
`_parse_and_validate`, which still runs `extract_json` and rejects non-dict output with
`ToolError` — a loud failure rather than a silent one, but a failure that previously could
not occur. Tools that declare an `output_schema` are unaffected.

Expressing "any object" is not possible under strict-mode schemas, so there is no
constraint that satisfies both Anthropic and the others here.

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (`docs/`, `README.md`, docstrings)
- [x] Tests added/updated

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
