### PR TITLE
feat(verl): process-wide user-simulator inference engine

### DIFF
--- a/configs/examples/verl_conversational/user_sim_engine.yaml
+++ b/configs/examples/verl_conversational/user_sim_engine.yaml
@@ -1,0 +1,18 @@
+# Inference config for the simulated user.
+#
+# Must be a REMOTE-backed engine. One engine is cached per worker process and shared by
+# every concurrent rollout in it, so an in-process engine (NATIVE / VLLM / LLAMACPP) would
+# need a lock that serializes them all. See user_sim_provider.user_sim_engine.
+#
+# Settings match the validated job-273 run so rollouts stay comparable.
+#
+# Requirements:
+#   - export OPENAI_API_KEY=your_key_here
+model:
+  model_name: "gpt-4o-mini"
+
+engine: OPENAI
+
+generation:
+  max_new_tokens: 256
+  temperature: 1.0

--- a/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
@@ -1,0 +1,88 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-wide user-simulator inference engine for the verl agent-loop adapter."""
+
+from __future__ import annotations
+
+from functools import cache
+
+from oumi.builders.inference_engines import build_inference_engine
+from oumi.core.configs.inference_config import InferenceConfig
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.types.conversation import Conversation
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+# Engines that hold a model in-process. Rejected before `build_inference_engine` so we
+# never pay to load weights just to refuse them.
+_IN_PROCESS_ENGINES = frozenset(
+    {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }
+)
+
+
+@cache
+def user_sim_engine(config_path: str) -> tuple[RemoteInferenceEngine, InferenceConfig]:
+    """Builds the user-sim engine once per process.
+
+    Agent loops are instantiated per trajectory, so building the engine in the loop's
+    `__init__` would construct one per rollout.
+
+    Returns:
+        The engine and the config it was built from.
+    """
+    cfg = InferenceConfig.from_yaml(config_path)
+    if cfg.engine is None:
+        raise ValueError(f"No inference engine set in {config_path}.")
+    if cfg.engine in _IN_PROCESS_ENGINES:
+        raise ValueError(
+            f"The user simulator requires a remote inference engine; got "
+            f"{cfg.engine} from {config_path}. One engine is shared by every "
+            "concurrent rollout in a worker, so an in-process engine would need a "
+            "lock that serializes them all. "
+            "Use REMOTE_VLLM, SGLANG, or a hosted provider."
+        )
+    engine = build_inference_engine(
+        engine_type=cfg.engine,
+        model_params=cfg.model,
+        remote_params=cfg.remote_params,
+    )
+    # Free: every engine that loads weights was already rejected above, so nothing
+    # expensive reaches this. Catches a new engine type added between releases.
+    if not isinstance(engine, RemoteInferenceEngine):
+        raise ValueError(
+            f"User-sim engine {type(engine).__name__} is not remote-backed; "
+            f"got {cfg.engine} from {config_path}."
+        )
+    return engine, cfg
+
+
+def infer_one(
+    engine: RemoteInferenceEngine, cfg: InferenceConfig, conversation: Conversation
+) -> str:
+    """Runs one blocking user-sim generation.
+
+    Returns:
+        The simulated user's reply text.
+    """
+    results = engine.infer([conversation], inference_config=cfg)
+    content = results[0].messages[-1].content
+    if not isinstance(content, str):
+        raise RuntimeError(
+            f"user-sim engine returned non-text content: {type(content)}"
+        )
+    return content

--- a/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oumi.builders.inference_engines import ENGINE_MAP
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.inference.base_inference_engine import BaseInferenceEngine
+from oumi.core.trainers.verl_agentic.user_sim_provider import (
+    _IN_PROCESS_ENGINES,
+    user_sim_engine,
+)
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+_BUILD = "oumi.core.trainers.verl_agentic.user_sim_provider.build_inference_engine"
+
+
+def _write_config(tmp_path, engine: str) -> str:
+    path = tmp_path / f"user_sim_{engine.lower()}.yaml"
+    path.write_text(
+        f"model:\n  model_name: 'gpt-4o-mini'\nengine: {engine}\n"
+        "remote_params:\n  api_url: 'http://localhost:8000/v1/chat/completions'\n"
+    )
+    return str(path)
+
+
+@pytest.mark.parametrize("engine", ["NATIVE", "VLLM", "LLAMACPP"])
+def test_in_process_engine_rejected_before_build(tmp_path, engine):
+    config_path = _write_config(tmp_path, engine)
+    with patch(_BUILD) as build:
+        with pytest.raises(ValueError, match="remote inference engine"):
+            user_sim_engine(config_path)
+    build.assert_not_called()
+
+
+def test_missing_engine_rejected(tmp_path):
+    path = tmp_path / "no_engine.yaml"
+    path.write_text("model:\n  model_name: 'gpt-4o-mini'\n")
+    with pytest.raises(ValueError, match="No inference engine"):
+        user_sim_engine(str(path))
+
+
+def test_remote_engine_built_once(tmp_path):
+    config_path = _write_config(tmp_path, "REMOTE_VLLM")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=RemoteInferenceEngine)
+        first = user_sim_engine(config_path)
+        second = user_sim_engine(config_path)
+    assert first is second
+    assert build.call_count == 1
+
+
+def test_non_remote_engine_rejected(tmp_path):
+    """A newly-added engine type that isn't remote-backed must not slip through."""
+    config_path = _write_config(tmp_path, "REMOTE")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=BaseInferenceEngine)
+        with pytest.raises(ValueError, match="not remote-backed"):
+            user_sim_engine(config_path)
+
+
+@pytest.mark.parametrize("engine_type,engine_cls", sorted(ENGINE_MAP.items(), key=str))
+def test_every_engine_is_classified(engine_type, engine_cls):
+    """A new engine type must be either in-process or remote-backed, never neither."""
+    assert (engine_type in _IN_PROCESS_ENGINES) ^ issubclass(
+        engine_cls, RemoteInferenceEngine
+    ), f"{engine_type} is classified neither in-process nor remote"
+
+
+def test_in_process_set_matches_expected_members():
+    assert _IN_PROCESS_ENGINES == {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }


### PR DESCRIPTION
## What
Adds one shared remote inference engine per worker process for generating simulated-user replies.

## Why
Creating a new inference engine for every conversation wastes resources, while sharing an in-process model would force concurrent conversations to run one at a time. The simulator therefore needs a reusable remote engine with early validation for unsupported configurations.

## How
The simulator loads its configuration once per worker, reuses the resulting remote engine, and rejects local model engines before they load weights.

Predecessor: #2610 · Successor: #2612

## Testing
Unit tests verify remote-engine reuse and confirm that missing, local, or otherwise non-remote engines are rejected before use. Standard lints clean.
