### PR TITLE
Remask tool response when it is nested in assistant span

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -34,6 +34,10 @@ from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.utils.logging import logger
 
 _VERY_LARGE_INTEGER = int(1e30)
+
+# Placeholder message contents for the probe conversation that template detection
+# renders. Deliberately unlike anything a chat template emits, so they can be located
+# by string search in the rendered output to find the turn boundaries around them.
 _SENTINEL_SYS = "<<__S__>>"
 _SENTINEL_USER = "<<__U__>>"
 _SENTINEL_ASST = "<<__A__>>"
@@ -41,9 +45,16 @@ _FIX_HINT = (
     "Fix: provide response_template (and end_of_turn_template for "
     "all_assistant_turns) in collator_kwargs."
 )
+
+# The `train_split.train_target` options that mask by span. Only these unmask a stretch
+# of the sequence wholesale and so can expose a tool result nested in an assistant turn
 _SPAN_TRAIN_TARGETS = ("all_assistant_turns", "final_assistant_turn")
+
+# The collator_kwargs keys holding the tool-result bracket, as (opener, closer).
 _TOOL_TEMPLATE_KEYS = ("tool_response_template", "end_of_tool_response_template")
 
+# Family labels shared by the two tables below, which together map an HF model_type
+# to a bracket.
 _GEMMA_4 = "gemma-4"
 _GLM_4_MOE = "glm-4.5/4.6"
 
@@ -73,17 +84,57 @@ def _detect_eot_template(
     after_text: str,
     between_text: str,
 ) -> tuple[list[int], str]:
-    """Detect end-of-turn token IDs and template string.
+    r"""Detect end-of-turn token IDs and template string.
 
     Compares token-ID prefixes of the text after the last assistant turn
     (end-of-sequence) with the text between assistant turns (mid-conversation).
+    Both start with the turn closer and diverge after it, so what they agree on
+    is the marker. Comparing IDs rather than characters keeps the result on token
+    boundaries, so it can still be matched against a tokenized example.
 
     Primary: longest common token-ID prefix.
     Fallback: first token of between_text (for models like GPT OSS
     that use different mid-conversation vs end-of-sequence tokens).
 
+    Args:
+        tokenizer: Tokenizer to tokenize texts.
+        after_text: Rendered text following the final assistant turn, i.e. the
+            end-of-sequence side of the comparison.
+        between_text: Rendered text between an assistant turn and the next user
+            turn, i.e. the mid-conversation side.
+
     Returns:
-        (eot_ids, end_of_turn_template)
+        (eot_ids, end_of_turn_template): the end-of-turn token IDs and the same
+        markers decoded back to a string.
+
+    Examples:
+        Qwen2.5 closes every assistant turn the same way, so the two sides agree
+        for the whole marker and the primary path returns it::
+
+            after_text    '<|im_end|>\n'
+            between_text  '<|im_end|>\n<|im_start|>user\n'
+            after_ids     [151645, 198]
+            between_ids   [151645, 198, 151644, 872, 198]
+                           ^^^^^^^^^^^ agree, then diverge
+            -> eot_ids [151645, 198], '<|im_end|>\n'
+
+        GPT OSS ends the final turn with a different token than a mid-conversation
+        turn, so the two disagree at position 0 and the fallback takes the first
+        token of between_text -- the mid-conversation closer is the one span
+        masking needs, and the end-of-sequence token is irrelevant to it::
+
+            after_text    '<|return|>'
+            between_text  '<|end|><|start|>user<|message|>'
+            after_ids     [200002]
+            between_ids   [200007, 200006, 1428, 200008]
+                           ^ differs at position 0, so no common prefix
+            -> eot_ids [200007], '<|end|>'
+
+        Olmo-3 lands on the same fallback, ending the conversation with
+        '<|endoftext|>' but its turns with '<|im_end|>'. Note the fallback claims
+        exactly one token: with no agreement to measure against there is nothing
+        to say how far the marker extends, so it does not guess. That is why
+        Olmo-3 detects '<|im_end|>' while Qwen2.5 keeps its trailing newline.
     """
     after_ids = tokenizer.encode(after_text, add_special_tokens=False)
     between_ids = tokenizer.encode(between_text, add_special_tokens=False)
@@ -108,14 +159,45 @@ def _detect_response_template(
     header_text: str,
     eot_ids: list[int],
 ) -> str:
-    """Detect the assistant response header from the user-to-assistant boundary.
+    r"""Detect the assistant response header from the user-to-assistant boundary.
 
     Strips the leading end-of-turn prefix (which belongs to the previous
     turn, not the response header) and any ``<think>`` blocks injected
     by reasoning-model chat templates (e.g. Qwen3).
 
+    Args:
+        tokenizer: Tokenizer whose chat template produced `header_text`.
+        eot_ids: End-of-turn token IDs from ``_detect_eot_template``.
+        header_text: Rendered text between the end of a user turn and the start of
+            the assistant's content.
+
     Returns:
-        response_template string
+        The response_template string.
+
+    Raises:
+        ValueError: The header is nothing but a ``<think>`` block, leaving no
+            usable response_template.
+
+    Examples:
+        Qwen2.5. The slice starts with the user turn's closer, which is dropped
+        because it belongs to that turn, and the trailing newline goes so the
+        marker survives BPE merging with whatever content follows::
+
+            header_text  '<|im_end|>\n<|im_start|>assistant\n'
+            header_ids   [151645, 198, 151644, 77091, 198]
+            eot_ids      [151645, 198]        -> drop this prefix
+            remaining    '<|im_start|>assistant\n'
+            -> '<|im_start|>assistant'
+
+        Qwen3 renders an empty reasoning block into the header. Everything from
+        ``<think>`` on is model output, not a boundary marker, so it is cut::
+
+            header_text  '<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n'
+            remaining    '<|im_start|>assistant\n<think>\n\n</think>\n\n'
+            -> '<|im_start|>assistant'
+
+        A header that is *only* a reasoning block leaves nothing to match on, so
+        that case raises rather than returning a marker that would silently fail.
     """
     resp_ids = tokenizer.encode(header_text, add_special_tokens=False)
     eot_len = len(eot_ids)
@@ -153,11 +235,18 @@ def resolve_collator_templates(
     Applies the chat template to a known test conversation, then finds
     the assistant boundary strings in the rendered output.
 
+    Args:
+        tokenizer: Tokenizer to probe. Its chat template is rendered against a
+            sentinel conversation; the tokenizer is not modified.
+
     Returns:
         (response_template, end_of_turn_template)
 
     Raises:
-        ValueError: If templates cannot be extracted.
+        ValueError: If templates cannot be extracted — the tokenizer has no chat
+            template, the render did not return a string, the assistant turn
+            boundaries were not locatable in it, or either extracted template came
+            out empty.
     """
     msgs_with_sys = [
         {"role": "system", "content": _SENTINEL_SYS},
@@ -434,7 +523,29 @@ def build_data_collator(
 def build_collator_from_config(
     config: TrainingConfig, tokenizer: BaseTokenizer | None, debug: bool = False
 ) -> Callable | None:
-    """Creates data collator if specified in config."""
+    """Creates data collator if specified in config.
+
+    Resolves everything the collator needs from the config: the label ignore index,
+    the visual-model kwargs, the train_target and its templates, and — for models
+    whose chat template nests tool results inside the assistant turn — the tool-result
+    bracket. Anything set in ``collator_kwargs`` overrides what is resolved here.
+
+    Args:
+        config: Training config. Its train split supplies ``collator_name``,
+            ``train_target`` and ``collator_kwargs``; ``config.model`` supplies the
+            model name used to look up the architecture and the max sequence length.
+        tokenizer: Tokenizer the collator will use. Required whenever the split names
+            a collator; templates are auto-detected from its chat template.
+        debug: If True, the collator logs a single collated example.
+
+    Returns:
+        The collator, or None when the train split names no collator.
+
+    Raises:
+        ValueError: No tokenizer was given for a split that names a collator, a
+            required processor name is missing, the completions collator was left
+            unconfigured, or the tool-result bracket was only half supplied.
+    """
     train_split = config.data.get_split(DatasetSplit.TRAIN)
     if not train_split.collator_name:
         return None

--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -27,6 +27,7 @@ from oumi.core.collators.vision_language_sft_collator import VisionLanguageSftCo
 from oumi.core.configs import DatasetSplit, TrainingConfig
 from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
+    find_model_type_using_model_name,
 )
 from oumi.core.configs.params.data_params import TrainTarget
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
@@ -40,6 +41,31 @@ _FIX_HINT = (
     "Fix: provide response_template (and end_of_turn_template for "
     "all_assistant_turns) in collator_kwargs."
 )
+_SPAN_TRAIN_TARGETS = ("all_assistant_turns", "final_assistant_turn")
+_TOOL_TEMPLATE_KEYS = ("tool_response_template", "end_of_tool_response_template")
+
+_GEMMA_4 = "gemma-4"
+_GLM_4_MOE = "glm-4.5/4.6"
+
+# The bracket each family's chat template wraps a tool result in.
+_TOOL_RESPONSE_BRACKETS: dict[str, tuple[str, str]] = {
+    _GEMMA_4: ("<|tool_response>", "<tool_response|>"),
+    _GLM_4_MOE: ("<tool_response>", "</tool_response>"),
+}
+
+# HF ``config.model_type`` -> family, for architectures whose chat template renders
+# tool results inside the assistant turn. Keying on model_type rather than repo name
+# to also cover finetunes, mirrors, quantizations and local checkpoints
+#
+# WARNING: "glm4v" is excluded even though GLM-4.6V-Flash nests, because GLM-4.1V
+# reports the same model_type without nesting. GLM-4.6V-Flash therefore needs the
+# bracket set in collator_kwargs.
+_NESTING_MODEL_TYPES: dict[str, str] = {
+    "gemma4": _GEMMA_4,  # E2B/E4B/26B-A4B/31B, plus their -it and QAT variants
+    "gemma4_unified": _GEMMA_4,  # 12B
+    "glm4_moe": _GLM_4_MOE,  # GLM-4.5, -Air, 4.6, and FP8 variants
+    "glm4v_moe": _GLM_4_MOE,  # GLM-4.5V, GLM-4.6V
+}
 
 
 def _detect_eot_template(
@@ -194,6 +220,95 @@ def resolve_collator_templates(
         raise ValueError(f"Extracted end_of_turn_template is empty.\n{_FIX_HINT}")
 
     return response_template, end_of_turn_template
+
+
+def _known_tool_response_markers(model_type: str | None) -> tuple[str, str] | None:
+    """The tool-result bracket for an architecture known to nest tool results.
+
+    Args:
+        model_type: HF ``config.model_type``, or None when it could not be read.
+
+    Returns:
+        (opener, closer) when the architecture is listed in ``_NESTING_MODEL_TYPES``,
+        else None.
+    """
+    family = _NESTING_MODEL_TYPES.get(model_type or "")
+    return _TOOL_RESPONSE_BRACKETS[family] if family else None
+
+
+def _resolve_tool_bracket(
+    collator_kwargs: dict,
+    config_collator_kwargs: dict,
+    model_type: str | None,
+) -> tuple[str, str] | None:
+    """The bracket around tool results this model nests inside the assistant turn.
+
+    Span masking unmasks everything between ``response_template`` and the next
+    ``end_of_turn_template``. Some chat templates render tool results inside that
+    span, which trains the model on environment output. The returned bracket lets the
+    collator mask it again.
+
+    Args:
+        collator_kwargs: Auto-resolved kwargs built so far; read for ``train_target``.
+        config_collator_kwargs: User-supplied ``collator_kwargs`` from the data config.
+            A bracket set here is an override and wins over the known-model lookup.
+        model_type: HF ``config.model_type`` for the model being trained, or None when
+            it could not be determined.
+
+    Returns:
+        (tool_response_opener, tool_response_closer) strings, or None when the bracket
+        is already configured, the train_target isn't span-based, or the architecture
+        isn't a known nester.
+
+    Raises:
+        ValueError: Only one of the two markers was supplied.
+    """
+    # 1. Check if the user has supplied a tool response prefix. User specification wins
+    user_defined_prefix = [
+        key for key in _TOOL_TEMPLATE_KEYS if config_collator_kwargs.get(key)
+    ]
+    if user_defined_prefix:
+        if len(user_defined_prefix) == 1:
+            # One marker alone masks nothing, so a half-configured pair is always a
+            # mistake rather than a partial opt-in.
+            missing = next(
+                key for key in _TOOL_TEMPLATE_KEYS if key not in user_defined_prefix
+            )
+            raise ValueError(
+                f"collator_kwargs sets '{user_defined_prefix[0]}' without "
+                f"'{missing}'. Tool results are only excluded from the training "
+                "loss when both markers are set.\n"
+                f"Fix: also set '{missing}' in collator_kwargs."
+            )
+        else:
+            return None  # Hand-supplied bracket wins; nothing to look up.
+
+    # 1b. Skip if on the legacy path
+    if collator_kwargs.get("train_target") not in _SPAN_TRAIN_TARGETS:
+        return None  # Only span-based masking can unmask a tool result.
+
+    # 2. Check if the model being trained is in the known list of models that nest tool
+    # response in assistant span
+    tool_response_markers = _known_tool_response_markers(model_type)
+    if tool_response_markers:
+        logger.info(
+            "Architecture %r renders tool results inside the assistant turn; masking "
+            "them via bracket %r.",
+            model_type,
+            tool_response_markers,
+        )
+        return tool_response_markers
+
+    # 3. Autodetection of tool response prefix from chat template fallback
+    # Not implemented yet, current active mechanisms are active override or
+    # using a known nested model
+    # TODO(OPE-2185): fall back to probing the chat template.
+    logger.warning(
+        "No tool-response bracket specified for architecture %r; if your model chat "
+        "template nests tool results in assistant span, it will not be remasked.",
+        model_type,
+    )
+    return None
 
 
 def build_data_collator(
@@ -429,6 +544,19 @@ def build_collator_from_config(
                 "Fix: set train_target in your data config, "
                 "or provide response_template in collator_kwargs."
             )
+
+        tool_bracket = _resolve_tool_bracket(
+            collator_kwargs,
+            config_collator_kwargs,
+            find_model_type_using_model_name(
+                config.model.model_name,
+                trust_remote_code=config.model.trust_remote_code,
+                revision=config.model.model_revision,
+            ),
+        )
+        if tool_bracket is not None:
+            opener_key, closer_key = _TOOL_TEMPLATE_KEYS
+            collator_kwargs[opener_key], collator_kwargs[closer_key] = tool_bracket
 
     # User-provided collator_kwargs override auto-resolved values
     collator_kwargs.update(config_collator_kwargs)

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -34,6 +34,8 @@ class TextCompletionsCollatorWithPadding:
         instruction_template: str | None = None,
         debug: bool = False,
         end_of_turn_template: str | None = None,
+        tool_response_template: str | list[int] | None = None,
+        end_of_tool_response_template: str | list[int] | None = None,
         ignore_index: int = -100,
         pad_to_multiple_of: int | None = None,
     ):
@@ -48,6 +50,11 @@ class TextCompletionsCollatorWithPadding:
             or ``"final_assistant_turn"``.
         end_of_turn_template: String marking the end of a turn.
             Required for ``all_assistant_turns``.
+        tool_response_template: String or token IDs opening a tool result that the
+            chat template renders inside the assistant turn (e.g. gemma-4's
+            ``<|tool_response>``). Auto-detected by ``resolve_tool_response_template``.
+        end_of_tool_response_template: String or token IDs closing such a tool result.
+            Both are needed to exclude tool results from the loss.
         ignore_index: Value used for masked labels. Must match the ignore_index
             of the loss function (default: -100).
         pad_to_multiple_of: If set, pad each batch up to a multiple of this
@@ -65,6 +72,8 @@ class TextCompletionsCollatorWithPadding:
             response_template=response_template,
             train_target=train_target,
             end_of_turn_template=end_of_turn_template,
+            tool_response_template=tool_response_template,
+            end_of_tool_response_template=end_of_tool_response_template,
             ignore_index=ignore_index,
         )
 

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -52,7 +52,7 @@ class TextCompletionsCollatorWithPadding:
             Required for ``all_assistant_turns``.
         tool_response_template: String or token IDs opening a tool result that the
             chat template renders inside the assistant turn (e.g. gemma-4's
-            ``<|tool_response>``). Auto-detected by ``resolve_tool_response_template``.
+            ``<|tool_response>``).
         end_of_tool_response_template: String or token IDs closing such a tool result.
             Both are needed to exclude tool results from the loss.
         ignore_index: Value used for masked labels. Must match the ignore_index

--- a/src/oumi/core/collators/text_completions_collator_with_padding.py
+++ b/src/oumi/core/collators/text_completions_collator_with_padding.py
@@ -93,12 +93,28 @@ class TextCompletionsCollatorWithPadding:
         self._has_logged_example = False
 
     def _collate(self, inputs: list[Any]) -> dict[str, Any]:
+        """Collates and masks a batch, then applies any padding multiple.
+
+        Args:
+            inputs: Examples to collate, each holding at least ``input_ids``.
+
+        Returns:
+            The collated batch.
+        """
         result = self._default_collator(inputs)
         if self._pad_to_multiple_of:
             result = self._pad_batch_to_multiple(result)
         return result
 
     def _pad_batch_to_multiple(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Right-pads a collated batch up to a multiple of ``pad_to_multiple_of``.
+
+        Args:
+            result: Collated batch. Modified in place and also returned.
+
+        Returns:
+            The batch, padded. Unchanged when its length is already a multiple.
+        """
         multiple = self._pad_to_multiple_of
         assert multiple is not None
         seq_len = result[_INPUT_IDS_KEY].shape[1]
@@ -108,6 +124,16 @@ class TextCompletionsCollatorWithPadding:
             return result
 
         def _extend(tensor: torch.Tensor, value: int) -> torch.Tensor:
+            """Appends `extra` columns of `value` to the right of `tensor`.
+
+            Args:
+                tensor: Batch-first 2-D tensor to extend.
+                value: Fill value for the new columns — the pad token for input_ids,
+                    the ignore index for labels, 1 for an attention mask.
+
+            Returns:
+                A new tensor; the input is left alone.
+            """
             tail = tensor.new_full((tensor.shape[0], extra), value)
             return torch.cat([tensor, tail], dim=1)
 
@@ -195,7 +221,15 @@ class TextCompletionsCollatorWithPadding:
 
         # Extract the first example from the batched tensors for cleaner debug output
         def _to_py(x):
-            """Convert tensor-like objects to Python native types."""
+            """Convert tensor-like objects to Python native types.
+
+            Args:
+                x: Value to convert. Anything exposing ``tolist`` or ``item`` is
+                    unwrapped; anything else is returned as-is.
+
+            Returns:
+                The plain-Python equivalent, for readable debug logging.
+            """
             if hasattr(x, "tolist"):
                 return x.tolist()
             elif hasattr(x, "item"):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -53,6 +53,11 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             Resolved by the builder before construction.
         end_of_turn_template: String or token IDs marking the end of a
             conversational turn. Required for ``all_assistant_turns`` mode.
+        tool_response_template: String or token IDs opening a tool result that the
+            chat template renders inside the assistant turn (e.g. gemma-4's
+            ``<|tool_response>``). Resolved by the builder.
+        end_of_tool_response_template: String or token IDs closing such a tool
+            result. Both are needed to exclude tool results from the loss.
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
@@ -77,6 +82,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         *args,
         train_target: str,
         end_of_turn_template: str | list[int] | None = None,
+        tool_response_template: str | list[int] | None = None,
+        end_of_tool_response_template: str | list[int] | None = None,
         mlm: bool = False,
         ignore_index: int = -100,
         padding_free: bool = False,
@@ -92,6 +99,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.response_token_ids: list[int] = self._tokenize_template(response_template)  # type: ignore[assignment]
         self.end_of_turn_template = end_of_turn_template
         self.end_of_turn_token_ids = self._tokenize_template(end_of_turn_template)
+        self.tool_response_token_ids = self._tokenize_template(tool_response_template)
+        self.end_of_tool_response_token_ids = self._tokenize_template(
+            end_of_tool_response_template
+        )
 
         if train_target not in self._VALID_TRAIN_TARGETS:
             valid = sorted(self._VALID_TRAIN_TARGETS - {"_legacy_instruction_response"})
@@ -143,6 +154,39 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             if seq[i] == first and seq[i : i + plen] == pattern:
                 positions.append(i)
         return positions
+
+    def _mask_tool_response_spans(
+        self,
+        batch: dict[str, Any],
+        i: int,
+        seq: list[int],
+        start_idx: int,
+        end_idx: int,
+    ) -> None:
+        """Re-masks tool results that the chat template nested in an unmasked span.
+
+        Some templates (e.g. gemma-4) render tool results inside the assistant turn, so
+        the span between response_template and end_of_turn_template contains
+        environment output the model never generates.
+
+        An opener with no closer before `end_idx` masks through `end_idx`: truncation
+        can cut a block in half, and over-masking is the safe direction.
+        """
+        open_ids = self.tool_response_token_ids
+        close_ids = self.end_of_tool_response_token_ids
+        if not open_ids or not close_ids:
+            return
+
+        cursor = start_idx
+        while cursor < end_idx:
+            opens = self._find_pattern(seq[cursor:end_idx], open_ids)
+            if not opens:
+                return
+            block_start = cursor + opens[0]
+            closes = self._find_pattern(seq[block_start:end_idx], close_ids)
+            block_end = block_start + closes[0] + len(close_ids) if closes else end_idx
+            batch["labels"][i, block_start:block_end] = self.ignore_index
+            cursor = block_end
 
     def _apply_span_masking(
         self, batch: dict[str, Any], examples: list[list[int] | Any | dict[str, Any]]
@@ -212,6 +256,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                 batch["labels"][i, content_start:unmask_end] = batch["input_ids"][
                     i, content_start:unmask_end
                 ]
+                self._mask_tool_response_spans(batch, i, seq, content_start, unmask_end)
 
     # ------------------------------------------------------------------
     # Main collation
@@ -262,6 +307,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     # Make pytorch loss function ignore all tokens up through the end
                     # of the response key
                     batch["labels"][i, :response_token_ids_end_idx] = self.ignore_index
+
+                    # The unmasked tail is one assistant turn, so it carries the same
+                    # nested-tool-result exposure as span masking.
+                    self._mask_tool_response_spans(
+                        batch,
+                        i,
+                        batch["input_ids"][i].tolist(),
+                        response_token_ids_end_idx,
+                        batch["input_ids"].shape[1],
+                    )
 
         else:
             for i in range(len(examples)):

--- a/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
+++ b/src/oumi/core/collators/trl_data_collator_for_completion_only_lm.py
@@ -61,6 +61,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         mlm: Whether to use masked language modeling. Default False.
         ignore_index: Label value for masked tokens. Default -100.
         padding_free: Remove padding and add position_ids. Default False.
+        *args: Forwarded unchanged to ``DataCollatorForLanguageModeling``.
+        **kwargs: Forwarded unchanged to ``DataCollatorForLanguageModeling`` — this is
+            how ``tokenizer``, ``pad_to_multiple_of`` and the rest of the base
+            collator's settings are passed. Nothing here is read by this subclass.
     """
 
     _VALID_TRAIN_TARGETS = {t.value for t in TrainTarget} | {
@@ -68,7 +72,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     }
 
     def _tokenize_template(self, template: str | list[int] | None) -> list[int] | None:
-        """Encode a template string into token IDs, or pass through if already IDs."""
+        """Encode a template string into token IDs, or pass through if already IDs.
+
+        Args:
+            template: Boundary marker to tokenize. A string is encoded without special
+                tokens; a list of token IDs is copied through unchanged, which is how
+                the builder passes markers it resolved itself; None passes through.
+
+        Returns:
+            The token IDs, or None when `template` is None.
+        """
         if template is None:
             return None
         if isinstance(template, str):
@@ -144,7 +157,19 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
     @staticmethod
     def _find_pattern(seq: list[int], pattern: list[int]) -> list[int]:
-        """Return all start positions where *pattern* appears in *seq*."""
+        """Return all start positions where *pattern* appears in *seq*.
+
+        Args:
+            seq: Token IDs to search.
+            pattern: Token IDs to find. An empty pattern matches nothing.
+
+        Returns:
+            Every index in `seq` where `pattern` starts, ascending. Overlapping
+            occurrences are all reported -- searching ``[1, 1, 1]`` for ``[1, 1]``
+            returns ``[0, 1]``, not just ``[0]``, because the scan does not skip
+            past a match it has already found. Callers pass boundary markers that
+            cannot overlap a copy of themselves, so this never comes up in practice.
+        """
         plen = len(pattern)
         if plen == 0:
             return []
@@ -158,8 +183,8 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     def _mask_tool_response_spans(
         self,
         batch: dict[str, Any],
-        i: int,
-        seq: list[int],
+        row_idx: int,
+        row_token_ids: list[int],
         start_idx: int,
         end_idx: int,
     ) -> None:
@@ -171,6 +196,44 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
         An opener with no closer before `end_idx` masks through `end_idx`: truncation
         can cut a block in half, and over-masking is the safe direction.
+
+        Args:
+            batch: Collated batch. Modified in place: the labels of every bracketed
+                tool result found in the span are set to ``ignore_index``.
+            row_idx: Which example in the batch to mask.
+            row_token_ids: That row's token IDs, as a Python list. Passed in rather
+                than read off `batch` because the caller already has it decoded.
+            start_idx: First position of the span to scan, inclusive. Callers pass the
+                start of a just-unmasked assistant span.
+            end_idx: Position to stop scanning at, exclusive.
+
+        Returns:
+            None. The masking is applied to `batch` in place.
+
+        Examples:
+            A gemma-4 style turn, where the model calls a tool, the environment
+            answers inside the same turn, and the model then answers the user.
+            Span masking has already unmasked the whole turn; this walks it and
+            takes the tool result back out, leaving the call and the answer::
+
+                <resp> call <open> result <close> answer <eot>
+                       ^^^^ ^^^^^^^^^^^^^^^^^^^^ ^^^^^^
+                       kept       masked          kept
+
+            Parallel tool calls give two blocks in one turn. The loop resumes at
+            `cursor = block_end`, so the second is found on the next pass::
+
+                <resp> <open> a <close> <open> b <close> answer <eot>
+                       ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^
+                          masked            masked
+
+            An opener whose closer was cut off by truncation masks everything to
+            `end_idx`. Over-masking costs a little signal; under-masking would
+            train on environment output, so the bias goes this way on purpose::
+
+                <resp> call <open> result-cut-off-here|
+                       ^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                       kept        masked to end_idx
         """
         open_ids = self.tool_response_token_ids
         close_ids = self.end_of_tool_response_token_ids
@@ -179,13 +242,13 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
 
         cursor = start_idx
         while cursor < end_idx:
-            opens = self._find_pattern(seq[cursor:end_idx], open_ids)
+            opens = self._find_pattern(row_token_ids[cursor:end_idx], open_ids)
             if not opens:
                 return
             block_start = cursor + opens[0]
-            closes = self._find_pattern(seq[block_start:end_idx], close_ids)
+            closes = self._find_pattern(row_token_ids[block_start:end_idx], close_ids)
             block_end = block_start + closes[0] + len(close_ids) if closes else end_idx
-            batch["labels"][i, block_start:block_end] = self.ignore_index
+            batch["labels"][row_idx, block_start:block_end] = self.ignore_index
             cursor = block_end
 
     def _apply_span_masking(
@@ -196,6 +259,15 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         Masks all labels, then unmarks assistant response spans bounded by
         response_template and end_of_turn_template (inclusive — the EOT token
         is unmasked so the model learns to produce it).
+
+        Args:
+            batch: Collated batch. Its ``labels`` are rewritten in place.
+            examples: The pre-collation examples, used only for their count — the
+                token IDs are read back off `batch` so that padding and truncation
+                already applied by the base collator are accounted for.
+
+        Returns:
+            None. The masking is applied to `batch` in place.
         """
         resp_ids = self.response_token_ids
         eot_ids = self.end_of_turn_token_ids
@@ -265,7 +337,16 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     def torch_call(
         self, examples: list[list[int] | Any | dict[str, Any]]
     ) -> dict[str, Any]:
-        """Collates a list of examples into a batch."""
+        """Collates a list of examples into a batch.
+
+        Args:
+            examples: Examples to collate, each a list of token IDs or a mapping
+                holding at least ``input_ids``. Passed through to the base collator,
+                which handles padding.
+
+        Returns:
+            The collated batch, with ``labels`` masked according to ``train_target``.
+        """
         batch = super().torch_call(examples)
 
         if self.train_target == "all_assistant_turns":

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -686,6 +686,37 @@ def find_internal_model_config_using_model_name(
     return llm_info.config if llm_info is not None else None
 
 
+def find_model_type_using_model_name(
+    model_name: str, trust_remote_code: bool, revision: str | None = None
+) -> str | None:
+    """Finds the HuggingFace ``config.model_type`` for a model.
+
+    Unlike `find_internal_model_config_using_model_name`, this reports the architecture
+    whether or not it appears in the supported models registry. That registry is scoped
+    to VLMs, so text LLMs resolve to None there by design; use this to branch on
+    architecture for them.
+
+    Args:
+        model_name: The model name, either:
+            - A HuggingFace model ID (e.g., "meta-llama/Llama-2-7b-hf")
+            - A local path to a model directory
+            - A custom model name registered in Oumi
+        trust_remote_code: Whether to trust external code associated with the model.
+        revision: The HuggingFace model revision to load, if any.
+
+    Returns:
+        The model_type string, or None if the model is a custom Oumi model, which has
+        no HuggingFace config.
+    """
+    if is_custom_model(model_name):
+        return None
+
+    hf_config = find_model_hf_config(
+        model_name, trust_remote_code=trust_remote_code, revision=revision
+    )
+    return hf_config.model_type
+
+
 def find_internal_model_config(
     model_params: ModelParams,
 ) -> InternalModelConfig | None:

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -13,11 +13,34 @@
 # limitations under the License.
 
 import functools
+import json
 
 import pytest
 import transformers
 
-from oumi.builders.collators import resolve_collator_templates
+from oumi.builders.collators import (
+    build_collator_from_config,
+    build_data_collator,
+    resolve_collator_templates,
+)
+from oumi.core.configs import (
+    DataParams,
+    DatasetParams,
+    DatasetSplitParams,
+    ModelParams,
+    TrainingConfig,
+    TrainTarget,
+)
+from oumi.core.constants import LABEL_IGNORE_INDEX
+from oumi.core.types import Conversation, Message, Role
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    FunctionDefinition,
+    JSONSchema,
+    ToolCall,
+    ToolDefinition,
+)
+from oumi.utils.packaging import is_transformers_v5
 from tests.markers import requires_hf_token
 
 
@@ -229,3 +252,283 @@ def test_template_detection_newer_transformers(
     assert response_template.strip()
     assert end_of_turn_template.strip()
     assert "<think>" not in response_template
+
+
+# -- Tool results nested inside assistant turns --------------------------------
+# gemma-4 and GLM-4.5 render tool results inside the model turn, so span masking
+# trains on environment output unless the tool-result bracket is subtracted.
+
+_SYSTEM_TEXT = "SYSTEM_PROMPT_TEXT"
+_USER_TEXT_1 = "USER_ASKS_WEATHER_AND_FLIGHTS"
+_USER_TEXT_2 = "USER_ASKS_TOKYO"
+_ASSISTANT_TEXT_1 = "ASSISTANT_ANSWERS_PARIS"
+_ASSISTANT_TEXT_2 = "ASSISTANT_ANSWERS_TOKYO"
+_TOOL_RESULT_1 = "TOOL_RESULT_PARIS_WEATHER"
+_TOOL_RESULT_2 = "TOOL_RESULT_BOSTON_FLIGHTS"
+_TOOL_RESULT_3 = "TOOL_RESULT_TOKYO_WEATHER"
+
+
+def _tool_conversation() -> Conversation:
+    """Mock multi-turn conversation with parallel tool calls and interleaved results."""
+
+    def _call(call_id: str, name: str, **arguments) -> ToolCall:
+        return ToolCall(
+            id=call_id,
+            function=FunctionCall(name=name, arguments=json.dumps(arguments)),
+        )
+
+    def _tool(name: str, **properties) -> ToolDefinition:
+        return ToolDefinition(
+            function=FunctionDefinition(
+                name=name,
+                description=f"{name} description",
+                parameters=JSONSchema(
+                    type="object",
+                    properties={k: JSONSchema(type="string") for k in properties},
+                    required=list(properties),
+                ),
+            )
+        )
+
+    return Conversation(
+        tools=[_tool("get_weather", city=""), _tool("search_flights", origin="")],
+        messages=[
+            Message(role=Role.SYSTEM, content=_SYSTEM_TEXT),
+            Message(role=Role.USER, content=_USER_TEXT_1),
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=[
+                    _call("weathr001", "get_weather", city="Paris"),
+                    _call("flight001", "search_flights", origin="Boston"),
+                ],
+            ),
+            Message(role=Role.TOOL, tool_call_id="weathr001", content=_TOOL_RESULT_1),
+            Message(role=Role.TOOL, tool_call_id="flight001", content=_TOOL_RESULT_2),
+            Message(role=Role.ASSISTANT, content=_ASSISTANT_TEXT_1),
+            Message(role=Role.USER, content=_USER_TEXT_2),
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=[_call("weathr002", "get_weather", city="Tokyo")],
+            ),
+            Message(role=Role.TOOL, tool_call_id="weathr002", content=_TOOL_RESULT_3),
+            Message(role=Role.ASSISTANT, content=_ASSISTANT_TEXT_2),
+        ],
+    )
+
+
+def _template_inputs(conversation: Conversation):
+    """Messages/tools shaped for templates that require mapping arguments."""
+    data = conversation.to_dict()
+    messages = []
+    for message in data["messages"]:
+        message = dict(message)
+        if message.get("tool_calls"):
+            message["content"] = message.get("content") or ""
+            message["tool_calls"] = [
+                {
+                    **call,
+                    "function": {
+                        **call["function"],
+                        "arguments": json.loads(call["function"]["arguments"]),
+                    },
+                }
+                for call in message["tool_calls"]
+            ]
+        messages.append(message)
+    return messages, data.get("tools")
+
+
+def _build_collator(tokenizer, model_name: str):
+    """The collator the trainer would build for this model, bracket and all."""
+    config = TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                train_target=TrainTarget.ALL_ASSISTANT_TURNS,
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        # The bracket is keyed on the model's config.model_type, so model_name has to
+        # be the real checkpoint rather than a stand-in.
+        model=ModelParams(
+            model_name=model_name,
+            trust_remote_code=True,
+            model_max_length=8192,
+        ),
+    )
+    collator = build_collator_from_config(config, tokenizer=tokenizer)
+    assert collator is not None
+    return collator
+
+
+def _encode_conversation(tokenizer, conversation: Conversation) -> list[int]:
+    messages, tools = _template_inputs(conversation)
+    encoded = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        return_dict=True,
+        add_generation_prompt=False,
+    )
+    return list(encoded["input_ids"])
+
+
+def _labels(collator, input_ids: list[int]) -> list[int]:
+    batch = collator([{"input_ids": input_ids, "attention_mask": [1] * len(input_ids)}])
+    return batch["labels"][0].tolist()
+
+
+def _masked_bracket_regions_are_complete(collator, input_ids, labels) -> bool:
+    """Every token from a tool-result opener through its closer must be masked.
+
+    The payload sentinels only cover the tool result's own text; this also covers the
+    bracket tokens and whatever the template renders between them. Returns True when
+    the model uses no bracket.
+    """
+    opener = collator._default_collator.tool_response_token_ids
+    closer = collator._default_collator.end_of_tool_response_token_ids
+    if not opener or not closer:
+        return True
+
+    # Slicing past the end yields a short list, which never equals the marker, so no
+    # bounds arithmetic is needed here.
+    opener_starts = [
+        i for i in range(len(input_ids)) if input_ids[i : i + len(opener)] == opener
+    ]
+    closer_ends = [
+        i + len(closer)
+        for i in range(len(input_ids))
+        if input_ids[i : i + len(closer)] == closer
+    ]
+    assert opener_starts, "bracket was resolved but never occurs in the conversation"
+
+    for start in opener_starts:
+        # The block ends at the first closer after this opener. An opener with no
+        # closer runs to the end of the sequence, which is what the collator masks.
+        end = next((e for e in closer_ends if e > start), len(input_ids))
+        if any(label != LABEL_IGNORE_INDEX for label in labels[start:end]):
+            return False
+    return True
+
+
+def _sentinel_labels(tokenizer, input_ids, labels, text: str) -> list[int]:
+    """The labels the collator gave the tokens spelling `text`.
+
+    Compares token ids rather than decoded text: a payload that is only partly masked
+    still decodes to something, so a substring check would pass on it.
+    """
+    tokens = tokenizer.encode(text, add_special_tokens=False)
+    for start in range(len(input_ids)):
+        if input_ids[start : start + len(tokens)] == tokens:
+            return labels[start : start + len(tokens)]
+    raise AssertionError(f"sentinel {text!r} is not in the tokenized conversation")
+
+
+def _assert_excluded_from_loss(tokenizer, input_ids, labels, text: str, model: str):
+    """Every token spelling `text` must be masked."""
+    sentinel = _sentinel_labels(tokenizer, input_ids, labels, text)
+    in_loss = sum(label != LABEL_IGNORE_INDEX for label in sentinel)
+    assert not in_loss, (
+        f"{model} trains on {text!r}: {in_loss} of its {len(sentinel)} tokens are "
+        "in the loss"
+    )
+
+
+def _assert_included_in_loss(tokenizer, input_ids, labels, text: str, model: str):
+    """Every token spelling `text` must contribute to the loss."""
+    sentinel = _sentinel_labels(tokenizer, input_ids, labels, text)
+    masked = sum(label == LABEL_IGNORE_INDEX for label in sentinel)
+    assert not masked, (
+        f"{model} drops {text!r} from the loss: {masked} of its {len(sentinel)} "
+        "tokens are masked"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code",
+    [
+        pytest.param(
+            "google/gemma-4-E2B-it",
+            False,
+            id="gemma-4-nested",
+            marks=pytest.mark.skipif(
+                not is_transformers_v5(),
+                reason="gemma-4 tokenizers require transformers v5",
+            ),
+        ),
+        pytest.param("zai-org/GLM-4.5", False, id="glm-4.5-nested"),
+        pytest.param("Qwen/Qwen3-0.6B", False, id="qwen3-separate-turn"),
+    ],
+)
+def test_tool_results_are_excluded_from_the_loss(model_name, trust_remote_code):
+    tokenizer = _load_tokenizer(model_name, trust_remote_code)
+
+    conversation = _tool_conversation()
+    collator = _build_collator(tokenizer, model_name)
+    input_ids = _encode_conversation(tokenizer, conversation)
+    labels = _labels(collator, input_ids)
+
+    # Environment output must never be trained on.
+    for tool_result in (_TOOL_RESULT_1, _TOOL_RESULT_2, _TOOL_RESULT_3):
+        _assert_excluded_from_loss(
+            tokenizer, input_ids, labels, tool_result, model_name
+        )
+
+    # Prompt text is context, not a target.
+    for prompt_text in (_SYSTEM_TEXT, _USER_TEXT_1, _USER_TEXT_2):
+        _assert_excluded_from_loss(
+            tokenizer, input_ids, labels, prompt_text, model_name
+        )
+
+    # The model's own turns must survive, including the answer that gemma-4 renders
+    # after the tool results inside the same turn.
+    for assistant_text in (_ASSISTANT_TEXT_1, _ASSISTANT_TEXT_2):
+        _assert_included_in_loss(
+            tokenizer, input_ids, labels, assistant_text, model_name
+        )
+
+    # The sentinels above only cover the payload. This covers the bracket tokens and
+    # anything the template puts between them.
+    assert _masked_bracket_regions_are_complete(collator, input_ids, labels), (
+        f"{model_name} leaves part of a bracketed tool result in the loss"
+    )
+
+
+def test_bracket_forced_onto_a_separate_turn_model_changes_nothing():
+    """Qwen3 emits <tool_response> markers, but in a turn of their own.
+
+    Assert that providing a bracket for template that does not nest change results.
+    """
+    model_name = "Qwen/Qwen3-0.6B"
+    tokenizer = _load_tokenizer(model_name)
+
+    conversation = _tool_conversation()
+    input_ids = _encode_conversation(tokenizer, conversation)
+
+    response_template, end_of_turn_template = resolve_collator_templates(tokenizer)
+    baseline = build_data_collator(
+        "text_completions_only_with_padding",
+        tokenizer=tokenizer,
+        max_length=None,
+        response_template=response_template,
+        end_of_turn_template=end_of_turn_template,
+        train_target="all_assistant_turns",
+    )
+    forced = build_data_collator(
+        "text_completions_only_with_padding",
+        tokenizer=tokenizer,
+        max_length=None,
+        response_template=response_template,
+        end_of_turn_template=end_of_turn_template,
+        train_target="all_assistant_turns",
+        tool_response_template="<tool_response>",
+        end_of_tool_response_template="</tool_response>",
+    )
+
+    # The markers really are present, so this is not a vacuous comparison.
+    opener = forced._default_collator.tool_response_token_ids
+    assert any(
+        input_ids[i : i + len(opener)] == opener for i in range(len(input_ids))
+    ), "expected <tool_response> to appear in the rendered conversation"
+
+    assert _labels(forced, input_ids) == _labels(baseline, input_ids)

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 import oumi.core.constants as constants
+from oumi.builders import build_tokenizer
 from oumi.builders.collators import (
+    _NESTING_MODEL_TYPES,
+    _TOOL_RESPONSE_BRACKETS,
+    _known_tool_response_markers,
     build_collator_from_config,
     build_data_collator,
     resolve_collator_templates,
@@ -496,3 +500,198 @@ def test_old_recipe_eot_sets_all_assistant(mock_tokenizer):
     collator = build_collator_from_config(config, tokenizer=mock_tokenizer)
     assert collator is not None
     assert collator._default_collator.train_target == "all_assistant_turns"
+
+
+# ---------------------------------------------------------------------------
+# Tool-result bracket for architectures that nest tool results in assistant turns
+# ---------------------------------------------------------------------------
+
+# Verified against transformers 5.7.0. Keep in sync with _TOOL_RESPONSE_BRACKETS.
+_GEMMA4_BRACKET = ("<|tool_response>", "<tool_response|>")
+_GLM4_BRACKET = ("<tool_response>", "</tool_response>")
+
+_SPAN_KWARGS = {
+    "response_template": "<|assistant|>",
+    "end_of_turn_template": "<|end|>",
+}
+
+
+@pytest.fixture(scope="module")
+def real_tokenizer():
+    """A real tokenizer, so bracket strings encode to comparable token IDs."""
+    return build_tokenizer(
+        ModelParams(
+            model_name="MlpEncoder",
+            torch_dtype_str="float16",
+            trust_remote_code=False,
+            tokenizer_name="openai-community/gpt2",
+            tokenizer_pad_token="<|endoftext|>",
+        )
+    )
+
+
+def _tool_config(
+    model_name: str,
+    collator_kwargs: dict | None = None,
+    train_target: TrainTarget | None = None,
+) -> TrainingConfig:
+    """Config whose model_name drives the architecture lookup."""
+    return TrainingConfig(
+        data=DataParams(
+            train=DatasetSplitParams(
+                collator_name="text_completions_only_with_padding",
+                train_target=train_target,
+                collator_kwargs=(
+                    dict(_SPAN_KWARGS) if collator_kwargs is None else collator_kwargs
+                ),
+                datasets=[DatasetParams(dataset_name="dummy", split="train")],
+            )
+        ),
+        model=ModelParams(
+            model_name=model_name,
+            tokenizer_name="openai-community/gpt2",
+            trust_remote_code=True,
+            model_max_length=512,
+        ),
+    )
+
+
+#
+# _known_tool_response_markers: pure lookup on model_type
+#
+
+
+@pytest.mark.parametrize(
+    "model_type,bracket",
+    [
+        pytest.param("gemma4", _GEMMA4_BRACKET, id="gemma4"),
+        pytest.param("gemma4_unified", _GEMMA4_BRACKET, id="gemma4_unified-12b"),
+        pytest.param("glm4_moe", _GLM4_BRACKET, id="glm4_moe"),
+        pytest.param("glm4v_moe", _GLM4_BRACKET, id="glm4v_moe"),
+    ],
+)
+def test_nesting_architectures_map_to_their_bracket(model_type, bracket):
+    assert _known_tool_response_markers(model_type) == bracket
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        pytest.param("qwen3", id="qwen3"),
+        pytest.param("llama", id="llama"),
+        pytest.param("gemma3", id="gemma3-different-generation"),
+        pytest.param("chatglm", id="chatglm-older-glm"),
+        # GLM-4.6V-Flash reports glm4v, but so does GLM-4.1V, which does not nest.
+        # Leaving out glm4v is deliberate.
+        pytest.param("glm4v", id="glm4v-ambiguous"),
+        pytest.param(None, id="model-type-unknown"),
+        pytest.param("", id="model-type-empty"),
+    ],
+)
+def test_non_nesting_architectures_map_to_no_bracket(model_type):
+    assert _known_tool_response_markers(model_type) is None
+
+
+def test_registry_families_all_have_brackets():
+    assert set(_NESTING_MODEL_TYPES.values()) <= set(_TOOL_RESPONSE_BRACKETS)
+
+
+#
+# End-to-end through build_collator_from_config
+#
+
+
+@pytest.mark.parametrize(
+    "model_name,bracket",
+    [
+        pytest.param("google/gemma-4-E2B-it", _GEMMA4_BRACKET, id="gemma-4"),
+        pytest.param("zai-org/GLM-4.5", _GLM4_BRACKET, id="glm-4.5"),
+    ],
+)
+def test_known_architecture_resolves_bracket(model_name, bracket, real_tokenizer):
+    collator = build_collator_from_config(
+        _tool_config(model_name), tokenizer=real_tokenizer
+    )
+    assert collator is not None
+    inner = collator._default_collator
+
+    opener, closer = bracket
+    assert inner.tool_response_token_ids == real_tokenizer.encode(
+        opener, add_special_tokens=False
+    )
+    assert inner.end_of_tool_response_token_ids == real_tokenizer.encode(
+        closer, add_special_tokens=False
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        pytest.param("Qwen/Qwen3-0.6B", id="qwen3"),
+        pytest.param("google/gemma-3-4b-it", id="gemma-3"),
+        pytest.param("MlpEncoder", id="custom-oumi-model"),
+    ],
+)
+def test_unknown_architecture_resolves_no_bracket(model_name, real_tokenizer):
+    """Unlisted architectures are untouched — the fallback path must stay inert."""
+    collator = build_collator_from_config(
+        _tool_config(model_name), tokenizer=real_tokenizer
+    )
+    assert collator is not None
+    assert collator._default_collator.tool_response_token_ids is None
+
+
+def test_supplied_bracket_overrides_known_architecture(real_tokenizer):
+    """A hand-configured bracket wins over the built-in table."""
+    config = _tool_config(
+        "google/gemma-4-E2B-it",
+        collator_kwargs={
+            **_SPAN_KWARGS,
+            "tool_response_template": "<custom_open>",
+            "end_of_tool_response_template": "<custom_close>",
+        },
+    )
+
+    collator = build_collator_from_config(config, tokenizer=real_tokenizer)
+    assert collator is not None
+    assert collator._default_collator.tool_response_token_ids == real_tokenizer.encode(
+        "<custom_open>", add_special_tokens=False
+    )
+
+
+def test_non_span_train_target_resolves_no_bracket(real_tokenizer):
+    """Only span masking can unmask a tool result, so legacy mode needs no bracket."""
+    config = _tool_config(
+        "google/gemma-4-E2B-it",
+        collator_kwargs={
+            "response_template": "<|assistant|>",
+            "instruction_template": "<|user|>",
+        },
+    )
+
+    with pytest.deprecated_call():
+        collator = build_collator_from_config(config, tokenizer=real_tokenizer)
+
+    assert collator is not None
+    assert collator._default_collator.train_target == "_legacy_instruction_response"
+    assert collator._default_collator.tool_response_token_ids is None
+
+
+@pytest.mark.parametrize(
+    "supplied,missing",
+    [
+        ("tool_response_template", "end_of_tool_response_template"),
+        ("end_of_tool_response_template", "tool_response_template"),
+    ],
+)
+def test_build_collator_half_supplied_tool_bracket_raises(
+    supplied, missing, mock_tokenizer
+):
+    """One marker alone masks nothing, so it must be reported rather than ignored."""
+    config = _tool_config(
+        "Qwen/Qwen3-0.6B",
+        collator_kwargs={**_SPAN_KWARGS, supplied: "<|tres|>"},
+    )
+
+    with pytest.raises(ValueError, match=f"without '{missing}'"):
+        build_collator_from_config(config, tokenizer=mock_tokenizer)

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -411,7 +411,9 @@ def test_resolve_templates_error(make_tok, match):
 def _completions_config(
     train_target: TrainTarget | None = None,
     collator_kwargs: dict | None = None,
+    model_name: str = "MlpEncoder",
 ) -> TrainingConfig:
+    """Config for the completions collator; model_name drives the bracket lookup."""
     return TrainingConfig(
         data=DataParams(
             train=DatasetSplitParams(
@@ -422,8 +424,9 @@ def _completions_config(
             )
         ),
         model=ModelParams(
-            model_name="MlpEncoder",
+            model_name=model_name,
             tokenizer_name="openai-community/gpt2",
+            trust_remote_code=True,
             model_max_length=512,
         ),
     )
@@ -531,32 +534,6 @@ def real_tokenizer():
     )
 
 
-def _tool_config(
-    model_name: str,
-    collator_kwargs: dict | None = None,
-    train_target: TrainTarget | None = None,
-) -> TrainingConfig:
-    """Config whose model_name drives the architecture lookup."""
-    return TrainingConfig(
-        data=DataParams(
-            train=DatasetSplitParams(
-                collator_name="text_completions_only_with_padding",
-                train_target=train_target,
-                collator_kwargs=(
-                    dict(_SPAN_KWARGS) if collator_kwargs is None else collator_kwargs
-                ),
-                datasets=[DatasetParams(dataset_name="dummy", split="train")],
-            )
-        ),
-        model=ModelParams(
-            model_name=model_name,
-            tokenizer_name="openai-community/gpt2",
-            trust_remote_code=True,
-            model_max_length=512,
-        ),
-    )
-
-
 #
 # _known_tool_response_markers: pure lookup on model_type
 #
@@ -611,7 +588,8 @@ def test_registry_families_all_have_brackets():
 )
 def test_known_architecture_resolves_bracket(model_name, bracket, real_tokenizer):
     collator = build_collator_from_config(
-        _tool_config(model_name), tokenizer=real_tokenizer
+        _completions_config(collator_kwargs=dict(_SPAN_KWARGS), model_name=model_name),
+        tokenizer=real_tokenizer,
     )
     assert collator is not None
     inner = collator._default_collator
@@ -637,7 +615,8 @@ def test_known_architecture_resolves_bracket(model_name, bracket, real_tokenizer
 def test_unknown_architecture_resolves_no_bracket(model_name, real_tokenizer):
     """Unlisted architectures are untouched — the fallback path must stay inert."""
     collator = build_collator_from_config(
-        _tool_config(model_name), tokenizer=real_tokenizer
+        _completions_config(collator_kwargs=dict(_SPAN_KWARGS), model_name=model_name),
+        tokenizer=real_tokenizer,
     )
     assert collator is not None
     assert collator._default_collator.tool_response_token_ids is None
@@ -645,8 +624,8 @@ def test_unknown_architecture_resolves_no_bracket(model_name, real_tokenizer):
 
 def test_supplied_bracket_overrides_known_architecture(real_tokenizer):
     """A hand-configured bracket wins over the built-in table."""
-    config = _tool_config(
-        "google/gemma-4-E2B-it",
+    config = _completions_config(
+        model_name="google/gemma-4-E2B-it",
         collator_kwargs={
             **_SPAN_KWARGS,
             "tool_response_template": "<custom_open>",
@@ -663,8 +642,8 @@ def test_supplied_bracket_overrides_known_architecture(real_tokenizer):
 
 def test_non_span_train_target_resolves_no_bracket(real_tokenizer):
     """Only span masking can unmask a tool result, so legacy mode needs no bracket."""
-    config = _tool_config(
-        "google/gemma-4-E2B-it",
+    config = _completions_config(
+        model_name="google/gemma-4-E2B-it",
         collator_kwargs={
             "response_template": "<|assistant|>",
             "instruction_template": "<|user|>",
@@ -687,8 +666,8 @@ def test_legacy_train_target_still_accepts_a_hand_supplied_bracket(real_tokenize
     markers are tokenized and stored; ``torch_call``'s legacy branch ignores them.
     Supplying one marker raises, supplying both is silently inert.
     """
-    config = _tool_config(
-        "google/gemma-4-E2B-it",
+    config = _completions_config(
+        model_name="google/gemma-4-E2B-it",
         collator_kwargs={
             "response_template": "<|assistant|>",
             "instruction_template": "<|user|>",
@@ -722,8 +701,8 @@ def test_build_collator_half_supplied_tool_bracket_raises(
     supplied, missing, mock_tokenizer
 ):
     """One marker alone masks nothing, so it must be reported rather than ignored."""
-    config = _tool_config(
-        "Qwen/Qwen3-0.6B",
+    config = _completions_config(
+        model_name="Qwen/Qwen3-0.6B",
         collator_kwargs={**_SPAN_KWARGS, supplied: "<|tres|>"},
     )
 

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -22,6 +22,7 @@ from oumi.core.configs import (
     TrainingParams,
     TrainTarget,
 )
+from tests.markers import requires_hf_token
 
 
 def test_build_data_collator_empty_name(mock_tokenizer):
@@ -628,7 +629,8 @@ def test_known_architecture_resolves_bracket(model_name, bracket, real_tokenizer
     "model_name",
     [
         pytest.param("Qwen/Qwen3-0.6B", id="qwen3"),
-        pytest.param("google/gemma-3-4b-it", id="gemma-3"),
+        # Gated repo: resolving the architecture needs an authenticated config fetch.
+        pytest.param("google/gemma-3-4b-it", id="gemma-3", marks=requires_hf_token()),
         pytest.param("MlpEncoder", id="custom-oumi-model"),
     ],
 )
@@ -675,6 +677,38 @@ def test_non_span_train_target_resolves_no_bracket(real_tokenizer):
     assert collator is not None
     assert collator._default_collator.train_target == "_legacy_instruction_response"
     assert collator._default_collator.tool_response_token_ids is None
+
+
+def test_legacy_train_target_still_accepts_a_hand_supplied_bracket(real_tokenizer):
+    """A hand-supplied bracket reaches the legacy collator, which never applies it.
+
+    ``_resolve_tool_bracket`` returns early for a user-supplied pair, so the
+    "only span masking can unmask a tool result" guard below it never runs. The
+    markers are tokenized and stored; ``torch_call``'s legacy branch ignores them.
+    Supplying one marker raises, supplying both is silently inert.
+    """
+    config = _tool_config(
+        "google/gemma-4-E2B-it",
+        collator_kwargs={
+            "response_template": "<|assistant|>",
+            "instruction_template": "<|user|>",
+            "tool_response_template": "<custom_open>",
+            "end_of_tool_response_template": "<custom_close>",
+        },
+    )
+
+    with pytest.deprecated_call():
+        collator = build_collator_from_config(config, tokenizer=real_tokenizer)
+
+    assert collator is not None
+    inner = collator._default_collator
+    assert inner.train_target == "_legacy_instruction_response"
+    assert inner.tool_response_token_ids == real_tokenizer.encode(
+        "<custom_open>", add_special_tokens=False
+    )
+    assert inner.end_of_tool_response_token_ids == real_tokenizer.encode(
+        "<custom_close>", add_special_tokens=False
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -20,6 +20,12 @@ IGNORE = constants.LABEL_IGNORE_INDEX
 # Template strings for span-masking tests — chosen to be unambiguous in GPT-2's vocab.
 _RESP_STR = " ASSISTANT_RESPONSE_START"
 _EOT_STR = " TURN_ENDS_HERE"
+_INST_STR = " USER_TURN_STARTS"
+
+# Markers standing in for a template that renders tool results inside the assistant
+# turn (gemma-4 renders <|tool_response>...<tool_response|> there).
+_TOOL_OPEN_STR = " TOOL_RESULT_STARTS"
+_TOOL_CLOSE_STR = " TOOL_RESULT_ENDS"
 
 # Arbitrary token IDs used as "content" that must not appear in any template.
 _SENTINELS = [601, 602, 603, 604, 605, 606, 607, 608]
@@ -280,13 +286,26 @@ def get_template_token_ids() -> tuple[list[int], list[int]]:
     return encode_template(_RESP_STR), encode_template(_EOT_STR)
 
 
-def make_span_collator() -> TextCompletionsCollatorWithPadding:
+def make_span_collator(
+    train_target: str = "all_assistant_turns",
+    *,
+    tool_bracket: bool = False,
+    instruction_template: str | None = None,
+) -> TextCompletionsCollatorWithPadding:
+    """Span collator, optionally configured with the tool-result bracket.
+
+    `tool_bracket` is the only difference between the two collators an inertness
+    test compares, so both come from here.
+    """
     tokenizer, _ = create_test_tokenizer()
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
-        train_target="all_assistant_turns",
+        train_target=train_target,
+        instruction_template=instruction_template,
         end_of_turn_template=_EOT_STR,
+        tool_response_template=_TOOL_OPEN_STR if tool_bracket else None,
+        end_of_tool_response_template=_TOOL_CLOSE_STR if tool_bracket else None,
     )
 
 
@@ -650,33 +669,17 @@ def test_pad_to_multiple_of_none_keeps_longest_in_batch():
 # Tool results nested inside an assistant turn
 # ---------------------------------------------------------------------------
 
-# Markers standing in for a template that renders tool results inside the assistant
-# turn (gemma-4 renders <|tool_response>...<tool_response|> there).
-_TOOL_OPEN_STR = " TOOL_RESULT_STARTS"
-_TOOL_CLOSE_STR = " TOOL_RESULT_ENDS"
-
 
 def get_tool_template_token_ids() -> tuple[list[int], list[int]]:
     return encode_template(_TOOL_OPEN_STR), encode_template(_TOOL_CLOSE_STR)
 
 
-def make_tool_span_collator(
-    train_target: str = "all_assistant_turns",
-    instruction_template: str | None = None,
-) -> TextCompletionsCollatorWithPadding:
-    tokenizer, _ = create_test_tokenizer()
-    return TextCompletionsCollatorWithPadding(
-        tokenizer=tokenizer,
-        response_template=_RESP_STR,
-        train_target=train_target,
-        instruction_template=instruction_template,
-        end_of_turn_template=_EOT_STR,
-        tool_response_template=_TOOL_OPEN_STR,
-        end_of_tool_response_template=_TOOL_CLOSE_STR,
-    )
-
-
 def test_span_tool_response_is_masked_inside_assistant_turn():
+    """Masking keys off the markers alone, not on the text between them.
+
+    A model that emits the markers itself loses that stretch from the loss. The
+    answer assertion below bounds the damage: it stops at the closer.
+    """
     resp, eot = get_template_token_ids()
     tool_open, tool_close = get_tool_template_token_ids()
     call = [_SENTINELS[0]]
@@ -684,7 +687,7 @@ def test_span_tool_response_is_masked_inside_assistant_turn():
     answer = [_SENTINELS[3]]
     seq = flat(resp, call, tool_open, payload, tool_close, answer, eot)
 
-    labels = get_span_labels(make_tool_span_collator(), seq)
+    labels = get_span_labels(make_span_collator(tool_bracket=True), seq)
 
     at = len(resp)
     assert all(v == IGNORE for v in labels[:at]), "response header must stay masked"
@@ -719,7 +722,7 @@ def test_span_parallel_tool_responses_are_both_masked():
         eot,
     )
 
-    labels = get_span_labels(make_tool_span_collator(), seq)
+    labels = get_span_labels(make_span_collator(tool_bracket=True), seq)
 
     assert _SENTINELS[0] not in labels
     assert _SENTINELS[1] not in labels
@@ -735,7 +738,7 @@ def test_span_unclosed_tool_response_masks_through_span_end():
     # result: the rest of that turn drops out of the loss.
     seq = flat(resp, tool_open, payload, eot)
 
-    labels = get_span_labels(make_tool_span_collator(), seq)
+    labels = get_span_labels(make_span_collator(tool_bracket=True), seq)
 
     assert all(v == IGNORE for v in labels), (
         "an unclosed tool result must mask through the end of the span"
@@ -759,7 +762,7 @@ def test_span_tool_masking_leaves_other_turns_untouched():
         eot,
     )
 
-    labels = get_span_labels(make_tool_span_collator(), seq)
+    labels = get_span_labels(make_span_collator(tool_bracket=True), seq)
 
     assert _SENTINELS[0] not in labels
     start = len(seq) - len(plain) - len(eot)
@@ -785,7 +788,9 @@ def test_final_assistant_turn_tool_response_is_masked():
     answer = [_SENTINELS[1]]
     seq = flat([_SENTINELS[2]], resp, tool_open, payload, tool_close, answer, eot)
 
-    labels = get_span_labels(make_tool_span_collator("final_assistant_turn"), seq)
+    labels = get_span_labels(
+        make_span_collator("final_assistant_turn", tool_bracket=True), seq
+    )
 
     assert _SENTINELS[0] not in labels, "tool result must be masked"
     assert _SENTINELS[1] in labels, "final answer must stay trained"
@@ -796,15 +801,20 @@ def test_final_assistant_turn_tool_response_is_masked():
 # ---------------------------------------------------------------------------
 
 
-def test_bracket_is_inert_when_markers_never_appear():
+@pytest.mark.parametrize(
+    "train_target", ["all_assistant_turns", "final_assistant_turn"]
+)
+def test_bracket_is_inert_when_markers_never_appear(train_target):
     """The common case: the template simply never emits the bracket."""
     resp, eot = get_template_token_ids()
     call = [_SENTINELS[0]]
     answer = [_SENTINELS[1]]
     seq = flat(resp, call, answer, eot)
 
-    with_bracket = get_span_labels(make_tool_span_collator(), seq)
-    without_bracket = get_span_labels(make_span_collator(), seq)
+    with_bracket = get_span_labels(
+        make_span_collator(train_target, tool_bracket=True), seq
+    )
+    without_bracket = get_span_labels(make_span_collator(train_target), seq)
 
     assert with_bracket == without_bracket
 
@@ -835,7 +845,7 @@ def test_bracket_is_inert_when_tool_result_sits_in_its_own_turn():
         eot,
     )
 
-    with_bracket = get_span_labels(make_tool_span_collator(), seq)
+    with_bracket = get_span_labels(make_span_collator(tool_bracket=True), seq)
     without_bracket = get_span_labels(make_span_collator(), seq)
 
     assert with_bracket == without_bracket
@@ -846,52 +856,9 @@ def test_bracket_is_inert_when_tool_result_sits_in_its_own_turn():
     assert _SENTINELS[2] in with_bracket
 
 
-def test_bracket_is_inert_for_final_assistant_turn_when_markers_are_absent():
-    resp, _ = get_template_token_ids()
-    prompt = [_SENTINELS[0]]
-    answer = [_SENTINELS[1]]
-    seq = flat(prompt, resp, answer)
-
-    with_bracket = get_span_labels(make_tool_span_collator("final_assistant_turn"), seq)
-    without_bracket = get_span_labels(
-        TextCompletionsCollatorWithPadding(
-            tokenizer=create_test_tokenizer()[0],
-            response_template=_RESP_STR,
-            train_target="final_assistant_turn",
-        ),
-        seq,
-    )
-
-    assert with_bracket == without_bracket
-
-
-def test_bracket_inside_an_assistant_turn_is_not_inert():
-    """
-    If the markers land inside an assistant span for a reason other than a nested tool
-    result — the model genuinely emitting that text, say — re-masking drops real model
-    output from the loss.
-    """
-    resp, eot = get_template_token_ids()
-    tool_open, tool_close = get_tool_template_token_ids()
-    quoted = [_SENTINELS[0]]
-    answer = [_SENTINELS[1]]
-    seq = flat(resp, tool_open, quoted, tool_close, answer, eot)
-
-    with_bracket = get_span_labels(make_tool_span_collator(), seq)
-    without_bracket = get_span_labels(make_span_collator(), seq)
-
-    assert with_bracket != without_bracket
-    assert _SENTINELS[0] in without_bracket, "baseline trains on the quoted text"
-    assert _SENTINELS[0] not in with_bracket, "bracket masks it"
-    # Everything after the closer still trains, so the damage is bounded.
-    assert _SENTINELS[1] in with_bracket
-
-
 # ---------------------------------------------------------------------------
 # Legacy instruction/response masking with a bracket configured
 # ---------------------------------------------------------------------------
-
-_INST_STR = " USER_TURN_STARTS"
 
 
 def test_legacy_instruction_response_accepts_the_bracket_but_never_applies_it():
@@ -909,7 +876,11 @@ def test_legacy_instruction_response_accepts_the_bracket_but_never_applies_it():
     answer = [_SENTINELS[2]]
     seq = flat(inst, question, resp, tool_open, payload, tool_close, answer)
 
-    with_bracket = make_tool_span_collator("_legacy_instruction_response", _INST_STR)
+    with_bracket = make_span_collator(
+        "_legacy_instruction_response",
+        tool_bracket=True,
+        instruction_template=_INST_STR,
+    )
     inner = with_bracket._default_collator
     assert inner.tool_response_token_ids == tool_open, "bracket is stored, not dropped"
     assert inner.end_of_tool_response_token_ids == tool_close

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -48,6 +48,23 @@ def create_test_tokenizer() -> tuple[BaseTokenizer, int]:
     return tokenizer, int(tokenizer.pad_token_id)
 
 
+@functools.cache
+def encode_template(template: str) -> list[int]:
+    """Encode a template, asserting it shares no token ID with _SENTINELS.
+
+    A collision would make a "content survived" assertion pass on a template token,
+    so every template used as a boundary marker goes through here.
+    """
+    tokenizer, _ = create_test_tokenizer()
+    ids = tokenizer.encode(template, add_special_tokens=False)
+    collisions = sorted(set(ids) & set(_SENTINELS))
+    assert not collisions, (
+        f"Template {template!r} encodes to sentinel IDs {collisions}. "
+        "Adjust _SENTINELS."
+    )
+    return ids
+
+
 def test_success_basic():
     tokenizer, pad_token_id = create_test_tokenizer()
 
@@ -258,18 +275,9 @@ def test_debug_logging(caplog):
 # ===========================================================================
 
 
-@functools.cache
 def get_template_token_ids() -> tuple[list[int], list[int]]:
-    """Return (resp_ids, eot_ids) encoded once and cached."""
-    tokenizer, _ = create_test_tokenizer()
-    resp = tokenizer.encode(_RESP_STR, add_special_tokens=False)
-    eot = tokenizer.encode(_EOT_STR, add_special_tokens=False)
-    forbidden = set(resp) | set(eot)
-    for sentinel in _SENTINELS:
-        assert sentinel not in forbidden, (
-            f"Sentinel {sentinel} collides with a template token ID. Adjust _SENTINELS."
-        )
-    return resp, eot
+    """Return (resp_ids, eot_ids)."""
+    return encode_template(_RESP_STR), encode_template(_EOT_STR)
 
 
 def make_span_collator() -> TextCompletionsCollatorWithPadding:
@@ -517,8 +525,7 @@ def test_leading_newline_bpe_merge_regression():
 def test_span_masking_with_leading_newline_content():
     """Content starting with \\n is correctly unmasked when template is stripped."""
     tokenizer, _ = create_test_tokenizer()
-    resp_ids = tokenizer.encode(_RESP_STR, add_special_tokens=False)
-    eot_ids = tokenizer.encode(_EOT_STR, add_special_tokens=False)
+    resp_ids, eot_ids = get_template_token_ids()
     nl_ids = tokenizer.encode("\n\n", add_special_tokens=False)
     content = [_SENTINELS[0], _SENTINELS[1]]
 
@@ -650,25 +657,19 @@ _TOOL_CLOSE_STR = " TOOL_RESULT_ENDS"
 
 
 def get_tool_template_token_ids() -> tuple[list[int], list[int]]:
-    tokenizer, _ = create_test_tokenizer()
-    open_ids = tokenizer.encode(_TOOL_OPEN_STR, add_special_tokens=False)
-    close_ids = tokenizer.encode(_TOOL_CLOSE_STR, add_special_tokens=False)
-    forbidden = set(open_ids) | set(close_ids)
-    for sentinel in _SENTINELS:
-        assert sentinel not in forbidden, (
-            f"Sentinel {sentinel} collides with a tool marker ID. Adjust _SENTINELS."
-        )
-    return open_ids, close_ids
+    return encode_template(_TOOL_OPEN_STR), encode_template(_TOOL_CLOSE_STR)
 
 
 def make_tool_span_collator(
     train_target: str = "all_assistant_turns",
+    instruction_template: str | None = None,
 ) -> TextCompletionsCollatorWithPadding:
     tokenizer, _ = create_test_tokenizer()
     return TextCompletionsCollatorWithPadding(
         tokenizer=tokenizer,
         response_template=_RESP_STR,
         train_target=train_target,
+        instruction_template=instruction_template,
         end_of_turn_template=_EOT_STR,
         tool_response_template=_TOOL_OPEN_STR,
         end_of_tool_response_template=_TOOL_CLOSE_STR,
@@ -884,3 +885,48 @@ def test_bracket_inside_an_assistant_turn_is_not_inert():
     assert _SENTINELS[0] not in with_bracket, "bracket masks it"
     # Everything after the closer still trains, so the damage is bounded.
     assert _SENTINELS[1] in with_bracket
+
+
+# ---------------------------------------------------------------------------
+# Legacy instruction/response masking with a bracket configured
+# ---------------------------------------------------------------------------
+
+_INST_STR = " USER_TURN_STARTS"
+
+
+def test_legacy_instruction_response_accepts_the_bracket_but_never_applies_it():
+    """A bracket set on the legacy path is tokenized and then ignored.
+
+    ``torch_call`` only re-masks tool results on the two span targets, so a nested
+    tool result stays in the loss here. The pair is accepted without complaint,
+    which is what makes it easy to miss.
+    """
+    resp, _ = get_template_token_ids()
+    inst = encode_template(_INST_STR)
+    tool_open, tool_close = get_tool_template_token_ids()
+    question = [_SENTINELS[0]]
+    payload = [_SENTINELS[1]]
+    answer = [_SENTINELS[2]]
+    seq = flat(inst, question, resp, tool_open, payload, tool_close, answer)
+
+    with_bracket = make_tool_span_collator("_legacy_instruction_response", _INST_STR)
+    inner = with_bracket._default_collator
+    assert inner.tool_response_token_ids == tool_open, "bracket is stored, not dropped"
+    assert inner.end_of_tool_response_token_ids == tool_close
+
+    without_bracket = TextCompletionsCollatorWithPadding(
+        tokenizer=create_test_tokenizer()[0],
+        response_template=_RESP_STR,
+        instruction_template=_INST_STR,
+        train_target="_legacy_instruction_response",
+    )
+
+    labels = get_span_labels(with_bracket, seq)
+
+    assert labels == get_span_labels(without_bracket, seq), (
+        "the bracket changed nothing"
+    )
+    assert _SENTINELS[0] not in labels, "the user turn is masked, as legacy intends"
+    assert _SENTINELS[1] in labels, (
+        "the nested tool result is still trained on despite the configured bracket"
+    )

--- a/tests/unit/core/collators/test_text_completions_collator_with_padding.py
+++ b/tests/unit/core/collators/test_text_completions_collator_with_padding.py
@@ -637,3 +637,250 @@ def test_pad_to_multiple_of_none_keeps_longest_in_batch():
     }
     batch = collator([row])
     assert batch["input_ids"].shape[1] == len(row["input_ids"])
+
+
+# ---------------------------------------------------------------------------
+# Tool results nested inside an assistant turn
+# ---------------------------------------------------------------------------
+
+# Markers standing in for a template that renders tool results inside the assistant
+# turn (gemma-4 renders <|tool_response>...<tool_response|> there).
+_TOOL_OPEN_STR = " TOOL_RESULT_STARTS"
+_TOOL_CLOSE_STR = " TOOL_RESULT_ENDS"
+
+
+def get_tool_template_token_ids() -> tuple[list[int], list[int]]:
+    tokenizer, _ = create_test_tokenizer()
+    open_ids = tokenizer.encode(_TOOL_OPEN_STR, add_special_tokens=False)
+    close_ids = tokenizer.encode(_TOOL_CLOSE_STR, add_special_tokens=False)
+    forbidden = set(open_ids) | set(close_ids)
+    for sentinel in _SENTINELS:
+        assert sentinel not in forbidden, (
+            f"Sentinel {sentinel} collides with a tool marker ID. Adjust _SENTINELS."
+        )
+    return open_ids, close_ids
+
+
+def make_tool_span_collator(
+    train_target: str = "all_assistant_turns",
+) -> TextCompletionsCollatorWithPadding:
+    tokenizer, _ = create_test_tokenizer()
+    return TextCompletionsCollatorWithPadding(
+        tokenizer=tokenizer,
+        response_template=_RESP_STR,
+        train_target=train_target,
+        end_of_turn_template=_EOT_STR,
+        tool_response_template=_TOOL_OPEN_STR,
+        end_of_tool_response_template=_TOOL_CLOSE_STR,
+    )
+
+
+def test_span_tool_response_is_masked_inside_assistant_turn():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    call = [_SENTINELS[0]]
+    payload = [_SENTINELS[1], _SENTINELS[2]]
+    answer = [_SENTINELS[3]]
+    seq = flat(resp, call, tool_open, payload, tool_close, answer, eot)
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    at = len(resp)
+    assert all(v == IGNORE for v in labels[:at]), "response header must stay masked"
+    assert labels[at : at + len(call)] == call, "tool call is the model's own output"
+    at += len(call)
+    masked = len(tool_open) + len(payload) + len(tool_close)
+    assert all(v == IGNORE for v in labels[at : at + masked]), (
+        "tool result and both markers must be masked"
+    )
+    at += masked
+    assert labels[at : at + len(answer)] == answer, (
+        "assistant text after the tool result must stay trained"
+    )
+    assert labels[at + len(answer) :] == eot
+
+
+def test_span_parallel_tool_responses_are_both_masked():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    first = [_SENTINELS[0]]
+    second = [_SENTINELS[1]]
+    answer = [_SENTINELS[2]]
+    seq = flat(
+        resp,
+        tool_open,
+        first,
+        tool_close,
+        tool_open,
+        second,
+        tool_close,
+        answer,
+        eot,
+    )
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert _SENTINELS[0] not in labels
+    assert _SENTINELS[1] not in labels
+    assert _SENTINELS[2] in labels
+
+
+def test_span_unclosed_tool_response_masks_through_span_end():
+    resp, eot = get_template_token_ids()
+    tool_open, _ = get_tool_template_token_ids()
+    payload = [_SENTINELS[0], _SENTINELS[1]]
+    # Truncation can drop the closing marker; over-masking is the safe direction.
+    # The cost lands on a model that emits the opener without ever nesting a tool
+    # result: the rest of that turn drops out of the loss.
+    seq = flat(resp, tool_open, payload, eot)
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert all(v == IGNORE for v in labels), (
+        "an unclosed tool result must mask through the end of the span"
+    )
+
+
+def test_span_tool_masking_leaves_other_turns_untouched():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    plain = [_SENTINELS[1], _SENTINELS[2]]
+    seq = flat(
+        resp,
+        tool_open,
+        payload,
+        tool_close,
+        eot,
+        [_SENTINELS[3]],
+        resp,
+        plain,
+        eot,
+    )
+
+    labels = get_span_labels(make_tool_span_collator(), seq)
+
+    assert _SENTINELS[0] not in labels
+    start = len(seq) - len(plain) - len(eot)
+    assert labels[start : start + len(plain)] == plain
+
+
+def test_span_without_tool_templates_trains_tool_response():
+    """Without the pair, behavior is unchanged — this is the bug being fixed."""
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    seq = flat(resp, tool_open, payload, tool_close, eot)
+
+    labels = get_span_labels(make_span_collator(), seq)
+
+    assert _SENTINELS[0] in labels
+
+
+def test_final_assistant_turn_tool_response_is_masked():
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    payload = [_SENTINELS[0]]
+    answer = [_SENTINELS[1]]
+    seq = flat([_SENTINELS[2]], resp, tool_open, payload, tool_close, answer, eot)
+
+    labels = get_span_labels(make_tool_span_collator("final_assistant_turn"), seq)
+
+    assert _SENTINELS[0] not in labels, "tool result must be masked"
+    assert _SENTINELS[1] in labels, "final answer must stay trained"
+
+
+# ---------------------------------------------------------------------------
+# A bracket configured for a model that does not actually nest
+# ---------------------------------------------------------------------------
+
+
+def test_bracket_is_inert_when_markers_never_appear():
+    """The common case: the template simply never emits the bracket."""
+    resp, eot = get_template_token_ids()
+    call = [_SENTINELS[0]]
+    answer = [_SENTINELS[1]]
+    seq = flat(resp, call, answer, eot)
+
+    with_bracket = get_span_labels(make_tool_span_collator(), seq)
+    without_bracket = get_span_labels(make_span_collator(), seq)
+
+    assert with_bracket == without_bracket
+
+
+def test_bracket_is_inert_when_tool_result_sits_in_its_own_turn():
+    """Separate-turn templates (e.g. Qwen3) emit the markers outside assistant spans.
+
+    This test asserts that tool response regions remain masked even if the tool
+    response prefix is provided for chat templates that do not nest. Re-masking only
+    runs over assistant spans that were just unmasked, so the bracket is never even
+    scanned.
+    """
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    call = [_SENTINELS[0]]
+    payload = [_SENTINELS[1]]
+    answer = [_SENTINELS[2]]
+    # ... <resp> call <eot> | <tool_open> payload <tool_close> | <resp> answer <eot>
+    seq = flat(
+        resp,
+        call,
+        eot,
+        tool_open,
+        payload,
+        tool_close,
+        resp,
+        answer,
+        eot,
+    )
+
+    with_bracket = get_span_labels(make_tool_span_collator(), seq)
+    without_bracket = get_span_labels(make_span_collator(), seq)
+
+    assert with_bracket == without_bracket
+    # The tool payload was already masked by span masking alone.
+    assert _SENTINELS[1] not in without_bracket
+    # Both assistant turns still train.
+    assert _SENTINELS[0] in with_bracket
+    assert _SENTINELS[2] in with_bracket
+
+
+def test_bracket_is_inert_for_final_assistant_turn_when_markers_are_absent():
+    resp, _ = get_template_token_ids()
+    prompt = [_SENTINELS[0]]
+    answer = [_SENTINELS[1]]
+    seq = flat(prompt, resp, answer)
+
+    with_bracket = get_span_labels(make_tool_span_collator("final_assistant_turn"), seq)
+    without_bracket = get_span_labels(
+        TextCompletionsCollatorWithPadding(
+            tokenizer=create_test_tokenizer()[0],
+            response_template=_RESP_STR,
+            train_target="final_assistant_turn",
+        ),
+        seq,
+    )
+
+    assert with_bracket == without_bracket
+
+
+def test_bracket_inside_an_assistant_turn_is_not_inert():
+    """
+    If the markers land inside an assistant span for a reason other than a nested tool
+    result — the model genuinely emitting that text, say — re-masking drops real model
+    output from the loss.
+    """
+    resp, eot = get_template_token_ids()
+    tool_open, tool_close = get_tool_template_token_ids()
+    quoted = [_SENTINELS[0]]
+    answer = [_SENTINELS[1]]
+    seq = flat(resp, tool_open, quoted, tool_close, answer, eot)
+
+    with_bracket = get_span_labels(make_tool_span_collator(), seq)
+    without_bracket = get_span_labels(make_span_collator(), seq)
+
+    assert with_bracket != without_bracket
+    assert _SENTINELS[0] in without_bracket, "baseline trains on the quoted text"
+    assert _SENTINELS[0] not in with_bracket, "bracket masks it"
+    # Everything after the closer still trains, so the damage is bounded.
+    assert _SENTINELS[1] in with_bracket

--- a/tests/unit/core/configs/internal/test_supported_models.py
+++ b/tests/unit/core/configs/internal/test_supported_models.py
@@ -4,6 +4,7 @@ from oumi.core.configs.internal.supported_models import (
     find_internal_model_config,
     find_internal_model_config_using_model_name,
     find_model_hf_config,
+    find_model_type_using_model_name,
 )
 from oumi.core.configs.params.model_params import ModelParams
 
@@ -39,3 +40,49 @@ def test_common_vlm_models(model_name: str, trust_remote_code):
         )
         is not None
     ), debug_tag
+
+
+#
+# find_model_type_using_model_name
+#
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        pytest.param("google/gemma-4-E2B-it", "gemma4", id="gemma-4"),
+        pytest.param("zai-org/GLM-4.5", "glm4_moe", id="glm-4.5"),
+        pytest.param("Qwen/Qwen3-0.6B", "qwen3", id="qwen3"),
+    ],
+)
+def test_find_model_type_reports_text_model_architectures(model_name, expected):
+    """Check that HF models have resolvable model type and config"""
+    assert find_model_type_using_model_name(model_name, True) == expected
+    assert find_internal_model_config_using_model_name(model_name, True) is None
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        pytest.param("MlpEncoder", id="custom-oumi-model"),
+        pytest.param("CnnClassifier", id="custom-oumi-model-2"),
+    ],
+)
+def test_find_model_type_returns_none_for_custom_models(model_name):
+    """Oumi's own models have no HuggingFace config to read."""
+    assert find_model_type_using_model_name(model_name, False) is None
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        pytest.param("does-not-exist/nope-123", id="unresolvable"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_find_model_type_propagates_unreadable_configs(model_name):
+    """Same contract as the other lookups in this module: an unreadable config is an
+    error, not a None. Callers that reach this point have already loaded the config.
+    """
+    with pytest.raises(OSError):
+        find_model_type_using_model_name(model_name, False)


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
PR https://github.com/oumi-ai/oumi/pull/2590 is being split into two parts. This PR contains part 1: the tool remasking logic from https://github.com/oumi-ai/oumi/pull/2590

## Background
Some chat templates render tool results inside the assistant turn (like Gemma 4), which leaves them unmasked. This results in model being trained on environment output leading to model degradation.

This seems to be a common problems faced by the community trying to use Gemma 4 for agentic cases:
[git.sethpc.xyz/Seth/gemma4-research/src/commit/91aaaa48d7275333e92f76a6b4be6c1a5cdbeb89/tooling/fine-tuning](https://git.sethpc.xyz/Seth/gemma4-research/src/commit/91aaaa48d7275333e92f76a6b4be6c1a5cdbeb89/tooling/fine-tuning)
there has not been a canonical way or fix suggested by the community for this issue

The original PR https://github.com/oumi-ai/oumi/pull/2590 suggested a two fold fix:
1. In `collators.py`: We have a mechanism that autodetects tool_response start and end if the user does not supply it and we detect that tool response is indeed nested in assistant span.
2. In `trl_data_collator_for_completion_only_lm.py`: we remask the regions between tool_response start and end, if they are supplied.

Gemma 4's chat template did indeed change between the API repo pinned version (`4742fe843c`) and the latest commit.

In the pinned version, tool response is in tool turn (refer to picture 1). In their latest version, tool response has been shifted to be with assistant (refer to picture 2).

<img width="3834" height="1846" alt="image" src="https://github.com/user-attachments/assets/f194442a-5c94-494b-97c0-79b0ef66f133" />

<img width="3834" height="1852" alt="image" src="https://github.com/user-attachments/assets/676911a6-a8a1-4658-8fbe-a093c1d1c7c3" />


## Design

@wizeng23 flagged that the autodetection of the tool response template has high blast radius in the original implementation. We worked together to find a few ways to derisk the process:

1. Split the probe and the remasking logic into two different PRs. The remaksing logic can merge in first to unblock critical workflows. While the probe detection logic can be tested and reviewed more thoroughly

2. Limit the activation of probe using certain checks in `collators.py`:

```
if the user has supplied the tool response prefix, apply remasking using this
for models with the known nesting behavior, we maintain a dict of the tool response prefix and just apply the remask directly
else, run the probe to autodetect the tool prefix. 
```

This PR contains the above two things.

A followup PR will be about the probe.

## Testing

- All unit and integration tests pass
- Barring an unrelated data type issue, which I fixed locally, I validated that training runs for the following configurations on exun:

Qwen3.5 + tools dataset: https://wandb.ai/shanghongsim/huggingface/runs/josebt7u
Qwen3.5 + alpaca: https://wandb.ai/shanghongsim/huggingface/runs/ode8xa6c
Gemma 4 + tools dataset: https://wandb.ai/shanghongsim/huggingface/runs/otgby2y6
Gemma 4 + alpaca: https://wandb.ai/shanghongsim/huggingface/runs/mx7b8551

The tool dataset is a realistic enterprise use case.

<img width="1497" height="318" alt="image" src="https://github.com/user-attachments/assets/0aef0089-c8a9-4a02-adf8-e86334346f07" />

Losses and mean accuracy look reasoanble. 


<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
