### PR TITLE
feat(verl): route agent-loop rows via agent_name and validate the config

### DIFF
--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
+from oumi.core.rollout.user_sim import DEFAULT_MAX_TURNS
 from oumi.core.types.conversation import Conversation
 from oumi.core.types.conversation import Role as ConversationRole
 from oumi.utils.conversation_utils import create_list_of_message_json_dicts
@@ -80,6 +81,15 @@ class VerlGrpoTrainer(BaseTrainer):
     For documentation on the underlying verl RayPPOTrainer, see
     https://verl.readthedocs.io/en/latest/examples/config.html.
     """
+
+    # Must match the `name` in the agent-loop YAML and the @register decorator on
+    # UserSimToolAgentLoop; verl looks the row's `agent_name` up in its registry.
+    OUMI_AGENT_LOOP_NAME = "oumi_user_sim_tool_agent"
+    # verl's own fallback. Plain rows must still carry the key: `Dataset.map` fixes
+    # the output schema from the first row, so a mix of rows with and without
+    # `agent_name` either raises or silently drops the column, which would route
+    # agent-loop rows to single-turn generation with no error.
+    VERL_DEFAULT_AGENT_LOOP_NAME = "single_turn_agent"
 
     def __init__(
         self,
@@ -143,9 +153,11 @@ class VerlGrpoTrainer(BaseTrainer):
         # verl trainer uses private methods and properties of `transformers`
         # processor, so we need to pass the raw processor here.
         self._processor = processor.raw_processor if processor is not None else None
+        self._uses_agent_loop = False
         # Detect what dataset post-processing function to use (if any).
         process_fn = self._detect_dataset_process_fn()
         # Generate files and set self._train_filepath and self._val_filepath.
+        # Also sets self._uses_agent_loop, which _create_config validates against.
         self._create_dataset_files(process_fn)
         self._setup_verl_trainer()
 
@@ -249,46 +261,99 @@ class VerlGrpoTrainer(BaseTrainer):
         return (prompt_messages, images, answer)
 
     @staticmethod
-    def _create_verl_data_entry_from_tool_agent_conversation(
+    def _create_verl_agent_loop_entry(
         conversation: Conversation,
         ground_truth: str,
         tools_kwargs: dict[str, Any],
+        interaction_kwargs: dict[str, Any] | None,
         ability: str,
         idx: int,
         data_source: str,
         split: str,
     ) -> dict:
-        """Build a verl row from a structured tool-agent prompt."""
+        """Build a verl row routed to Oumi's agent loop (tools, user sim, or both)."""
         if any(
             message.count_content_items().image_items
             for message in conversation.messages
         ):
-            raise ValueError("Tool-agent conversations do not support images.")
+            raise ValueError("Agent-loop conversations do not support images.")
         if not conversation.messages or conversation.messages[-1].role not in (
             ConversationRole.USER,
             ConversationRole.TOOL,
         ):
             raise ValueError(
-                "Tool-agent conversation prompts must end with a user or tool message."
+                "Agent-loop conversation prompts must end with a user or tool message."
             )
 
         prompt_messages = create_list_of_message_json_dicts(
             conversation.messages,
             group_adjacent_same_role_turns=False,
         )
+        extra_info: dict[str, Any] = {
+            "split": split,
+            "index": idx,
+            "need_tools_kwargs": bool(tools_kwargs),
+            "tools_kwargs": tools_kwargs,
+        }
+        if interaction_kwargs:
+            extra_info["interaction_kwargs"] = interaction_kwargs
         return {
             "data_source": data_source,
             "prompt": prompt_messages,
             "images": [],
             "ability": ability,
-            "agent_name": "tool_agent",
+            "agent_name": VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME,
             "reward_model": {"style": "rule", "ground_truth": ground_truth},
-            "extra_info": {
-                "split": split,
-                "index": idx,
-                "need_tools_kwargs": True,
-                "tools_kwargs": tools_kwargs,
-            },
+            "extra_info": extra_info,
+        }
+
+    @staticmethod
+    def _parse_tools_kwargs(metadata: dict) -> dict[str, Any]:
+        """Validates and returns the row's per-tool kwargs.
+
+        Returns:
+            A mapping of tool name to that tool's kwargs.
+        """
+        tools_kwargs = metadata.get("tools_kwargs")
+        tools_kwargs_error = (
+            "Tool-agent conversation metadata 'tools_kwargs' must be a "
+            "mapping of tool names to dictionaries."
+        )
+        if not isinstance(tools_kwargs, dict):
+            raise ValueError(f"{tools_kwargs_error} Got {type(tools_kwargs).__name__}.")
+        for tool_name, tool_kwargs in tools_kwargs.items():
+            if not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict):
+                raise ValueError(
+                    f"{tools_kwargs_error} Got {tool_name!r}: "
+                    f"{type(tool_kwargs).__name__}."
+                )
+        return tools_kwargs
+
+    @staticmethod
+    def _parse_interaction_kwargs(
+        conversation: Conversation, interaction_kwargs: dict
+    ) -> dict[str, Any]:
+        """Validates and normalizes the row's simulated-user settings.
+
+        Returns:
+            The persona, goal and turn cap the agent loop needs.
+        """
+        if (
+            not conversation.messages
+            or conversation.messages[-1].role != ConversationRole.USER
+        ):
+            raise ValueError(
+                "interaction rows must end on a user turn (the opening "
+                "customer message)."
+            )
+        # `.get(k, default)` returns None when the key is present but null.
+        max_turns = interaction_kwargs.get("max_turns")
+        if max_turns is None:
+            max_turns = DEFAULT_MAX_TURNS
+        return {
+            "user_persona": interaction_kwargs["user_persona"],
+            "goal": interaction_kwargs.get("goal", ""),
+            "max_turns": max_turns,
         }
 
     @staticmethod
@@ -297,40 +362,48 @@ class VerlGrpoTrainer(BaseTrainer):
     ) -> dict:
         # Peek at metadata off the raw JSON so only the branch that needs a
         # `Conversation` pays for building one.
-        raw_conversation = example["conversation_json"]
+        raw_conversation = example.get("conversation_json") or "{}"
         metadata = json.loads(raw_conversation).get("metadata") or {}
-        if metadata.get("agent_name") == "tool_agent":
+        wants_tools = metadata.get("agent_name") == "tool_agent"
+        interaction_kwargs = metadata.get("interaction_kwargs")
+        # Both are optional and compose: the loop runs tools until the assistant stops
+        # calling them, then hands over to the simulated user. Either alone is valid.
+        if wants_tools or interaction_kwargs:
             conversation = Conversation.from_json(raw_conversation)
-            ground_truth = metadata.get("ground_truth")
-            if not isinstance(ground_truth, str) or not ground_truth:
-                raise ValueError(
-                    "Tool-agent conversation metadata must include a non-empty "
-                    "string 'ground_truth'."
-                )
-            tools_kwargs = metadata.get("tools_kwargs")
-            tools_kwargs_error = (
-                "Tool-agent conversation metadata 'tools_kwargs' must be a "
-                "mapping of tool names to dictionaries."
+            tools_kwargs = (
+                VerlGrpoTrainer._parse_tools_kwargs(metadata) if wants_tools else {}
             )
-            if not isinstance(tools_kwargs, dict):
-                raise ValueError(
-                    f"{tools_kwargs_error} Got {type(tools_kwargs).__name__}."
+            resolved_interaction = (
+                VerlGrpoTrainer._parse_interaction_kwargs(
+                    conversation, interaction_kwargs
                 )
-            for tool_name, tool_kwargs in tools_kwargs.items():
-                if not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict):
+                if interaction_kwargs
+                else None
+            )
+            ground_truth: str = ""
+            if wants_tools:
+                declared = metadata.get("ground_truth")
+                if not isinstance(declared, str) or not declared:
                     raise ValueError(
-                        f"{tools_kwargs_error} Got {tool_name!r}: "
-                        f"{type(tool_kwargs).__name__}."
+                        "Tool-agent conversation metadata must include a non-empty "
+                        "string 'ground_truth'."
                     )
-            ability = metadata.get("ability", "tool_agent")
+                ground_truth = declared
+            elif resolved_interaction is not None:
+                # Simulator-only rows are graded against the customer's goal.
+                ground_truth = resolved_interaction["goal"]
+            ability = metadata.get(
+                "ability", "tool_agent" if wants_tools else "conversation"
+            )
             if not isinstance(ability, str):
                 raise ValueError(
-                    "Tool-agent conversation metadata 'ability' must be a string."
+                    "Agent-loop conversation metadata 'ability' must be a string."
                 )
-            return VerlGrpoTrainer._create_verl_data_entry_from_tool_agent_conversation(
+            return VerlGrpoTrainer._create_verl_agent_loop_entry(
                 conversation,
                 ground_truth,
                 tools_kwargs,
+                resolved_interaction,
                 ability,
                 idx,
                 data_source,
@@ -344,6 +417,7 @@ class VerlGrpoTrainer(BaseTrainer):
             "prompt": prompt_messages,
             "images": images,
             "ability": "math",
+            "agent_name": VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME,
             "reward_model": {"style": "rule", "ground_truth": answer},
             "extra_info": {
                 "split": split,
@@ -383,6 +457,9 @@ class VerlGrpoTrainer(BaseTrainer):
                 with_indices=True,
                 num_proc=num_proc,
             )
+            # Read this off the mapped dataset, not from inside process_fn: the map
+            # runs in subprocesses, so a flag set there never reaches us.
+            self._uses_agent_loop = "agent_name" in train_dataset.column_names
 
         train_dataset.to_parquet(train_file)
         self._train_filepath = str(train_file)
@@ -515,7 +592,35 @@ class VerlGrpoTrainer(BaseTrainer):
             raise ValueError(
                 "Actor and critic must use the same strategy when using FSDP."
             )
+        if self._uses_agent_loop:
+            self._validate_agent_loop_config(config.actor_rollout_ref.rollout)
         return config
+
+    @staticmethod
+    def _validate_agent_loop_config(rollout: DictConfig) -> None:
+        """Fails loudly when agent-loop rows would silently fall back to plain gen.
+
+        verl only consults a row's `agent_name` on the async agent-loop path; without
+        these settings it runs `single_turn_agent`, skipping tools and the simulated
+        user with no error.
+        """
+        if rollout.mode != "async" or not rollout.multi_turn.enable:
+            raise ValueError(
+                "Dataset rows route to Oumi's agent loop, but "
+                f"rollout.mode={rollout.mode!r} and "
+                f"multi_turn.enable={rollout.multi_turn.enable}. verl would fall back "
+                "to single_turn_agent and silently skip tools and the simulated user. "
+                "Set actor_rollout_ref.rollout.mode=async and "
+                "actor_rollout_ref.rollout.multi_turn.enable=true in "
+                "training.verl_config_overrides."
+            )
+        if not rollout.agent.agent_loop_config_path:
+            raise ValueError(
+                "Dataset rows route to Oumi's agent loop, but "
+                "actor_rollout_ref.rollout.agent.agent_loop_config_path is unset. "
+                "Point it at the agent-loop YAML registering "
+                f"{VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME!r}."
+            )
 
     def _setup_verl_trainer(self):
         """Sets up verl's RayPPOTrainer."""

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -88,6 +88,23 @@ actor_rollout_ref:
     entropy_checkpointing: false
   rollout:
     name: vllm
+    # `sync` runs plain single-turn generation. Tools and the simulated user both
+    # need verl's async agent-loop path, which reads each row's `agent_name`.
+    # Enable it per-recipe via `training.verl_config_overrides` -- these defaults are
+    # shared with the single-turn recipes:
+    #
+    #   actor_rollout_ref:
+    #     rollout:
+    #       mode: async
+    #       multi_turn:
+    #         enable: true
+    #         max_assistant_turns: 6        # generation safety rail; null = unbounded
+    #         tool_config_path: <verl tool config>   # only when tools are used
+    #       agent:
+    #         agent_loop_config_path: <yaml registering oumi_user_sim_tool_agent>
+    #
+    # VerlGrpoTrainer._validate_agent_loop_config raises at config time if rows route
+    # to the agent loop without these, so a missing override fails before any GPU work.
     mode: sync
     temperature: 1.0
     top_k: -1

--- a/tests/unit/core/trainers/test_verl_grpo_interaction_entry.py
+++ b/tests/unit/core/trainers/test_verl_grpo_interaction_entry.py
@@ -1,0 +1,280 @@
+import json
+
+import pytest
+
+from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
+
+
+def _conv_json(messages, metadata=None):
+    d = {"messages": messages}
+    if metadata is not None:
+        d["metadata"] = metadata
+    return json.dumps(d)
+
+
+def _interaction_example():
+    return {
+        "conversation_json": _conv_json(
+            [
+                {"role": "system", "content": "You are a support agent."},
+                {"role": "user", "content": "My order #4421 is late."},
+            ],
+            metadata={
+                "interaction_kwargs": {
+                    "user_persona": "You are Jane, a customer whose order #4421 "
+                    "is late.",
+                    "goal": "get a refund or delivery date",
+                    "max_turns": 6,
+                }
+            },
+        ),
+    }
+
+
+def test_interaction_branch_shape():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=3, data_source="support", split="train"
+    )
+    assert len(entry["prompt"]) == 2
+    assert entry["prompt"][0]["role"] == "system"
+    assert entry["prompt"][-1]["role"] == "user"
+    assert entry["reward_model"]["ground_truth"] == "get a refund or delivery date"
+    ik = entry["extra_info"]["interaction_kwargs"]
+    assert ik["max_turns"] == 6
+    assert ik["goal"] == "get a refund or delivery date"
+    assert ik["user_persona"].startswith("You are Jane")
+
+
+def test_interaction_row_must_end_on_user():
+    bad = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "resolved"},
+            ],
+            metadata={"interaction_kwargs": {"user_persona": "p", "goal": "g"}},
+        )
+    }
+    with pytest.raises(ValueError):
+        VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            bad, idx=0, data_source="s", split="train"
+        )
+
+
+def test_missing_conversation_json_raises_with_context():
+    with pytest.raises(ValueError, match="conversation_json"):
+        VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            {}, idx=0, data_source="s", split="train"
+        )
+
+
+def test_non_interaction_row_uses_final_turn_path():
+    example = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "2+2?"}, {"role": "assistant", "content": "4"}]
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="math", split="train"
+    )
+    assert entry["reward_model"]["ground_truth"] == "4"
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+AGENT_NAME = "oumi_user_sim_tool_agent"
+
+
+def test_interaction_row_routes_to_agent_loop():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=3, data_source="support", split="train"
+    )
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["reward_model"]["style"] == "rule"
+    assert entry["reward_model"]["ground_truth"] == "get a refund or delivery date"
+    assert entry["extra_info"]["tools_kwargs"] == {}
+    assert entry["extra_info"]["need_tools_kwargs"] is False
+    kwargs = entry["extra_info"]["interaction_kwargs"]
+    assert kwargs["user_persona"].startswith("You are Jane")
+    assert kwargs["max_turns"] == 6
+    assert "name" not in kwargs
+
+
+def test_tool_agent_row_routes_to_same_loop():
+    example = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "How many orders?"}],
+            metadata={
+                "agent_name": "tool_agent",
+                "ground_truth": "SELECT count(*) FROM orders",
+                "tools_kwargs": {"run_sql": {"create_kwargs": {}}},
+            },
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="spider", split="train"
+    )
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["extra_info"]["need_tools_kwargs"] is True
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+def test_plain_row_carries_verl_default_agent_name():
+    """Plain rows still need the key so a mixed dataset keeps a uniform schema."""
+    example = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="math", split="train"
+    )
+    assert entry["agent_name"] == VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME
+
+
+def _mapped(rows):
+    from datasets import Dataset
+
+    return Dataset.from_list(rows).map(
+        lambda ex, i: VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            ex, i, "src", "train"
+        ),
+        with_indices=True,
+    )
+
+
+@pytest.mark.parametrize("plain_first", [True, False])
+def test_mixed_rows_keep_agent_name_in_both_orders(plain_first):
+    """`Dataset.map` fixes the schema from row 0, so every row must carry agent_name.
+
+    Without it, plain-first silently drops the column and agent-loop rows fall back to
+    single-turn generation with no error.
+    """
+    interaction = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "late order"}],
+            metadata={"interaction_kwargs": {"user_persona": "Jane", "goal": "refund"}},
+        )
+    }
+    plain = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        )
+    }
+    rows = [plain, interaction] if plain_first else [interaction, plain]
+
+    mapped = _mapped(rows)
+
+    assert "agent_name" in mapped.column_names
+    assert set(mapped["agent_name"]) == {
+        VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME,
+        VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME,
+    }
+
+
+def test_interaction_only_dataset_writes_parquet(tmp_path):
+    """Simulator-only rows carry `tools_kwargs={}`; the schema must still serialize."""
+    rows = [
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "late order"}],
+                metadata={"interaction_kwargs": {"user_persona": "Jane"}},
+            )
+        }
+    ]
+    out = tmp_path / "train.parquet"
+
+    _mapped(rows).to_parquet(str(out))
+
+    assert out.stat().st_size > 0
+
+
+def test_explicit_null_max_turns_falls_back_to_default():
+    """`.get(key, default)` returns None when the key is present but null."""
+    from oumi.core.rollout.user_sim import DEFAULT_MAX_TURNS
+
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "hi"}],
+                metadata={
+                    "interaction_kwargs": {"user_persona": "Jane", "max_turns": None}
+                },
+            )
+        },
+        idx=0,
+        data_source="src",
+        split="train",
+    )
+
+    assert entry["extra_info"]["interaction_kwargs"]["max_turns"] == DEFAULT_MAX_TURNS
+
+
+def _tools_and_sim_example():
+    return {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "where is order #4421?"}],
+            metadata={
+                "agent_name": "tool_agent",
+                "ground_truth": "SELECT status FROM orders WHERE id=4421",
+                "tools_kwargs": {"run_sql": {"create_kwargs": {}}},
+                "interaction_kwargs": {
+                    "user_persona": "You are Jane, chasing order #4421.",
+                    "goal": "get a delivery date",
+                    "max_turns": 4,
+                },
+            },
+        )
+    }
+
+
+def test_row_can_carry_both_tools_and_simulated_user():
+    """The loop runs tools then hands over to the simulator; the row must say so."""
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _tools_and_sim_example(), idx=0, data_source="support", split="train"
+    )
+
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["extra_info"]["tools_kwargs"] == {"run_sql": {"create_kwargs": {}}}
+    assert entry["extra_info"]["need_tools_kwargs"] is True
+    assert entry["extra_info"]["interaction_kwargs"]["user_persona"].startswith(
+        "You are Jane"
+    )
+    assert entry["extra_info"]["interaction_kwargs"]["max_turns"] == 4
+    assert entry["reward_model"]["ground_truth"] == (
+        "SELECT status FROM orders WHERE id=4421"
+    )
+
+
+def test_tools_only_row_has_no_simulator():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "how many orders?"}],
+                metadata={
+                    "agent_name": "tool_agent",
+                    "ground_truth": "SELECT count(*) FROM orders",
+                    "tools_kwargs": {"run_sql": {}},
+                },
+            )
+        },
+        idx=0,
+        data_source="spider",
+        split="train",
+    )
+
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+def test_simulator_only_row_has_no_tools():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=0, data_source="support", split="train"
+    )
+
+    assert entry["extra_info"]["tools_kwargs"] == {}
+    assert entry["extra_info"]["need_tools_kwargs"] is False

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -175,7 +175,7 @@ def test_create_verl_data_entry_tool_agent_carries_metadata():
     row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
         _example(convo), 0, "nl2sql", "train"
     )
-    assert row["agent_name"] == "tool_agent"
+    assert row["agent_name"] == VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME
     assert row["reward_model"]["ground_truth"] == "SELECT count(*) FROM t"
     assert row["extra_info"]["need_tools_kwargs"] is True
     assert "run_sql" in row["extra_info"]["tools_kwargs"]


### PR DESCRIPTION
## What
Routes simulator and tool conversations through multi-turn generation while keeping ordinary examples on the default single-turn path.

## Why
Mixed datasets can silently discard per-row generation choices when the first example is ordinary, causing interactive examples to run as single-turn generation. Misconfigured training should fail before GPU allocation instead of quietly skipping tools or simulated users.

## How
Every dataset row now identifies its generation path, with simulator and tool settings allowed together. Configuration validation requires asynchronous multi-turn generation whenever any row needs interactive behavior.

Predecessor: #2612

## Testing
Unit tests cover mixed-row ordering, simulator-only and tool-only rows, combined behavior, serialization, and invalid configurations. Standard lints clean.
