### PR TITLE
[Synth Env] Move guided-decoding opt-out onto the synthetic env only

### DIFF
--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -225,7 +225,7 @@ At the config level:
 - Tools do not declare an `environment` field. The parent environment owns the binding.
 - `deterministic_outputs` is only used for tools in `deterministic` environments.
 - `read_only` is only meaningful for tools in stateful `synthetic` environments.
-- `env_kwargs.guided_decoding` (default `true`) constrains simulated tool output to each tool's `output_schema`. Set it to `false` when a schema is too large for the provider's grammar compiler, or when constrained decoding is too slow — output is still validated against `output_schema` after generation, so an off-schema response raises a tool error instead of being silently accepted. Individual tools can override the env default with their own `guided_decoding` field.
+- `env_kwargs.use_guided_decoding` (default `true`) constrains simulated tool output to each tool's `output_schema`, and applies to every tool in the environment. Set it to `false` when a schema is too large for the provider's grammar compiler, or when constrained decoding is too slow — output is still validated against `output_schema` after generation, so an off-schema response raises a tool error instead of being silently accepted. To mix policies across tools, put them in separate `synthetic` environments.
 - Multiturn attributes reference environments (not individual tools) to select which tools are available.
 
 Example:

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -77,13 +77,6 @@ class ToolParams(BaseParams):
     ``SyntheticEnvironment``, ``context`` for an ``ExecutableEnvironment`` — and
     must return a ``ToolResult``.
     """
-    guided_decoding: bool | None = None
-    """Per-tool override of the synthetic env's ``guided_decoding`` default.
-
-    ``None`` inherits ``SyntheticEnvironmentKwargs.guided_decoding``. Inert when the
-    tool has no ``output_schema`` (nothing to constrain), and in environments that
-    don't LLM-simulate tool output.
-    """
 
     @classmethod
     def create(cls, raw: Any) -> ToolParams:
@@ -105,7 +98,6 @@ class ToolParams(BaseParams):
                 else None
             ),
             read_only=raw.get("read_only", True),
-            guided_decoding=raw.get("guided_decoding"),
             executor=raw.get("executor", ""),
         )
 

--- a/src/oumi/environments/synthetic_environment.py
+++ b/src/oumi/environments/synthetic_environment.py
@@ -79,13 +79,13 @@ class SyntheticEnvironmentKwargs(BaseParams):
     tool_persona: str = ""
     state_params: SyntheticStateParams | None = None
     cache_by_input: bool = True
-    guided_decoding: bool = True
+    use_guided_decoding: bool = True
     """Constrain simulator output to each tool's ``output_schema``.
 
-    Set to ``False`` to generate freely and rely on the ``jsonschema``
-    post-validation instead: large ``output_schema`` values can exceed a
-    provider's grammar-compiler limits or make constrained decoding several
-    times slower.
+    Applies to every tool in this environment. Set to ``False`` to generate
+    freely and rely on the ``jsonschema`` post-validation instead: large
+    ``output_schema`` values can exceed a provider's grammar-compiler limits or
+    make constrained decoding several times slower.
     """
 
     def __post_init__(self) -> None:
@@ -424,18 +424,13 @@ class SyntheticEnvironment(BaseEnvironment):
         """Overlay guided decoding for the tool's output_schema onto base_config.
 
         No constraint is sent when the tool has no ``output_schema`` (nothing to
-        constrain) or when ``guided_decoding`` is off (env default, or the tool's
-        own override), leaving ``_parse_and_validate`` as the only schema check.
+        constrain) or when ``use_guided_decoding`` is off, leaving
+        ``_parse_and_validate`` as the only schema check.
         """
         assert self._base_inference_config is not None
-        use_guided = (
-            self._kwargs.guided_decoding
-            if tool.guided_decoding is None
-            else tool.guided_decoding
-        )
         guided = (
             GuidedDecodingParams(json=tool.output_schema)
-            if use_guided and tool.output_schema
+            if self._kwargs.use_guided_decoding and tool.output_schema
             else None
         )
         sim_gen = dataclasses.replace(

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -2443,7 +2443,7 @@ def test_dispatch_tool_calls_recovers_from_unguided_schema_drift(
         description="FAQ env",
         env_type="synthetic",
         tools=[tool],
-        env_kwargs={"tool_persona": "Answer FAQs.", "guided_decoding": False},
+        env_kwargs={"tool_persona": "Answer FAQs.", "use_guided_decoding": False},
     )
     mock_build_environment.return_value = SyntheticEnvironment.from_params(env_params)
 

--- a/tests/unit/environments/test_synthetic_environment.py
+++ b/tests/unit/environments/test_synthetic_environment.py
@@ -343,28 +343,19 @@ def test_simulator_inference_config_overlays_guided_decoding():
 
 
 def test_simulator_inference_config_omits_guided_decoding_when_disabled():
-    env, _ = _attached_env(['{"a": "x"}'], guided_decoding=False)
+    env, _ = _attached_env(['{"a": "x"}'], use_guided_decoding=False)
     cfg = env._simulator_inference_config(env._lookup_tool("answer"))
     assert cfg.generation.guided_decoding is None
 
 
-@pytest.mark.parametrize(
-    "env_default,tool_override,expect_guided",
-    [
-        (True, None, True),
-        (True, False, False),
-        (False, None, False),
-        (False, True, True),
-    ],
-)
-def test_tool_guided_decoding_overrides_env_default(
-    env_default, tool_override, expect_guided
-):
+def test_use_guided_decoding_applies_to_every_tool_in_the_env():
+    """The env-level flag is the only granularity; it covers all its tools."""
     params = _typed_params()
-    params.tools = [_typed_tool(guided_decoding=tool_override)]
-    env, _ = _attached_env(['{"a": "x"}'], params=params, guided_decoding=env_default)
-    cfg = env._simulator_inference_config(env._lookup_tool("answer"))
-    assert (cfg.generation.guided_decoding is not None) == expect_guided
+    params.tools = [_typed_tool(id="a"), _typed_tool(id="b")]
+    env, _ = _attached_env(['{"a": "x"}'], params=params, use_guided_decoding=False)
+    for tool_id in ("a", "b"):
+        cfg = env._simulator_inference_config(env._lookup_tool(tool_id))
+        assert cfg.generation.guided_decoding is None
 
 
 def test_simulator_inference_config_omits_guided_decoding_without_output_schema():
@@ -378,7 +369,7 @@ def test_simulator_inference_config_omits_guided_decoding_without_output_schema(
 
 def test_system_prompt_carries_output_schema_when_guidance_disabled():
     """Free generation leans on the prompt, so the full schema must stay in it."""
-    env, _ = _attached_env(['{"a": "x"}'], guided_decoding=False)
+    env, _ = _attached_env(['{"a": "x"}'], use_guided_decoding=False)
     tool = env._lookup_tool("answer")
     prompt = str(env.build_call_conversation("answer", {"q": "hi"}).messages[0].content)
     assert json.dumps(tool.to_llm_schema(), indent=2) in prompt
@@ -386,7 +377,7 @@ def test_system_prompt_carries_output_schema_when_guidance_disabled():
 
 
 def test_step_without_guided_decoding_still_validates_output_schema():
-    env, _ = _attached_env(['{"a": 1}'], guided_decoding=False)
+    env, _ = _attached_env(['{"a": 1}'], use_guided_decoding=False)
     with pytest.raises(ToolError, match="failed schema validation"):
         env.step([("answer", {"q": "x"})])
 


### PR DESCRIPTION
# Description

Follow-up to #2588, addressing post-merge review. Net removal — no new behavior.

**Drop `ToolParams.guided_decoding`.** Guided decoding only means anything for an
environment that LLM-simulates tool output. `ToolParams` is shared with the
deterministic, executable, and database env families, where the field was inert and
nothing signalled that to a reader. The environment-level flag already covers every tool
the environment owns, since tools are declared inside exactly one environment. An
environment needing different policies for different tools can be split into two
`synthetic` environments sharing a `tool_persona`.

**Rename `guided_decoding` → `use_guided_decoding`.** A bare noun phrase reads like it
holds a `GuidedDecodingParams`, which is a real class in oumi. `_simulator_inference_config`
had both meanings ten lines apart:

```python
self._kwargs.guided_decoding             # bool
...generation, guided_decoding=guided    # GuidedDecodingParams | None
```

The `use_` prefix makes the flag read as the question it answers.

Resolution collapses to a single lookup:

```python
guided = (
    GuidedDecodingParams(json=tool.output_schema)
    if self._kwargs.use_guided_decoding and tool.output_schema
    else None
)
```

`tool.output_schema` is still consulted, so a schemaless tool still gets no constraint
even with the flag on — that part of #2588 is unchanged, as is the `jsonschema`
post-validation and the recoverable `ToolError` path.

**No migration needed.** Nothing consumes either field yet — no stored config carries the
key and no downstream schema references it — so this is free now and would not be later.

## Related issues

Follow-up to #2588.

## Before submitting

- [ ] This PR only changes documentation. (`docs/`, `README.md`, docstrings)
- [x] Tests added/updated

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
