### PR TITLE
Add methods to convert tool arguments between json string and dictionary

### DIFF
--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -160,7 +160,7 @@ class FunctionCall(BaseModel):
 
     @pydantic.field_validator("arguments", mode="before")
     @classmethod
-    def _coerce_arguments(cls, raw: Any) -> str:
+    def _coerce_arguments_to_str(cls, raw: Any) -> str:
         """Normalize dict/list arguments to a JSON string.
 
         Runs in ``mode="before"`` so we can intercept non-string inputs
@@ -175,7 +175,7 @@ class FunctionCall(BaseModel):
             f"arguments must be a str, dict, or list; got {type(raw).__name__}."
         )
 
-    def parsed_arguments(self) -> dict[str, Any]:
+    def get_arguments_dict(self) -> dict[str, Any]:
         """Returns ``arguments`` decoded from its JSON string form.
 
         The string is the storage contract; every consumer that needs a dict

--- a/src/oumi/core/types/tool_call.py
+++ b/src/oumi/core/types/tool_call.py
@@ -25,9 +25,11 @@ keys at validation time would silently lose information that
 downstream code relies on.
 """
 
+import json
 from enum import Enum
 from typing import Any, Literal
 
+import pydantic
 from pydantic import BaseModel, ConfigDict, JsonValue
 
 # The seven primitive types defined by JSON Schema.
@@ -155,6 +157,45 @@ class FunctionCall(BaseModel):
     (NOT a dict). Some providers return malformed JSON; downstream
     code is responsible for parsing and handling errors.
     """
+
+    @pydantic.field_validator("arguments", mode="before")
+    @classmethod
+    def _coerce_arguments(cls, raw: Any) -> str:
+        """Normalize dict/list arguments to a JSON string.
+
+        Runs in ``mode="before"`` so we can intercept non-string inputs
+        (e.g., dicts from JSONL files) and serialize them before Pydantic's
+        core validator enforces the ``str`` type.
+        """
+        if isinstance(raw, str):
+            return raw
+        if isinstance(raw, (dict, list)):
+            return json.dumps(raw)
+        raise ValueError(
+            f"arguments must be a str, dict, or list; got {type(raw).__name__}."
+        )
+
+    def parsed_arguments(self) -> dict[str, Any]:
+        """Returns ``arguments`` decoded from its JSON string form.
+
+        The string is the storage contract; every consumer that needs a dict
+        decodes it here rather than reimplementing the parse and its error
+        handling.
+        """
+        if not self.arguments:
+            return {}
+        try:
+            parsed = json.loads(self.arguments)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Function '{self.name}' has invalid JSON arguments: {e}"
+            ) from e
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Function '{self.name}' arguments must be a JSON object, "
+                f"got {type(parsed).__name__}."
+            )
+        return parsed
 
 
 class ToolCall(BaseModel):

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -406,7 +406,7 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             "type": "tool_use",
             "id": tool_call.id,
             "name": tool_call.function.name,
-            "input": tool_call.function.parsed_arguments(),
+            "input": tool_call.function.get_arguments_dict(),
         }
 
     @staticmethod

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -402,12 +402,11 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         Anthropic expects a parsed ``input`` dict; OpenAI keeps ``arguments`` as
         a JSON string, so it is decoded here.
         """
-        args = tool_call.function.arguments
         return {
             "type": "tool_use",
             "id": tool_call.id,
             "name": tool_call.function.name,
-            "input": json.loads(args) if args else {},
+            "input": tool_call.function.parsed_arguments(),
         }
 
     @staticmethod

--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -89,7 +89,7 @@ def test_execute_routes_into_shared_env(tmp_path):
         tool.execute(iid, {"query": "SELECT count(*) FROM t"}, agent_data=ad)
     )
     assert reward == 0.0
-    assert "2" in resp.text
+    assert resp.text is not None and "2" in resp.text
 
 
 def test_invalid_env_config_is_rejected_at_construction(tmp_path):
@@ -122,4 +122,4 @@ def test_failed_tool_call_becomes_an_observation(tmp_path):
         tool.execute(iid, {"query": "NOT VALID SQL"}, agent_data=ad)
     )
     assert reward == 0.0
-    assert resp.text.startswith("Tool error:")
+    assert resp.text is not None and resp.text.startswith("Tool error:")

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -17,7 +17,7 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
-from oumi.core.types.tool_call import ToolCall, ToolDefinition
+from oumi.core.types.tool_call import FunctionCall, ToolCall, ToolDefinition
 from oumi.utils.image_utils import load_image_png_bytes_from_path
 
 _SMALL_B64_IMAGE: Final[str] = (
@@ -1350,6 +1350,57 @@ def test_typed_field_access_on_message_tool_calls():
     assert msg.tool_calls[0].id == "call_abc"
     assert msg.tool_calls[0].function.name == "get_weather"
     assert msg.tool_calls[0].function.arguments == '{"city": "SF"}'
+
+
+def test_function_call_dict_arguments_coerced_to_json_string():
+    """Dict arguments are serialized to a JSON string on input."""
+    fc = FunctionCall(name="fn", arguments={"key": "value"})  # type: ignore[arg-type]
+    assert fc.arguments == '{"key": "value"}'
+    assert isinstance(fc.arguments, str)
+
+
+def test_function_call_list_arguments_coerced_to_json_string():
+    """List arguments are serialized to a JSON string on input."""
+    fc = FunctionCall(name="fn", arguments=[1, 2, 3])  # type: ignore[arg-type]
+    assert fc.arguments == "[1, 2, 3]"
+
+
+def test_function_call_string_arguments_pass_through():
+    """String arguments pass through the validator unchanged."""
+    fc = FunctionCall(name="fn", arguments='{"key": "value"}')
+    assert fc.arguments == '{"key": "value"}'
+
+
+def test_function_call_rejects_unsupported_arguments_type():
+    """Non-str/dict/list arguments raise ValueError."""
+    with pytest.raises(ValueError, match="must be a str, dict, or list"):
+        FunctionCall(name="fn", arguments=42)  # type: ignore[arg-type]
+
+
+def test_function_call_parsed_arguments_returns_mapping():
+    """parsed_arguments() decodes the JSON string to a dict."""
+    fc = FunctionCall(name="fn", arguments='{"city": "SF"}')
+    assert fc.parsed_arguments() == {"city": "SF"}
+
+
+def test_function_call_parsed_arguments_empty_returns_empty_dict():
+    """parsed_arguments() returns {} for empty string arguments."""
+    fc = FunctionCall(name="fn", arguments="")
+    assert fc.parsed_arguments() == {}
+
+
+def test_function_call_parsed_arguments_invalid_json_raises():
+    """parsed_arguments() raises ValueError naming the function on bad JSON."""
+    fc = FunctionCall(name="broken_fn", arguments="{bad json")
+    with pytest.raises(ValueError, match="broken_fn"):
+        fc.parsed_arguments()
+
+
+def test_function_call_parsed_arguments_non_object_raises():
+    """parsed_arguments() raises ValueError if JSON is valid but not an object."""
+    fc = FunctionCall(name="fn", arguments="[1, 2]")
+    with pytest.raises(ValueError, match="JSON object"):
+        fc.parsed_arguments()
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/core/types/test_conversation.py
+++ b/tests/unit/core/types/test_conversation.py
@@ -1377,30 +1377,30 @@ def test_function_call_rejects_unsupported_arguments_type():
         FunctionCall(name="fn", arguments=42)  # type: ignore[arg-type]
 
 
-def test_function_call_parsed_arguments_returns_mapping():
-    """parsed_arguments() decodes the JSON string to a dict."""
+def test_function_call_get_arguments_dict_returns_mapping():
+    """get_arguments_dict() decodes the JSON string to a dict."""
     fc = FunctionCall(name="fn", arguments='{"city": "SF"}')
-    assert fc.parsed_arguments() == {"city": "SF"}
+    assert fc.get_arguments_dict() == {"city": "SF"}
 
 
-def test_function_call_parsed_arguments_empty_returns_empty_dict():
-    """parsed_arguments() returns {} for empty string arguments."""
+def test_function_call_get_arguments_dict_empty_returns_empty_dict():
+    """get_arguments_dict() returns {} for empty string arguments."""
     fc = FunctionCall(name="fn", arguments="")
-    assert fc.parsed_arguments() == {}
+    assert fc.get_arguments_dict() == {}
 
 
-def test_function_call_parsed_arguments_invalid_json_raises():
-    """parsed_arguments() raises ValueError naming the function on bad JSON."""
+def test_function_call_get_arguments_dict_invalid_json_raises():
+    """get_arguments_dict() raises ValueError naming the function on bad JSON."""
     fc = FunctionCall(name="broken_fn", arguments="{bad json")
     with pytest.raises(ValueError, match="broken_fn"):
-        fc.parsed_arguments()
+        fc.get_arguments_dict()
 
 
-def test_function_call_parsed_arguments_non_object_raises():
-    """parsed_arguments() raises ValueError if JSON is valid but not an object."""
+def test_function_call_get_arguments_dict_non_object_raises():
+    """get_arguments_dict() raises ValueError if JSON is valid but not an object."""
     fc = FunctionCall(name="fn", arguments="[1, 2]")
     with pytest.raises(ValueError, match="JSON object"):
-        fc.parsed_arguments()
+        fc.get_arguments_dict()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
`FunctionCall.arguments` is typed `str` to match the OpenAI wire format, but some datasets (such as those from real enterprise use cases) carry the arguments as a JSON object. Loading such a file raised a validation error, so every caller had to pre-serialize to dict to json string.

Decisions:
1. Keep string as the single storage contract rather than dict because other workflows like synthesis or inference may return malformed json, which will raise if we store as dict. We want to be able to store the malformed json for error logging purposes and re-feed into the system for the LLM to correct in next turn.
2. Add method coerce dict/list to a JSON string in a `mode="before"` validator to enable us to take in datasets carry the arguments as a JSON object.
3. Add `parsed_arguments()` so consumers that need a mapping decode it in one place with one error message instead of reimplementing `json.loads` and its failure handling.

The Anthropic engine, which needs a parsed `input` dict, switches to `parsed_arguments()`.

Other misc edits: narrow two `resp.text` assertions in the verl tool tests to satisfy pyright
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
