### PR TITLE
Fix how verl saves model

### DIFF
--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -70,6 +70,10 @@ from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
 # Returns an example converted to verl format.
 _DatasetProcessFn = Callable[[dict, int, str, str], dict]
 
+# Passes verl's `save_freq > 0` check (which enables its last-step save) while
+# being too large for `step % save_freq` to ever match: final checkpoint only.
+_SAVE_FINAL_STEP_ONLY_FREQ = 10**9
+
 
 class VerlGrpoTrainer(BaseTrainer):
     """verl GRPO Trainer.
@@ -460,6 +464,16 @@ class VerlGrpoTrainer(BaseTrainer):
             config.trainer.test_freq = training_params.eval_steps
         if not training_params.save_epoch:
             config.trainer.save_freq = training_params.save_steps
+
+        # The HF export merges a verl checkpoint, and verl only writes one when
+        # save_freq > 0. Without this, `save_steps: -1` + save_final_model trains
+        # fine and exports nothing.
+        if training_params.save_final_model and config.trainer.save_freq <= 0:
+            config.trainer.save_freq = _SAVE_FINAL_STEP_ONLY_FREQ
+            logger.info(
+                f"save_steps={training_params.save_steps} would write no checkpoint "
+                "to export from; checkpointing the final step instead."
+            )
 
         # Specific checkpoint to resume from takes precedence over starting
         # from last checkpoint.

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -240,11 +240,28 @@ def _log_feedback_request():
     )
 
 
-def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
+def _save_final_model(trainer: BaseTrainer, config: TrainingConfig) -> None:
+    """Saves the final training state and model, if enabled."""
+    if not config.training.save_final_model:
+        return
+
+    logger.info("Saving final state...")
+    trainer.save_state()
+
+    barrier()
+
+    logger.info("Saving final model...")
+    trainer.save_model(config=config)
+
+
+def _verl_train(partial_trainer: Callable[[], BaseTrainer], config: TrainingConfig):
     """Runs verl training.
 
     This function initializes Ray, and then initializes and kicks off the trainer in a
     remote Ray function.
+
+    The final model is saved inside the remote function: the trainer is constructed
+    there, so it isn't reachable from the common save path in `train()`.
     """
     try:
         import ray  # pyright: ignore[reportMissingImports]
@@ -273,6 +290,8 @@ def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
         trainer.train()
 
         logger.info("Training is Complete.")
+
+        _save_final_model(trainer, config)
 
     ray.get(_run_verl_train.remote(partial_trainer))
     _log_feedback_request()
@@ -454,7 +473,7 @@ def train(
             processor=processor,
             **training_kwargs,
         )
-        _verl_train(partial_trainer)
+        _verl_train(partial_trainer, config)
         return
 
     checkpoint_location = _find_checkpoint_to_resume_from(
@@ -603,15 +622,7 @@ def train(
     log_peak_gpu_memory()
 
     # Save final checkpoint & training state.
-    if config.training.save_final_model:
-        logger.info("Saving final state...")
-        trainer.save_state()
-
-        barrier()
-
-        logger.info("Saving final model...")
-
-        trainer.save_model(config=config)
+    _save_final_model(trainer, config)
 
     barrier()
 

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,5 +1,6 @@
 import json
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -225,3 +226,140 @@ def test_create_verl_data_entry_tool_agent_preserves_structured_history():
         {"role": "tool", "content": '{"rows":[[2]]}', "tool_call_id": "call_1"},
     ]
     assert json.loads(json.dumps(row["prompt"])) == row["prompt"]
+
+
+def _make_trainer_for_config(save_steps: int, save_final_model: bool):
+    """Builds a trainer with just enough state for `_create_config`.
+
+    `_create_config` only reads `_oumi_config`, `_train_filepath`, `_val_filepath`,
+    `_reward_funcs` and `_temp_output_dir`, so we bypass `__init__` entirely. That
+    keeps this a unit test: no tokenizer download, no Ray, no GPU.
+    """
+    from oumi.core.configs import (
+        DataParams,
+        DatasetParams,
+        DatasetSplitParams,
+        ModelParams,
+        TrainerType,
+        TrainingConfig,
+        TrainingParams,
+    )
+
+    trainer = object.__new__(VerlGrpoTrainer)
+    trainer._oumi_config = TrainingConfig(
+        model=ModelParams(model_name="Qwen/Qwen2.5-0.5B-Instruct"),
+        data=DataParams(
+            train=DatasetSplitParams(
+                datasets=[DatasetParams(dataset_name="d1shs0ap/countdown")]
+            ),
+            # verl requires a validation split.
+            validation=DatasetSplitParams(
+                datasets=[DatasetParams(dataset_name="d1shs0ap/countdown")]
+            ),
+        ),
+        training=TrainingParams(
+            trainer_type=TrainerType.VERL_GRPO,
+            max_steps=2,
+            save_steps=save_steps,
+            save_epoch=False,
+            save_final_model=save_final_model,
+            enable_wandb=False,
+            output_dir="/tmp/oumi-verl-unit-test",
+        ),
+    )
+    trainer._train_filepath = "/tmp/train.parquet"
+    trainer._val_filepath = "/tmp/val.parquet"
+    trainer._reward_funcs = []
+    trainer._temp_output_dir = Path("/tmp/oumi-verl-unit-test/verl_output")
+    return trainer
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+@pytest.mark.parametrize(
+    "save_steps,save_final_model,expect_checkpoint",
+    [
+        # `save_steps: -1` is what configs/examples/grpo_verl_countdown ships.
+        # verl only writes a checkpoint when save_freq > 0, so without the
+        # override the run would train fine and export nothing.
+        (-1, True, True),
+        (0, True, True),
+        # An explicit cadence is left alone.
+        (5, True, True),
+        # Nothing will be exported, so no checkpoint needs forcing.
+        (-1, False, False),
+    ],
+)
+def test_save_freq_guarantees_a_checkpoint_to_export(
+    save_steps, save_final_model, expect_checkpoint
+):
+    """save_final_model requires a verl checkpoint to merge into HF format."""
+    verl_config = _make_trainer_for_config(
+        save_steps, save_final_model
+    )._create_config()
+
+    # verl saves when `save_freq > 0 and (is_last_step or step % save_freq == 0)`,
+    # so any positive value guarantees the final step is checkpointed.
+    if expect_checkpoint:
+        assert verl_config.trainer.save_freq > 0
+    else:
+        assert verl_config.trainer.save_freq <= 0
+
+    if save_steps > 0:
+        # An explicit cadence must not be silently overridden.
+        assert verl_config.trainer.save_freq == save_steps
+    elif save_final_model:
+        # Forced value must be large enough that only the last step matches,
+        # otherwise we would checkpoint every step.
+        assert verl_config.trainer.save_freq > verl_config.trainer.total_training_steps
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_verl_train_saves_final_model():
+    """The verl path must reach save_model(); it returns before the shared one."""
+    from oumi.train import _verl_train
+
+    trainer = MagicMock()
+    config = MagicMock()
+    config.training.save_final_model = True
+
+    import ray  # pyright: ignore[reportMissingImports]
+
+    # Run the remote function inline so call order is observable.
+    with (
+        patch.object(ray, "is_initialized", return_value=True),
+        patch.object(
+            ray, "remote", lambda fn: type("_F", (), {"remote": staticmethod(fn)})
+        ),
+        patch.object(ray, "get", lambda x: x),
+    ):
+        _verl_train(lambda: trainer, config)
+
+    trainer.train.assert_called_once()
+    trainer.save_model.assert_called_once_with(config=config)
+    assert trainer.method_calls.index(call.train()) < trainer.method_calls.index(
+        call.save_model(config=config)
+    )
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_verl_train_respects_save_final_model_false():
+    """save_final_model=False must not export."""
+    from oumi.train import _verl_train
+
+    trainer = MagicMock()
+    config = MagicMock()
+    config.training.save_final_model = False
+
+    import ray  # pyright: ignore[reportMissingImports]
+
+    with (
+        patch.object(ray, "is_initialized", return_value=True),
+        patch.object(
+            ray, "remote", lambda fn: type("_F", (), {"remote": staticmethod(fn)})
+        ),
+        patch.object(ray, "get", lambda x: x),
+    ):
+        _verl_train(lambda: trainer, config)
+
+    trainer.train.assert_called_once()
+    trainer.save_model.assert_not_called()

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -4,6 +4,15 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from oumi.core.configs import (
+    DataParams,
+    DatasetParams,
+    DatasetSplitParams,
+    ModelParams,
+    TrainerType,
+    TrainingConfig,
+    TrainingParams,
+)
 from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
 from oumi.core.types.conversation import (
     ContentItem,
@@ -228,23 +237,19 @@ def test_create_verl_data_entry_tool_agent_preserves_structured_history():
     assert json.loads(json.dumps(row["prompt"])) == row["prompt"]
 
 
-def _make_trainer_for_config(save_steps: int, save_final_model: bool):
+def _make_trainer_for_config(
+    save_steps: int,
+    save_final_model: bool,
+    save_epoch: bool = False,
+    output_dir: str = "/tmp/oumi-verl-unit-test",
+):
     """Builds a trainer with just enough state for `_create_config`.
 
     `_create_config` only reads `_oumi_config`, `_train_filepath`, `_val_filepath`,
     `_reward_funcs` and `_temp_output_dir`, so we bypass `__init__` entirely. That
-    keeps this a unit test: no tokenizer download, no Ray, no GPU.
+    keeps this a unit test: no tokenizer download, no Ray, no GPU. `_export_hf_model`
+    additionally reads `_final_output_dir`.
     """
-    from oumi.core.configs import (
-        DataParams,
-        DatasetParams,
-        DatasetSplitParams,
-        ModelParams,
-        TrainerType,
-        TrainingConfig,
-        TrainingParams,
-    )
-
     trainer = object.__new__(VerlGrpoTrainer)
     trainer._oumi_config = TrainingConfig(
         model=ModelParams(model_name="Qwen/Qwen2.5-0.5B-Instruct"),
@@ -261,16 +266,17 @@ def _make_trainer_for_config(save_steps: int, save_final_model: bool):
             trainer_type=TrainerType.VERL_GRPO,
             max_steps=2,
             save_steps=save_steps,
-            save_epoch=False,
+            save_epoch=save_epoch,
             save_final_model=save_final_model,
             enable_wandb=False,
-            output_dir="/tmp/oumi-verl-unit-test",
+            output_dir=output_dir,
         ),
     )
     trainer._train_filepath = "/tmp/train.parquet"
     trainer._val_filepath = "/tmp/val.parquet"
     trainer._reward_funcs = []
-    trainer._temp_output_dir = Path("/tmp/oumi-verl-unit-test/verl_output")
+    trainer._final_output_dir = Path(output_dir)
+    trainer._temp_output_dir = Path(output_dir) / "verl_output"
     return trainer
 
 
@@ -363,3 +369,83 @@ def test_verl_train_respects_save_final_model_false():
 
     trainer.train.assert_called_once()
     trainer.save_model.assert_not_called()
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+@pytest.mark.parametrize("save_steps", [-1, 0, 100, 500])
+@pytest.mark.parametrize("save_final_model", [True, False])
+def test_save_epoch_is_effectively_dead_on_verl(save_steps, save_final_model):
+    """BUG: `save_epoch=True` collapses every cadence to final-checkpoint-only.
+
+    `_create_config` only copies `save_steps` into verl's `save_freq` when
+    `save_epoch` is False, so turning `save_epoch` on leaves `save_freq` at
+    verl's `-1` default. The `save_final_model` guard then rewrites that to
+    `_SAVE_FINAL_STEP_ONLY_FREQ`, which is deliberately too large for
+    `step % save_freq` to ever match. Two things go wrong:
+
+    1. No per-epoch checkpoint is written -- exactly what `save_epoch` asked for.
+    2. An explicit `save_steps` is silently dropped, inverting the precedence
+       documented on `TrainingParams.save_epoch` ("If both `save_steps` and
+       `save_epoch` are set, then `save_steps` takes precedence").
+    """
+    verl_config = _make_trainer_for_config(
+        save_steps, save_final_model=save_final_model, save_epoch=True
+    )._create_config()
+
+    # An explicitly requested cadence never reaches verl. (`save_steps <= 0` is
+    # not asserted here: it coincides with the `-1` default verl already has.)
+    if save_steps > 0:
+        assert verl_config.trainer.save_freq != save_steps
+
+    if save_final_model:
+        # Too large for `global_step % save_freq` to ever match: final step only.
+        assert verl_config.trainer.save_freq > verl_config.trainer.total_training_steps
+    else:
+        # Fails verl's `save_freq > 0` check: no checkpoint at all.
+        assert verl_config.trainer.save_freq <= 0
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_verl_checkpoint_and_export_paths(tmp_path):
+    """Documents the on-disk layout verl checkpoints into.
+
+        <output_dir>/                          <- `_final_output_dir`, HF export target
+        └── verl_output/                   <- `_temp_output_dir` == verl's
+            │                                 `trainer.default_local_dir`
+            ├── global_step_5/
+            │   └── actor/                 <- FSDP shards; merge source
+            │       └── huggingface/       <- config/tokenizer, i.e.
+            │                                 `hf_model_config_path`
+            └── global_step_10/
+                └── actor/
+                    └── huggingface/
+
+    `_export_hf_model` picks the `global_step_N` with the largest N and merges
+    it up into `<output_dir>` itself, so the exported HF model sits alongside
+    the raw verl checkpoints rather than inside them.
+    """
+    trainer = _make_trainer_for_config(
+        save_steps=5, save_final_model=True, output_dir=str(tmp_path)
+    )
+
+    # verl is pointed at the nested directory, never at the export directory.
+    verl_config = trainer._create_config()
+    assert verl_config.trainer.default_local_dir == str(tmp_path / "verl_output")
+
+    for step in (5, 10):
+        (tmp_path / "verl_output" / f"global_step_{step}" / "actor").mkdir(parents=True)
+    # A bare checkpoint with no `actor/` payload must be ignored, not crash the
+    # export by looking like the newest step.
+    (tmp_path / "verl_output" / "global_step_20").mkdir()
+
+    with patch(
+        "oumi.core.trainers.verl_grpo_trainer.FSDPModelMerger"
+    ) as mock_merger_cls:
+        assert trainer._export_hf_model() is True
+
+    merger_config = mock_merger_cls.call_args.args[0]
+    latest = tmp_path / "verl_output" / "global_step_10"
+    assert merger_config.local_dir == str(latest / "actor")
+    assert merger_config.hf_model_config_path == str(latest / "actor" / "huggingface")
+    assert merger_config.target_dir == str(tmp_path)
+    mock_merger_cls.return_value.merge_and_save.assert_called_once()

--- a/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
+++ b/tests/unit/core/trainers/verl_agentic/test_oumi_verl_tool.py
@@ -78,6 +78,7 @@ def test_execute_routes_into_shared_env(tmp_path):
         tool.execute(iid, {"query": "SELECT count(*) FROM t"}, agent_data=ad)
     )
     assert reward == 0.0
+    assert resp.text is not None
     assert "2" in resp.text
 
 
@@ -116,4 +117,5 @@ def test_failed_tool_call_becomes_an_observation(tmp_path):
         tool.execute(iid, {"query": "NOT VALID SQL"}, agent_data=ad)
     )
     assert reward == 0.0
+    assert resp.text is not None
     assert resp.text.startswith("Tool error:")


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Previously, `trainer.save_model` was never called for verl trainer in `src/train.py`. This led to verl models being saved as raw sharded pytorch files. 

This PR changes verl trainer to call `trainer.save_model` when training completes, which searches through the verl checkpoints, picks the latest checkpoint and merges the sharded weights via FSDP into HF compatible version. The model weights and tokenizer is then stored in the root of the output path. Tests have been aded to documents save path structure.


<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
