### PR TITLE
Ensure tool call args are in correct type for chat template

### DIFF
--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import base64
-from typing import Any
+from typing import Any, Literal
 
 import PIL.Image
 
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Type
+from oumi.core.types.tool_call import FunctionCall
 from oumi.utils.image_utils import (
     DEFAULT_IMAGE_MODE,
     load_image_png_bytes_from_path,
@@ -294,6 +295,51 @@ def create_list_of_message_json_dicts(
         result.append(item)
 
     return result
+
+
+def create_chat_template_inputs(
+    conversation: Conversation,
+    *,
+    tool_arguments_format: Literal["mapping", "string"],
+    content_format: Literal["null", "empty"],
+) -> tuple[list[dict], list[dict] | None]:
+    """Returns ``(messages, tools)`` shaped for ``tokenizer.apply_chat_template``.
+
+    Adapts the Oumi ``Conversation`` wire format to the form HuggingFace chat
+    templates expect. This is one-directional — nothing parses rendered text
+    back into a ``Conversation``.
+
+    Args:
+        conversation: The source conversation.
+        tool_arguments_format: How ``function.arguments`` should appear in the output.
+            ``"mapping"`` decodes JSON strings to dicts (required by most
+            templates); ``"string"`` leaves them as JSON strings.
+        content_format: How ``content`` on assistant messages that carry
+            only tool_calls should appear. ``"null"`` keeps ``None``;
+            ``"empty"`` coerces to ``""``.
+    """
+    data = conversation.to_dict()
+    messages = data["messages"]
+
+    for msg_idx, msg_dict in enumerate(messages):
+        tool_calls = msg_dict.get("tool_calls")
+        if not tool_calls:
+            continue
+
+        if tool_arguments_format == "mapping":
+            for tool_call in tool_calls:
+                function = tool_call["function"]
+                try:
+                    function["arguments"] = FunctionCall.model_validate(
+                        function
+                    ).parsed_arguments()
+                except ValueError as e:
+                    raise ValueError(f"Message {msg_idx}: {e}") from e
+
+        if content_format == "empty" and msg_dict.get("content") is None:
+            msg_dict["content"] = ""
+
+    return messages, data.get("tools")
 
 
 def remove_excessive_images(

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -332,7 +332,7 @@ def create_chat_template_inputs(
                 try:
                     function["arguments"] = FunctionCall.model_validate(
                         function
-                    ).parsed_arguments()
+                    ).get_arguments_dict()
                 except ValueError as e:
                     raise ValueError(f"Message {msg_idx}: {e}") from e
 

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import json
 
 import pytest
 import transformers
@@ -44,6 +43,7 @@ from oumi.utils.canonical_tool_conversations import (
     USER_TEXT_2,
     canonical_tool_conversation,
 )
+from oumi.utils.conversation_utils import create_chat_template_inputs
 from oumi.utils.packaging import is_transformers_v5
 from tests.markers import requires_hf_token
 
@@ -265,24 +265,9 @@ def test_template_detection_newer_transformers(
 
 def _template_inputs(conversation: Conversation):
     """Messages/tools shaped for templates that require mapping arguments."""
-    data = conversation.to_dict()
-    messages = []
-    for message in data["messages"]:
-        message = dict(message)
-        if message.get("tool_calls"):
-            message["content"] = message.get("content") or ""
-            message["tool_calls"] = [
-                {
-                    **call,
-                    "function": {
-                        **call["function"],
-                        "arguments": json.loads(call["function"]["arguments"]),
-                    },
-                }
-                for call in message["tool_calls"]
-            ]
-        messages.append(message)
-    return messages, data.get("tools")
+    return create_chat_template_inputs(
+        conversation, tool_arguments_format="mapping", content_format="empty"
+    )
 
 
 def _build_collator(tokenizer, model_name: str):

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -15,7 +15,7 @@ from oumi.core.types.tool_call import (
     FunctionCall,
     ToolCall,
 )
-from oumi.core.types.tool_conversations import (
+from oumi.utils.canonical_tool_conversations import (
     ARGUMENT_SENTINEL,
     FIRST_TOOL_CALL_INDEX,
     canonical_tool_conversation,

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -11,11 +11,20 @@ from oumi.builders import build_tokenizer
 from oumi.core.configs import ModelParams
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Role, Type
-from oumi.core.types.tool_call import ToolCall
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    ToolCall,
+)
+from oumi.core.types.tool_conversations import (
+    ARGUMENT_SENTINEL,
+    FIRST_TOOL_CALL_INDEX,
+    canonical_tool_conversation,
+)
 from oumi.utils.conversation_utils import (
     base64encode_content_item_image_bytes,
     convert_message_to_json_content,
     convert_message_to_json_content_list,
+    create_chat_template_inputs,
     create_list_of_message_json_dicts,
     load_image_bytes_to_content_item,
     load_pil_image_from_content_item,
@@ -881,6 +890,94 @@ def test_create_list_of_message_json_dicts_no_tool_keys_when_unset():
     for d in result:
         assert "tool_calls" not in d
         assert "tool_call_id" not in d
+
+
+# -----------------------------------------------------------------------------
+# create_chat_template_inputs
+# -----------------------------------------------------------------------------
+
+
+def test_create_chat_template_inputs_mapping_arguments():
+    """tool_arguments_format='mapping' decodes arguments to a dict."""
+    conv = canonical_tool_conversation()
+    messages, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    tc = messages[FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert tc["function"]["arguments"] == {"city": ARGUMENT_SENTINEL}
+    assert isinstance(tc["function"]["arguments"], dict)
+
+
+def test_create_chat_template_inputs_string_arguments():
+    """tool_arguments_format='string' keeps arguments as a JSON string."""
+    conv = canonical_tool_conversation()
+    messages, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="string", content_format="null"
+    )
+    tc = messages[FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert tc["function"]["arguments"] == f'{{"city": "{ARGUMENT_SENTINEL}"}}'
+    assert isinstance(tc["function"]["arguments"], str)
+
+
+def test_create_chat_template_inputs_null_content():
+    """content_format='null' preserves None content on tool-call messages."""
+    conv = canonical_tool_conversation()
+    messages, _ = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert messages[FIRST_TOOL_CALL_INDEX]["content"] is None
+
+
+def test_create_chat_template_inputs_empty_content():
+    """content_format='empty' coerces None content to empty string."""
+    conv = canonical_tool_conversation()
+    messages, _ = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="empty"
+    )
+    assert messages[FIRST_TOOL_CALL_INDEX]["content"] == ""
+
+
+def test_create_chat_template_inputs_returns_tools():
+    """The tools list is forwarded from the conversation."""
+    conv = canonical_tool_conversation()
+    _, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert tools is not None
+    assert len(tools) == 2
+    assert tools[0]["function"]["name"] == "get_weather"
+
+
+def test_create_chat_template_inputs_no_tools_returns_none():
+    """Conversations without tools return tools=None."""
+    conv = Conversation(messages=[Message(role=Role.USER, content="hi")])
+    _, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert tools is None
+
+
+def test_create_chat_template_inputs_bad_json_names_message_index():
+    """Malformed JSON arguments raise ValueError naming the message index."""
+    conv = Conversation(
+        messages=[
+            Message(role=Role.USER, content="hi"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="call_bad",
+                        function=FunctionCall(name="fn", arguments="{bad json"),
+                    )
+                ],
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="Message 1"):
+        create_chat_template_inputs(
+            conv, tool_arguments_format="mapping", content_format="null"
+        )
 
 
 #


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
HuggingFace chat templates do not agree on the shape of a tool call. Some iterate `function.arguments` as a mapping and raise on a string (eg Gemma 4), others concatenate it as a string and raise on a mapping (eg Deepseek). 

`content` is the same story: some stringify `None` into the text they train on, others drop the whole tool call when it is `""`.

`Conversation.to_dict()` only emit tool calls as string, so a caller that needed tool calls in a different format need to adapt it themselves. `create_chat_template_inputs(conversation, *, tool_arguments_format, content_format)` takes an Oumi Conversation and returns (messages, tools). Specifically, it also converts the tool call arguments to the format that the caller expects (string or dict types). Malformed JSON arguments raise with the offending message index.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
