### PR TITLE
Tool response in assistant span detection and tests

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -48,6 +48,8 @@ _TOOL_FIX_HINT = (
     "collator_kwargs, or use a chat template that renders tool results in their "
     "own turn."
 )
+_SPAN_TRAIN_TARGETS = ("all_assistant_turns", "final_assistant_turn")
+_TOOL_TEMPLATE_KEYS = ("tool_response_template", "end_of_tool_response_template")
 _PROBE_RESULT = "PROBE_TOOL_RESULT_"
 _PROBE_CALL_ID = "probecall"
 _PROBE_TOOLS: list[Any] = [
@@ -284,12 +286,12 @@ def resolve_tool_response_template(
     """Detects the bracket around tool results nested inside assistant spans.
 
     Span masking unmasks everything between ``response_template`` and the next
-    ``end_of_turn_template``. Some chat templates (gemma-4) render tool results
-    *inside* the assistant turn, which puts environment output inside that span.
-    This finds the marker pair bracketing those results so masking can exclude them.
+    ``end_of_turn_template``. Some chat templates (e.g. gemma-4) render tool results
+    inside the assistant turn resulting in environment output being unmasked.
+    The returned bracket lets the collator remask it.
 
-    Returns token ids rather than strings: ``_tokenize_template`` accepts either, and
-    ids avoid a decode/re-encode round trip that isn't guaranteed to be lossless.
+    Returns token ids rather than strings to avoid a decode/re-encode round trip
+    that isn't guaranteed to be lossless.
 
     Returns:
         (opener_ids, closer_ids) when tool results are nested and a specific bracket
@@ -383,6 +385,62 @@ def resolve_tool_response_template(
         closer,
     )
     return [open_id], [close_id]
+
+
+def _resolve_tool_bracket(
+    tokenizer: "BaseTokenizer",
+    collator_kwargs: dict,
+    config_collator_kwargs: dict,
+) -> tuple[list[int], list[int]] | None:
+    """The bracket around tool results this template nests in the assistant turn.
+
+    Some templates render tool results inside the assistant turn, which leaves them
+    unmasked. The returned bracket lets the collator mask them again.
+
+    Returns:
+        (opener_ids, closer_ids), or None when the bracket is already configured, the
+        train_target isn't span-based, or tool results aren't nested.
+
+    Raises:
+        ValueError: Only one of the two markers was supplied, or the template nests
+            tool results but no bracket could be recovered.
+    """
+    supplied = [key for key in _TOOL_TEMPLATE_KEYS if config_collator_kwargs.get(key)]
+    if len(supplied) == 1:
+        # One marker alone masks nothing, and it would also suppress the detection
+        # that reports a nesting template.
+        missing = next(key for key in _TOOL_TEMPLATE_KEYS if key not in supplied)
+        raise ValueError(
+            f"collator_kwargs sets '{supplied[0]}' without '{missing}'. Tool results "
+            "are only excluded from the training loss when both markers are set.\n"
+            f"Fix: also set '{missing}' in collator_kwargs."
+        )
+    if supplied:
+        return None  # Hand-supplied bracket wins; nothing to detect.
+
+    if collator_kwargs.get("train_target") not in _SPAN_TRAIN_TARGETS:
+        return None  # Only span-based masking can unmask a tool result.
+
+    response_template = config_collator_kwargs.get(
+        "response_template", collator_kwargs.get("response_template")
+    )
+    if not response_template:
+        return None
+
+    # Needed only to tell a nested tool result from one in its own turn.
+    turn_boundary = config_collator_kwargs.get(
+        "end_of_turn_template"
+    ) or collator_kwargs.get("end_of_turn_template")
+    if not turn_boundary:
+        # train_target='final_assistant_turn' carries no end_of_turn_template. Detection
+        # can fail, and a hand-supplied response_template is the usual reason it was
+        # bypassed, so give up on the bracket rather than failing the build.
+        try:
+            turn_boundary = resolve_collator_templates(tokenizer)[1]
+        except ValueError:
+            return None
+
+    return resolve_tool_response_template(tokenizer, response_template, turn_boundary)
 
 
 def build_data_collator(
@@ -619,39 +677,12 @@ def build_collator_from_config(
                 "or provide response_template in collator_kwargs."
             )
 
-    # Templates that nest tool results inside the assistant turn put environment output
-    # inside the unmasked span.
-    _tool_keys = ("tool_response_template", "end_of_tool_response_template")
-    supplied_tool_keys = [key for key in _tool_keys if config_collator_kwargs.get(key)]
-    if len(supplied_tool_keys) == 1:
-        # Masking needs both markers, so one alone would silently do nothing — and it
-        # would also suppress the auto-detection that reports a nesting template.
-        missing = next(key for key in _tool_keys if key not in supplied_tool_keys)
-        raise ValueError(
-            f"collator_kwargs sets '{supplied_tool_keys[0]}' without '{missing}'. "
-            "Tool results are only excluded from the training loss when both markers "
-            f"are set.\nFix: also set '{missing}' in collator_kwargs."
-        )
-
-    effective_response = config_collator_kwargs.get(
-        "response_template", collator_kwargs.get("response_template")
+    tool_bracket = _resolve_tool_bracket(
+        tokenizer, collator_kwargs, config_collator_kwargs
     )
-    effective_eot = config_collator_kwargs.get(
-        "end_of_turn_template", collator_kwargs.get("end_of_turn_template")
-    )
-    if (
-        collator_kwargs.get("train_target")
-        in ("all_assistant_turns", "final_assistant_turn")
-        and effective_response
-        and effective_eot
-        and not supplied_tool_keys
-    ):
-        tool_bracket = resolve_tool_response_template(
-            tokenizer, effective_response, effective_eot
-        )
-        if tool_bracket is not None:
-            collator_kwargs["tool_response_template"] = tool_bracket[0]
-            collator_kwargs["end_of_tool_response_template"] = tool_bracket[1]
+    if tool_bracket is not None:
+        opener_key, closer_key = _TOOL_TEMPLATE_KEYS
+        collator_kwargs[opener_key], collator_kwargs[closer_key] = tool_bracket
 
     # User-provided collator_kwargs override auto-resolved values
     collator_kwargs.update(config_collator_kwargs)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -49,8 +49,6 @@ _TOOL_FIX_HINT = (
     "own turn."
 )
 _PROBE_RESULT = "PROBE_TOOL_RESULT_"
-# Mistral's template rejects any tool call id whose length isn't exactly 9 (its error
-# message claims alphanumeric too, but only the length is checked).
 _PROBE_CALL_ID = "probecall"
 _PROBE_TOOLS: list[Any] = [
     {
@@ -622,9 +620,7 @@ def build_collator_from_config(
             )
 
     # Templates that nest tool results inside the assistant turn put environment output
-    # inside the unmasked span. Resolved here, after both paths above have settled
-    # train_target, and before the user override below so a hand-supplied bracket
-    # short-circuits the resolver (which raises when it can't recover one).
+    # inside the unmasked span.
     _tool_keys = ("tool_response_template", "end_of_tool_response_template")
     supplied_tool_keys = [key for key in _tool_keys if config_collator_kwargs.get(key)]
     if len(supplied_tool_keys) == 1:

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -14,6 +14,9 @@
 
 import warnings
 from collections.abc import Callable
+from typing import Any, cast
+
+from transformers import PreTrainedTokenizerFast
 
 import oumi.core.constants as constants
 from oumi.core.collators.text_collator_with_padding import TextCollatorWithPadding
@@ -40,6 +43,27 @@ _FIX_HINT = (
     "Fix: provide response_template (and end_of_turn_template for "
     "all_assistant_turns) in collator_kwargs."
 )
+_TOOL_FIX_HINT = (
+    "Fix: provide tool_response_template and end_of_tool_response_template in "
+    "collator_kwargs, or use a chat template that renders tool results in their "
+    "own turn."
+)
+_PROBE_RESULT = "PROBE_TOOL_RESULT_"
+_PROBE_CALL_ID = "probecall"  # 9 alphanumeric chars exactly: Mistral validates this
+_PROBE_TOOLS: list[Any] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "probe_fn",
+            "description": "probe",
+            "parameters": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+            },
+        },
+    }
+]
 
 
 def _detect_eot_template(
@@ -194,6 +218,174 @@ def resolve_collator_templates(
         raise ValueError(f"Extracted end_of_turn_template is empty.\n{_FIX_HINT}")
 
     return response_template, end_of_turn_template
+
+
+def _probe_messages(num_results: int) -> list[dict]:
+    """Conversation with one tool call answered by `num_results` tool messages.
+
+    Only the result count varies, so diffing two renders isolates one rendered tool
+    result. Keeping a single tool call keeps the probe renderable on templates that
+    reject parallel calls, and keeps tool-call text out of the diff.
+    """
+    messages: list[dict] = [
+        {"role": "user", "content": "PROBE_USER"},
+        {
+            "role": "assistant",
+            # Explicit empty content: Phi, DeepSeek and Granite templates read
+            # message.content unconditionally and raise on a tool_calls-only message.
+            "content": "",
+            "tool_calls": [
+                {
+                    # Mistral requires 9-character alphanumeric tool call ids.
+                    "id": _PROBE_CALL_ID,
+                    "type": "function",
+                    # A mapping, not a JSON string: gemma-4 and Qwen3.5 reject strings.
+                    "function": {"name": "probe_fn", "arguments": {"a": "1"}},
+                }
+            ],
+        },
+    ]
+    messages += [
+        {
+            "role": "tool",
+            "tool_call_id": _PROBE_CALL_ID,
+            "name": "probe_fn",
+            "content": f"{_PROBE_RESULT}{i}",
+        }
+        for i in range(num_results)
+    ]
+    messages.append({"role": "assistant", "content": "PROBE_ANSWER"})
+    return messages
+
+
+def _inserted_ids(shorter: list[int], longer: list[int]) -> list[int]:
+    """Token ids `longer` gained over `shorter`, stripping common prefix and suffix.
+
+    Diffing ids rather than characters matters because adjacent renders often share
+    leading characters (a tool block opening with ``<|tres|>`` followed by
+    ``<|start|>``), and a character diff would split the marker and lose it.
+    """
+    prefix = 0
+    while (
+        prefix < len(shorter)
+        and prefix < len(longer)
+        and shorter[prefix] == longer[prefix]
+    ):
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < len(shorter) - prefix
+        and suffix < len(longer) - prefix
+        and shorter[len(shorter) - suffix - 1] == longer[len(longer) - suffix - 1]
+    ):
+        suffix += 1
+    return longer[prefix : len(longer) - suffix]
+
+
+def resolve_tool_response_template(
+    tokenizer: "BaseTokenizer",
+    response_template: str,
+    end_of_turn_template: str,
+) -> tuple[list[int], list[int]] | None:
+    """Detects the bracket around tool results nested inside assistant spans.
+
+    Span masking unmasks everything between ``response_template`` and the next
+    ``end_of_turn_template``. Some chat templates (gemma-4) render tool results
+    *inside* the assistant turn, which puts environment output inside that span.
+    This finds the marker pair bracketing those results so masking can exclude them.
+
+    Returns token ids rather than strings: ``_tokenize_template`` accepts either, and
+    ids avoid a decode/re-encode round trip that isn't guaranteed to be lossless.
+
+    Returns:
+        (opener_ids, closer_ids) when tool results are nested and a specific bracket
+        was recovered. None when they aren't nested (nothing to mask), or when the
+        probe couldn't be rendered (nesting undetermined).
+
+    Raises:
+        ValueError: Tool results are nested inside assistant spans but no specific
+            bracket was recovered, so they can't be excluded from the loss.
+    """
+    try:
+        one = tokenizer.apply_chat_template(
+            _probe_messages(1),
+            tools=_PROBE_TOOLS,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+        two = tokenizer.apply_chat_template(
+            _probe_messages(2),
+            tools=_PROBE_TOOLS,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+    except Exception as e:
+        # A template that rejects the probe tells us nothing about nesting.
+        logger.debug(
+            "Tool-response probe failed to render: %s: %s", type(e).__name__, e
+        )
+        return None
+
+    if not isinstance(one, str) or not isinstance(two, str):
+        return None
+
+    first_result = f"{_PROBE_RESULT}0"
+    if first_result not in one:
+        # Template drops tool messages entirely (e.g. oumi's `default`); nothing to
+        # mask.
+        return None
+
+    # Nested when the closest preceding turn boundary is an assistant header.
+    head = one[: one.index(first_result)]
+    if head.rfind(response_template) <= head.rfind(end_of_turn_template):
+        return None
+
+    one_ids = tokenizer.encode(one, add_special_tokens=False)
+    two_ids = tokenizer.encode(two, add_special_tokens=False)
+    block_ids = _inserted_ids(one_ids, two_ids)
+    if not block_ids:
+        logger.debug("Could not isolate a rendered tool-result block.")
+        return None
+
+    # Whitespace can itself be in the added vocab (Falcon3 adds a newline token), and a
+    # newline is never a tool-result delimiter, so it can't stand in as a marker.
+    # get_added_vocab/convert_ids_to_tokens are declared on the concrete tokenizer
+    # classes, not on the PreTrainedTokenizerBase alias; the cast is types-only.
+    vocab_tokenizer = cast(PreTrainedTokenizerFast, tokenizer)
+    added_vocab = set(vocab_tokenizer.get_added_vocab())
+    tokens = vocab_tokenizer.convert_ids_to_tokens(block_ids)
+    markers = [
+        (token_id, token)
+        for token_id, token in zip(block_ids, tokens)
+        # transformers 5 widened decode's return type to str | list[str]; a single
+        # sequence of ids always decodes to a str.
+        if token in added_vocab and cast(str, tokenizer.decode([token_id])).strip()
+    ]
+    if len(markers) < 2:
+        raise ValueError(
+            "Chat template renders tool results inside assistant turns, but no marker "
+            "tokens bracket them, so they cannot be excluded from the training loss.\n"
+            f"{_TOOL_FIX_HINT}"
+        )
+
+    (open_id, opener), (close_id, closer) = markers[0], markers[-1]
+
+    # The bracket must identify tool results, not every turn (e.g. Llama's <|eot_id|>).
+    if one_ids.count(open_id) != 1 or one_ids.count(close_id) != 1:
+        raise ValueError(
+            "Chat template renders tool results inside assistant turns, but the "
+            f"candidate bracket ({opener!r}, {closer!r}) also appears elsewhere, so it "
+            "cannot be used to exclude them from the training loss.\n"
+            f"{_TOOL_FIX_HINT}"
+        )
+
+    logger.info(
+        "Chat template nests tool results inside assistant turns; masking them via "
+        "bracket (%r, %r).",
+        opener,
+        closer,
+    )
+    return [open_id], [close_id]
 
 
 def build_data_collator(
@@ -429,6 +621,31 @@ def build_collator_from_config(
                 "Fix: set train_target in your data config, "
                 "or provide response_template in collator_kwargs."
             )
+
+    # Templates that nest tool results inside the assistant turn put environment output
+    # inside the unmasked span. Resolved here, after both paths above have settled
+    # train_target, and before the user override below so a hand-supplied bracket
+    # short-circuits the resolver (which raises when it can't recover one).
+    _tool_keys = ("tool_response_template", "end_of_tool_response_template")
+    effective_response = config_collator_kwargs.get(
+        "response_template", collator_kwargs.get("response_template")
+    )
+    effective_eot = config_collator_kwargs.get(
+        "end_of_turn_template", collator_kwargs.get("end_of_turn_template")
+    )
+    if (
+        collator_kwargs.get("train_target")
+        in ("all_assistant_turns", "final_assistant_turn")
+        and effective_response
+        and effective_eot
+        and not any(config_collator_kwargs.get(key) for key in _tool_keys)
+    ):
+        tool_bracket = resolve_tool_response_template(
+            tokenizer, effective_response, effective_eot
+        )
+        if tool_bracket is not None:
+            collator_kwargs["tool_response_template"] = tool_bracket[0]
+            collator_kwargs["end_of_tool_response_template"] = tool_bracket[1]
 
     # User-provided collator_kwargs override auto-resolved values
     collator_kwargs.update(config_collator_kwargs)

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -49,7 +49,9 @@ _TOOL_FIX_HINT = (
     "own turn."
 )
 _PROBE_RESULT = "PROBE_TOOL_RESULT_"
-_PROBE_CALL_ID = "probecall"  # 9 alphanumeric chars exactly: Mistral validates this
+# Mistral's template rejects any tool call id whose length isn't exactly 9 (its error
+# message claims alphanumeric too, but only the length is checked).
+_PROBE_CALL_ID = "probecall"
 _PROBE_TOOLS: list[Any] = [
     {
         "type": "function",
@@ -220,12 +222,11 @@ def resolve_collator_templates(
     return response_template, end_of_turn_template
 
 
-def _probe_messages(num_results: int) -> list[dict]:
+def _tool_probe_messages(num_results: int) -> list[dict]:
     """Conversation with one tool call answered by `num_results` tool messages.
 
     Only the result count varies, so diffing two renders isolates one rendered tool
-    result. Keeping a single tool call keeps the probe renderable on templates that
-    reject parallel calls, and keeps tool-call text out of the diff.
+    result.
     """
     messages: list[dict] = [
         {"role": "user", "content": "PROBE_USER"},
@@ -258,13 +259,8 @@ def _probe_messages(num_results: int) -> list[dict]:
     return messages
 
 
-def _inserted_ids(shorter: list[int], longer: list[int]) -> list[int]:
-    """Token ids `longer` gained over `shorter`, stripping common prefix and suffix.
-
-    Diffing ids rather than characters matters because adjacent renders often share
-    leading characters (a tool block opening with ``<|tres|>`` followed by
-    ``<|start|>``), and a character diff would split the marker and lose it.
-    """
+def _diff_ids(shorter: list[int], longer: list[int]) -> list[int]:
+    """Token ids `longer` gained over `shorter`, stripping common prefix and suffix."""
     prefix = 0
     while (
         prefix < len(shorter)
@@ -308,13 +304,13 @@ def resolve_tool_response_template(
     """
     try:
         one = tokenizer.apply_chat_template(
-            _probe_messages(1),
+            _tool_probe_messages(1),
             tools=_PROBE_TOOLS,
             tokenize=False,
             add_generation_prompt=False,
         )
         two = tokenizer.apply_chat_template(
-            _probe_messages(2),
+            _tool_probe_messages(2),
             tools=_PROBE_TOOLS,
             tokenize=False,
             add_generation_prompt=False,
@@ -330,36 +326,37 @@ def resolve_tool_response_template(
         return None
 
     first_result = f"{_PROBE_RESULT}0"
+    # Template drops tool messages entirely; nothing to mask.
     if first_result not in one:
-        # Template drops tool messages entirely (e.g. oumi's `default`); nothing to
-        # mask.
         return None
 
     # Nested when the closest preceding turn boundary is an assistant header.
     head = one[: one.index(first_result)]
-    if head.rfind(response_template) <= head.rfind(end_of_turn_template):
+    not_nested = head.rfind(response_template) <= head.rfind(end_of_turn_template)
+    if not_nested:
         return None
 
     one_ids = tokenizer.encode(one, add_special_tokens=False)
     two_ids = tokenizer.encode(two, add_special_tokens=False)
-    block_ids = _inserted_ids(one_ids, two_ids)
-    if not block_ids:
-        logger.debug("Could not isolate a rendered tool-result block.")
-        return None
+    tool_response_ids = _diff_ids(one_ids, two_ids)
+    if not tool_response_ids:
+        raise ValueError(
+            "Chat template renders tool results inside assistant turns, but adding a "
+            "second tool result did not change the rendered output, so the tool-result "
+            "block could not be isolated and cannot be excluded from the training "
+            f"loss.\n{_TOOL_FIX_HINT}"
+        )
 
-    # Whitespace can itself be in the added vocab (Falcon3 adds a newline token), and a
-    # newline is never a tool-result delimiter, so it can't stand in as a marker.
+    # Filter for marker tokens
     # get_added_vocab/convert_ids_to_tokens are declared on the concrete tokenizer
     # classes, not on the PreTrainedTokenizerBase alias; the cast is types-only.
     vocab_tokenizer = cast(PreTrainedTokenizerFast, tokenizer)
     added_vocab = set(vocab_tokenizer.get_added_vocab())
-    tokens = vocab_tokenizer.convert_ids_to_tokens(block_ids)
+    tool_response_tokens = vocab_tokenizer.convert_ids_to_tokens(tool_response_ids)
     markers = [
         (token_id, token)
-        for token_id, token in zip(block_ids, tokens)
-        # transformers 5 widened decode's return type to str | list[str]; a single
-        # sequence of ids always decodes to a str.
-        if token in added_vocab and cast(str, tokenizer.decode([token_id])).strip()
+        for token_id, token in zip(tool_response_ids, tool_response_tokens)
+        if token in added_vocab
     ]
     if len(markers) < 2:
         raise ValueError(
@@ -370,7 +367,9 @@ def resolve_tool_response_template(
 
     (open_id, opener), (close_id, closer) = markers[0], markers[-1]
 
-    # The bracket must identify tool results, not every turn (e.g. Llama's <|eot_id|>).
+    # A candidate is only a delimiter if it appears once per tool result and nowhere
+    # else e.g. Falcon3 has a newline in its added vocab and plain-text tool tags, so
+    # its only candidate delimiters are newlines, which occur throughout the render.
     if one_ids.count(open_id) != 1 or one_ids.count(close_id) != 1:
         raise ValueError(
             "Chat template renders tool results inside assistant turns, but the "
@@ -627,6 +626,17 @@ def build_collator_from_config(
     # train_target, and before the user override below so a hand-supplied bracket
     # short-circuits the resolver (which raises when it can't recover one).
     _tool_keys = ("tool_response_template", "end_of_tool_response_template")
+    supplied_tool_keys = [key for key in _tool_keys if config_collator_kwargs.get(key)]
+    if len(supplied_tool_keys) == 1:
+        # Masking needs both markers, so one alone would silently do nothing — and it
+        # would also suppress the auto-detection that reports a nesting template.
+        missing = next(key for key in _tool_keys if key not in supplied_tool_keys)
+        raise ValueError(
+            f"collator_kwargs sets '{supplied_tool_keys[0]}' without '{missing}'. "
+            "Tool results are only excluded from the training loss when both markers "
+            f"are set.\nFix: also set '{missing}' in collator_kwargs."
+        )
+
     effective_response = config_collator_kwargs.get(
         "response_template", collator_kwargs.get("response_template")
     )
@@ -638,7 +648,7 @@ def build_collator_from_config(
         in ("all_assistant_turns", "final_assistant_turn")
         and effective_response
         and effective_eot
-        and not any(config_collator_kwargs.get(key) for key in _tool_keys)
+        and not supplied_tool_keys
     ):
         tool_bracket = resolve_tool_response_template(
             tokenizer, effective_response, effective_eot

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -34,6 +34,8 @@ class TextCompletionsCollatorWithPadding:
         instruction_template: str | None = None,
         debug: bool = False,
         end_of_turn_template: str | None = None,
+        tool_response_template: str | list[int] | None = None,
+        end_of_tool_response_template: str | list[int] | None = None,
         ignore_index: int = -100,
         pad_to_multiple_of: int | None = None,
     ):
@@ -48,6 +50,11 @@ class TextCompletionsCollatorWithPadding:
             or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
             Required for ``all_assistant_turns``.
+        tool_response_template: String or token IDs opening a tool result that the
+            chat template renders inside the assistant turn (e.g. gemma-4's
+            ``<|tool_response>``). Auto-detected by ``resolve_tool_response_template``.
+        end_of_tool_response_template: String or token IDs closing such a tool result.
+            Both are needed to exclude tool results from the loss.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         pad_to_multiple_of: If set, pad each batch up to a multiple of this
@@ -65,6 +72,8 @@ class TextCompletionsCollatorWithPadding:
             response_template=response_template,
             train_target=train_target,
             end_of_turn_template=end_of_turn_template,
+            tool_response_template=tool_response_template,
+            end_of_tool_response_template=end_of_tool_response_template,
             ignore_index=ignore_index,
         )
 

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -77,6 +77,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         *args,
         train_target: str,
         end_of_turn_template: str | list[int] | None = None,
+        tool_response_template: str | list[int] | None = None,
+        end_of_tool_response_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -92,6 +94,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.response_token_ids: list[int] = self._tokenize_template(response_template)  # type: ignore[assignment]
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
+        self.tool_response_token_ids = self._tokenize_template(tool_response_template)
+        self.end_of_tool_response_token_ids = self._tokenize_template(
+            end_of_tool_response_template
+        )
 
         if train_target not in self._VALID_TRAIN_TARGETS:
             valid = sorted(self._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"})
@@ -143,6 +149,34 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             if seq[i] == first and seq[i : i + plen] == pattern:
                 positions.append(i)
         return positions
+
+    def _mask_tool_response_spans(
+        self, batch: dict[str, Any], i: int, seq: list[int], start: int, end: int
+    ) -> None:
+        """Re-masks tool results that the chat template nested in an unmasked span.
+
+        Some templates (e.g. gemma-4) render tool results inside the assistant turn, so
+        the span between response_template and end_of_turn_template contains
+        environment output the model never generates.
+
+        An opener with no closer before `end` masks through `end`: truncation can cut a
+        block in half, and over-masking is the safe direction.
+        """
+        open_ids = self.tool_response_token_ids
+        close_ids = self.end_of_tool_response_token_ids
+        if not open_ids or not close_ids:
+            return
+
+        cursor = start
+        while cursor < end:
+            opens = self._find_pattern(seq[cursor:end], open_ids)
+            if not opens:
+                return
+            block_start = cursor + opens[0]
+            closes = self._find_pattern(seq[block_start:end], close_ids)
+            block_end = block_start + closes[0] + len(close_ids) if closes else end
+            batch["labels"][i, block_start:block_end] = self.ignore_index
+            cursor = block_end
 
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
@@ -212,6 +246,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 batch["labels"][i, content_start:unmask_end] = batch["input_ids"][
                     i, content_start:unmask_end
                 ]
+                self._mask_tool_response_spans(batch, i, seq, content_start, unmask_end)
 
     # ------------------------------------------------------------------
     # Main collation
@@ -262,6 +297,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     # Make pytorch loss function ignore all tokens up through the end
                     # of the response key
                     batch["labels"][i, :response_token_ids_end_idx] = self.ignore_index
+
+                    # The unmasked tail is one assistant turn, so it carries the same
+                    # nested-tool-result exposure as span masking.
+                    self._mask_tool_response_spans(
+                        batch,
+                        i,
+                        batch["input_ids"][i].tolist(),
+                        response_token_ids_end_idx,
+                        batch["input_ids"].shape[1],
+                    )
 
         else:
             for i in range(len(examples)):

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -13,11 +13,26 @@
 # limitations under the License.
 
 import functools
+import json
+from typing import Any
 
 import pytest
 import transformers
 
-from oumi.builders.collators import resolve_collator_templates
+from oumi.builders import build_data_collator
+from oumi.builders.collators import (
+    resolve_collator_templates,
+    resolve_tool_response_template,
+)
+from oumi.core.constants import LABEL_IGNORE_INDEX
+from oumi.core.types import Conversation, Message, Role
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    FunctionDefinition,
+    JSONSchema,
+    ToolCall,
+    ToolDefinition,
+)
 from tests.markers import requires_hf_token
 
 
@@ -229,3 +244,231 @@ def test_template_detection_newer_transformers(
     assert response_template.strip()
     assert end_of_turn_template.strip()
     assert "<think>" not in response_template
+
+
+# -- Tool results nested inside assistant turns --------------------------------
+# gemma-4 and GLM-4.5 render tool results *inside* the model turn, so span masking
+# unmasks environment output unless the tool-result bracket is subtracted.
+
+
+def _tool_conversation() -> Conversation:
+    """Multi-turn conversation with parallel tool calls and interleaved results."""
+
+    def _call(call_id: str, name: str, **arguments) -> ToolCall:
+        return ToolCall(
+            id=call_id,
+            function=FunctionCall(name=name, arguments=json.dumps(arguments)),
+        )
+
+    def _tool(name: str, **properties) -> ToolDefinition:
+        return ToolDefinition(
+            function=FunctionDefinition(
+                name=name,
+                description=f"{name} description",
+                parameters=JSONSchema(
+                    type="object",
+                    properties={k: JSONSchema(type="string") for k in properties},
+                    required=list(properties),
+                ),
+            )
+        )
+
+    return Conversation(
+        tools=[_tool("get_weather", city=""), _tool("search_flights", origin="")],
+        messages=[
+            Message(role=Role.SYSTEM, content=_SYSTEM_TEXT),
+            Message(role=Role.USER, content=_USER_TEXT_1),
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=[
+                    _call("weathr001", "get_weather", city="Paris"),
+                    _call("flight001", "search_flights", origin="Boston"),
+                ],
+            ),
+            Message(role=Role.TOOL, tool_call_id="weathr001", content=_TOOL_RESULT_1),
+            Message(role=Role.TOOL, tool_call_id="flight001", content=_TOOL_RESULT_2),
+            Message(role=Role.ASSISTANT, content=_ASSISTANT_TEXT_1),
+            Message(role=Role.USER, content=_USER_TEXT_2),
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=[_call("weathr002", "get_weather", city="Tokyo")],
+            ),
+            Message(role=Role.TOOL, tool_call_id="weathr002", content=_TOOL_RESULT_3),
+            Message(role=Role.ASSISTANT, content=_ASSISTANT_TEXT_2),
+        ],
+    )
+
+
+_SYSTEM_TEXT = "SYSTEM_PROMPT_TEXT"
+_USER_TEXT_1 = "USER_ASKS_WEATHER_AND_FLIGHTS"
+_USER_TEXT_2 = "USER_ASKS_TOKYO"
+_ASSISTANT_TEXT_1 = "ASSISTANT_ANSWERS_PARIS"
+_ASSISTANT_TEXT_2 = "ASSISTANT_ANSWERS_TOKYO"
+_TOOL_RESULT_1 = "TOOL_RESULT_PARIS_WEATHER"
+_TOOL_RESULT_2 = "TOOL_RESULT_BOSTON_FLIGHTS"
+_TOOL_RESULT_3 = "TOOL_RESULT_TOKYO_WEATHER"
+
+
+def _template_inputs(tokenizer, conversation: Conversation):
+    """Messages/tools shaped for templates that require mapping arguments."""
+    data = conversation.to_dict()
+    messages = []
+    for message in data["messages"]:
+        message = dict(message)
+        if message.get("tool_calls"):
+            message["content"] = message.get("content") or ""
+            message["tool_calls"] = [
+                {
+                    **call,
+                    "function": {
+                        **call["function"],
+                        "arguments": json.loads(call["function"]["arguments"]),
+                    },
+                }
+                for call in message["tool_calls"]
+            ]
+        messages.append(message)
+    return messages, data.get("tools")
+
+
+def _trained_text(tokenizer, conversation: Conversation) -> str:
+    """Decoded text of every token the collator leaves in the loss."""
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    bracket = resolve_tool_response_template(
+        tokenizer, response_template, end_of_turn_template
+    )
+    collator_kwargs: dict[str, Any] = {}
+    if bracket is not None:
+        collator_kwargs = {
+            "tool_response_template": bracket[0],
+            "end_of_tool_response_template": bracket[1],
+        }
+
+    messages, tools = _template_inputs(tokenizer, conversation)
+    encoded = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        return_dict=True,
+        add_generation_prompt=False,
+    )
+    input_ids = list(encoded["input_ids"])
+
+    collator = build_data_collator(
+        "text_completions_only_with_padding",
+        tokenizer=tokenizer,
+        max_length=None,
+        response_template=response_template,
+        end_of_turn_template=end_of_turn_template,
+        train_target="all_assistant_turns",
+        **collator_kwargs,
+    )
+    batch = collator([{"input_ids": input_ids, "attention_mask": [1] * len(input_ids)}])
+    labels = batch["labels"][0].tolist()
+    return tokenizer.decode(
+        [
+            token
+            for token, label in zip(input_ids, labels)
+            if label != LABEL_IGNORE_INDEX
+        ],
+        skip_special_tokens=False,
+    )
+
+
+def _masked_bracket_regions_are_complete(tokenizer, conversation: Conversation) -> bool:
+    """Every token between a tool-result bracket pair must be masked.
+
+    Works on token ids, so it catches a partially-masked payload that a decoded
+    substring assertion would miss (drop only the first token and the remainder no
+    longer matches the sentinel). Returns True when the template doesn't nest.
+    """
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    bracket = resolve_tool_response_template(
+        tokenizer, response_template, end_of_turn_template
+    )
+    if bracket is None:
+        return True
+    open_ids, close_ids = bracket
+
+    messages, tools = _template_inputs(tokenizer, conversation)
+    encoded = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        return_dict=True,
+        add_generation_prompt=False,
+    )
+    input_ids = list(encoded["input_ids"])
+    collator = build_data_collator(
+        "text_completions_only_with_padding",
+        tokenizer=tokenizer,
+        max_length=None,
+        response_template=response_template,
+        end_of_turn_template=end_of_turn_template,
+        train_target="all_assistant_turns",
+        tool_response_template=open_ids,
+        end_of_tool_response_template=close_ids,
+    )
+    labels = collator(
+        [{"input_ids": input_ids, "attention_mask": [1] * len(input_ids)}]
+    )["labels"][0].tolist()
+
+    starts = [
+        i
+        for i in range(len(input_ids) - len(open_ids) + 1)
+        if input_ids[i : i + len(open_ids)] == open_ids
+    ]
+    assert starts, "bracket was resolved but never occurs in the tokenized conversation"
+    for start in starts:
+        closes = [
+            i
+            for i in range(start, len(input_ids) - len(close_ids) + 1)
+            if input_ids[i : i + len(close_ids)] == close_ids
+        ]
+        end = closes[0] + len(close_ids) if closes else len(input_ids)
+        if any(label != LABEL_IGNORE_INDEX for label in labels[start:end]):
+            return False
+    return True
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code",
+    [
+        pytest.param("google/gemma-4-E2B-it", False, id="gemma-4-nested"),
+        pytest.param("zai-org/GLM-4.5", False, id="glm-4.5-nested"),
+        pytest.param("Qwen/Qwen3-0.6B", False, id="qwen3-separate-turn"),
+    ],
+)
+@requires_hf_token()
+def test_tool_results_are_excluded_from_the_loss(model_name, trust_remote_code):
+    try:
+        tokenizer = _load_tokenizer(model_name, trust_remote_code)
+    except Exception as e:
+        pytest.skip(f"Could not load tokenizer {model_name}: {e}")
+
+    trained = _trained_text(tokenizer, _tool_conversation())
+
+    # Environment output must never be trained on: the harness emits it, not the model.
+    for tool_result in (_TOOL_RESULT_1, _TOOL_RESULT_2, _TOOL_RESULT_3):
+        assert tool_result not in trained, (
+            f"{model_name} trains on tool result {tool_result!r}"
+        )
+
+    # Prompt text is context, not a target.
+    for prompt_text in (_SYSTEM_TEXT, _USER_TEXT_1, _USER_TEXT_2):
+        assert prompt_text not in trained, (
+            f"{model_name} trains on prompt text {prompt_text!r}"
+        )
+
+    # The model's own turns must survive, including the answer that gemma-4 renders
+    # after the tool results inside the same turn.
+    for assistant_text in (_ASSISTANT_TEXT_1, _ASSISTANT_TEXT_2):
+        assert assistant_text in trained, (
+            f"{model_name} dropped assistant text {assistant_text!r} from the loss"
+        )
+
+    # Token-level check: the assertions above compare decoded substrings, which a
+    # partially-masked payload would slip past.
+    assert _masked_bracket_regions_are_complete(tokenizer, _tool_conversation()), (
+        f"{model_name} leaves part of a bracketed tool result in the loss"
+    )

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -718,3 +718,39 @@ def test_build_collator_half_supplied_tool_bracket_raises(
 
     with pytest.raises(ValueError, match=f"without '{missing}'"):
         build_collator_from_config(config, tokenizer=mock_tokenizer)
+
+
+@pytest.mark.parametrize(
+    "train_target", [TrainTarget.ALL_ASSISTANT_TURNS, TrainTarget.FINAL_ASSISTANT_TURN]
+)
+def test_build_collator_resolves_tool_bracket_for_both_span_targets(train_target):
+    """final_assistant_turn has no end_of_turn_template but still needs the bracket.
+
+    Its unmasked tail is an assistant turn, so a nested tool result leaks there too.
+    """
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_TOOL_TEMPLATE)
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                train_target=train_target,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=64,
+        ),
+    )
+
+    collator = build_collator_from_config(config, tokenizer=tokenizer)
+    assert collator is not None
+
+    inner = collator._default_collator
+    assert inner.tool_response_token_ids == tokenizer.encode(
+        "<|tres|>", add_special_tokens=False
+    )
+    assert inner.end_of_tool_response_token_ids == tokenizer.encode(
+        "<|etres|>", add_special_tokens=False
+    )

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -633,14 +633,88 @@ def test_resolve_tool_response_template_rejected_probe_returns_none():
     )
 
 
-def test_resolve_tool_response_template_ignores_whitespace_markers():
-    """Whitespace in the added vocab must not be mistaken for a delimiter.
+def test_resolve_tool_response_template_whitespace_in_added_vocab_raises():
+    """A tokenizer with whitespace in its added vocab must not yield a bogus bracket.
 
-    Falcon3 adds a newline token, which would otherwise be picked as the bracket
-    around a tool result that has no real marker tokens.
+    Falcon3 adds a newline token, so a nesting template with plain-text tool tags
+    offers newlines as the only marker candidates. Whichever guard rejects them, the
+    contract is that nothing gets masked on a guess.
     """
     tokenizer = _tokenizer_with_tool_markers(_NESTED_NO_MARKER_TEMPLATE)
     tokenizer.add_special_tokens({"additional_special_tokens": ["\n"]})
 
-    with pytest.raises(ValueError, match="no marker tokens bracket them"):
+    with pytest.raises(ValueError):
         resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)
+
+
+# Renders only the first tool result, so adding a second changes nothing — the block
+# cannot be isolated even though tool results are nested in the assistant turn.
+_NESTED_FIRST_RESULT_ONLY_TEMPLATE = (
+    "{%- set ns = namespace(seen=false) -%}"
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "{%- if not ns.seen -%}"
+    "<|tres|>{{ m['content'] }}<|etres|>"
+    "{%- set ns.seen = true -%}"
+    "{%- endif -%}"
+    "{%- else -%}"
+    "<|start|>{{ m['role'] }}\n"
+    "{{ m['content'] if m['content'] is defined and m['content'] else '' }}"
+    "{%- if not (loop.nextitem is defined and loop.nextitem['role'] == 'tool') -%}"
+    "<|eot|>"
+    "{%- endif -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+)
+
+
+def test_resolve_tool_response_template_unisolatable_block_raises():
+    """A nested tool result we can't isolate must fail, not silently pass.
+
+    Reaching that point means the template nests tool results, so returning None
+    would leave environment output in the loss with no way to exclude it.
+    """
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_FIRST_RESULT_ONLY_TEMPLATE)
+
+    with pytest.raises(ValueError, match="did not change the rendered output"):
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)
+
+
+def _tool_kwargs_config(collator_kwargs: dict) -> TrainingConfig:
+    return TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                collator_kwargs=collator_kwargs,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name="MlpEncoder",
+            tokenizer_name="openai-community/gpt2",
+            model_max_length=64,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "supplied,missing",
+    [
+        ("tool_response_template", "end_of_tool_response_template"),
+        ("end_of_tool_response_template", "tool_response_template"),
+    ],
+)
+def test_build_collator_half_supplied_tool_bracket_raises(
+    supplied, missing, mock_tokenizer
+):
+    """One marker alone masks nothing, so it must be reported rather than ignored."""
+    config = _tool_kwargs_config(
+        {
+            "response_template": "<|start|>assistant",
+            "end_of_turn_template": "<|eot|>",
+            supplied: "<|tres|>",
+        }
+    )
+
+    with pytest.raises(ValueError, match=f"without '{missing}'"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock
 import pytest
 
 import oumi.core.constants as constants
+from oumi.builders import build_tokenizer
 from oumi.builders.collators import (
     build_collator_from_config,
     build_data_collator,
     resolve_collator_templates,
+    resolve_tool_response_template,
 )
 from oumi.core.configs import (
     DataParams,
@@ -496,3 +498,149 @@ def test_old_recipe_eot_sets_all_assistant(mock_tokenizer):
     collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
     assert collator is not None
     assert collator._default_collator.train_target == "all_assistant_turns"
+
+
+#
+# resolve_tool_response_template
+#
+
+# Chat templates rendering tool results either inside or outside the assistant turn.
+# `<|tres|>` / `<|etres|>` stand in for gemma-4's `<|tool_response>` pair.
+_NESTED_TOOL_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "<|tres|>{{ m['content'] }}<|etres|>"
+    "{%- else -%}"
+    "<|start|>{{ m['role'] }}\n"
+    "{{ m['content'] if m['content'] is defined and m['content'] else '' }}"
+    "{%- if not (loop.nextitem is defined and loop.nextitem['role'] == 'tool') -%}"
+    "<|eot|>"
+    "{%- endif -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+)
+_SEPARATE_TURN_TOOL_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "<|start|>tool\n<|tres|>{{ m['content'] }}<|etres|><|eot|>"
+    "{%- else -%}"
+    "<|start|>{{ m['role'] }}\n"
+    "{{ m['content'] if m['content'] is defined and m['content'] else '' }}<|eot|>"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+)
+_NESTED_NO_MARKER_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "tool result: {{ m['content'] }} end"
+    "{%- else -%}"
+    "<|start|>{{ m['role'] }}\n"
+    "{{ m['content'] if m['content'] is defined and m['content'] else '' }}"
+    "{%- if not (loop.nextitem is defined and loop.nextitem['role'] == 'tool') -%}"
+    "<|eot|>"
+    "{%- endif -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+)
+_NESTED_AMBIGUOUS_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "<|start|>{{ m['content'] }}<|start|>"
+    "{%- else -%}"
+    "<|start|>{{ m['role'] }}\n"
+    "{{ m['content'] if m['content'] is defined and m['content'] else '' }}"
+    "{%- if not (loop.nextitem is defined and loop.nextitem['role'] == 'tool') -%}"
+    "<|eot|>"
+    "{%- endif -%}"
+    "{%- endif -%}"
+    "{%- endfor -%}"
+)
+_REJECTING_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'tool' -%}"
+    "{{ raise_exception('tool messages unsupported') }}"
+    "{%- endif -%}"
+    "<|start|>{{ m['role'] }}\n<|eot|>"
+    "{%- endfor -%}"
+)
+
+_TOOL_RESPONSE_TEMPLATE_ARGS = ("<|start|>assistant", "<|eot|>")
+
+
+def _tokenizer_with_tool_markers(chat_template: str):
+    """Fresh tokenizer whose added vocab holds the marker tokens the templates emit."""
+    tokenizer = build_tokenizer(
+        ModelParams(
+            model_name="MlpEncoder",
+            torch_dtype_str="float16",
+            trust_remote_code=False,
+            tokenizer_name="openai-community/gpt2",
+            tokenizer_pad_token="<|endoftext|>",
+        )
+    )
+    tokenizer.add_special_tokens(
+        {
+            "additional_special_tokens": [
+                "<|start|>",
+                "<|eot|>",
+                "<|tres|>",
+                "<|etres|>",
+            ]
+        }
+    )
+    tokenizer.chat_template = chat_template
+    return tokenizer
+
+
+def test_resolve_tool_response_template_nested():
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_TOOL_TEMPLATE)
+
+    result = resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)
+
+    assert result is not None
+    open_ids, close_ids = result
+    assert open_ids == tokenizer.encode("<|tres|>", add_special_tokens=False)
+    assert close_ids == tokenizer.encode("<|etres|>", add_special_tokens=False)
+
+
+def test_resolve_tool_response_template_separate_turn_returns_none():
+    tokenizer = _tokenizer_with_tool_markers(_SEPARATE_TURN_TOOL_TEMPLATE)
+
+    assert (
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS) is None
+    )
+
+
+def test_resolve_tool_response_template_no_marker_raises():
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_NO_MARKER_TEMPLATE)
+
+    with pytest.raises(ValueError, match="no marker tokens bracket them"):
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)
+
+
+def test_resolve_tool_response_template_ambiguous_bracket_raises():
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_AMBIGUOUS_TEMPLATE)
+
+    with pytest.raises(ValueError, match="appears elsewhere"):
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)
+
+
+def test_resolve_tool_response_template_rejected_probe_returns_none():
+    tokenizer = _tokenizer_with_tool_markers(_REJECTING_TEMPLATE)
+
+    assert (
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS) is None
+    )
+
+
+def test_resolve_tool_response_template_ignores_whitespace_markers():
+    """Whitespace in the added vocab must not be mistaken for a delimiter.
+
+    Falcon3 adds a newline token, which would otherwise be picked as the bracket
+    around a tool result that has no real marker tokens.
+    """
+    tokenizer = _tokenizer_with_tool_markers(_NESTED_NO_MARKER_TEMPLATE)
+    tokenizer.add_special_tokens({"additional_special_tokens": ["\n"]})
+
+    with pytest.raises(ValueError, match="no marker tokens bracket them"):
+        resolve_tool_response_template(tokenizer, *_TOOL_RESPONSE_TEMPLATE_ARGS)

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -637,3 +637,152 @@ def test_pad_to_multiple_of_none_keeps_longest_in_batch():
     }
     batch = collator([row])
     assert batch["input_ids"].shape[1] == len(row["input_ids"])
+
+
+# ---------------------------------------------------------------------------
+# Tool results nested inside an assistant turn
+# ---------------------------------------------------------------------------
+
+# Markers standing in for a template that renders tool results inside the assistant
+# turn (gemma-4 renders <|tool_response|>...<tool_response|> there).
+_TOOL_OPEN_STR = " TOOL_RESULT_STARTS"
+_TOOL_CLOSE_STR = " TOOL_RESULT_ENDS"
+
+
+def get_tool_template_token_ids() -> tuple[list[int], list[int]]:
+    tokenizer, _ = create_test_tokenizer()
+    open_ids = tokenizer.encode(_TOOL_OPEN_STR, add_special_tokens=False)
+    close_ids = tokenizer.encode(_TOOL_CLOSE_STR, add_special_tokens=False)
+    forbidden = set(open_ids) | set(close_ids)
+    for sentinel in _SENTINELS:
+        assert sentinel not in forbidden, (
+            f"Sentinel {sentinel} collides with a tool marker ID. Adjust _SENTINELS."
+        )
+    return open_ids, close_ids
+
+
+def make_tool_span_collator(
+    train_target: str = "all_assistant_turns",
+) -> TextCompletionsCollatorWithPadding:
+    tokenizer, _ = create_test_tokenizer()
+    return TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=_RESP_STR,
+        train_target=train_target,
+        end_of_turn_template=_EOT_STR,
+        tool_response_template=_TOOL_OPEN_STR,
+        end_of_tool_response_template=_TOOL_CLOSE_STR,
+    )
+
+
+def test_span_tool_response_is_masked_inside_assistant_turn():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    call = [_SENTINELS[0]]
+    payload = [_SENTINELS[1], _SENTINELS[2]]
+    answer = [_SENTINELS[3]]
+    seq = flat(resp, call, tool_open, payload, tool_close, answer, eot)
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    at = len(resp)
+    assert all(v == IGNORE for v in labels[:at]), "response header must stay masked"
+    assert labels[at : at + len(call)] == call, "tool call is the model's own output"
+    at += len(call)
+    masked = len(tool_open) + len(payload) + len(tool_close)
+    assert all(v == IGNORE for v in labels[at : at + masked]), (
+        "tool result and both markers must be masked"
+    )
+    at += masked
+    assert labels[at : at + len(answer)] == answer, (
+        "assistant text after the tool result must stay trained"
+    )
+    assert labels[at + len(answer) :] == eot
+
+
+def test_span_parallel_tool_responses_are_both_masked():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    first = [_SENTINELS[0]]
+    second = [_SENTINELS[1]]
+    answer = [_SENTINELS[2]]
+    seq = flat(
+        resp,
+        tool_open,
+        first,
+        tool_close,
+        tool_open,
+        second,
+        tool_close,
+        answer,
+        eot,
+    )
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert _SENTINELS[0] not in labels
+    assert _SENTINELS[1] not in labels
+    assert _SENTINELS[2] in labels
+
+
+def test_span_unclosed_tool_response_masks_through_span_end():
+    resp, eot = get_template_token_ids()
+    tool_open, _ = get_tool_template_token_ids()
+    payload = [_SENTINELS[0], _SENTINELS[1]]
+    # Truncation can drop the closing marker; over-masking is the safe direction.
+    seq = flat(resp, tool_open, payload, eot)
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels), (
+        "an unclosed tool result must mask through the end of the span"
+    )
+
+
+def test_span_tool_masking_leaves_other_turns_untouched():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    plain = [_SENTINELS[1], _SENTINELS[2]]
+    seq = flat(
+        resp,
+        tool_open,
+        payload,
+        tool_close,
+        eot,
+        [_SENTINELS[3]],
+        resp,
+        plain,
+        eot,
+    )
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert _SENTINELS[0] not in labels
+    start = len(seq) - len(plain) - len(eot)
+    assert labels[start : start + len(plain)] == plain
+
+
+def test_span_without_tool_templates_trains_tool_response():
+    """Without the pair, behavior is unchanged — this is the bug being fixed."""
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    seq = flat(resp, tool_open, payload, tool_close, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert _SENTINELS[0] in labels
+
+
+def test_final_assistant_turn_tool_response_is_masked():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    answer = [_SENTINELS[1]]
+    seq = flat([_SENTINELS[2]], resp, tool_open, payload, tool_close, answer, eot)
+
+    labels = get_span_labels(make_tool_span_collator("final_assistant_turn"), seq)
+
+    assert _SENTINELS[0] not in labels, "tool result must be masked"
+    assert _SENTINELS[1] in labels, "final answer must stay trained"


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Some chat templates render tool results inside the assistant turn (like Gemma 4), which leaves them unmasked. This results in model being trained on environment output leading to model degradation. 

This seems to be a common problems faced by the community trying to use Gemma 4 for agentic cases: 
https://git.sethpc.xyz/Seth/gemma4-research/src/commit/91aaaa48d7275333e92f76a6b4be6c1a5cdbeb89/tooling/fine-tuning
there has not been a canonical way or fix suggested by the community for this issue

Our fix here is two fold:
1. In `collators.py`: We have a mechanism that autodetects tool_response start and end if the user does not supply it and we detect that tool response is indeed nested in assistant span. 
2. In `trl_data_collator_for_completion_only_lm.py`: we remask the regions between tool_response start and end, if they are supplied.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->



<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
