### PR TITLE
Detect the tool-call form a chat template accepts

### DIFF
--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -249,16 +249,11 @@ class BaseSftDataset(BaseMapDataset, ABC):
                 instruction_token_ids=self.instruction_token_ids,
             )
 
-    def _tokenize(
-        self, sample: dict | pd.Series | Conversation, tokenize: bool = True
-    ) -> dict:
+    def _tokenize(self, sample: Conversation, tokenize: bool = True) -> dict:
         if self._tokenizer is None:
             raise ValueError("Tokenizer is required for tokenization.")
 
-        chat_input: dict | pd.Series | Conversation | list[dict] = sample
-        tools = None
-        if isinstance(sample, Conversation):
-            chat_input, tools = apply_chat_template_inputs(self._tokenizer, sample)
+        chat_input, tools = apply_chat_template_inputs(self._tokenizer, sample)
 
         results = self._tokenizer.apply_chat_template(
             chat_input,  # type: ignore

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -22,6 +22,7 @@ from typing_extensions import override
 from oumi.core.datasets.base_map_dataset import BaseMapDataset
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.tokenizers.utils import (
+    apply_chat_template_inputs,
     tokenize_for_completions_only_training_with_prefix,
     tokenize_for_completions_only_training_with_template,
 )
@@ -254,14 +255,20 @@ class BaseSftDataset(BaseMapDataset, ABC):
         if self._tokenizer is None:
             raise ValueError("Tokenizer is required for tokenization.")
 
+        chat_input: dict | pd.Series | Conversation | list[dict] = sample
+        tools = None
+        if isinstance(sample, Conversation):
+            chat_input, tools = apply_chat_template_inputs(self._tokenizer, sample)
+
         results = self._tokenizer.apply_chat_template(
-            sample,  # type: ignore
+            chat_input,  # type: ignore
             tokenize=tokenize,
             return_dict=tokenize,
             return_tensors=self._return_tensors,
             max_length=self._tokenizer.model_max_length,
             truncation=True,
             add_generation_prompt=(self.task == "generation"),
+            tools=tools,  # type: ignore[arg-type]
         )
 
         if tokenize:

--- a/src/oumi/core/tokenizers/utils.py
+++ b/src/oumi/core/tokenizers/utils.py
@@ -21,7 +21,7 @@ import transformers
 
 from oumi.core.constants import LABEL_IGNORE_INDEX
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
-from oumi.core.types import Conversation
+from oumi.core.types import Conversation, Role
 from oumi.utils.canonical_tool_conversations import (
     ARGUMENT_SENTINEL,
     canonical_tool_conversation,
@@ -34,7 +34,19 @@ class ChatTemplateToolFormat(NamedTuple):
     """The form a chat template expects tool-call data in."""
 
     arguments: Literal["mapping", "string"]
+    """Shape of ``function.arguments`` on rendered tool calls.
+
+    ``"mapping"`` decodes the stored JSON string into a dict before rendering,
+    which most templates require; ``"string"`` passes the JSON string through
+    unchanged, for templates that double-encode dicts (e.g. Qwen2.5).
+    """
+
     content: Literal["null", "empty"]
+    """Value of ``content`` on assistant messages that only carry tool calls.
+
+    ``"null"`` keeps ``None``; ``"empty"`` coerces it to ``""``, for templates
+    that stringify ``None`` into a literal ``"None"`` (e.g. GLM-4.5).
+    """
 
 
 # Candidate payload shapes, in preference order. The first that renders cleanly wins.
@@ -127,7 +139,9 @@ def detect_chat_template_tool_format(
     (arguments x content) combinations and returns the first that renders
     cleanly. Deterministic tie-break prefers ``("mapping", "empty")``.
 
-    Cached per tokenizer — cost is at most 4 string renders, once.
+    Cached per tokenizer — cost is at most 4 string renders, once. The cache
+    also means the fallback warning fires once, at the moment the first
+    tool-carrying record is rendered.
 
     Args:
         tokenizer: The tokenizer whose chat template is probed.
@@ -145,12 +159,40 @@ def detect_chat_template_tool_format(
             return candidate
 
     logger.warning(
-        "No tool-call form rendered correctly for %r; falling back to %r. "
-        "Tool calls may not render as expected.",
+        "No tool-call form rendered correctly for %r: its chat template "
+        "rejected or corrupted every candidate in %r. Tool calls in this data "
+        "will be rendered with the fallback form %r and may not match how the "
+        "model is expected to emit them (dropped, double-encoded, or "
+        "reformatted). Under the fallback form, %s\nChat template:\n%s",
         getattr(tokenizer, "name_or_path", None) or "<unknown>",
+        [tuple(c) for c in _CANDIDATE_FORMATS],
         tuple(_FALLBACK_FORMAT),
+        _describe_fallback_rendering(tokenizer),
+        getattr(tokenizer, "chat_template", None) or "<none>",
     )
     return _FALLBACK_FORMAT
+
+
+def _describe_fallback_rendering(tokenizer: BaseTokenizer) -> str:
+    """Shows what the canonical record becomes under the fallback form.
+
+    The rendered text — or the exception the template raises — is the evidence
+    a reader needs to judge whether the fallback output is usable for training.
+    """
+    messages, tools = create_chat_template_inputs(
+        canonical_tool_conversation(),
+        tool_arguments_format=_FALLBACK_FORMAT.arguments,
+        content_format=_FALLBACK_FORMAT.content,
+    )
+    try:
+        rendered = tokenizer.apply_chat_template(
+            messages,  # type: ignore
+            tokenize=False,
+            tools=tools,  # type: ignore[arg-type]
+        )
+    except Exception as e:
+        return f"rendering the canonical example record raises {type(e).__name__}: {e}"
+    return f"the canonical example record renders as:\n{rendered}"
 
 
 def apply_chat_template_inputs(
@@ -158,10 +200,13 @@ def apply_chat_template_inputs(
 ) -> tuple[Conversation | list[dict], list[dict] | None]:
     """Returns the ``(conversation, tools)`` pair to hand ``apply_chat_template``.
 
-    A conversation without tools is returned untouched, so that path is
-    unchanged and never pays for a probe.
+    A conversation with neither tool definitions nor tool calls is returned
+    untouched, so that path is unchanged and never pays for a probe.
     """
-    if not conversation.tools:
+    has_tool_calls = any(
+        m.tool_calls for m in conversation.messages if m.role == Role.ASSISTANT
+    )
+    if not conversation.tools and not has_tool_calls:
         return conversation, None
 
     fmt = detect_chat_template_tool_format(tokenizer)

--- a/src/oumi/core/tokenizers/utils.py
+++ b/src/oumi/core/tokenizers/utils.py
@@ -13,13 +13,163 @@
 # limitations under the License.
 
 
+import functools
+from typing import Literal, NamedTuple
+
 import numpy as np
 import transformers
 
 from oumi.core.constants import LABEL_IGNORE_INDEX
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
 from oumi.core.types import Conversation
+from oumi.utils.canonical_tool_conversations import (
+    ARGUMENT_SENTINEL,
+    canonical_tool_conversation,
+)
+from oumi.utils.conversation_utils import create_chat_template_inputs
 from oumi.utils.logging import logger
+
+
+class ChatTemplateToolFormat(NamedTuple):
+    """The form a chat template expects tool-call data in."""
+
+    arguments: Literal["mapping", "string"]
+    content: Literal["null", "empty"]
+
+
+# Candidate payload shapes, in preference order. The first that renders cleanly wins.
+#
+# Note: `content: ""` is preferred over `None` because a template that interpolates
+# `content` unconditionally renders `""` as nothing, but stringifies `None` into
+# the literal text "None". GLM-4.5 does exactly this, injecting a stray `None`
+# line before every tool call. Where `""` is instead the worse choice --
+# DeepSeek-V3 drops the tool call entirely -- it is *detectably* worse, so the
+# scan moves on and still resolves ("string", "null").
+_CANDIDATE_FORMATS: tuple[ChatTemplateToolFormat, ...] = (
+    ChatTemplateToolFormat(arguments="mapping", content="empty"),
+    ChatTemplateToolFormat(arguments="mapping", content="null"),
+    ChatTemplateToolFormat(arguments="string", content="empty"),
+    ChatTemplateToolFormat(arguments="string", content="null"),
+)
+
+# Used when no candidate renders; see `detect_chat_template_tool_format`.
+_FALLBACK_FORMAT = _CANDIDATE_FORMATS[0]
+
+
+def _probe_renders_sentinel(
+    tokenizer: BaseTokenizer,
+    *,
+    arguments_form: Literal["mapping", "string"],
+    content_form: Literal["null", "empty"],
+) -> bool | None:
+    """Render the canonical tool call and check whether the sentinel survives.
+
+    Detection is limited to the sentinel's presence and its escaping. Structural
+    validation is not possible because templates share no common format:
+
+        gemma-4   <|tool_call>call:get_weather{city:<|"|><sentinel><|"|>}<tool_call|>
+        GLM-4.5   <tool_call>get_weather<arg_key>city</arg_key>
+                  <arg_value><sentinel></arg_value></tool_call>
+        Qwen3.5   <tool_call><function=get_weather><parameter=city>
+                  <sentinel></parameter></function>
+
+    So a template that mangles the output around the sentinel, while preserving
+    the sentinel itself, is not detected here.
+
+    Args:
+        tokenizer: The tokenizer whose chat template is rendered. Not modified.
+        arguments_form: The shape to give ``function.arguments``. ``"mapping"``
+            decodes the stored JSON string to a dict; ``"string"`` leaves it.
+        content_form: The value to give ``content`` on the tool-call message.
+            ``"null"`` keeps ``None``; ``"empty"`` uses ``""``.
+
+    Returns:
+        True if the sentinel rendered verbatim, meaning this form is usable.
+        False if the template silently dropped the tool call, or double-encoded
+        the arguments so the value arrived escaped.
+        None if the template raised, meaning it rejects this form outright.
+    """
+    messages, tools = create_chat_template_inputs(
+        canonical_tool_conversation(),
+        tool_arguments_format=arguments_form,
+        content_format=content_form,
+    )
+
+    try:
+        rendered: str = tokenizer.apply_chat_template(
+            messages,  # type: ignore
+            tokenize=False,
+            tools=tools,  # type: ignore[arg-type]
+        )
+    except Exception:
+        return None
+
+    # The template dropped the tool call without complaining.
+    if ARGUMENT_SENTINEL not in rendered:
+        return False
+
+    # An escaped quote beside the value means the template JSON-encoded
+    # arguments that were already a JSON string, so the model would train on
+    # `"{\"city\": \"<sentinel>\"}"` where an object belongs.
+    if f'\\"{ARGUMENT_SENTINEL}' in rendered or f'{ARGUMENT_SENTINEL}\\"' in rendered:
+        return False
+
+    return True
+
+
+@functools.cache
+def detect_chat_template_tool_format(
+    tokenizer: BaseTokenizer,
+) -> ChatTemplateToolFormat:
+    """Probe the tokenizer's chat template to find the accepted tool-call form.
+
+    Renders a canonical tool call with a sentinel value across the four
+    (arguments x content) combinations and returns the first that renders
+    cleanly. Deterministic tie-break prefers ``("mapping", "empty")``.
+
+    Cached per tokenizer — cost is at most 4 string renders, once.
+
+    Args:
+        tokenizer: The tokenizer whose chat template is probed.
+
+    Returns:
+        The first form that rendered cleanly, or ``("mapping", "empty")`` with a
+        warning logged when no form did.
+    """
+    for candidate in _CANDIDATE_FORMATS:
+        if _probe_renders_sentinel(
+            tokenizer,
+            arguments_form=candidate.arguments,
+            content_form=candidate.content,
+        ):
+            return candidate
+
+    logger.warning(
+        "No tool-call form rendered correctly for %r; falling back to %r. "
+        "Tool calls may not render as expected.",
+        getattr(tokenizer, "name_or_path", None) or "<unknown>",
+        tuple(_FALLBACK_FORMAT),
+    )
+    return _FALLBACK_FORMAT
+
+
+def apply_chat_template_inputs(
+    tokenizer: BaseTokenizer, conversation: Conversation
+) -> tuple[Conversation | list[dict], list[dict] | None]:
+    """Returns the ``(conversation, tools)`` pair to hand ``apply_chat_template``.
+
+    A conversation without tools is returned untouched, so that path is
+    unchanged and never pays for a probe.
+    """
+    if not conversation.tools:
+        return conversation, None
+
+    fmt = detect_chat_template_tool_format(tokenizer)
+    return create_chat_template_inputs(
+        conversation,
+        tool_arguments_format=fmt.arguments,
+        content_format=fmt.content,
+    )
 
 
 #
@@ -29,11 +179,14 @@ def tokenize_for_completions_only_training_with_template(
     tokenizer: BaseTokenizer, conversation: Conversation
 ) -> dict:
     """Tokenize a conversation for completions-only training with a template."""
+    chat_input, tools = apply_chat_template_inputs(tokenizer, conversation)
+
     batch: transformers.BatchEncoding = tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+        conversation=chat_input,  # type: ignore
         tokenize=True,
         return_dict=True,
         return_assistant_tokens_mask=True,
+        tools=tools,  # type: ignore[arg-type]
     )
 
     data = batch.data
@@ -57,11 +210,14 @@ def tokenize_for_completions_only_training_with_prefix(
     instruction_token_ids: list[int],
 ) -> dict:
     """Tokenize a conversation for completions-only training with a prefix."""
+    chat_input, tools = apply_chat_template_inputs(tokenizer, conversation)
+
     prompt: str = tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+        conversation=chat_input,  # type: ignore
         tokenize=False,
         return_dict=False,
         return_assistant_tokens_mask=False,
+        tools=tools,  # type: ignore[arg-type]
     )
     tokenizer_batch: transformers.BatchEncoding = tokenizer(
         prompt, truncation=True, padding=False, return_tensors="pt"
@@ -241,8 +397,11 @@ def tokenizer_for_inference(
     tokenizer: BaseTokenizer, conversation: Conversation
 ) -> dict:
     """Tokenize a conversation for inference."""
+    chat_input, tools = apply_chat_template_inputs(tokenizer, conversation)
+
     return tokenizer.apply_chat_template(
-        conversation=conversation,  # type: ignore
+        conversation=chat_input,  # type: ignore
         tokenize=True,
         return_dict=True,
+        tools=tools,  # type: ignore[arg-type]
     )

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -34,6 +34,7 @@ from oumi.core.configs import (
 from oumi.core.constants import LABEL_IGNORE_INDEX
 from oumi.core.tokenizers.utils import (
     _probe_renders_sentinel,
+    apply_chat_template_inputs,
     detect_chat_template_tool_format,
 )
 from oumi.core.types import Conversation
@@ -682,6 +683,32 @@ def test_template_with_no_working_form_falls_back_and_warns():
 
     assert tuple(resolved) == ("mapping", "empty")
     mock_logger.warning.assert_called_once()
+
+
+def test_tool_calls_without_tool_definitions_still_get_shaped():
+    """Messages can carry `tool_calls` while the top-level `tools` list is unset.
+
+    Such a conversation must still go through format detection and the
+    chat-template adapter — gating on `conversation.tools` alone would hand the
+    raw wire form to the template, hitting the exact double-encode and
+    missing-`type` failures the probe exists to catch.
+    """
+    tokenizer = _load_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
+    conversation = canonical_tool_conversation().model_copy(update={"tools": None})
+
+    chat_input, tools = apply_chat_template_inputs(tokenizer, conversation)
+
+    assert tools is None
+    assert isinstance(chat_input, list)
+    tool_call = chat_input[FIRST_TOOL_CALL_INDEX]["tool_calls"][0]
+    assert tool_call["type"] == "function"
+    fmt = detect_chat_template_tool_format(tokenizer)
+    if fmt.arguments == "mapping":
+        assert isinstance(tool_call["function"]["arguments"], dict)
+
+    rendered = tokenizer.apply_chat_template(chat_input, tokenize=False, tools=tools)
+    assert ARGUMENT_SENTINEL in rendered
+    assert f'\\"{ARGUMENT_SENTINEL}' not in rendered
 
 
 def test_glm_does_not_render_a_literal_none_for_null_content():

--- a/tests/integration/builders/test_collator_template_detection.py
+++ b/tests/integration/builders/test_collator_template_detection.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+from unittest.mock import patch
 
 import pytest
 import transformers
@@ -31,6 +32,10 @@ from oumi.core.configs import (
     TrainTarget,
 )
 from oumi.core.constants import LABEL_IGNORE_INDEX
+from oumi.core.tokenizers.utils import (
+    _probe_renders_sentinel,
+    detect_chat_template_tool_format,
+)
 from oumi.core.types import Conversation
 from oumi.utils.canonical_tool_conversations import (
     ARGUMENT_SENTINEL,
@@ -498,3 +503,204 @@ def test_deepseek_renders_a_conversation_whose_tool_calls_omit_type():
     )
 
     assert ARGUMENT_SENTINEL in rendered
+
+
+#
+# Tool-format detection against the shipped templates.
+#
+
+
+@pytest.mark.parametrize(
+    "model_name,trust_remote_code,expected_format",
+    [
+        pytest.param(
+            "google/gemma-4-E2B-it",
+            False,
+            ("mapping", "empty"),
+            id="gemma-4-raises-on-string-arguments",
+            marks=pytest.mark.skipif(
+                not is_transformers_v5(),
+                reason="gemma-4 tokenizers require transformers v5",
+            ),
+        ),
+        pytest.param(
+            "zai-org/GLM-4.5",
+            False,
+            ("mapping", "empty"),
+            id="glm-4.5-iterates-arguments-items",
+        ),
+        pytest.param(
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            False,
+            ("string", "null"),
+            id="deepseek-r1-concatenates-arguments",
+        ),
+        pytest.param(
+            "Qwen/Qwen3.5-0.8B",
+            True,
+            ("mapping", "empty"),
+            id="qwen3.5-rejects-string-arguments",
+        ),
+        pytest.param(
+            "Qwen/Qwen3.6-35B-A3B",
+            True,
+            ("mapping", "empty"),
+            id="qwen3.6-rejects-string-arguments",
+        ),
+        pytest.param(
+            "MiniMaxAI/MiniMax-M2.5",
+            True,
+            ("mapping", "empty"),
+            id="minimax-m2.5-rejects-string-arguments",
+        ),
+        pytest.param(
+            "openai/gpt-oss-20b",
+            True,
+            ("mapping", "empty"),
+            id="gpt-oss-requires-non-null-content",
+            marks=requires_hf_token(),
+        ),
+    ],
+)
+def test_detected_tool_format_matches_the_shipped_template(
+    model_name, trust_remote_code, expected_format
+):
+    tokenizer = _load_tokenizer(model_name, trust_remote_code)
+
+    assert tuple(detect_chat_template_tool_format(tokenizer)) == expected_format
+
+
+@pytest.mark.parametrize(
+    "model_name,arguments_form,content_form,expected_verdict",
+    [
+        pytest.param(
+            "google/gemma-4-E2B-it",
+            "string",
+            "empty",
+            None,
+            id="gemma-4-raises-rather-than-accepting-a-string",
+            marks=pytest.mark.skipif(
+                not is_transformers_v5(),
+                reason="gemma-4 tokenizers require transformers v5",
+            ),
+        ),
+        pytest.param(
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            "mapping",
+            "null",
+            None,
+            id="deepseek-r1-raises-rather-than-accepting-a-mapping",
+        ),
+        pytest.param(
+            # DeepSeek renders the call only when `content` is None, so "" silently
+            # drops it.
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            "string",
+            "empty",
+            False,
+            id="deepseek-r1-drops-the-tool-call-for-empty-content",
+        ),
+        pytest.param(
+            "HuggingFaceTB/SmolLM3-3B",
+            "mapping",
+            "empty",
+            False,
+            id="smollm3-drops-the-tool-call-without-raising",
+        ),
+        pytest.param(
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            "string",
+            "empty",
+            False,
+            id="qwen2.5-double-encodes-without-raising",
+        ),
+        pytest.param(
+            "Qwen/Qwen3.5-0.8B",
+            "mapping",
+            "empty",
+            True,
+            id="qwen3.5-renders-the-sentinel-verbatim",
+        ),
+    ],
+)
+def test_probe_verdict_for_shipped_template(
+    model_name, arguments_form, content_form, expected_verdict
+):
+    tokenizer = _load_tokenizer(model_name)
+
+    verdict = _probe_renders_sentinel(
+        tokenizer, arguments_form=arguments_form, content_form=content_form
+    )
+
+    assert verdict is expected_verdict
+
+
+def test_double_encoding_is_why_qwen2_5_rejects_string_arguments():
+    """Qwen2.5 pipes `arguments` through `tojson` with no type check.
+
+    Given the JSON string Oumi stores, it encodes the value a second time and
+    the model would train on `"{\\"city\\": \\"...\\"}"` where an object belongs.
+    Nothing raises and the sentinel survives verbatim, so the escape check is
+    the only thing standing between this and silently corrupted data.
+    """
+    tokenizer = _load_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
+    messages, tools = create_chat_template_inputs(
+        canonical_tool_conversation(),
+        tool_arguments_format="string",  # type: ignore[arg-type]
+        content_format="empty",  # type: ignore[arg-type]
+    )
+
+    rendered = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        tools=tools,  # type: ignore[arg-type]
+    )
+
+    # Not a vacuous rejection: the value is present, just escaped.
+    assert ARGUMENT_SENTINEL in rendered
+    assert f'\\"{ARGUMENT_SENTINEL}' in rendered
+    assert (
+        _probe_renders_sentinel(
+            tokenizer, arguments_form="string", content_form="empty"
+        )
+        is False
+    )
+
+
+def test_template_with_no_working_form_falls_back_and_warns():
+    """SmolLM3 has no branch that renders an assistant message's `tool_calls`.
+
+    Every form is rejected, so detection cannot do better than warn and return
+    the preferred default.
+    """
+    # A fresh instance, so the cached detection for this model does not hide the
+    # warning this test is asserting on.
+    tokenizer = transformers.AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM3-3B")
+
+    with patch("oumi.core.tokenizers.utils.logger") as mock_logger:
+        resolved = detect_chat_template_tool_format(tokenizer)
+
+    assert tuple(resolved) == ("mapping", "empty")
+    mock_logger.warning.assert_called_once()
+
+
+def test_glm_does_not_render_a_literal_none_for_null_content():
+    """GLM-4.5 stringifies `content: None` into the text it trains on.
+
+    Its template pipes content through `visible_text(m.content)` unconditionally,
+    so `None` becomes the literal word. Both content forms render and the
+    argument sentinel survives either way, which is why the candidate order --
+    not the probe's accept/reject -- is what keeps this out of the data.
+    """
+    tokenizer = _load_tokenizer("zai-org/GLM-4.5")
+    resolved = detect_chat_template_tool_format(tokenizer)
+
+    messages, tools = _template_inputs(canonical_tool_conversation())
+    rendered = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        tools=tools,  # type: ignore[arg-type]
+    )
+
+    assert resolved.content == "empty"
+    assert "\nNone\n" not in rendered


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Templates disagree irreconcilably on how a tool call must be handed to `apply_chat_template`, and they disagree silently. 
- Qwen3.5 and gemma-4 raise on a JSON-string `arguments` while DeepSeek raises on a mapping. 
- Qwen2.5 accepts a string and pipes it through `tojson` with no type check, so the model trains on `"{\"city\": \"...\"}"` where an object belongs and does not raise. 
- GLM-4.5 renders `content: None` as the literal word "None" before every tool call while DeepSeek drops the call entirely when `content` is `""`.

The difference are all encoded in the model's chat template defined in jinja. The most general way to detect the differences is via a probe based approach. For each model chat template:
1. Render the canonical tool conversation across the four (arguments x content) combinations 
2. Take the first option where the argument sentinel survives verbatim and unescaped. 

Notes:
- A template that raises rejects that form outright; one that drops the call, or double-encodes it so the sentinel arrives escaped, is rejected too. 
- Order  prefers `("mapping", "empty")`, which is what keeps GLM's stray "None" out of the data. Both content forms render there, so the probe cannot separate them and the preference has to.

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: medium
<!-- liberate-note-end -->
