### PR TITLE
feat(tools): reject unsupported JSON Schema keywords in tool definitions

### DIFF
--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -29,7 +29,6 @@ from oumi.core.types.tool_call import (
     ToolDefinition,
 )
 
-
 # Schema keywords that break tool use across common backends. oneOf/allOf/not
 # and if/then/else are unsupported by guided decoding; anyOf at the schema root
 # is additionally rejected by hosted structured-output APIs (Anthropic, OpenAI),

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -30,6 +30,47 @@ from oumi.core.types.tool_call import (
 )
 
 
+# Schema keywords that break tool use across common backends. oneOf/allOf/not
+# and if/then/else are unsupported by guided decoding; anyOf at the schema root
+# is additionally rejected by hosted structured-output APIs (Anthropic, OpenAI),
+# which require the root to be a plain object. anyOf is allowed when nested.
+_UNSUPPORTED_KEYWORDS = frozenset({"oneOf", "allOf", "not", "if", "then", "else"})
+_UNSUPPORTED_ROOT_KEYWORDS = _UNSUPPORTED_KEYWORDS | {"anyOf"}
+# Keys whose values are name->subschema maps (a property literally named "not"
+# is data, not a keyword), so we recurse into their values, not the map itself.
+_NAME_MAP_KEYWORDS = frozenset(
+    {"properties", "patternProperties", "$defs", "definitions"}
+)
+
+
+def reject_unsupported_schema_keywords(schema: Any, *, _root: bool = True) -> None:
+    """Reject JSON-Schema keywords that break tool use across backends.
+
+    Walks ``schema`` structure-aware (a property *named* like a keyword is data,
+    not a keyword) and raises ``ValueError`` naming the first offending keyword.
+    """
+    if isinstance(schema, list):
+        for item in schema:
+            reject_unsupported_schema_keywords(item, _root=False)
+        return
+    if not isinstance(schema, Mapping):
+        return
+    banned = _UNSUPPORTED_ROOT_KEYWORDS if _root else _UNSUPPORTED_KEYWORDS
+    present = banned.intersection(schema)
+    if present:
+        raise ValueError(
+            f"Unsupported JSON Schema keyword {next(iter(present))!r}: "
+            "oneOf, allOf, not, and if/then/else break guided decoding, and "
+            "anyOf is not allowed at the schema root."
+        )
+    for key, value in schema.items():
+        if key in _NAME_MAP_KEYWORDS and isinstance(value, Mapping):
+            for sub in value.values():
+                reject_unsupported_schema_keywords(sub, _root=False)
+        else:
+            reject_unsupported_schema_keywords(value, _root=False)
+
+
 class ToolError(Exception):
     """Base class for tool errors surfaced back to the LLM.
 
@@ -120,6 +161,9 @@ class ToolParams(BaseParams):
             self.output_schema = self.output_schema.model_dump(
                 mode="json", exclude_none=True
             )
+        reject_unsupported_schema_keywords(self.parameters)
+        if self.output_schema is not None:
+            reject_unsupported_schema_keywords(self.output_schema)
 
     def to_llm_schema(self) -> dict[str, Any]:
         """Export a provider-agnostic schema for LLM tool registration."""

--- a/src/oumi/core/configs/synthesis_config.py
+++ b/src/oumi/core/configs/synthesis_config.py
@@ -92,6 +92,15 @@ class SynthesisConfig(BaseConfig):
                 raise OumiConfigError("Output path must end with .jsonl.")
 
         self.environment_config = self._resolve_environment_config()
+        if (
+            self.environment_config
+            and self.environment_config.environments
+            and not self.strategy_params.multiturn_attributes
+        ):
+            raise OumiConfigError(
+                "Environments require a multi-turn attribute; tools are only "
+                "called during a multi-turn rollout."
+            )
         self._validate_available_tooling()
 
     def _resolve_environment_config(self) -> EnvironmentConfig | None:

--- a/src/oumi/core/synthesis/synthesis_pipeline.py
+++ b/src/oumi/core/synthesis/synthesis_pipeline.py
@@ -22,6 +22,7 @@ from oumi.core.synthesis.attribute_transformation import AttributeTransformer
 from oumi.core.synthesis.conversation_synthesizer import ConversationSynthesizer
 from oumi.core.synthesis.data_synthesizer import DataSynthesizer
 from oumi.core.synthesis.dataset_planner import DatasetPlanner
+from oumi.exceptions import OumiConfigError
 from oumi.utils.io_utils import save_jsonlines
 from oumi.utils.logging import logger
 
@@ -31,6 +32,18 @@ class SynthesisPipeline:
 
     def __init__(self, config: SynthesisConfig):
         """Initialize the synthesis pipeline."""
+        # SynthesisConfig validates this too, but environment_config is often
+        # assigned directly onto an already-constructed config, which runs no
+        # validation.
+        if (
+            config.environment_config
+            and config.environment_config.environments
+            and not config.strategy_params.multiturn_attributes
+        ):
+            raise OumiConfigError(
+                "Environments require a multi-turn attribute; tools are only "
+                "called during a multi-turn rollout."
+            )
         self._config = config
         attribute_synthesizer = AttributeSynthesizer(
             config.strategy_params, config.inference_config

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -233,3 +233,64 @@ def test_synthetic_state_params_accepts_partial_inputs():
     assert SyntheticStateParams(
         initial_state={"files": {"count": 1}}
     ).initial_state == {"files": {"count": 1}}
+
+
+def _tool_with_parameters(parameters: dict[str, Any]) -> ToolParams:
+    return ToolParams(id="t", name="T", description="d", parameters=parameters)
+
+
+@pytest.mark.parametrize("keyword", ["oneOf", "allOf", "not", "if", "then", "else"])
+def test_tool_params_rejects_unsupported_keyword_in_parameters(keyword):
+    with pytest.raises(ValueError, match=keyword):
+        _tool_with_parameters(
+            {"type": "object", "properties": {"x": {keyword: [{"type": "string"}]}}}
+        )
+
+
+@pytest.mark.parametrize("keyword", ["oneOf", "allOf", "not"])
+def test_tool_params_rejects_unsupported_keyword_in_output_schema(keyword):
+    with pytest.raises(ValueError, match=keyword):
+        ToolParams(
+            id="t",
+            name="T",
+            description="d",
+            output_schema={keyword: [{"type": "object"}]},
+        )
+
+
+def test_tool_params_rejects_anyof_at_root():
+    with pytest.raises(ValueError, match="anyOf"):
+        _tool_with_parameters({"anyOf": [{"type": "object"}, {"type": "object"}]})
+
+
+def test_tool_params_allows_nested_anyof():
+    tool = _tool_with_parameters(
+        {
+            "type": "object",
+            "properties": {"x": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+        }
+    )
+    assert tool.parameters["properties"]["x"]["anyOf"]
+
+
+def test_tool_params_allows_property_named_like_keyword():
+    # A property literally named "not" is data, not the "not" keyword.
+    tool = _tool_with_parameters(
+        {"type": "object", "properties": {"not": {"type": "string"}}}
+    )
+    assert "not" in tool.parameters["properties"]
+
+
+def test_tool_params_rejects_keyword_buried_in_list_form_items():
+    with pytest.raises(ValueError, match="oneOf"):
+        _tool_with_parameters(
+            {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "array",
+                        "prefixItems": [{"oneOf": [{"type": "string"}]}],
+                    }
+                },
+            }
+        )

--- a/tests/unit/core/configs/test_synthesis_config.py
+++ b/tests/unit/core/configs/test_synthesis_config.py
@@ -101,6 +101,19 @@ def _synthetic_env_params(
     )
 
 
+def _chat_multiturn_attribute(**kwargs) -> MultiTurnAttribute:
+    return MultiTurnAttribute(
+        id="chat",
+        min_turns=1,
+        max_turns=2,
+        role_instruction_messages={
+            Role.USER: "You are a user.",
+            Role.ASSISTANT: "You are an assistant.",
+        },
+        **kwargs,
+    )
+
+
 def test_invalid_output_path():
     """Test that setting output_path raises OumiConfigError."""
     inference_config = InferenceConfig(output_path="some/path")
@@ -111,8 +124,7 @@ def test_invalid_output_path():
 
 def test_synthesis_config_with_top_level_environment_config():
     env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
-    params = GeneralSynthesisParams()
-    params.multiturn_attributes = []
+    params = GeneralSynthesisParams(multiturn_attributes=[_chat_multiturn_attribute()])
 
     config = SynthesisConfig(
         strategy_params=params,
@@ -129,10 +141,38 @@ def test_synthesis_config_loads_environment_config_from_path(tmp_path):
     env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
     env_config.to_yaml(env_config_path)
 
-    config = SynthesisConfig(environment_config_path=str(env_config_path))
+    params = GeneralSynthesisParams(multiturn_attributes=[_chat_multiturn_attribute()])
+
+    config = SynthesisConfig(
+        strategy_params=params,
+        environment_config_path=str(env_config_path),
+    )
 
     assert config.environment_config is not None
     assert config.environment_config.all_tools[0].id == "answer_faq"
+
+
+def test_synthesis_config_rejects_environments_without_multiturn_attribute():
+    env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
+
+    with pytest.raises(OumiConfigError, match="require a multi-turn attribute"):
+        SynthesisConfig(environment_config=env_config)
+
+
+def test_synthesis_config_rejects_environment_path_without_multiturn_attribute(
+    tmp_path,
+):
+    env_config_path = tmp_path / "environments.yaml"
+    EnvironmentConfig(environments=[_synthetic_env_params()]).to_yaml(env_config_path)
+
+    with pytest.raises(OumiConfigError, match="require a multi-turn attribute"):
+        SynthesisConfig(environment_config_path=str(env_config_path))
+
+
+def test_synthesis_config_allows_no_environments_without_multiturn_attribute():
+    config = SynthesisConfig()
+
+    assert config.environment_config is None
 
 
 def test_synthesis_config_validates_available_tools():

--- a/tests/unit/core/synthesis/test_synthesis_pipeline.py
+++ b/tests/unit/core/synthesis/test_synthesis_pipeline.py
@@ -18,7 +18,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from oumi.core.configs.environment_config import EnvironmentConfig
 from oumi.core.configs.inference_config import InferenceConfig
+from oumi.core.configs.params.environment_params import EnvironmentParams
 from oumi.core.configs.params.synthesis_params import (
     GeneralSynthesisParams,
     GeneratedAttribute,
@@ -28,6 +30,7 @@ from oumi.core.configs.params.synthesis_params import (
     TransformationType,
     TransformedAttribute,
 )
+from oumi.core.configs.params.tool_params import ToolParams
 from oumi.core.configs.synthesis_config import SynthesisConfig
 from oumi.core.synthesis.attribute_synthesizer import AttributeSynthesizer
 from oumi.core.synthesis.attribute_transformation import AttributeTransformer
@@ -36,6 +39,7 @@ from oumi.core.synthesis.data_synthesizer import DataSynthesizer
 from oumi.core.synthesis.dataset_planner import DatasetPlanner
 from oumi.core.synthesis.synthesis_pipeline import SynthesisPipeline
 from oumi.core.types.conversation import Role
+from oumi.exceptions import OumiConfigError
 
 
 @pytest.fixture
@@ -844,3 +848,33 @@ def test_passthrough_with_missing_bracket_paths():
             "items[0].field": "present",
         }
     ]
+
+
+def test_pipeline_rejects_environments_assigned_without_multiturn_attribute():
+    """Environments assigned after __post_init__ still require a multiturn attr."""
+    config = SynthesisConfig(
+        num_samples=5,
+        strategy_params=GeneralSynthesisParams(),
+        inference_config=InferenceConfig(),
+    )
+    config.environment_config = EnvironmentConfig(
+        environments=[
+            EnvironmentParams(
+                id="faq",
+                name="FAQ",
+                description="FAQ tools",
+                env_type="synthetic",
+                tools=[
+                    ToolParams(
+                        id="answer_faq",
+                        name="AnswerFAQ",
+                        description="Answer a FAQ question.",
+                    )
+                ],
+                env_kwargs={"tool_persona": "Answer FAQs."},
+            )
+        ]
+    )
+
+    with pytest.raises(OumiConfigError, match="require a multi-turn attribute"):
+        SynthesisPipeline(config)


### PR DESCRIPTION
# Description

A tool's `parameters` / `output_schema` can contain JSON Schema keywords that silently break tool use downstream, only surfacing as a cryptic failure deep in inference. This validates them at `ToolParams` construction and raises a clear `ValueError` naming the offending keyword instead.

Rejected keywords:

- **`oneOf`, `allOf`, `not`, `if`/`then`/`else` anywhere** — these break guided/constrained decoding. The synthetic-environment tool simulator feeds `output_schema` into guided decoding, which cannot compile them.
- **`anyOf` at the schema root** — hosted structured-output APIs (Anthropic, OpenAI) require the schema root to be a plain object and reject a root `anyOf`. Nested `anyOf` is allowed.

Details:

- Validation runs in `ToolParams.__post_init__`, after the `JSONSchema`→dict coercion, for both `parameters` and `output_schema`.
- The walk is **structure-aware**: a property literally named `not`/`oneOf` (real data under `properties`) is not treated as a keyword, and it recurses through list-form schemas (`items`, `prefixItems`, arrays of subschemas).
- Additionally, this rejects a synthesis config that provides environments but no
multi-turn attribute — tools are only exercised inside a multi-turn attribute's
rollout, so that combination silently produced a non-agentic dataset; it now fails
at config validation.

Note on the root-`anyOf` rule: this is a portability choicemitation. oumi's own guided decoding (xgrammar/outlines)supports `anyOf`, but a tool schema is provider-portable and the hosted structured-output APIs reject a non-object root, so rejecting it uniformly keeps a tool usable across every backend. Happy to scope this to only the guided-decoding keywords if reviewers prefer to allow root
`anyOf` for engines that support it.

## Related issues

Fixes LOU-2709

## Before submitting

- [ ] This PR only changes documentation. (You can ignore tt case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the s
- [x] Did you add / update tests where needed?

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
