### PR TITLE
feat(verl): UserSimToolAgentLoop for simulated-user rollouts

### DIFF
--- a/configs/examples/verl_conversational/user_sim_agent_loop.yaml
+++ b/configs/examples/verl_conversational/user_sim_agent_loop.yaml
@@ -1,0 +1,12 @@
+# verl agent-loop registry entry. Must be a LIST -- verl iterates it
+# (verl/experimental/agent_loop/agent_loop.py:444-449). Keys beyond `name` and `_target_`
+# are passed to the loop's constructor by hydra.
+#
+# Wire it up in training.verl_config_overrides alongside:
+#   actor_rollout_ref.rollout.mode: async
+#   actor_rollout_ref.rollout.multi_turn.enable: true
+#   actor_rollout_ref.rollout.agent.agent_loop_config_path: <this file>
+# VerlGrpoTrainer._validate_agent_loop_config fails loudly if any is missing.
+- name: oumi_user_sim_tool_agent
+  _target_: oumi.core.trainers.verl_agentic.user_sim_agent_loop.UserSimToolAgentLoop
+  user_sim_inference: configs/examples/verl_conversational/user_sim_engine.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,11 @@ gpu = [
     "bitsandbytes>=0.47,<0.50",     # Used for QLora, and PagedAdam implementation
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.
-    "verl>=0.5,<0.8; python_version >= '3.10'", # Used for the VERL_GRPO trainer
+    # The agent loop works on 0.7 and 0.8 alike, but VerlGrpoTrainer's worker imports
+    # are still 0.7-only: 0.8 removed verl.workers.fsdp_workers, and
+    # AsyncActorRolloutRefWorker / CriticWorker have no counterpart in engine_workers.
+    # >=0.7: UserSimToolAgentLoop needs AgentLoopBase.apply_chat_template, which 0.6 lacks.
+    "verl>=0.7,<0.8; python_version >= '3.10'", # Used for the VERL_GRPO trainer
     "vllm>=0.14,<0.22",                         # For VLLMInferenceEngine, and vLLM-powered GRPO training.
     "kernels>=0.11,<0.15",                      # For compute kernel implementations (e.g., attn_implementation in gold trainer)
 ]

--- a/src/oumi/core/trainers/verl_agentic/user_sim_agent_loop.py
+++ b/src/oumi/core/trainers/verl_agentic/user_sim_agent_loop.py
@@ -1,0 +1,195 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""verl agent loop adding persona-driven simulated-user turns to ToolAgentLoop."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from verl.experimental.agent_loop.tool_agent_loop import (  # pyright: ignore[reportMissingImports]
+    AgentState,
+    ToolAgentLoop,
+)
+
+from oumi.core.rollout.user_sim import (
+    DEFAULT_DONE_SENTINEL,
+    DEFAULT_MAX_TURNS,
+    RolloutState,
+    next_user_turn,
+)
+from oumi.core.trainers.verl_agentic.user_sim_provider import infer_one, user_sim_engine
+
+
+# Deliberately NOT decorated with verl's @register. That decorator does
+# `_agent_loop_registry[name] = {"_target_": fqdn}` — an unconditional overwrite that
+# drops every other key. Since importing this module is what resolves `_target_`, the
+# decorator would wipe the `user_sim_inference` path the agent-loop YAML supplies.
+# Registration comes from `agent_loop_config_path`; see user_sim_agent_loop.yaml.
+class UserSimToolAgentLoop(ToolAgentLoop):
+    """ToolAgentLoop plus a simulated user that speaks when the assistant stops."""
+
+    def __init__(
+        self, *args: Any, user_sim_inference: str | None = None, **kwargs: Any
+    ):
+        """Stores the user-sim config path; the engine itself is cached per process."""
+        super().__init__(*args, **kwargs)
+        self._sim_config_path = user_sim_inference
+        self._sim: RolloutState | None = None
+        # verl instantiates one loop per rollout, so this is per-conversation state.
+        self._sim_history: list[dict[str, Any]] = []
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs: Any):
+        """Runs the rollout.
+
+        Returns:
+            verl's `AgentLoopOutput`, with `sim_user_turns` in `extra_fields` when
+            a simulated user took part.
+        """
+        sim_kwargs = (kwargs.get("extra_info") or {}).get("interaction_kwargs") or {}
+        if sim_kwargs:
+            if not self._sim_config_path:
+                raise ValueError(
+                    "Row carries interaction_kwargs but the agent-loop config has no "
+                    "'user_sim_inference' path. Add it to the YAML that "
+                    "agent_loop_config_path points at."
+                )
+            self._sim = RolloutState(
+                persona=sim_kwargs["user_persona"],
+                goal=sim_kwargs.get("goal", ""),
+                max_turns=sim_kwargs.get("max_turns") or DEFAULT_MAX_TURNS,
+            )
+            # Tracked separately from verl's `messages`, which holds tool results with
+            # no assistant turn requesting them -- a shape chat APIs reject outright.
+            # `messages_to_history` drops everything the customer would not have seen.
+            self._sim_history = [dict(message) for message in kwargs["raw_prompt"]]
+        output = await super().run(sampling_params, **kwargs)
+        # Written once, after the rollout: incremental writes to extra_fields make the
+        # dict truthy, which stops verl copying engine telemetry into it.
+        if self._sim is not None:
+            output.extra_fields["sim_user_turns"] = self._sim.turn_idx
+        return output
+
+    async def _handle_generating_state(
+        self,
+        agent_data: Any,
+        sampling_params: dict[str, Any],
+        ignore_termination: bool = False,
+    ) -> AgentState:
+        """Adds a simulated-user turn when the assistant stops without calling a tool.
+
+        Returns:
+            The next agent state.
+        """
+        state = await super()._handle_generating_state(
+            agent_data, sampling_params, ignore_termination
+        )
+        # `_sim` and `_sim_config_path` are set together in `run()`; both are absent
+        # for tool-only rows, which take the stock ToolAgentLoop path.
+        if self._sim is None:
+            return state
+        if state is not AgentState.TERMINATED:
+            # Heading to tools, so the assistant has not addressed the customer yet.
+            return state
+        self._sim_history.append(
+            {"role": "assistant", "content": await self._decode_response(agent_data)}
+        )
+        if self._hard_cap_hit(agent_data, ignore_termination):
+            return state
+        return await self._run_simulated_user_turn(
+            agent_data, self._sim, str(self._sim_config_path)
+        )
+
+    def _hard_cap_hit(self, agent_data: Any, ignore_termination: bool = False) -> bool:
+        """Mirrors ToolAgentLoop._handle_generating_state's termination checks.
+
+        Returns:
+            Whether the parent terminated because a hard cap was reached.
+        """
+        if (
+            not ignore_termination
+            and len(agent_data.response_mask) >= self.response_length
+        ):
+            return True
+        if (
+            self.max_assistant_turns
+            and agent_data.assistant_turns >= self.max_assistant_turns
+        ):
+            return True
+        if self.max_user_turns and agent_data.user_turns >= self.max_user_turns:
+            return True
+        return False
+
+    async def _run_simulated_user_turn(
+        self, agent_data: Any, sim: RolloutState, config_path: str
+    ) -> AgentState:
+        """Generates one simulated-user turn and appends it as environment text.
+
+        Returns:
+            `GENERATING` if the conversation continues, else `TERMINATED`.
+        """
+        engine, cfg = user_sim_engine(config_path)
+        done, text, score = await asyncio.to_thread(
+            next_user_turn,
+            sim,
+            self._sim_history,
+            lambda conversation: infer_one(engine, cfg, conversation),
+            DEFAULT_DONE_SENTINEL,
+        )
+        agent_data.user_turns += 1
+        agent_data.turn_scores.append(score)
+        if done:
+            return AgentState.TERMINATED
+        self._sim_history.append({"role": "user", "content": text})
+        fits = await self._append_environment_turn(
+            agent_data, [{"role": "user", "content": text}]
+        )
+        return AgentState.GENERATING if fits else AgentState.TERMINATED
+
+    async def _append_environment_turn(
+        self, agent_data: Any, messages: list[dict[str, Any]]
+    ) -> bool:
+        """Appends environment-authored messages, which never carry gradient.
+
+        Mirrors `_handle_processing_tools_state`: the mask is 0 because the policy did
+        not produce these tokens, and the length check precedes any mutation.
+
+        Returns:
+            Whether the turn fit within the response budget.
+        """
+        agent_data.messages.extend(messages)
+        response_ids = await self.apply_chat_template(
+            messages, remove_system_prompt=True
+        )
+        if len(agent_data.response_mask) + len(response_ids) >= self.response_length:
+            return False
+        agent_data.prompt_ids += response_ids
+        agent_data.response_mask += [0] * len(response_ids)
+        if agent_data.response_logprobs:
+            agent_data.response_logprobs += [0.0] * len(response_ids)
+        return True
+
+    async def _decode_response(self, agent_data: Any) -> str:
+        """Decodes the assistant's latest turn.
+
+        Returns:
+            The assistant's text, as the simulated user would read it.
+        """
+        return await self.loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(
+                agent_data.response_ids, skip_special_tokens=True
+            ),
+        )

--- a/tests/unit/core/configs/test_parse_configs.py
+++ b/tests/unit/core/configs/test_parse_configs.py
@@ -52,6 +52,8 @@ def _get_all_config_paths(exclude_yaml_suffixes: set[str] | None) -> list[str]:
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            # verl's agent-loop registry format: a bare list, not an Oumi config.
+            "user_sim_agent_loop.yaml",
         }
     ),
 )
@@ -88,6 +90,8 @@ def test_parse_configs(config_path: str):
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            # verl's agent-loop registry format: a bare list, not an Oumi config.
+            "user_sim_agent_loop.yaml",
         }
     ),
 )

--- a/tests/unit/core/trainers/verl_agentic/test_user_sim_agent_loop.py
+++ b/tests/unit/core/trainers/verl_agentic/test_user_sim_agent_loop.py
@@ -1,0 +1,374 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("verl")
+
+from verl.experimental.agent_loop.tool_agent_loop import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    AgentState,
+    ToolAgentLoop,
+)
+
+from oumi.core.rollout.user_sim import RolloutState  # noqa: E402
+from oumi.core.trainers.verl_agentic.user_sim_agent_loop import (  # noqa: E402
+    UserSimToolAgentLoop,
+)
+
+_MODULE = "oumi.core.trainers.verl_agentic.user_sim_agent_loop"
+PROMPT_LEN = 10
+# 4 token ids per appended message, from the stub apply_chat_template below.
+TOKENS_PER_MESSAGE = 4
+SEED_TURN = {"role": "user", "content": "my order is late"}
+
+
+def _agent_data(policy_tokens: int = 3):
+    """Rollout state after the policy has generated `policy_tokens` tokens."""
+    return SimpleNamespace(
+        messages=[dict(SEED_TURN)],
+        prompt_ids=list(range(PROMPT_LEN)) + [900 + i for i in range(policy_tokens)],
+        response_ids=[900 + i for i in range(policy_tokens)],
+        response_mask=[1] * policy_tokens,
+        response_logprobs=[],
+        turn_scores=[],
+        user_turns=0,
+        assistant_turns=1,
+        extra_fields={},
+    )
+
+
+def _loop(response_length: int = 1000, max_turns: int = 4):
+    loop = UserSimToolAgentLoop.__new__(UserSimToolAgentLoop)
+    loop.response_length = response_length
+    loop.max_assistant_turns = None
+    loop.max_user_turns = None
+    loop.loop = asyncio.new_event_loop()
+    loop.tokenizer = SimpleNamespace(decode=lambda ids, **kw: "let me check on that")
+    loop._sim_config_path = "unused.yaml"
+    loop._sim = RolloutState(persona="Jane", max_turns=max_turns)
+    # `run()` seeds this from `raw_prompt`; these tests enter below `run()`.
+    loop._sim_history = [dict(SEED_TURN)]
+
+    async def _apply_chat_template(messages, **kwargs):
+        return [100 + i for i in range(TOKENS_PER_MESSAGE * len(messages))]
+
+    loop.apply_chat_template = _apply_chat_template
+    return loop
+
+
+def _run_sim_turn(loop, data, turn_result):
+    with (
+        patch(f"{_MODULE}.next_user_turn", return_value=turn_result),
+        patch(f"{_MODULE}.user_sim_engine", return_value=(object(), object())),
+        patch.object(
+            ToolAgentLoop,
+            "_handle_generating_state",
+            return_value=AgentState.TERMINATED,
+        ),
+    ):
+        return loop.loop.run_until_complete(
+            loop._handle_generating_state(data, {}, False)
+        )
+
+
+def test_simulated_user_tokens_are_masked_zero():
+    loop, data = _loop(), _agent_data()
+    state = _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert state is AgentState.GENERATING
+    assert data.response_mask[:3] == [1, 1, 1], "policy tokens must stay mask 1"
+    assert set(data.response_mask[3:]) == {0}, "simulated-user tokens must be mask 0"
+    assert len(data.response_mask) == 3 + TOKENS_PER_MESSAGE
+
+
+def test_boundary_invariant_holds_after_append():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert len(data.prompt_ids) - len(data.response_mask) == PROMPT_LEN
+
+
+def test_assistant_turn_reaches_simulator_without_duplicating_tokens():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert [m["role"] for m in loop._sim_history] == ["user", "assistant", "user"]
+    assert loop._sim_history[1]["content"] == "let me check on that"
+    # Only the simulated-user turn adds tokens; the assistant's are already there.
+    assert len(data.prompt_ids) == PROMPT_LEN + 3 + TOKENS_PER_MESSAGE
+
+
+def test_user_turn_counted_and_score_recorded():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.5))
+
+    assert data.user_turns == 1
+    assert data.turn_scores == [0.5]
+
+
+def test_done_sentinel_terminates_without_tokenizing():
+    loop, data = _loop(), _agent_data()
+    before = list(data.prompt_ids)
+    state = _run_sim_turn(loop, data, (True, "", 0.0))
+
+    assert state is AgentState.TERMINATED
+    assert data.prompt_ids == before, "a finished turn must not be tokenized"
+
+
+def test_overlong_turn_terminates_without_mutating():
+    loop, data = _loop(response_length=4), _agent_data()
+    before_ids, before_mask = list(data.prompt_ids), list(data.response_mask)
+    state = _run_sim_turn(loop, data, (False, "x", 0.0))
+
+    assert state is AgentState.TERMINATED
+    assert data.prompt_ids == before_ids
+    assert data.response_mask == before_mask
+
+
+@pytest.mark.parametrize(
+    "cap_attr,counter_attr",
+    [("max_assistant_turns", "assistant_turns"), ("max_user_turns", "user_turns")],
+)
+def test_turn_caps_prevent_simulated_user_turn(cap_attr, counter_attr):
+    loop, data = _loop(), _agent_data()
+    setattr(loop, cap_attr, 1)
+    setattr(data, counter_attr, 1)
+
+    assert loop._hard_cap_hit(data) is True
+
+
+def test_response_length_cap_prevents_simulated_user_turn():
+    loop, data = _loop(response_length=3), _agent_data()
+
+    assert loop._hard_cap_hit(data) is True
+    assert loop._hard_cap_hit(data, ignore_termination=True) is False
+
+
+def test_no_caps_hit_allows_simulated_user_turn():
+    loop, data = _loop(), _agent_data()
+
+    assert loop._hard_cap_hit(data) is False
+
+
+def test_importing_this_module_does_not_clobber_yaml_registry_entry():
+    """verl's @register overwrites the registry entry with {_target_} alone.
+
+    Importing this module is what resolves `_target_`, so decorating the loop would
+    drop the `user_sim_inference` key that agent_loop_config_path supplies.
+    """
+    import importlib
+
+    from verl.experimental.agent_loop.agent_loop import (  # pyright: ignore[reportMissingImports]
+        _agent_loop_registry,
+    )
+
+    name = "oumi_user_sim_tool_agent"
+    target = "oumi.core.trainers.verl_agentic.user_sim_agent_loop.UserSimToolAgentLoop"
+    saved = _agent_loop_registry.get(name)
+    try:
+        _agent_loop_registry[name] = {
+            "_target_": target,
+            "user_sim_inference": "configs/user_sim_engine.yaml",
+        }
+        importlib.reload(importlib.import_module(_MODULE))
+        assert (
+            _agent_loop_registry[name].get("user_sim_inference")
+            == "configs/user_sim_engine.yaml"
+        ), "module import stripped the YAML-supplied constructor kwargs"
+    finally:
+        if saved is None:
+            _agent_loop_registry.pop(name, None)
+        else:
+            _agent_loop_registry[name] = saved
+
+
+# --- Verification item 9: tools and the simulator compose ---------------------
+
+
+def _generating_state(loop, data, parent_returns):
+    """Runs our override with the parent's decision stubbed to `parent_returns`."""
+    with patch.object(
+        ToolAgentLoop, "_handle_generating_state", return_value=parent_returns
+    ):
+        return loop.loop.run_until_complete(
+            loop._handle_generating_state(data, {}, False)
+        )
+
+
+def test_tool_path_is_never_intercepted():
+    """A pending tool call belongs to the parent; the simulator must stay out of it."""
+    loop, data = _loop(), _agent_data()
+
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        state = _generating_state(loop, data, AgentState.PROCESSING_TOOLS)
+
+    assert state is AgentState.PROCESSING_TOOLS
+    sim.assert_not_called()
+    assert data.user_turns == 0
+
+
+def test_simulator_skipped_entirely_when_not_configured():
+    """Tool-only rows must behave exactly like stock ToolAgentLoop."""
+    loop, data = _loop(), _agent_data()
+    loop._sim = None
+
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        state = _generating_state(loop, data, AgentState.TERMINATED)
+
+    assert state is AgentState.TERMINATED
+    sim.assert_not_called()
+
+
+def test_tool_turn_then_simulated_user_turn_interleave():
+    """user -> assistant(tool_call) -> tool -> assistant(text) -> sim_user -> assistant.
+
+    The tool result and the simulated-user turn are both environment text, so the
+    mask must read 1,0,1,0 across the four spans.
+    """
+    loop, data = _loop(), _agent_data(policy_tokens=3)
+
+    # The assistant calls a tool: the parent routes to PROCESSING_TOOLS, and the
+    # simulator stays out of it -- the customer was not addressed by a tool call.
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        assert (
+            _generating_state(loop, data, AgentState.PROCESSING_TOOLS)
+            is AgentState.PROCESSING_TOOLS
+        )
+    sim.assert_not_called()
+
+    # verl's tool path appends the tool result exactly as we append environment text.
+    loop.loop.run_until_complete(
+        loop._append_environment_turn(
+            data, [{"role": "tool", "content": "status=late"}]
+        )
+    )
+    tool_span = len(data.response_mask)
+
+    # The policy generates again, this time with no tool call.
+    data.response_ids = [950, 951]
+    data.prompt_ids += data.response_ids
+    data.response_mask += [1, 1]
+    data.assistant_turns += 1
+
+    state = _run_sim_turn(loop, data, (False, "when will it arrive?", 0.0))
+
+    assert state is AgentState.GENERATING
+    # verl's own bookkeeping: environment turns only, never assistant turns.
+    assert [m["role"] for m in data.messages] == ["user", "tool", "user"]
+    # What the persona sees: no tool traffic, and no tool-calling assistant turn,
+    # which carried no text for the customer to read.
+    assert [m["role"] for m in loop._sim_history] == ["user", "assistant", "user"]
+    assert loop._sim_history[1]["content"] == "let me check on that"
+    assert data.response_mask[:3] == [1, 1, 1], "first assistant turn"
+    assert set(data.response_mask[3:tool_span]) == {0}, "tool result is environment"
+    assert data.response_mask[tool_span : tool_span + 2] == [1, 1], "second assistant"
+    assert set(data.response_mask[tool_span + 2 :]) == {0}, "simulated user"
+    assert len(data.prompt_ids) - len(data.response_mask) == PROMPT_LEN
+
+
+# --- rollout output shape -----------------------------------------------------
+
+SIM_KWARGS = {"user_persona": "Jane", "goal": "get a refund", "max_turns": 3}
+
+
+def _fresh_loop(config_path: str | None = "unused.yaml"):
+    """A loop as `__init__` leaves it: configured, but with no rollout state yet."""
+    loop = _loop()
+    loop._sim = None
+    loop._sim_history = []
+    loop._sim_config_path = config_path
+    return loop
+
+
+def _run_rollout(loop, extra_info, sim_turns_taken=0, engine_telemetry=None):
+    """Runs `run()` with the parent stubbed to take `sim_turns_taken` user turns."""
+    output = SimpleNamespace(extra_fields=dict(engine_telemetry or {}))
+
+    async def _parent(_self, sampling_params, **kwargs):
+        if loop._sim is not None:
+            loop._sim.turn_idx = sim_turns_taken
+        return output
+
+    with patch.object(ToolAgentLoop, "run", _parent):
+        return loop.loop.run_until_complete(
+            loop.run({}, extra_info=extra_info, raw_prompt=[SEED_TURN])
+        )
+
+
+def test_rollout_output_reports_simulated_user_turns():
+    loop = _fresh_loop()
+
+    output = _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS}, sim_turns_taken=2)
+
+    assert output.extra_fields["sim_user_turns"] == 2
+
+
+def test_tool_only_rollout_output_carries_no_simulator_field():
+    """Rows without a persona must produce stock ToolAgentLoop output."""
+    loop = _fresh_loop()
+
+    output = _run_rollout(loop, {"tools_kwargs": {"run_sql": {}}})
+
+    assert loop._sim is None
+    assert "sim_user_turns" not in output.extra_fields
+
+
+def test_rollout_output_keeps_engine_telemetry():
+    """`sim_user_turns` is written after the parent returns, so it must not clobber."""
+    loop = _fresh_loop()
+
+    output = _run_rollout(
+        loop,
+        {"interaction_kwargs": SIM_KWARGS},
+        sim_turns_taken=1,
+        engine_telemetry={"num_turns": 12},
+    )
+
+    assert output.extra_fields == {"num_turns": 12, "sim_user_turns": 1}
+
+
+def test_persona_row_without_engine_config_fails_loudly():
+    """Silently dropping the persona would train on single-turn rollouts instead."""
+    loop = _fresh_loop(config_path=None)
+
+    with pytest.raises(ValueError, match="user_sim_inference"):
+        _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS})
+
+
+def test_simulator_history_starts_as_a_copy_of_the_prompt():
+    loop = _fresh_loop()
+
+    _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS})
+
+    assert loop._sim_history == [SEED_TURN]
+    loop._sim_history[0]["content"] = "mutated"
+    assert SEED_TURN["content"] == "my order is late", "prompt rows must not alias"
+
+
+# --- Verification item 7: drift guards ----------------------------------------
+
+
+def test_parent_generating_state_signature_is_unchanged():
+    """Our override must keep matching ToolAgentLoop's, which we delegate to."""
+    import inspect
+
+    assert list(
+        inspect.signature(ToolAgentLoop._handle_generating_state).parameters
+    ) == ["self", "agent_data", "sampling_params", "ignore_termination"]
+
+
+def test_agent_state_members_are_known():
+    """An unrecognized state upstream may need handling in _handle_generating_state.
+
+    INTERACTING exists in 0.7 and was removed in 0.8; it is inert for us either way,
+    since we never set `interaction_config_path`.
+    """
+    required = {"PENDING", "GENERATING", "PROCESSING_TOOLS", "TERMINATED"}
+    tolerated = required | {"INTERACTING"}
+    members = set(AgentState.__members__)
+
+    assert required <= members, (
+        f"upstream dropped a state we rely on: {required - members}"
+    )
+    assert members <= tolerated, f"unhandled new AgentState: {members - tolerated}"


### PR DESCRIPTION
## What
Adds multi-turn simulated users to verl tool-enabled rollouts without training on text written by the simulated user.

## Why
Tool use and persona-driven user replies need to interleave without treating environment-authored text as model output. Firm response and turn limits are also needed so rollouts stop safely.

## How
The existing tool loop handles tool calls; after the assistant finishes responding, a simulated user may continue the conversation. Simulated-user tokens are excluded from training loss, and all limits are checked before conversation state changes.

Predecessor: #2611 · Successor: #2613

## Testing
An end-to-end cluster run completed successfully with correct token masks across 24 rollouts; focused tests cover tool handoffs, masking, limits, completion, and telemetry. Standard lints clean.
