### PR TITLE
[Inference] Raise a clear error when a 2xx API response body parses to JSON null

### DIFF
--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -573,6 +573,13 @@ class RemoteInferenceEngine(BaseInferenceEngine):
         Returns:
             Conversation: The conversation including the generated response.
         """
+        if not isinstance(response, dict):
+            # A 2xx response can still carry a body that parses to JSON `null`
+            # (or a non-object); surface it clearly instead of a TypeError below.
+            raise RuntimeError(
+                "Expected a JSON object in API response, got "
+                f"{type(response).__name__}: {str(response)[:200]}"
+            )
         if "error" in response:
             raise RuntimeError(
                 f"API error: {response['error'].get('message', response['error'])}"

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, cast
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -2284,6 +2284,20 @@ def test_convert_api_output_no_usage():
     result = engine._convert_api_output_to_conversation(response, original)
     assert "usage" not in result.metadata
     assert result.metadata["key"] == "value"
+
+
+def test_convert_api_output_null_response_raises_runtime_error():
+    """A 2xx response whose JSON body is `null` must raise a clear RuntimeError."""
+    engine = RemoteInferenceEngine(
+        _get_default_model_params(),
+        remote_params=RemoteParams(api_url=_TARGET_SERVER),
+    )
+    original = Conversation(
+        messages=[Message(content="Hello", role=Role.USER)],
+    )
+    null_body = cast(dict, None)
+    with pytest.raises(RuntimeError, match="Expected a JSON object"):
+        engine._convert_api_output_to_conversation(null_body, original)
 
 
 def test_convert_api_output_content_null_returns_empty_string():


### PR DESCRIPTION
# Description

`RemoteInferenceEngine._convert_api_output_to_conversation` assumes the parsed response body is a JSON object. A provider can return an HTTP 2xx whose body parses to JSON `null` (or another non-object); `response.json()` succeeds, so the parse-failure retry branch is bypassed, and `if "error" in response:` then crashes with `TypeError: argument of type 'NoneType' is not iterable`. After retries this surfaces as the confusing `RuntimeError: Failed to process successful response: argument of type 'NoneType' is not iterable` (observed in production via Sentry, triggered by an OpenAI call).

This change guards the conversion with an `isinstance(response, dict)` check and raises a `RuntimeError` that states what actually happened (`Expected a JSON object in API response, got NoneType: None`). Retry behavior is unchanged: the existing handler in `_query_api` already catches conversion failures and retries up to `max_retries`, so transient null bodies are absorbed and persistent ones fail with an actionable message.

## Related issues

None — found while investigating a production Sentry alert.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
