### PR TITLE
feat(collators): opt-in end-of-turn supervision + nested tool-result masking

### DIFF
--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -33,6 +33,9 @@ class TextCompletionsCollatorWithPadding:
         end_of_turn_template: str | list[int] | None = None,
         mask_tool_calls: bool = False,
         tool_call_start_template: str | list[int] | None = None,
+        tool_result_start_template: str | list[int] | None = None,
+        tool_result_end_template: str | list[int] | None = None,
+        supervise_end_of_turn: bool = False,
         ignore_index: int = -100,
     ):
         """Custom collator for text LLM training.
@@ -48,6 +51,15 @@ class TextCompletionsCollatorWithPadding:
         mask_tool_calls: When True, re-masks assistant spans containing tool calls.
         tool_call_start_template: String or token-ID list marking tool-call start.
             Required when mask_tool_calls=True.
+        tool_result_start_template: Marks the start of a tool RESULT nested inside
+            a model turn (Gemma 3/4 render results there). Those tokens are
+            environment output; supervising them teaches the model to invent
+            results. Templates that give results their own turn can omit this.
+        tool_result_end_template: Marks the end of such a nested tool result.
+        supervise_end_of_turn: When True the end-of-turn template is itself
+            supervised. Needed for causal-LM SFT where the model must emit the
+            terminator to stop; masked, it learns to produce content but never to
+            finish.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         """
@@ -58,6 +70,9 @@ class TextCompletionsCollatorWithPadding:
             end_of_turn_template=end_of_turn_template,
             mask_tool_calls=mask_tool_calls,
             tool_call_start_template=tool_call_start_template,
+            tool_result_start_template=tool_result_start_template,
+            tool_result_end_template=tool_result_end_template,
+            supervise_end_of_turn=supervise_end_of_turn,
             ignore_index=ignore_index,
         )
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -34,6 +34,9 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         end_of_turn_template: str | list[int] | None = None,
         mask_tool_calls: bool = False,
         tool_call_start_template: str | list[int] | None = None,
+        tool_result_start_template: str | list[int] | None = None,
+        tool_result_end_template: str | list[int] | None = None,
+        supervise_end_of_turn: bool = False,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -104,6 +107,22 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 UserWarning,
             )
 
+        # Some chat templates (Gemma 3/4) nest tool RESULTS inside the model turn,
+        # between the model's own tool calls. Those tokens are environment output,
+        # not model output: supervising them teaches the model to invent tool
+        # results. Templates that give tool results their own turn can leave these
+        # unset and nothing changes.
+        # Opt-in: whether the end-of-turn template itself is supervised. Default
+        # False preserves existing behaviour. Set True for causal-LM SFT where the
+        # model must emit the terminator to stop — leaving it masked trains the
+        # model to produce content but never to finish, and generation then runs to
+        # the token cap. It is one token per turn, so the loss curve looks healthy
+        # either way and only generation reveals it.
+        self.supervise_end_of_turn = supervise_end_of_turn
+
+        self.tool_result_start_token_ids = self._encode_template(tool_result_start_template)
+        self.tool_result_end_token_ids = self._encode_template(tool_result_end_template)
+
         self.ignore_index = ignore_index
         self.padding_free = padding_free
 
@@ -133,6 +152,41 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             if seq[i] == first and seq[i : i + plen] == pattern:
                 return True
         return False
+
+    def _model_authored_spans(
+        self, seq: list[int], start: int, end: int
+    ) -> list[tuple[int, int]]:
+        """Split [start, end) into the parts the MODEL authored.
+
+        Tool results nested inside a model turn are environment output. Without
+        this the whole turn is supervised and the model learns to emit
+        `<|tool_response>` blocks and their contents itself.
+        """
+        res_start = self.tool_result_start_token_ids
+        res_end = self.tool_result_end_token_ids
+        if not res_start or not res_end:
+            return [(start, end)]
+
+        spans: list[tuple[int, int]] = []
+        cursor = start
+        for rel in self._find_pattern(seq[start:end], res_start):
+            block_start = start + rel
+            if block_start < cursor:  # already consumed by a previous block
+                continue
+            if block_start > cursor:
+                spans.append((cursor, block_start))
+            closes = self._find_pattern(seq[block_start:end], res_end)
+            cursor = (block_start + closes[0] + len(res_end)) if closes else end
+        if cursor < end:
+            spans.append((cursor, end))
+        return spans
+
+    def _encode_template(self, template: str | list[int] | None) -> list[int] | None:
+        if template is None:
+            return None
+        if isinstance(template, str):
+            return self.tokenizer.encode(template, add_special_tokens=False)
+        return list(template)
 
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
@@ -183,6 +237,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 eot_positions = self._find_pattern(seq[content_start:n], eot_ids)
                 if eot_positions:
                     content_end = content_start + eot_positions[0]
+                    if self.supervise_end_of_turn:
+                        content_end += len(eot_ids)
                 else:
                     content_end = n
 
@@ -199,10 +255,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     ):
                         continue
 
-                # Step 5: unmask this assistant response span.
-                batch["labels"][i, content_start:content_end] = batch["input_ids"][
-                    i, content_start:content_end
-                ]
+                # Step 5: unmask this assistant response span, skipping any tool
+                # RESULT blocks nested inside it.
+                for lo, hi in self._model_authored_spans(seq, content_start, content_end):
+                    batch["labels"][i, lo:hi] = batch["input_ids"][i, lo:hi]
 
     # ------------------------------------------------------------------
     # Main collation

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -274,6 +274,9 @@ def get_template_token_ids() -> tuple[list[int], list[int], list[int]]:
 
 def make_span_collator(
     mask_tool_calls: bool = False,
+    tool_result_start_template: list[int] | None = None,
+    tool_result_end_template: list[int] | None = None,
+    supervise_end_of_turn: bool = False,
 ) -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
     resp_ids, eot_ids, tc_ids = get_template_token_ids()
@@ -283,6 +286,9 @@ def make_span_collator(
         end_of_turn_template=eot_ids,
         mask_tool_calls=mask_tool_calls,
         tool_call_start_template=tc_ids if mask_tool_calls else None,
+        tool_result_start_template=tool_result_start_template,
+        tool_result_end_template=tool_result_end_template,
+        supervise_end_of_turn=supervise_end_of_turn,
     )
 
 
@@ -594,3 +600,54 @@ def test_span_labels_numpy_values_match_expected():
     batch = make_span_collator()([{"input_ids": seq}])
     expected = [IGNORE] * len(resp) + content + [IGNORE] * len(eot)
     assert np.all(batch["labels"].numpy() == np.array([expected], dtype=np.int32))
+
+
+# --- opt-in behaviour for causal-LM SFT on tool-calling templates -------------
+
+
+def test_span_eot_supervised_when_opted_in():
+    """With supervise_end_of_turn, the terminator enters the loss.
+
+    Masked, the model learns to produce content but never to stop; generation
+    then runs to the token cap. Only generation reveals it — the terminator is a
+    single token per turn, so the loss curve is unchanged either way.
+    """
+    resp, eot, _ = get_template_token_ids()
+    content = [_SENTINELS[0]]
+    seq = flat(resp, content, eot)
+
+    labels = get_span_labels(make_span_collator(supervise_end_of_turn=True), seq)
+
+    eot_start = len(resp) + len(content)
+    assert labels[eot_start : eot_start + len(eot)] == eot
+
+
+def test_span_nested_tool_result_is_masked_when_templates_given():
+    """Templates like Gemma 3/4 nest tool RESULTS inside the model turn.
+
+    Those tokens are environment output. Supervising them teaches the model to
+    invent tool results, while the model's own call and the prose that follows
+    must stay supervised.
+    """
+    resp, eot, _ = get_template_token_ids()
+    res_start, res_end = [_SENTINELS[6]], [_SENTINELS[7]]
+    call = [_SENTINELS[0]]
+    result_body = [_SENTINELS[1], _SENTINELS[2]]
+    after = [_SENTINELS[3]]
+    seq = flat(resp, call, res_start, result_body, res_end, after, eot)
+
+    labels = get_span_labels(
+        make_span_collator(
+            tool_result_start_template=res_start,
+            tool_result_end_template=res_end,
+        ),
+        seq,
+    )
+
+    i = len(resp)
+    assert labels[i : i + len(call)] == call, "the model's own call must be supervised"
+    i += len(call)
+    n_result = len(res_start) + len(result_body) + len(res_end)
+    assert all(v == IGNORE for v in labels[i : i + n_result]), "tool result must be masked"
+    i += n_result
+    assert labels[i : i + len(after)] == after, "prose after the result must be supervised"


### PR DESCRIPTION
Two options for span masking on templates that nest tool RESULTS inside the model
turn (Gemma 3/4). Both default to the current behaviour, so existing runs and the
22 existing tests are unchanged.

supervise_end_of_turn (default False)
    Includes the end_of_turn template in the supervised span. For causal-LM SFT
    the model must emit the terminator to stop; masked, it learns to produce
    content but never to finish and generation runs to the token cap. This is a
    single token per turn, so the loss curve is identical either way and only
    generation reveals it — an adapter trained without it emitted 210 consecutive
    tool calls while its eval loss fell monotonically 1.381 -> 1.179.

tool_result_start_template / tool_result_end_template (default None)
    Excludes nested tool-result blocks from the supervised span. Gemma 4 renders
    `<|tool_response>...<tool_response|>` INSIDE the model turn, between the
    model's own calls, so a single span from response_template to end_of_turn
    supervises environment output and teaches the model to invent tool results.
    Verified on a real 4504-token multi-turn trajectory: the original supervises
    403 tokens including three tool-result blocks; with these set it supervises
    269, excluding them, while keeping the model's own calls and the prose that
    follows each result.

mask_tool_calls does not address this — it skips any span CONTAINING a tool call,
which on this template drops nearly all supervision.

Adds two regression tests. Both defects are invisible to token-count assertions
and appear only in generation, which is why the existing suite passes on them.

# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [ ] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
