### PR TITLE
Add muse_glimmer to the internal model type map

### DIFF
--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -622,6 +622,15 @@ def get_all_models_map() -> Mapping[
             model_class=transformers.AutoModelForImageTextToText,
             config=_create_internvl_config(),
         ),
+        _ModelTypeInfo(
+            model_type="muse_glimmer",
+            model_class=transformers.AutoModelForImageTextToText,
+            # muse_glimmer has no AutoModelForCausalLM registration in
+            # transformers, so the class mapping is required even for
+            # text-only SFT. chat_template is left empty so the tokenizer's
+            # built-in template is used.
+            config=InternalModelConfig(chat_template=""),
+        ),
     ]
 
     # Make it immutable.

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -625,10 +625,6 @@ def get_all_models_map() -> Mapping[
         _ModelTypeInfo(
             model_type="muse_glimmer",
             model_class=transformers.AutoModelForImageTextToText,
-            # muse_glimmer has no AutoModelForCausalLM registration in
-            # transformers, so the class mapping is required even for
-            # text-only SFT. chat_template is left empty so the tokenizer's
-            # built-in template is used.
             config=InternalModelConfig(chat_template=""),
         ),
     ]

--- a/src/oumi/core/configs/internal/supported_models.py
+++ b/src/oumi/core/configs/internal/supported_models.py
@@ -428,6 +428,11 @@ def _create_internvl_config() -> InternalModelConfig:
     return config
 
 
+def _create_muse_glimmer_config() -> InternalModelConfig:
+    # Empty chat_template: use the tokenizer's built-in template.
+    return InternalModelConfig(chat_template="")
+
+
 def _create_idefics3_vlm_config() -> InternalModelConfig:
     config = _create_default_vlm_config(
         supports_multiple_images=True, pixel_values_variable_shape=True
@@ -625,7 +630,7 @@ def get_all_models_map() -> Mapping[
         _ModelTypeInfo(
             model_type="muse_glimmer",
             model_class=transformers.AutoModelForImageTextToText,
-            config=InternalModelConfig(chat_template=""),
+            config=_create_muse_glimmer_config(),
         ),
     ]
 


### PR DESCRIPTION
MuseGlimmerForConditionalGeneration is registered only under `AutoModelForImageTextToText` in transformers — there is no `AutoModelForCausalLM` entry for `muse_glimmer` — so `build_model`'s default auto-class raises `ValueError: Unrecognized configuration class` for `meta-models/Muse-Glimmer-30B`, including for text-only SFT.

This adds the model type to `get_all_models_map` with the correct auto-class. `chat_template` is left empty so the tokenizer's built-in (ATEM) template is used rather than a named override.

Verified with a LoRA SFT run (TRL_SFT, completions-only collator, FSDP on `MuseGlimmerTextDecoderLayer`) that trains and saves cleanly.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
