### PR TITLE
Add Muse Glimmer 30B LoRA and inference recipes

### DIFF
--- a/configs/recipes/muse_glimmer/README.md
+++ b/configs/recipes/muse_glimmer/README.md
@@ -1,0 +1,107 @@
+# Muse Glimmer
+
+## Summary
+
+Configs for Meta Superintelligence Lab's Muse Glimmer model family. See the
+[model card](https://huggingface.co/meta-models/Muse-Glimmer-30B) for more information.
+Models in this family include:
+
+- [meta-models/Muse-Glimmer-30B](https://huggingface.co/meta-models/Muse-Glimmer-30B) (dense, ~29.6B, image + text, 131K context) — **LoRA config available**
+
+Muse Glimmer requires `transformers >= 5.15.0`, which must be upgraded manually
+(`uv pip install -U "transformers>=5.15"`) because oumi currently pins
+`transformers<5.10`. The architecture is absent from transformers 5.14.1 and earlier.
+
+Full fine-tuning is not provided: at ~29.6B parameters the model does not fit FFT at
+8K context on a single 8xH100 node.
+
+## Quickstart
+
+1. Follow our [quickstart](https://oumi.ai/docs/en/latest/get_started/quickstart.html) for installation.
+2. (Optional) if you wish to kick off jobs on a remote cluster, follow our [job launcher setup guide](https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup).
+3. Run your desired oumi command (examples below)!
+   - Note that installing the Oumi repository is **not required** to run the commands. We fetch the latest Oumi config remotely from GitHub thanks to the `oumi://` prefix.
+4. (Optional) If you wish to do deeper experimentation, follow our [instructions](https://oumi.ai/docs/en/latest/development/dev_setup.html) to clone the Oumi repository locally.
+   - Make sure to delete the `oumi://` prefix when running Oumi commands, to disable fetching the latest configs from GitHub!
+
+## Example Commands
+
+### LoRA Training
+
+LoRA is scoped to the language-model layers only. The ViT-G/14 perception encoder
+reuses the text model's projection names (`q_proj`, `k_proj`, `v_proj`), so the recipe
+targets the plain projection names and sets `lora_exclude_modules` to
+`[".*vision_tower.*", ".*vision_adapter.*", ".*vision_projection.*"]` to keep LoRA off
+the encoder and the modules that bridge it into the text hidden space. Oumi passes this
+list to PEFT's `exclude_modules`.
+
+To launch Muse Glimmer 30B LoRA training locally with FSDP (needs a multi-GPU node):
+
+```shell
+oumi distributed torchrun -m oumi train -c oumi://configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
+```
+
+To launch Muse Glimmer 30B LoRA training on a remote GCP 8x A100 cluster:
+
+```shell
+oumi launch up -c oumi://configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml --cluster muse-glimmer-30b-lora
+```
+
+### Inference
+
+```shell
+oumi infer -i -c oumi://configs/recipes/muse_glimmer/inference/30b_infer.yaml
+```
+
+vLLM has no *native* `MuseGlimmerForConditionalGeneration` entry as of v0.27.0, so the
+config uses Oumi's `NATIVE` engine. Add `adapter_model: <path>` under `model` to serve
+a tuned LoRA adapter.
+
+vLLM's transformers backend (`model_impl="transformers"`) **does not work** — tested
+on vLLM 0.27.0, don't retry without an upstream fix:
+
+- `tensor_parallel_size=2` fails outright: `mat1 and mat2 shapes cannot be multiplied
+  (65536x768 and 1536x1536)` — the vision encoder's `hidden_size` (1536) gets sharded
+  to 768 against an unsharded weight.
+- `tensor_parallel_size=1` loads and serves, but emits garbage: chat prompts return a
+  run of `<|eom|>` tokens, and a plain `"The capital of France is"` completion returns
+  `'\n_conassistant\nThe'`. The generic backend does not reproduce this model's
+  `final_logit_softcapping`, `output_multiplier`, `qk_scale_factor`, gated attention,
+  or `MuseGlimmerTextCenteredRMSNorm`, so the logits are simply wrong.
+
+LoRA serving on vLLM is therefore moot until a native `MuseGlimmer` implementation
+lands. Note the native engine is slow: 200 rows took ~85 min on 4xH100.
+
+## Validation
+
+LoRA was validated on banking77 (77-way intent classification, single integer ID
+per response), 200 held-out test rows, greedy decoding:
+
+| | Exact match |
+| :---- | :---: |
+| Base | 0.605 |
+| + LoRA (1 epoch, 104 steps) | **0.920** |
+
+Training used the `text_completions_only_with_padding` collator with
+`train_target: FINAL_ASSISTANT_TURN` so loss lands on the label rather than on the
+77-line classifier prompt. Loss 0.577 → 0.149, token accuracy 0.89 → 0.96.
+
+## Notes
+
+- **Chat template.** Muse Glimmer's built-in template emits
+  `<|start|>role<|message|>...<|eot|>` framing, and assistant turns render as
+  `<|start|>assistant to=user<|message|>`. Oumi keeps the tokenizer's own template
+  rather than substituting a bundled one.
+- **Stop tokens are not optional.** Turns end on `<|eot|>` (`200008`), but the
+  tokenizer's `eos_token` is `<|end_of_text|>` (`200001`), and Oumi's native engine
+  defaults `stop_token_ids` to the tokenizer's `eos_token_id` alone — it does not
+  read the model's `generation_config.json`, which lists both. With only `200001`,
+  responses never terminate: the model answers and then keeps opening fresh
+  `assistant to=user` turns until `max_new_tokens`. The inference config sets
+  `stop_token_ids: [200001, 200008]`; keep it when writing eval configs.
+- **Responses carry a ` to=user` prefix.** The generation prompt ends at
+  `<|start|>assistant`, so the model itself emits the ` to=user<|message|>` recipient
+  header and it lands in the decoded content. Strip it before exact-match scoring.
+- **Text-only.** The recipes fine-tune the text transformer on text-only data. Oumi
+  does not build a processor for this model, so image inputs are not supported for
+  training.

--- a/configs/recipes/muse_glimmer/inference/30b_infer.yaml
+++ b/configs/recipes/muse_glimmer/inference/30b_infer.yaml
@@ -16,7 +16,6 @@
 
 model:
   model_name: "meta-models/Muse-Glimmer-30B"
-  model_revision: "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"
@@ -33,4 +32,4 @@ generation:
   # keeps opening fresh `assistant to=user` turns until max_new_tokens.
   stop_token_ids: [200001, 200008]
 
-engine: NATIVE # vLLM has no MuseGlimmer entry as of v0.26.0.
+engine: NATIVE # vLLM has no MuseGlimmer entry as of v0.27.0.

--- a/configs/recipes/muse_glimmer/inference/30b_infer.yaml
+++ b/configs/recipes/muse_glimmer/inference/30b_infer.yaml
@@ -1,0 +1,36 @@
+# Inference config for meta-models/Muse-Glimmer-30B.
+#
+# Requirements:
+#   - transformers >= 5.15.0 (see configs/recipes/muse_glimmer/README.md)
+#
+# Usage:
+#   oumi infer -i -c oumi://configs/recipes/muse_glimmer/inference/30b_infer.yaml
+#
+# To serve a LoRA adapter, add `adapter_model: <path>` under `model`.
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "meta-models/Muse-Glimmer-30B"
+  model_revision: "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: false
+
+generation:
+  max_new_tokens: 2048
+  temperature: 0.1
+  top_p: 0.95
+  use_sampling: True
+  # REQUIRED. Assistant turns end on `<|eot|>` (200008), but the tokenizer's
+  # `eos_token` is `<|end_of_text|>` (200001) and Oumi defaults stop ids to that
+  # alone. Without 200008 the model never stops: it emits its answer and then
+  # keeps opening fresh `assistant to=user` turns until max_new_tokens.
+  stop_token_ids: [200001, 200008]
+
+engine: NATIVE # vLLM has no MuseGlimmer entry as of v0.26.0.

--- a/configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml
+++ b/configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml
@@ -1,0 +1,48 @@
+# Job config to LoRA tune Muse Glimmer 30B.
+#
+# Requirements:
+#   - Set up SkyPilot GCP: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html#setup
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi launch up -c oumi://configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml --cluster muse-glimmer-30b-lora
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/launch/launch.html
+#   - Config class: oumi.core.configs.JobConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/job_config.py
+#   - Other job configs: configs/**/*job.yaml
+
+name: muse-glimmer-30b-lora
+
+resources:
+  cloud: gcp
+  accelerators: "A100:8"
+  use_spot: false
+  disk_size: 500  # Disk size in GBs
+
+working_dir: .
+
+file_mounts:
+  ~/.netrc: ~/.netrc  # WandB credentials
+
+envs:
+  WANDB_PROJECT: oumi-train
+  OUMI_RUN_NAME: muse_glimmer_30b.lora
+
+setup: |
+  set -e
+  pip install uv && uv pip install --system oumi[gpu] hf_transfer
+  # Muse Glimmer landed in transformers 5.15.0; oumi pins `transformers<5.10`.
+  uv pip install --system -U "transformers>=5.15,<5.16"
+
+run: |
+  set -e  # Exit if any command failed.
+  source ./configs/examples/misc/sky_init.sh
+
+  set -x
+  oumi distributed torchrun -m oumi train \
+      -c oumi://configs/recipes/muse_glimmer/sft/30b_lora/train.yaml \
+      --training.run_name "${OUMI_RUN_NAME}.${SKYPILOT_TASK_ID}"
+
+  echo "Node ${SKYPILOT_NODE_RANK} is all done!"

--- a/configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml
+++ b/configs/recipes/muse_glimmer/sft/30b_lora/gcp_job.yaml
@@ -34,7 +34,7 @@ setup: |
   set -e
   pip install uv && uv pip install --system oumi[gpu] hf_transfer
   # Muse Glimmer landed in transformers 5.15.0; oumi pins `transformers<5.10`.
-  uv pip install --system -U "transformers>=5.15,<5.16"
+  uv pip install --system -U "transformers>=5.15"
 
 run: |
   set -e  # Exit if any command failed.

--- a/configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
+++ b/configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
@@ -26,7 +26,6 @@
 
 model:
   model_name: "meta-models/Muse-Glimmer-30B"
-  model_revision: "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
   model_max_length: 8192
   torch_dtype_str: "bfloat16"
   attn_implementation: "sdpa"

--- a/configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
+++ b/configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
@@ -1,0 +1,93 @@
+# LoRA SFT config for Muse Glimmer 30B.
+#
+# Model highlights:
+#   - 29.6B parameter dense multimodal model from Meta Superintelligence Lab
+#   - 131K context length; image + text inputs, text output
+#   - Alternating sliding (2048) / full attention, GQA 32:2, gated attention
+#   - LoRA is scoped to the text transformer only. The ViT-G/14 perception encoder
+#     reuses the `q_proj`/`k_proj`/`v_proj` names of the text model, so it must be
+#     excluded explicitly via `lora_exclude_modules` below.
+#
+# Requirements:
+#   - transformers >= 5.15.0, which must be installed manually
+#     (`uv pip install -U "transformers>=5.15"`) because oumi pins `transformers<5.10`.
+#     Muse Glimmer is absent from 5.14.1 and earlier.
+#   - peft (installed automatically with oumi)
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#
+# Usage:
+#   oumi distributed torchrun -m oumi train -c oumi://configs/recipes/muse_glimmer/sft/30b_lora/train.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/train/train.html
+#   - Config class: oumi.core.configs.TrainingConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/training_config.py
+#   - Other training configs: configs/**/*train.yaml
+
+model:
+  model_name: "meta-models/Muse-Glimmer-30B"
+  model_revision: "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
+  model_max_length: 8192
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: false
+  enable_liger_kernel: false  # Disabled (model applies final logit softcapping).
+
+data:
+  train:
+    datasets:
+      - dataset_name: "yahma/alpaca-cleaned"  # 51,760 examples
+
+training:
+  use_peft: true
+  trainer_type: "TRL_SFT"
+  save_final_model: true
+  num_train_epochs: 1
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8
+  max_grad_norm: 1.0
+
+  enable_gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: false
+  compile: false
+
+  optimizer: "adamw_torch_fused"
+  learning_rate: 2.0e-04
+  lr_scheduler_type: "cosine"
+  warmup_ratio: 0.05
+  weight_decay: 0.01
+
+  dataloader_num_workers: "auto"
+  dataloader_prefetch_factor: 8
+  logging_steps: 5
+  empty_device_cache_steps: 50
+  output_dir: "output/muse_glimmer_30b.lora"
+  include_performance_metrics: true
+  enable_wandb: true
+
+peft:
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - "q_proj"
+    - "k_proj"
+    - "v_proj"
+    - "o_proj"
+    - "gate_proj"
+    - "up_proj"
+    - "down_proj"
+  # Keep LoRA on the text transformer only; exclude the perception encoder and the
+  # modules that bridge it into the text hidden space.
+  lora_exclude_modules:
+    - ".*vision_tower.*"
+    - ".*vision_adapter.*"
+    - ".*vision_projection.*"
+
+fsdp:
+  enable_fsdp: true
+  sharding_strategy: "FULL_SHARD"
+  forward_prefetch: true
+  auto_wrap_policy: "TRANSFORMER_BASED_WRAP"
+  transformer_layer_cls: "MuseGlimmerTextDecoderLayer"


### PR DESCRIPTION
Adds LoRA SFT + inference recipes for [meta-models/Muse-Glimmer-30B](https://huggingface.co/meta-models/Muse-Glimmer-30B) (~29.6B dense, image+text, 131K context).

Builds on #2595, which added the `muse_glimmer` entry to the internal model map.

## Validation

banking77 (77-way intent classification), 200 held-out rows, greedy decoding, exact match on the integer label:

| | Exact match |
|---|---|
| Base | 0.605 |
| + LoRA (1 epoch, 104 steps) | **0.920** |

Training loss 0.577 → 0.149, token accuracy 0.89 → 0.96.

## Recipe notes

- **`transformers>=5.15.0` required** — the architecture is absent in 5.14.1. Oumi pins `<5.10`, so the README documents a manual upgrade, following the gemma4-12B precedent.
- **LoRA is scoped to the text transformer.** The ViT-G/14 perception encoder reuses the text model's `q_proj`/`k_proj`/`v_proj` names, so `lora_exclude_modules` is required to keep LoRA off the encoder and its projection into the text hidden space.
- **`stop_token_ids: [200001, 200008]` is mandatory.** Assistant turns end on `<|eot|>` (200008), which is *not* the tokenizer's `eos_token` (`<|end_of_text|>`, 200001). Oumi's native engine defaults stop ids to the tokenizer's eos alone and does not read `generation_config.json`, which correctly lists both. Without it, responses never terminate — the model answers and then keeps opening fresh `assistant to=user` turns until `max_new_tokens`.
- **Responses carry a ` to=user` prefix.** The generation prompt ends at `<|start|>assistant`, so the model emits the recipient header itself and it lands in the decoded content. Strip it before exact-match scoring.
- **FSDP wraps `MuseGlimmerTextDecoderLayer`.** FFT is not provided — at ~29.6B it does not fit at 8K context on a single 8xH100 node.
- **vLLM cannot serve this model** (no native entry as of 0.27.0; the transformers backend loads but produces garbage), so the inference config uses the `NATIVE` engine.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
