### PR TITLE
fix(collators): clamp auto-detected response template to the generati…

### DIFF
--- a/src/oumi/builders/collators.py
+++ b/src/oumi/builders/collators.py
@@ -227,6 +227,90 @@ def _detect_response_template(
     return response_template
 
 
+def _clamp_to_generation_prompt(
+    tokenizer: "BaseTokenizer",
+    response_template: str,
+    msgs: list[dict[str, str]],
+) -> str:
+    r"""Clamp the response template to the generation-prompt boundary.
+
+    Some chat templates render assistant headers that extend past the
+    generation prompt: e.g. harmony-style templates render assistant turns
+    as ``<|start|>assistant to=user<|message|>…`` while the generation
+    prompt is the bare ``<|start|>assistant``. Masking through the full
+    header leaves the trailing span (`` to=user<|message|>``) untrained,
+    even though inference expects the model to generate it — heavy
+    fine-tuning then corrupts that span. When the generation-prompt suffix
+    is a strict prefix of the detected header, prefer it so the rest of the
+    header is trained.
+
+    Args:
+        tokenizer: The tokenizer whose chat template is being probed.
+        response_template: The auto-detected assistant header.
+        msgs: A sentinel conversation ending with a user turn.
+
+    Returns:
+        The clamped response template, or the original when the
+        generation prompt is unavailable or is not a strict prefix.
+
+    Examples:
+        Muse Glimmer renders assistant headers past the generation prompt, so
+        the suffix is a proper prefix of the header and the clamp fires — the
+        span between the two boundaries (`` to=user<|message|>``) moves into
+        the trained region::
+
+            detected    '<|start|>assistant to=user<|message|>'
+            gen_suffix  '<|start|>assistant'
+            -> '<|start|>assistant'
+
+        Qwen2.5's generation prompt IS its assistant header (modulo the
+        trailing newline both sides strip), so the suffix is not strictly
+        shorter and nothing changes — the no-op case covering standard
+        templates::
+
+            detected    '<|im_start|>assistant'
+            gen_suffix  '<|im_start|>assistant\n'  ->  '<|im_start|>assistant'
+            -> unchanged
+
+        gemma-4-12B-it's generation prompt is *longer* than its header (the
+        template appends a thought-channel opener when prompting), so it is
+        not a prefix at all and nothing changes — the clamp only ever
+        shortens::
+
+            detected    '<|turn>model'
+            gen_suffix  '<|turn>model\n<|channel>thought\n<channel|>'
+            -> unchanged
+    """
+    try:
+        base = tokenizer.apply_chat_template(
+            msgs, tokenize=False, add_generation_prompt=False
+        )
+        gen = tokenizer.apply_chat_template(
+            msgs, tokenize=False, add_generation_prompt=True
+        )
+    except Exception:
+        return response_template
+    if not (isinstance(base, str) and isinstance(gen, str)):
+        return response_template
+    if not gen.startswith(base):
+        return response_template
+
+    gen_suffix = gen[len(base) :].rstrip("\n")
+    if (
+        gen_suffix
+        and len(gen_suffix) < len(response_template)
+        and response_template.startswith(gen_suffix)
+    ):
+        logger.info(
+            "Clamped auto-detected response_template to the generation-prompt "
+            "boundary: %r -> %r",
+            response_template,
+            gen_suffix,
+        )
+        return gen_suffix
+    return response_template
+
+
 def resolve_collator_templates(
     tokenizer: "BaseTokenizer",
 ) -> tuple[str, str]:
@@ -258,15 +342,17 @@ def resolve_collator_templates(
     msgs_no_sys = msgs_with_sys[1:]
 
     rendered = None
+    chosen_msgs = None
     for msgs in (msgs_with_sys, msgs_no_sys):
         try:
             rendered = tokenizer.apply_chat_template(
                 msgs, tokenize=False, add_generation_prompt=False
             )
+            chosen_msgs = msgs
             break
         except Exception:
             continue
-    if rendered is None:
+    if rendered is None or chosen_msgs is None:
         raise ValueError(
             f"Tokenizer has no chat template or it failed to render.\n{_FIX_HINT}"
         )
@@ -301,6 +387,10 @@ def resolve_collator_templates(
         tokenizer,
         header_text=rendered[second_user_end:second_asst],
         eot_ids=eot_ids,
+    )
+    # Shorten only when generation begins inside the detected header.
+    response_template = _clamp_to_generation_prompt(
+        tokenizer, response_template, chosen_msgs[:-1]
     )
 
     if not response_template.strip():

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -138,6 +138,13 @@ def _load_tokenizer(
             "[e~[\n",
             id="minimax-m2.5",
         ),
+        pytest.param(
+            "meta-models/Muse-Glimmer-30B",
+            False,
+            "<|start|>assistant",
+            "<|eot|>",
+            id="muse-glimmer",
+        ),
     ],
 )
 def test_template_detection_public(

--- a/tests/unit/builders/test_collators.py
+++ b/tests/unit/builders/test_collators.py
@@ -403,6 +403,51 @@ def test_resolve_templates_error(make_tok, match):
         resolve_collator_templates(make_tok())
 
 
+def _harmony_style_tokenizer():
+    """Mock whose assistant header extends past the generation prompt.
+
+    Assistant turns render as ``<|start|>assistant to=user<|message|>…`` while
+    the generation prompt is the bare ``<|start|>assistant``.
+    """
+    tok = MagicMock()
+    tok.pad_token_id = 0
+    tok.model_max_length = 2048
+
+    def _apply(messages, add_generation_prompt=False, **kw):
+        parts = []
+        for m in messages:
+            header = " to=user" if m["role"] == "assistant" else ""
+            parts.append(
+                f"<|start|>{m['role']}{header}<|message|>{m['content']}<|eot|>"
+            )
+        if add_generation_prompt:
+            parts.append("<|start|>assistant")
+        return "".join(parts)
+
+    tok.apply_chat_template = MagicMock(side_effect=_apply)
+
+    _encode_map = {
+        "<|eot|>": [8],
+        "<|eot|><|start|>user<|message|>": [8, 1, 2, 3],
+        "<|eot|><|start|>assistant to=user<|message|>": [8, 1, 4, 5, 6, 7],
+    }
+    _decode_map = {
+        (8,): "<|eot|>",
+        (1, 4, 5, 6, 7): "<|start|>assistant to=user<|message|>",
+    }
+    tok.encode = MagicMock(side_effect=lambda text, **kw: _encode_map[text])
+    tok.decode = MagicMock(side_effect=lambda ids, **kw: _decode_map[tuple(ids)])
+    return tok
+
+
+def test_resolve_templates_clamps_header_to_generation_prompt():
+    response_template, end_of_turn_template = resolve_collator_templates(
+        _harmony_style_tokenizer()
+    )
+    assert response_template == "<|start|>assistant"
+    assert end_of_turn_template == "<|eot|>"
+
+
 # ---------------------------------------------------------------------------
 # build_collator_from_config with train_target
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->

Some chat templates render assistant headers that extend past the generation prompt — harmony-style templates (e.g. `meta-models/Muse-Glimmer-30B`, gpt-oss) render assistant turns as `<|start|>assistant to=user<|message|>…` while the generation prompt is the bare `<|start|>assistant`. When collator templates are auto-detected (`train_target` set, no explicit `response_template`), detection returns the full header, so the trailing ` to=user<|message|>` span is masked out of the loss even though the model must generate it at inference. Heavy fine-tuning corrupts that untrained span: in our Muse-Glimmer FFT runs, the model emitted `' to51'` instead of ` to=user<|message|>51`, leaving 405/500 eval rows unparseable.

**Fix:** after detection, clamp `response_template` to the generation-prompt suffix whenever that suffix is a strict prefix of the detected header — the header remainder then stays in the trained span. The invariant enforced: the masking boundary equals the point where generation begins at inference.

**Blast radius:** none for standard templates. The clamp only fires when the rendered assistant header is strictly longer than the generation prompt; for every template where the two coincide (the normal case) it is a no-op by construction. Verified empirically: all 11 real-tokenizer detection tests (Qwen 2.5/3/3.5/3.6, DeepSeek-R1 ×2, Olmo3, SmolLM 2/3, MiniMax) produce byte-identical results with and without the change. Explicitly-configured `response_template`s are untouched — only auto-detection output changes. New unit test covers the harmony-style case; `meta-models/Muse-Glimmer-30B` added to the integration detection matrix.

**Before/after** (`resolve_collator_templates` on real tokenizers; auto-detection path):

```python
# meta-models/Muse-Glimmer-30B — clamped
before: ('<|start|>assistant to=user<|message|>', '<|eot|>')
after:  ('<|start|>assistant', '<|eot|>')
# trained span before:  '54<|eot|>'                      (header masked — corrupts under FFT)
# trained span after:   ' to=user<|message|>54<|eot|>'   (header supervised)

# google/gemma-4-12B-it — unchanged
before == after: ('<|turn>model', '<turn|>\n')

# Qwen/Qwen3.5-0.8B — unchanged
before == after: ('<|im_start|>assistant', '<|im_end|>\n')
```

Validated end-to-end on the enterprise platform: Muse-Glimmer FFT trained with auto-detected (clamped) templates matches the explicit-template run on banking77 (0.862 vs 0.868 accuracy, 500/500 parseable outputs both).

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Supports Muse-Glimmer-30B SFT onboarding (oumi-ai/api#6146).

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
