### PR TITLE
Fill tool-call `type` for samples that don't specify

### DIFF
--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import base64
-from typing import Any
+from typing import Any, Literal
 
 import PIL.Image
 
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Type
+from oumi.core.types.tool_call import FunctionCall
 from oumi.utils.image_utils import (
     DEFAULT_IMAGE_MODE,
     load_image_png_bytes_from_path,
@@ -294,6 +295,51 @@ def create_list_of_message_json_dicts(
         result.append(item)
 
     return result
+
+
+def create_chat_template_inputs(
+    conversation: Conversation,
+    *,
+    tool_arguments_format: Literal["mapping", "string"],
+    content_format: Literal["null", "empty"],
+) -> tuple[list[dict], list[dict] | None]:
+    """Returns ``(messages, tools)`` shaped for ``tokenizer.apply_chat_template``.
+
+    Adapts the Oumi ``Conversation`` wire format to the form HuggingFace chat
+    templates expect. This is one-directional — nothing parses rendered text
+    back into a ``Conversation``.
+
+    Args:
+        conversation: The source conversation.
+        tool_arguments_format: How ``function.arguments`` should appear in the output.
+            ``"mapping"`` decodes JSON strings to dicts (required by most
+            templates); ``"string"`` leaves them as JSON strings.
+        content_format: How ``content`` on assistant messages that carry
+            only tool_calls should appear. ``"null"`` keeps ``None``;
+            ``"empty"`` coerces to ``""``.
+    """
+    data = conversation.to_dict()
+    messages = data["messages"]
+
+    for msg_idx, msg_dict in enumerate(messages):
+        tool_calls = msg_dict.get("tool_calls")
+        if not tool_calls:
+            continue
+
+        if tool_arguments_format == "mapping":
+            for tool_call in tool_calls:
+                function = tool_call["function"]
+                try:
+                    function["arguments"] = FunctionCall.model_validate(
+                        function
+                    ).parsed_arguments()
+                except ValueError as e:
+                    raise ValueError(f"Message {msg_idx}: {e}") from e
+
+        if content_format == "empty" and msg_dict.get("content") is None:
+            msg_dict["content"] = ""
+
+    return messages, data.get("tools")
 
 
 def remove_excessive_images(

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -332,7 +332,7 @@ def create_chat_template_inputs(
                 try:
                     function["arguments"] = FunctionCall.model_validate(
                         function
-                    ).parsed_arguments()
+                    ).get_arguments_dict()
                 except ValueError as e:
                     raise ValueError(f"Message {msg_idx}: {e}") from e
 

--- a/src/oumi/utils/conversation_utils.py
+++ b/src/oumi/utils/conversation_utils.py
@@ -326,20 +326,48 @@ def create_chat_template_inputs(
         if not tool_calls:
             continue
 
-        if tool_arguments_format == "mapping":
-            for tool_call in tool_calls:
-                function = tool_call["function"]
-                try:
-                    function["arguments"] = FunctionCall.model_validate(
-                        function
-                    ).get_arguments_dict()
-                except ValueError as e:
-                    raise ValueError(f"Message {msg_idx}: {e}") from e
+        for tool_call in tool_calls:
+            _restore_default_type(tool_call)
+            if tool_arguments_format != "mapping":
+                continue
+            function = tool_call["function"]
+            try:
+                function["arguments"] = FunctionCall.model_validate(
+                    function
+                ).get_arguments_dict()
+            except ValueError as e:
+                raise ValueError(f"Message {msg_idx}: {e}") from e
 
         if content_format == "empty" and msg_dict.get("content") is None:
             msg_dict["content"] = ""
 
-    return messages, data.get("tools")
+    tools = data.get("tools")
+    for tool in tools or []:
+        _restore_default_type(tool)
+
+    return messages, tools
+
+
+def _restore_default_type(entry: dict) -> None:
+    """Re-adds ``type: "function"`` when it was left at its default.
+
+    ``Conversation.to_dict()`` dumps with ``exclude_unset=True``, so a
+    ``ToolCall`` or ``ToolDefinition`` built in code -- rather than parsed from
+    OpenAI-format JSON, which always spells ``type`` out -- loses the key
+    entirely. Templates read it directly: DeepSeek-V3 renders ``tool['type']``
+    and raises ``UndefinedError`` without it, so a programmatically built tool
+    conversation cannot be rendered for that model at all.
+
+    Only entries that actually carry a ``function`` get the key, and only when
+    it is missing, so an explicit value passes through and an entry of some
+    future non-function tool type is not mislabelled as one.
+
+    Scoped to this adapter rather than fixed in ``to_dict()``: that output also
+    feeds the inference engines, JSONL serialization, synthesis and analysis,
+    and rendering is the only place the missing key breaks anything.
+    """
+    if "function" in entry:
+        entry.setdefault("type", "function")
 
 
 def remove_excessive_images(

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -33,8 +33,10 @@ from oumi.core.configs import (
 from oumi.core.constants import LABEL_IGNORE_INDEX
 from oumi.core.types import Conversation
 from oumi.utils.canonical_tool_conversations import (
+    ARGUMENT_SENTINEL,
     ASSISTANT_TEXT_1,
     ASSISTANT_TEXT_2,
+    FIRST_TOOL_CALL_INDEX,
     SYSTEM_TEXT,
     TOOL_RESULT_1,
     TOOL_RESULT_2,
@@ -464,3 +466,35 @@ def test_bracket_forced_onto_a_separate_turn_model_changes_nothing():
     ), "expected <tool_response> to appear in the rendered conversation"
 
     assert _labels(forced, input_ids) == _labels(baseline, input_ids)
+
+
+#
+# Restoring a `type` that `to_dict()` left out.
+#
+
+
+def test_deepseek_renders_a_conversation_whose_tool_calls_omit_type():
+    """DeepSeek reads `type` directly off each tool call and tool definition.
+
+    `Conversation.to_dict()` dumps with `exclude_unset=True`, so a conversation
+    built in code drops the key. Without the adapter restoring it, this model
+    raises `UndefinedError` and the conversation cannot be rendered at all.
+    """
+    tokenizer = _load_tokenizer("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+    conversation = canonical_tool_conversation()
+
+    # Not a vacuous test: the key really is absent on the wire format.
+    raw = conversation.to_dict()
+    assert "type" not in raw["messages"][FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert "type" not in raw["tools"][0]
+
+    messages, tools = create_chat_template_inputs(
+        conversation, tool_arguments_format="string", content_format="null"
+    )
+    rendered = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        tools=tools,  # type: ignore[arg-type]
+    )
+
+    assert ARGUMENT_SENTINEL in rendered

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import json
 
 import pytest
 import transformers
@@ -44,6 +43,7 @@ from oumi.utils.canonical_tool_conversations import (
     USER_TEXT_2,
     canonical_tool_conversation,
 )
+from oumi.utils.conversation_utils import create_chat_template_inputs
 from oumi.utils.packaging import is_transformers_v5
 from tests.markers import requires_hf_token
 
@@ -265,24 +265,9 @@ def test_template_detection_newer_transformers(
 
 def _template_inputs(conversation: Conversation):
     """Messages/tools shaped for templates that require mapping arguments."""
-    data = conversation.to_dict()
-    messages = []
-    for message in data["messages"]:
-        message = dict(message)
-        if message.get("tool_calls"):
-            message["content"] = message.get("content") or ""
-            message["tool_calls"] = [
-                {
-                    **call,
-                    "function": {
-                        **call["function"],
-                        "arguments": json.loads(call["function"]["arguments"]),
-                    },
-                }
-                for call in message["tool_calls"]
-            ]
-        messages.append(message)
-    return messages, data.get("tools")
+    return create_chat_template_inputs(
+        conversation, tool_arguments_format="mapping", content_format="empty"
+    )
 
 
 def _build_collator(tokenizer, model_name: str):

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -15,7 +15,7 @@ from oumi.core.types.tool_call import (
     FunctionCall,
     ToolCall,
 )
-from oumi.core.types.tool_conversations import (
+from oumi.utils.canonical_tool_conversations import (
     ARGUMENT_SENTINEL,
     FIRST_TOOL_CALL_INDEX,
     canonical_tool_conversation,

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -11,11 +11,20 @@ from oumi.builders import build_tokenizer
 from oumi.core.configs import ModelParams
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.types.conversation import ContentItem, Conversation, Message, Role, Type
-from oumi.core.types.tool_call import ToolCall
+from oumi.core.types.tool_call import (
+    FunctionCall,
+    ToolCall,
+)
+from oumi.core.types.tool_conversations import (
+    ARGUMENT_SENTINEL,
+    FIRST_TOOL_CALL_INDEX,
+    canonical_tool_conversation,
+)
 from oumi.utils.conversation_utils import (
     base64encode_content_item_image_bytes,
     convert_message_to_json_content,
     convert_message_to_json_content_list,
+    create_chat_template_inputs,
     create_list_of_message_json_dicts,
     load_image_bytes_to_content_item,
     load_pil_image_from_content_item,
@@ -881,6 +890,94 @@ def test_create_list_of_message_json_dicts_no_tool_keys_when_unset():
     for d in result:
         assert "tool_calls" not in d
         assert "tool_call_id" not in d
+
+
+# -----------------------------------------------------------------------------
+# create_chat_template_inputs
+# -----------------------------------------------------------------------------
+
+
+def test_create_chat_template_inputs_mapping_arguments():
+    """tool_arguments_format='mapping' decodes arguments to a dict."""
+    conv = canonical_tool_conversation()
+    messages, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    tc = messages[FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert tc["function"]["arguments"] == {"city": ARGUMENT_SENTINEL}
+    assert isinstance(tc["function"]["arguments"], dict)
+
+
+def test_create_chat_template_inputs_string_arguments():
+    """tool_arguments_format='string' keeps arguments as a JSON string."""
+    conv = canonical_tool_conversation()
+    messages, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="string", content_format="null"
+    )
+    tc = messages[FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert tc["function"]["arguments"] == f'{{"city": "{ARGUMENT_SENTINEL}"}}'
+    assert isinstance(tc["function"]["arguments"], str)
+
+
+def test_create_chat_template_inputs_null_content():
+    """content_format='null' preserves None content on tool-call messages."""
+    conv = canonical_tool_conversation()
+    messages, _ = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert messages[FIRST_TOOL_CALL_INDEX]["content"] is None
+
+
+def test_create_chat_template_inputs_empty_content():
+    """content_format='empty' coerces None content to empty string."""
+    conv = canonical_tool_conversation()
+    messages, _ = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="empty"
+    )
+    assert messages[FIRST_TOOL_CALL_INDEX]["content"] == ""
+
+
+def test_create_chat_template_inputs_returns_tools():
+    """The tools list is forwarded from the conversation."""
+    conv = canonical_tool_conversation()
+    _, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert tools is not None
+    assert len(tools) == 2
+    assert tools[0]["function"]["name"] == "get_weather"
+
+
+def test_create_chat_template_inputs_no_tools_returns_none():
+    """Conversations without tools return tools=None."""
+    conv = Conversation(messages=[Message(role=Role.USER, content="hi")])
+    _, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+    assert tools is None
+
+
+def test_create_chat_template_inputs_bad_json_names_message_index():
+    """Malformed JSON arguments raise ValueError naming the message index."""
+    conv = Conversation(
+        messages=[
+            Message(role=Role.USER, content="hi"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="call_bad",
+                        function=FunctionCall(name="fn", arguments="{bad json"),
+                    )
+                ],
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="Message 1"):
+        create_chat_template_inputs(
+            conv, tool_arguments_format="mapping", content_format="null"
+        )
 
 
 #

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -21,6 +21,7 @@ from oumi.utils.canonical_tool_conversations import (
     canonical_tool_conversation,
 )
 from oumi.utils.conversation_utils import (
+    _restore_default_type,
     base64encode_content_item_image_bytes,
     convert_message_to_json_content,
     convert_message_to_json_content_list,
@@ -978,6 +979,80 @@ def test_create_chat_template_inputs_bad_json_names_message_index():
         create_chat_template_inputs(
             conv, tool_arguments_format="mapping", content_format="null"
         )
+
+
+# -----------------------------------------------------------------------------
+# create_chat_template_inputs: restoring a defaulted `type`
+# -----------------------------------------------------------------------------
+
+
+def test_create_chat_template_inputs_restores_tool_call_type():
+    """`exclude_unset` drops a defaulted `type`; templates read it directly.
+
+    The canonical conversation builds its tool calls without an explicit
+    `type`, which is what a conversation built in code rather than parsed from
+    OpenAI-format JSON looks like.
+    """
+    conv = canonical_tool_conversation()
+    raw = conv.to_dict()["messages"][FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert "type" not in raw
+
+    messages, _ = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+
+    restored = messages[FIRST_TOOL_CALL_INDEX]["tool_calls"]
+    assert [call["type"] for call in restored] == ["function", "function"]
+
+
+def test_create_chat_template_inputs_restores_tool_definition_type():
+    """Tool definitions lose a defaulted `type` by the same mechanism."""
+    conv = canonical_tool_conversation()
+    assert "type" not in conv.to_dict()["tools"][0]
+
+    _, tools = create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="null"
+    )
+
+    assert tools is not None
+    assert [tool["type"] for tool in tools] == ["function", "function"]
+
+
+def test_restore_default_type_leaves_an_explicit_type_alone():
+    """Only a missing key is filled; an explicit value passes through."""
+    entry = {"type": "custom_tool", "function": {"name": "f"}}
+
+    _restore_default_type(entry)
+
+    assert entry["type"] == "custom_tool"
+
+
+def test_restore_default_type_ignores_entries_without_a_function():
+    """A future non-function tool type must not be mislabelled as one."""
+    entry: dict = {"custom": {"name": "f"}}
+
+    _restore_default_type(entry)
+
+    assert "type" not in entry
+
+
+def test_create_chat_template_inputs_does_not_mutate_the_conversation():
+    """The adapter works on `to_dict()` output, which is a fresh copy."""
+    conv = canonical_tool_conversation()
+    message = conv.messages[FIRST_TOOL_CALL_INDEX]
+
+    create_chat_template_inputs(
+        conv, tool_arguments_format="mapping", content_format="empty"
+    )
+
+    assert message.content is None
+    assert message.tool_calls is not None
+    assert message.tool_calls[0].function.arguments == (
+        f'{{"city": "{ARGUMENT_SENTINEL}"}}'
+    )
+    assert (
+        "type" not in conv.to_dict()["messages"][FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    )
 
 
 #


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
`ToolCall.type` is not a parameter that every provider and model chat template expects or sets. Considered making it mandatory in our code but since it is not canonical to all providers across all workflows, there could be heterogeneity in inference or synthesis outputs hence we leave as optional in the core data type. 

`Conversation.to_dict()` dumps with `exclude_unset=True`, so a entries with unset `ToolCall.type` loses the key entirely. Some chat templates like Deepseek require this field, without it, it raises `UndefinedError: 'dict object' has no attribute 'type'`. To make training consistent, we add a `ToolCall.type` param for those samples with tool calls but leave`ToolCall.type` unset. This is in line with how a huggingface util implements formatting of json tool calls (https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205). This is explicitly scoped to training only rather than fixed in `to_dict()` or with a model validator so that it does not affect other workflows
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
