### PR TITLE
Add August/July/June news items to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## 🔥 News
 
-- [2026/08] Extended GRPO RL to support tool use
+- [2026/08] Extended GRPO reinforcement learning to support tool use
 - [2026/07] Added support for tools, environments (synthetic, deterministic, database), and agentic data synthesis
 - [2026/06] Added support for the Gemma 4 model family
 - [2026/06] Added partial-failure support across inference, judging, and data synthesis

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## 🔥 News
 
 - [2026/08] Extended GRPO RL to support tool use
-- [2026/07] Added support for tools, environment (synthetic, deterministic, database), and agentic data synthesis
+- [2026/07] Added support for tools, environments (synthetic, deterministic, database), and agentic data synthesis
 - [2026/06] Added support for the Gemma 4 model family
 - [2026/06] Added partial-failure support across inference, judging, and data synthesis
 - [2026/05] [Oumi v0.8 released](https://github.com/oumi-ai/oumi/releases/tag/v0.8) with `oumi deploy` CLI for dedicated inference endpoints, an `oumi-mcp` MCP server for Claude/Cursor integration, batch API support across Anthropic/Fireworks/Together, and Transformers v5 / TRL / vLLM dependency upgrades

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 ## 🔥 News
 
-- [2026/08] New synthetic tool-use environments: `DatabaseExecutableEnvironment` with an EHR example, optional guided decoding for tool simulation, and stricter deterministic-environment schema validation
-- [2026/07] New `OumiVerlTool` for verl tool reinforcement learning over any Oumi executable environment, built on the new `ExecutableEnvironment`/`ExecutableTool` base classes
+- [2026/08] Extended GRPO RL to support tool use
+- [2026/07] Added support for tools, environment (synthetic, deterministic, database), and agentic data synthesis
 - [2026/06] Added support for the Gemma 4 model family
-- [2026/06] Partial-failure support added across inference, judging, and data synthesis (`infer_partial`, `judge_partial`, `synthesize_partial`) so long-running jobs can recover per-row failures instead of failing the whole run
+- [2026/06] Added partial-failure support across inference, judging, and data synthesis
 - [2026/05] [Oumi v0.8 released](https://github.com/oumi-ai/oumi/releases/tag/v0.8) with `oumi deploy` CLI for dedicated inference endpoints, an `oumi-mcp` MCP server for Claude/Cursor integration, batch API support across Anthropic/Fireworks/Together, and Transformers v5 / TRL / vLLM dependency upgrades
 - [2026/03] Upgraded to Transformers v5, TRL v0.30, vLLM v0.19, and veRL v0.7 compatibility
 - [2026/03] [MCP Integration Phase 1](https://github.com/oumi-ai/oumi/pull/2234): package scaffold and dependencies for MCP server support

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@
 
 ## 🔥 News
 
+- [2026/08] New synthetic tool-use environments: `DatabaseExecutableEnvironment` with an EHR example, optional guided decoding for tool simulation, and stricter deterministic-environment schema validation
+- [2026/07] New `OumiVerlTool` for verl tool reinforcement learning over any Oumi executable environment, built on the new `ExecutableEnvironment`/`ExecutableTool` base classes
 - [2026/06] Added support for the Gemma 4 model family
+- [2026/06] Partial-failure support added across inference, judging, and data synthesis (`infer_partial`, `judge_partial`, `synthesize_partial`) so long-running jobs can recover per-row failures instead of failing the whole run
 - [2026/05] [Oumi v0.8 released](https://github.com/oumi-ai/oumi/releases/tag/v0.8) with `oumi deploy` CLI for dedicated inference endpoints, an `oumi-mcp` MCP server for Claude/Cursor integration, batch API support across Anthropic/Fireworks/Together, and Transformers v5 / TRL / vLLM dependency upgrades
 - [2026/03] Upgraded to Transformers v5, TRL v0.30, vLLM v0.19, and veRL v0.7 compatibility
 - [2026/03] [MCP Integration Phase 1](https://github.com/oumi-ai/oumi/pull/2234): package scaffold and dependencies for MCP server support


### PR DESCRIPTION
## Summary
- Adds three news entries covering recent major features: synthetic tool-use environments (Aug), `OumiVerlTool` for verl tool RL (Jul), and partial-failure support across inference/judging/synthesis (Jun)

## Test plan
- [x] Visual review of rendered README news section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- liberate-note-start -->
> [!NOTE]
> **Liberate**
> Risk: low
<!-- liberate-note-end -->
