### PR TITLE
fix(verl): export the final HF model after verl training

### DIFF
--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -618,6 +618,10 @@ class VerlGrpoTrainer(BaseTrainer):
             return False
         final_dir = Path(self._final_output_dir)
         temp_dir = Path(self._temp_output_dir)
+        # verl never creates this directory if it wrote no checkpoints.
+        if not temp_dir.is_dir():
+            logger.warning(f"No checkpoints found under {temp_dir}")
+            return False
         all_checkpoint_dirs: list[Path] = [
             f.absolute()
             for f in temp_dir.iterdir()

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -589,8 +589,8 @@ class VerlGrpoTrainer(BaseTrainer):
         logger.info("Starting verl training...")
         self._verl_trainer.fit()
 
-    # TODO: OPE-1192 - Implement saving model/trainer state. verl training should
-    # already handle saving models, including the final checkpoint.
+    # TODO: OPE-1192 - Implement saving trainer state. verl saves its own sharded
+    # checkpoints; `save_model` below merges the latest one into HF format.
 
     def save_state(self) -> None:
         """Saves the training state."""

--- a/src/oumi/train.py
+++ b/src/oumi/train.py
@@ -240,7 +240,7 @@ def _log_feedback_request():
     )
 
 
-def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
+def _verl_train(partial_trainer: Callable[[], BaseTrainer], config: TrainingConfig):
     """Runs verl training.
 
     This function initializes Ray, and then initializes and kicks off the trainer in a
@@ -268,13 +268,21 @@ def _verl_train(partial_trainer: Callable[[], BaseTrainer]):
     # decorator is only run if this function is run. This function should only be run
     # if ray is installed, preventing errors when it isn't.
     @ray.remote
-    def _run_verl_train(partial_trainer: Callable[[], BaseTrainer]):
+    def _run_verl_train(
+        partial_trainer: Callable[[], BaseTrainer], config: TrainingConfig
+    ):
         trainer = partial_trainer()
         trainer.train()
 
         logger.info("Training is Complete.")
 
-    ray.get(_run_verl_train.remote(partial_trainer))
+        # The trainer only exists inside this remote function, so the HF export has to
+        # happen here rather than on the generic `train()` path.
+        if config.training.save_final_model:
+            logger.info("Saving final model...")
+            trainer.save_model(config=config)
+
+    ray.get(_run_verl_train.remote(partial_trainer, config))
     _log_feedback_request()
 
 
@@ -454,7 +462,7 @@ def train(
             processor=processor,
             **training_kwargs,
         )
-        _verl_train(partial_trainer)
+        _verl_train(partial_trainer, config)
         return
 
     checkpoint_location = _find_checkpoint_to_resume_from(

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,5 +1,4 @@
 import json
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -234,9 +233,9 @@ def test_export_hf_model_without_checkpoints(make_temp_dir, tmp_path):
     temp_dir = tmp_path / "verl_output"
     if make_temp_dir:
         temp_dir.mkdir()
-    trainer = SimpleNamespace(
-        _final_output_dir=str(tmp_path / "final"),
-        _temp_output_dir=str(temp_dir),
-    )
+    # __init__ needs a live verl/Ray stack; the export only reads these two attrs.
+    trainer = object.__new__(VerlGrpoTrainer)
+    trainer._final_output_dir = tmp_path / "final"
+    trainer._temp_output_dir = temp_dir
 
-    assert VerlGrpoTrainer._export_hf_model(trainer) is False
+    assert trainer._export_hf_model() is False

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -225,3 +226,17 @@ def test_create_verl_data_entry_tool_agent_preserves_structured_history():
         {"role": "tool", "content": '{"rows":[[2]]}', "tool_call_id": "call_1"},
     ]
     assert json.loads(json.dumps(row["prompt"])) == row["prompt"]
+
+
+@pytest.mark.parametrize("make_temp_dir", [True, False])
+def test_export_hf_model_without_checkpoints(make_temp_dir, tmp_path):
+    """No checkpoints must return False, not raise -- verl skips the dir entirely."""
+    temp_dir = tmp_path / "verl_output"
+    if make_temp_dir:
+        temp_dir.mkdir()
+    trainer = SimpleNamespace(
+        _final_output_dir=str(tmp_path / "final"),
+        _temp_output_dir=str(temp_dir),
+    )
+
+    assert VerlGrpoTrainer._export_hf_model(trainer) is False

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -1,5 +1,6 @@
 import functools
 import sys
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -212,29 +213,13 @@ def test_recompile_limit_env_override_wins(monkeypatch, restore_dynamo_limits):
     assert torch._dynamo.config.cache_size_limit == 128
 
 
-class _InlineRay:
-    """Ray stand-in that runs the remote function inline, so no cluster is needed."""
-
-    @staticmethod
-    def is_initialized():
-        return True
-
-    @staticmethod
-    def init(**kwargs):
-        pass
-
-    @staticmethod
-    def remote(fn):
-        class _Handle:
-            @staticmethod
-            def remote(*args, **kwargs):
-                return functools.partial(fn, *args, **kwargs)
-
-        return _Handle
-
-    @staticmethod
-    def get(ref):
-        return ref()
+# Runs the remote function inline so no Ray cluster is needed. A MagicMock won't do:
+# it would swallow the call and the body would never execute.
+_INLINE_RAY = SimpleNamespace(
+    is_initialized=lambda: True,
+    remote=lambda fn: SimpleNamespace(remote=lambda *a: functools.partial(fn, *a)),
+    get=lambda ref: ref(),
+)
 
 
 @pytest.mark.parametrize("save_final_model,expected_saves", [(True, 1), (False, 0)])
@@ -245,7 +230,7 @@ def test_verl_train_exports_final_model(
     base_training_config.training.save_final_model = save_final_model
     trainer = Mock()
 
-    with patch.dict(sys.modules, {"ray": _InlineRay}):
+    with patch.dict(sys.modules, {"ray": _INLINE_RAY}):
         _verl_train(lambda: trainer, base_training_config)
 
     assert trainer.train.call_count == 1

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -1,3 +1,5 @@
+import functools
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,7 +13,7 @@ from oumi.core.configs import (
     TrainingParams,
 )
 from oumi.core.tokenizers.base_tokenizer import BaseTokenizer
-from oumi.train import train
+from oumi.train import _verl_train, train
 
 
 @pytest.fixture
@@ -208,3 +210,45 @@ def test_recompile_limit_env_override_wins(monkeypatch, restore_dynamo_limits):
         _config_with_collator_kwargs({"pad_to_multiple_of": 8192})
     )
     assert torch._dynamo.config.cache_size_limit == 128
+
+
+class _InlineRay:
+    """Ray stand-in that runs the remote function inline, so no cluster is needed."""
+
+    @staticmethod
+    def is_initialized():
+        return True
+
+    @staticmethod
+    def init(**kwargs):
+        pass
+
+    @staticmethod
+    def remote(fn):
+        class _Handle:
+            @staticmethod
+            def remote(*args, **kwargs):
+                return functools.partial(fn, *args, **kwargs)
+
+        return _Handle
+
+    @staticmethod
+    def get(ref):
+        return ref()
+
+
+@pytest.mark.parametrize("save_final_model,expected_saves", [(True, 1), (False, 0)])
+def test_verl_train_exports_final_model(
+    save_final_model, expected_saves, base_training_config
+):
+    """verl training must export the final model; it used to return before saving."""
+    base_training_config.training.save_final_model = save_final_model
+    trainer = Mock()
+
+    with patch.dict(sys.modules, {"ray": _InlineRay}):
+        _verl_train(lambda: trainer, base_training_config)
+
+    assert trainer.train.call_count == 1
+    assert trainer.save_model.call_count == expected_saves
+    if expected_saves:
+        trainer.save_model.assert_called_once_with(config=base_training_config)


### PR DESCRIPTION
## What

Exports the final HF model at the end of a verl GRPO run. Split out of #2592 per review.

## Why

`_verl_train()` called `trainer.train()` and returned, so the `save_final_model` block on the
generic `train()` path was never reached and `_export_hf_model()` was dead code. A finished run
left `output_dir` holding logs, telemetry and verl's sharded `verl_output/` — and no loadable
model. Recovering it meant running `verl.model_merger` by hand over 8 FSDP shards.

This regressed in #1749. The `save_model`/OPE-1192 TODO says verl "should already handle saving
models", which was true when verl 0.3's vendored config had
`checkpoint.contents: ['model', 'hf_model', ...]`. verl 0.4.0 dropped `hf_model` from the
default and the vendored config was refreshed wholesale, silently removing the HF export.

## How

- The trainer only exists inside the Ray remote function, so the export happens there rather
  than on the generic `train()` path. Gated on `save_final_model` (default `True`).
- `_export_hf_model()` now returns `False` with a warning when verl's output directory does not
  exist. verl never creates it when no checkpoints were written — `save_steps` disabled, or
  `max_steps` reached before the first save — so wiring `save_model()` up exposed a latent
  `FileNotFoundError` that killed a completed run after all the work was done.

Note that a config still needs `save_steps > 0` for there to be anything to merge. #2592 fixes
that for the Countdown example.

## Testing

Unit tests cover both export paths, and both fail on `main`:

- `save_model()` is called exactly when `save_final_model` is set (parametrized both ways).
- A run that wrote no checkpoints returns cleanly instead of raising (parametrized over the
  output dir existing-but-empty and not existing at all).

End to end on 8xH100: a full Countdown epoch (937 steps, exit 0) merged 8 FSDP shards into a
loadable 8.3 GB model in `output_dir` with no manual step. On `main` that directory holds only
`verl_output/`.

The no-checkpoint guard exists because the first version of this change crashed that completed
run with `FileNotFoundError` — the pre-existing unit tests only covered a temp dir that existed
but was empty.
