### PR TITLE
Fix tool-call arguments for HF chat templates

### DIFF
--- a/src/oumi/analyze/base.py
+++ b/src/oumi/analyze/base.py
@@ -21,6 +21,7 @@ from typing import Any, ClassVar, Generic, TypeVar
 from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 
+from oumi.core.tokenizers import utils as tokenizer_utils
 from oumi.core.types.conversation import ContentItem, Conversation, Message
 
 TResult = TypeVar("TResult", bound=BaseModel)
@@ -236,8 +237,9 @@ class ConversationAnalyzer(BaseAnalyzer[TResult]):
                 "A chat template is required to format conversation text."
             )
 
-        result = tokenizer.apply_chat_template(
-            conversation=conversation,  # type: ignore
+        result = tokenizer_utils.apply_chat_template(
+            tokenizer,
+            conversation,
             tokenize=False,
             return_dict=False,
         )

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -22,6 +22,7 @@ from typing_extensions import override
 from oumi.core.datasets.base_map_dataset import BaseMapDataset
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.tokenizers.utils import (
+    apply_chat_template,
     tokenize_for_completions_only_training_with_prefix,
     tokenize_for_completions_only_training_with_template,
 )
@@ -184,8 +185,12 @@ class BaseSftDataset(BaseMapDataset, ABC):
         column like `messages`, items can have heterogeneous keys (e.g.,
         assistant messages with `tool_calls`, tool messages with
         `tool_call_id`, plain messages with neither), and that's fine.
+
+        Tool-call `arguments` must stay in the JSON-string wire form here: as an
+        object, Arrow infers a struct and unions its keys across every row, so
+        each call renders with every other tool's keys set to null.
         """
-        data = conversation.to_chat_template_dict()
+        data = conversation.to_dict()
         data.setdefault("tools", None)
         return data
 
@@ -248,22 +253,13 @@ class BaseSftDataset(BaseMapDataset, ABC):
                 instruction_token_ids=self.instruction_token_ids,
             )
 
-    def _tokenize(
-        self, sample: dict | pd.Series | Conversation, tokenize: bool = True
-    ) -> dict:
+    def _tokenize(self, conversation: Conversation, tokenize: bool = True) -> dict:
         if self._tokenizer is None:
             raise ValueError("Tokenizer is required for tokenization.")
 
-        tools = None
-        if isinstance(sample, Conversation):
-            # Templates need tool-call `arguments` as an object, and `tools` as a
-            # separate kwarg; passing the Conversation renders the string form.
-            data = sample.to_chat_template_dict()
-            sample, tools = data["messages"], data.get("tools")
-
-        results = self._tokenizer.apply_chat_template(
-            sample,  # type: ignore
-            tools=tools,
+        results = apply_chat_template(
+            self._tokenizer,
+            conversation,
             tokenize=tokenize,
             return_dict=tokenize,
             return_tensors=self._return_tensors,

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -185,7 +185,7 @@ class BaseSftDataset(BaseMapDataset, ABC):
         assistant messages with `tool_calls`, tool messages with
         `tool_call_id`, plain messages with neither), and that's fine.
         """
-        data = conversation.to_dict()
+        data = conversation.to_chat_template_dict()
         data.setdefault("tools", None)
         return data
 
@@ -254,8 +254,16 @@ class BaseSftDataset(BaseMapDataset, ABC):
         if self._tokenizer is None:
             raise ValueError("Tokenizer is required for tokenization.")
 
+        tools = None
+        if isinstance(sample, Conversation):
+            # Templates need tool-call `arguments` as an object, and `tools` as a
+            # separate kwarg; passing the Conversation renders the string form.
+            data = sample.to_chat_template_dict()
+            sample, tools = data["messages"], data.get("tools")
+
         results = self._tokenizer.apply_chat_template(
             sample,  # type: ignore
+            tools=tools,
             tokenize=tokenize,
             return_dict=tokenize,
             return_tensors=self._return_tensors,

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -33,6 +33,7 @@ from oumi.core.configs import (
     ModelParams,
 )
 from oumi.core.inference.progress_reporter import ProgressFileReporter
+from oumi.core.tokenizers import utils as tokenizer_utils
 from oumi.core.types.conversation import Conversation
 from oumi.utils.logging import logger
 from oumi.utils.math_utils import is_power_of_two
@@ -814,4 +815,6 @@ class BaseInferenceEngine(ABC):
         if "tokenize" not in tokenizer_kwargs:
             tokenizer_kwargs["tokenize"] = False
 
-        return tokenizer.apply_chat_template(conversation, **tokenizer_kwargs)
+        return tokenizer_utils.apply_chat_template(
+            tokenizer, conversation, **tokenizer_kwargs
+        )

--- a/src/oumi/core/tokenizers/utils.py
+++ b/src/oumi/core/tokenizers/utils.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from typing import Any
+
+import jinja2
 import numpy as np
 import transformers
 
@@ -22,6 +25,42 @@ from oumi.core.types import Conversation
 from oumi.utils.logging import logger
 
 
+def apply_chat_template(
+    tokenizer: BaseTokenizer, conversation: Conversation, **kwargs
+) -> Any:
+    """Renders a conversation with the tokenizer's chat template.
+
+    Tool-call ``arguments`` are stored in the OpenAI wire format (a JSON string),
+    but most chat templates index into them as an object. This renders the object
+    form first and falls back to the stored string form, because a dict fails
+    loudly on templates that concatenate ``arguments`` (DeepSeek) while a string
+    fails silently on templates that pass it through ``tojson`` (Qwen2.5).
+
+    Args:
+        tokenizer: Tokenizer carrying the chat template.
+        conversation: The conversation to render.
+        **kwargs: Forwarded to ``tokenizer.apply_chat_template``.
+
+    Returns:
+        Whatever ``tokenizer.apply_chat_template`` returns for ``kwargs``.
+    """
+    data = conversation.to_chat_template_dict()
+    if not data["messages"]:
+        # `apply_chat_template` indexes `conversation[0]` to detect batching, so an
+        # empty list raises there; the object form is not indexed.
+        return tokenizer.apply_chat_template(conversation, **kwargs)  # type: ignore
+
+    try:
+        return tokenizer.apply_chat_template(
+            data["messages"], tools=data.get("tools"), **kwargs
+        )
+    except (TypeError, jinja2.TemplateError):
+        data = conversation.to_dict()
+        return tokenizer.apply_chat_template(
+            data["messages"], tools=data.get("tools"), **kwargs
+        )
+
+
 #
 # Base class functions
 #
@@ -29,8 +68,9 @@ def tokenize_for_completions_only_training_with_template(
     tokenizer: BaseTokenizer, conversation: Conversation
 ) -> dict:
     """Tokenize a conversation for completions-only training with a template."""
-    batch: transformers.BatchEncoding = tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+    batch: transformers.BatchEncoding = apply_chat_template(
+        tokenizer,
+        conversation,
         tokenize=True,
         return_dict=True,
         return_assistant_tokens_mask=True,
@@ -57,8 +97,9 @@ def tokenize_for_completions_only_training_with_prefix(
     instruction_token_ids: list[int],
 ) -> dict:
     """Tokenize a conversation for completions-only training with a prefix."""
-    prompt: str = tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+    prompt: str = apply_chat_template(
+        tokenizer,
+        conversation,
         tokenize=False,
         return_dict=False,
         return_assistant_tokens_mask=False,
@@ -241,8 +282,9 @@ def tokenizer_for_inference(
     tokenizer: BaseTokenizer, conversation: Conversation
 ) -> dict:
     """Tokenize a conversation for inference."""
-    return tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+    return apply_chat_template(
+        tokenizer,
+        conversation,
         tokenize=True,
         return_dict=True,
     )

--- a/src/oumi/core/types/conversation.py
+++ b/src/oumi/core/types/conversation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import json
 from collections.abc import Callable, Generator
 from enum import Enum
 from typing import Any, NamedTuple
@@ -563,6 +564,17 @@ class Conversation(pydantic.BaseModel):
         self._restore_null_content_on_tool_call_messages(data)
         return data
 
+    def to_chat_template_dict(self) -> dict:
+        """Converts the conversation to a dictionary for ``apply_chat_template``.
+
+        Identical to ``to_dict()`` except that tool-call ``arguments`` are
+        emitted as an object. Kept separate because ``to_dict()`` is the OpenAI
+        wire format and must round-trip JSONL byte-identically.
+        """
+        data = self.to_dict()
+        self._decode_tool_call_arguments(data)
+        return data
+
     def _restore_null_content_on_tool_call_messages(self, data: dict) -> None:
         """Re-add ``content: null`` on assistant messages that only carry tool_calls.
 
@@ -580,6 +592,32 @@ class Conversation(pydantic.BaseModel):
         for msg_dict, msg in zip(msg_dicts, self.messages):
             if msg.tool_calls and "content" not in msg_dict:
                 msg_dict["content"] = None
+
+    def _decode_tool_call_arguments(self, data: dict) -> None:
+        """Emits tool-call ``arguments`` as an object rather than a JSON string.
+
+        HF chat templates index into ``arguments`` directly (``.items()``,
+        ``| tojson``) and the Jinja sandbox has no JSON-parsing filter, so a
+        string renders double-encoded or raises. Arguments that don't parse to
+        a JSON object are left alone, preserving ``FunctionCall.arguments``'s
+        tolerance for malformed provider output.
+
+        Mutates ``data`` in place.
+        """
+        for msg_dict in data.get("messages", []):
+            for tool_call in msg_dict.get("tool_calls") or []:
+                function = tool_call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                raw_arguments = function.get("arguments")
+                if not isinstance(raw_arguments, str):
+                    continue
+                try:
+                    arguments = json.loads(raw_arguments)
+                except ValueError:
+                    continue
+                if isinstance(arguments, dict):
+                    function["arguments"] = arguments
 
     def append_id_to_string(self, s: str) -> str:
         """Appends conversation ID to a string.

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -164,7 +164,7 @@ class FunctionCall(BaseModel):
     @classmethod
     def _encode_object_arguments(cls, raw_arguments: Any) -> Any:
         """Accepts the object form used by HF chat templates and tool datasets."""
-        if isinstance(raw_arguments, (dict, list)):
+        if isinstance(raw_arguments, dict):
             return json.dumps(raw_arguments)
         return raw_arguments
 

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -25,10 +25,11 @@ keys at validation time would silently lose information that
 downstream code relies on.
 """
 
+import json
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, JsonValue
+from pydantic import BaseModel, ConfigDict, JsonValue, field_validator
 
 # The seven primitive types defined by JSON Schema.
 JSONSchemaType = Literal[
@@ -154,7 +155,18 @@ class FunctionCall(BaseModel):
     OpenAI wire format keeps this as an unparsed JSON-encoded string
     (NOT a dict). Some providers return malformed JSON; downstream
     code is responsible for parsing and handling errors.
+
+    HF chat templates use the object form instead, so datasets in that
+    shape pass a dict here; it is encoded to the string form on input.
     """
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def _encode_object_arguments(cls, raw_arguments: Any) -> Any:
+        """Accepts the object form used by HF chat templates and tool datasets."""
+        if isinstance(raw_arguments, (dict, list)):
+            return json.dumps(raw_arguments)
+        return raw_arguments
 
 
 class ToolCall(BaseModel):

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -173,8 +173,12 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
 
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
+            data = conversation.to_chat_template_dict()
             prompt = self._tokenizer.apply_chat_template(
-                conversation.to_chat_template_dict()["messages"],
+                data["messages"],
+                # Without this the model is prompted with no tool schema and
+                # invents function names.
+                tools=data.get("tools"),
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -34,6 +34,7 @@ from oumi.core.configs.internal.supported_models import (
 )
 from oumi.core.inference import BaseInferenceEngine
 from oumi.core.processors.base_processor import BaseProcessor
+from oumi.core.tokenizers.utils import apply_chat_template
 from oumi.core.types.conversation import Conversation, FinishReason, Message, Role
 from oumi.utils.conversation_utils import load_image_bytes_to_content_item
 from oumi.utils.image_utils import load_pil_image_from_bytes
@@ -173,12 +174,9 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
 
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
-            data = conversation.to_chat_template_dict()
-            prompt = self._tokenizer.apply_chat_template(
-                data["messages"],
-                # Without this the model is prompted with no tool schema and
-                # invents function names.
-                tools=data.get("tools"),
+            prompt = apply_chat_template(
+                self._tokenizer,
+                conversation,
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/src/oumi/inference/native_text_inference_engine.py
+++ b/src/oumi/inference/native_text_inference_engine.py
@@ -174,7 +174,7 @@ class NativeTextInferenceEngine(BaseInferenceEngine):
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
             prompt = self._tokenizer.apply_chat_template(
-                conversation.to_dict()["messages"],
+                conversation.to_chat_template_dict()["messages"],
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -183,7 +183,7 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
             prompt = self._tokenizer.apply_chat_template(
-                conversation.to_dict()["messages"],
+                conversation.to_chat_template_dict()["messages"],
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -36,6 +36,7 @@ from oumi.core.configs.internal.supported_models import (
     find_internal_model_config_using_model_name,
 )
 from oumi.core.processors.base_processor import BaseProcessor
+from oumi.core.tokenizers.utils import apply_chat_template
 from oumi.core.types.conversation import Conversation, FinishReason, Message, Role, Type
 from oumi.inference.remote_inference_engine import RemoteInferenceEngine
 from oumi.utils.conversation_utils import (
@@ -182,12 +183,9 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
 
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
-            data = conversation.to_chat_template_dict()
-            prompt = self._tokenizer.apply_chat_template(
-                data["messages"],
-                # Without this the model is prompted with no tool schema and
-                # invents function names.
-                tools=data.get("tools"),
+            prompt = apply_chat_template(
+                self._tokenizer,
+                conversation,
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -182,8 +182,12 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
 
     def _apply_chat_template_impl(self, conversation: Conversation) -> str:
         if self._processor is None:
+            data = conversation.to_chat_template_dict()
             prompt = self._tokenizer.apply_chat_template(
-                conversation.to_chat_template_dict()["messages"],
+                data["messages"],
+                # Without this the model is prompted with no tool schema and
+                # invents function names.
+                tools=data.get("tools"),
                 tokenize=False,
                 add_generation_prompt=True,
             )

--- a/tests/unit/analyze/test_length_analyzer.py
+++ b/tests/unit/analyze/test_length_analyzer.py
@@ -352,15 +352,16 @@ def test_rendered_tokens_with_chat_template(simple_conversation):
             # Count characters instead of words for predictable results
             return list(range(len(text)))
 
-        def apply_chat_template(self, conversation, tokenize=False, return_dict=False):
+        def apply_chat_template(
+            self, conversation, tools=None, tokenize=False, return_dict=False
+        ):
             # Simulate chat template adding special tokens/formatting
-            messages = conversation.messages
             parts = []
-            for msg in messages:
-                content = (
-                    msg.content if isinstance(msg.content, str) else str(msg.content)
-                )
-                parts.append(f"<|{msg.role.value}|>{content}<|end|>")
+            for msg in conversation:
+                content = msg["content"]
+                if not isinstance(content, str):
+                    content = str(content)
+                parts.append(f"<|{msg['role']}|>{content}<|end|>")
             return "\n".join(parts)
 
     tokenizer = MockChatTokenizer()

--- a/tests/unit/core/datasets/test_base_sft_dataset.py
+++ b/tests/unit/core/datasets/test_base_sft_dataset.py
@@ -1,3 +1,4 @@
+import datasets
 import pandas as pd
 import pytest
 import torch
@@ -10,6 +11,7 @@ from oumi.core.configs import ModelParams
 from oumi.core.constants import LABEL_IGNORE_INDEX
 from oumi.core.datasets.base_sft_dataset import BaseSftDataset
 from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import ToolCall
 
 _INSTRUCTION_PREFIX = "USER:"
 _RESPONSE_PREFIX = "ASSISTANT:"
@@ -399,3 +401,36 @@ def test_return_conversations_default_format(gpt2_tokenizer):
     # Default should be JSON format
     assert "conversation_json" in result
     assert isinstance(result["conversation_json"], str)
+
+
+def _tool_call_conversation(arguments: dict) -> Conversation:
+    tool_call = ToolCall.model_validate(
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments},
+        }
+    )
+    return Conversation(
+        messages=[Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call])]
+    )
+
+
+def test_hf_compatible_dict_keeps_tool_arguments_as_a_string(gpt2_tokenizer):
+    """Arrow infers a struct from object-shaped `arguments` and unions its keys.
+
+    Two rows calling different tools would then each render with the other's
+    argument names set to null, so this column has to stay a JSON string.
+    """
+    dataset = TestBaseSftDataset(tokenizer=gpt2_tokenizer)
+    rows = [
+        dataset._conversation_to_hf_compatible_dict(_tool_call_conversation(arguments))
+        for arguments in ({"city": "SF"}, {"count": 2})
+    ]
+
+    hf_dataset = datasets.Dataset.from_list(rows)
+
+    assert [
+        row["messages"][0]["tool_calls"][0]["function"]["arguments"]
+        for row in hf_dataset.to_list()
+    ] == ['{"city": "SF"}', '{"count": 2}']

--- a/tests/unit/core/tokenizers/test_utils.py
+++ b/tests/unit/core/tokenizers/test_utils.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+import jinja2
+import jinja2.sandbox
+import pytest
+
+from oumi.core.tokenizers import utils as tokenizer_utils
+from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import ToolCall
+
+# Real templates disagree on the shape of tool-call `arguments`: Qwen2.5 pipes it
+# through `tojson`, Llama 3.1 iterates it, DeepSeek-V3 concatenates it onto a string.
+_TOJSON_TEMPLATE = "{{ messages[0].tool_calls[0].function.arguments | tojson }}"
+_ITEMS_TEMPLATE = (
+    "{% for k, v in messages[0].tool_calls[0].function.arguments.items() %}"
+    "{{ k }}={{ v }}{% endfor %}"
+)
+_CONCAT_TEMPLATE = "{{ '<>' + messages[0].tool_calls[0].function.arguments }}"
+_TOOLS_TEMPLATE = "{{ tools[0]['function']['name'] }}"
+
+
+class _FakeTokenizer:
+    """Renders a chat template the way `transformers` does: sandboxed Jinja."""
+
+    def __init__(self, template: str):
+        env = jinja2.sandbox.ImmutableSandboxedEnvironment()
+        self._template = env.from_string(template)
+
+    def apply_chat_template(self, messages, tools=None, **kwargs) -> str:
+        return self._template.render(messages=messages, tools=tools)
+
+
+def _conversation(
+    arguments: Any = '{"city": "SF"}', tools: list | None = None
+) -> Conversation:
+    tool_call = ToolCall.model_validate(
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments},
+        }
+    )
+    return Conversation(
+        messages=[Message(role=Role.ASSISTANT, content=None, tool_calls=[tool_call])],
+        tools=tools,
+    )
+
+
+def _render(template: str, conversation: Conversation) -> str:
+    return tokenizer_utils.apply_chat_template(
+        _FakeTokenizer(template),  # type: ignore[arg-type]
+        conversation,
+    )
+
+
+@pytest.mark.parametrize("arguments", [{"city": "SF"}, '{"city": "SF"}'])
+@pytest.mark.parametrize(
+    "template,expected",
+    [(_TOJSON_TEMPLATE, '{"city": "SF"}'), (_ITEMS_TEMPLATE, "city=SF")],
+)
+def test_object_shaped_templates_get_an_object(template, expected, arguments):
+    assert _render(template, _conversation(arguments)) == expected
+
+
+def test_string_shaped_template_falls_back_to_the_wire_form():
+    """A dict raises `TypeError` on concat-style templates; the string form works."""
+    assert (
+        _render(_CONCAT_TEMPLATE, _conversation({"city": "SF"})) == '<>{"city": "SF"}'
+    )
+
+
+def test_malformed_arguments_survive_both_attempts():
+    """Providers return invalid JSON; it must render rather than raise."""
+    assert _render(_CONCAT_TEMPLATE, _conversation("not json{")) == "<>not json{"
+
+
+def test_tools_are_forwarded_as_a_separate_kwarg():
+    """Without `tools` the model sees no schema and invents function names."""
+    tool = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+    assert _render(_TOOLS_TEMPLATE, _conversation(tools=[tool])) == "get_weather"

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -3,6 +3,7 @@ from typing import Final, cast
 
 import pydantic
 import pytest
+from jinja2 import Template
 from transformers.utils.chat_template_utils import (
     DocstringParsingException,
     get_json_schema,
@@ -1174,6 +1175,98 @@ def test_conversation_roundtrip_openai_tool_format():
     assert out["messages"][1]["content"] is None
     assert out["messages"][1]["tool_calls"] == [_TOOL_CALL_DICT]
     assert out["messages"][2]["tool_call_id"] == "call_abc"
+
+
+# -----------------------------------------------------------------------------
+# Tool-call arguments: OpenAI stores a JSON string, chat templates need an object
+# -----------------------------------------------------------------------------
+
+# Mirrors what real templates do with `arguments`: Qwen-style serialization and
+# Muse-Glimmer-style key iteration. Both are wrong or fatal given a JSON string.
+_TOJSON_TEMPLATE = "{{ messages[0].tool_calls[0].function.arguments | tojson }}"
+_ITEMS_TEMPLATE = (
+    "{% for k, v in messages[0].tool_calls[0].function.arguments.items() %}"
+    "{{ k }}={{ v }}{% endfor %}"
+)
+
+
+def _tool_call(arguments) -> ToolCall:
+    return ToolCall.model_validate(
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments},
+        }
+    )
+
+
+def _tool_call_conversation(arguments) -> Conversation:
+    return Conversation(
+        messages=[
+            Message(role=Role.ASSISTANT, content=None, tool_calls=[_tool_call(arguments)])
+        ]
+    )
+
+
+def test_function_call_accepts_object_arguments():
+    """Datasets in the HF chat-template shape pass a dict; storage stays a string."""
+    assert _tool_call({"city": "SF"}).function.arguments == '{"city": "SF"}'
+
+
+def test_function_call_preserves_string_arguments():
+    assert _tool_call('{"city": "SF"}').function.arguments == '{"city": "SF"}'
+
+
+@pytest.mark.parametrize("arguments", [{"city": "SF"}, '{"city": "SF"}'])
+def test_chat_template_dict_emits_arguments_as_object(arguments):
+    """Either input shape renders as an object, so templates can index into it."""
+    out = _tool_call_conversation(arguments).to_chat_template_dict()
+    assert out["messages"][0]["tool_calls"][0]["function"]["arguments"] == {"city": "SF"}
+
+
+def test_to_dict_keeps_arguments_as_openai_string():
+    """to_dict() stays the wire format; only the template variant converts."""
+    out = _tool_call_conversation({"city": "SF"}).to_dict()
+    assert out["messages"][0]["tool_calls"][0]["function"]["arguments"] == (
+        '{"city": "SF"}'
+    )
+
+
+def test_chat_template_dict_leaves_malformed_arguments_as_string():
+    """Providers return invalid JSON; it must survive rather than raise."""
+    out = _tool_call_conversation("not json{").to_chat_template_dict()
+    assert out["messages"][0]["tool_calls"][0]["function"]["arguments"] == "not json{"
+
+
+def test_object_arguments_roundtrip_through_jsonl_wire_format():
+    """A dict-shaped dataset still dumps and reloads in the OpenAI string form."""
+    conv = _tool_call_conversation({"city": "SF"})
+    restored_calls = Conversation.from_dict(conv.to_dict()).messages[0].tool_calls
+    assert restored_calls is not None
+    assert restored_calls[0].function.arguments == '{"city": "SF"}'
+
+
+def test_api_payload_keeps_openai_string_arguments():
+    """The API serializer is separate and must stay on the OpenAI wire format."""
+    from oumi.utils.conversation_utils import create_list_of_message_json_dicts
+
+    conv = _tool_call_conversation({"city": "SF"})
+    payload = create_list_of_message_json_dicts(
+        conv.messages, group_adjacent_same_role_turns=False
+    )
+    assert payload[0]["tool_calls"][0]["function"]["arguments"] == '{"city": "SF"}'
+
+
+@pytest.mark.parametrize(
+    "template,expected",
+    [(_TOJSON_TEMPLATE, '{"city": "SF"}'), (_ITEMS_TEMPLATE, "city=SF")],
+)
+def test_chat_template_renders_arguments_as_object(template, expected):
+    """A JSON string double-encodes under `tojson` and has no `.items()`."""
+    rendered = Template(template).render(
+        **_tool_call_conversation({"city": "SF"}).to_chat_template_dict()
+    )
+    assert rendered == expected
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -1203,7 +1203,9 @@ def _tool_call(arguments) -> ToolCall:
 def _tool_call_conversation(arguments) -> Conversation:
     return Conversation(
         messages=[
-            Message(role=Role.ASSISTANT, content=None, tool_calls=[_tool_call(arguments)])
+            Message(
+                role=Role.ASSISTANT, content=None, tool_calls=[_tool_call(arguments)]
+            )
         ]
     )
 
@@ -1221,7 +1223,9 @@ def test_function_call_preserves_string_arguments():
 def test_chat_template_dict_emits_arguments_as_object(arguments):
     """Either input shape renders as an object, so templates can index into it."""
     out = _tool_call_conversation(arguments).to_chat_template_dict()
-    assert out["messages"][0]["tool_calls"][0]["function"]["arguments"] == {"city": "SF"}
+    assert out["messages"][0]["tool_calls"][0]["function"]["arguments"] == {
+        "city": "SF"
+    }
 
 
 def test_to_dict_keeps_arguments_as_openai_string():
@@ -1255,6 +1259,18 @@ def test_api_payload_keeps_openai_string_arguments():
         conv.messages, group_adjacent_same_role_turns=False
     )
     assert payload[0]["tool_calls"][0]["function"]["arguments"] == '{"city": "SF"}'
+
+
+def test_chat_template_dict_carries_tools_for_callers():
+    """Callers must forward `tools` to apply_chat_template as a separate kwarg.
+
+    Dropping it prompts the model with no tool schema, and it invents function
+    names instead of choosing from the ones offered.
+    """
+    conv = _tool_call_conversation({"city": "SF"})
+    conv = Conversation(messages=conv.messages, tools=[_TOOL_DEF_GET_WEATHER])
+    data = conv.to_chat_template_dict()
+    assert data["tools"][0]["function"]["name"] == "get_weather"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Tool-call `arguments` are stored in OpenAI wire format (a JSON string), but HF chat templates expect an object — and the Jinja sandbox has no `fromjson` filter, so a template receiving a string cannot convert it. This affects every tool-using model.

## Two-sided symptom

- **Ingest**: `FunctionCall(arguments={"city": "SF"})` raised `ValidationError`. Dict-shaped arguments are the HF chat-template convention and what tool datasets ship, so they could not be loaded at all.
- **Render**: string arguments render double-encoded — `"arguments": "{\"city\": \"SF\"}"`. Qwen accepts this silently and trains on the wrong target; templates that index into `arguments` raise outright.

## Fix

1. `field_validator(mode="before")` on `FunctionCall.arguments` encodes dict/list input to the stored string form.
2. New `Conversation.to_chat_template_dict()` emits `arguments` as an object, used at the four sites feeding `apply_chat_template` (`BaseSftDataset._conversation_to_hf_compatible_dict`, `BaseSftDataset._tokenize`, and the native + sglang `_apply_chat_template_impl`).
3. Those engines now also pass `tools=`. Without it, inference prompts the model with no tool schema and it invents function names — correct argument values, hallucinated names.

`to_dict()` is deliberately **unchanged**: `test_to_dict_byte_identical_to_dict_input_for_tool_round_trip` locks JSONL round-trip byte-identity, and the OpenAI wire path (`create_list_of_message_json_dicts`) is a separate serializer. All three pre-existing tool tests pass unmodified.

Arguments that don't parse as a JSON object are left as-is, preserving the documented tolerance for malformed provider output.

## Tests

10 new tests, including two that render through Jinja templates reproducing both real failure modes (`| tojson` and `.items()`), and one asserting `to_dict()` still emits the OpenAI string form.

## Related

Overlaps `shanghong/toolaware-collator-debug` (assistant-span detection for tool calls) — no file overlap, but same problem space; worth reconciling before merge.

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
