### PR TITLE
[ci] Use standard Ubuntu mirror for GPU tests

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -30,6 +30,15 @@ jobs:
           # Need full history for setuptools-scm to detect version
           fetch-depth: 0
 
+      - name: Configure Ubuntu package mirror
+        run: |
+          sudo find /etc/apt -type f \
+            \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i \
+              's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              {} +
+          echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries >/dev/null
+
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

- replace the GPU runner image's Azure-specific Ubuntu mirror with the standard Ubuntu HTTPS archive
- configure apt to retry transient package-download failures
- leave the CUDA version and GPU test commands unchanged

The GPU workflow repeatedly failed before Python setup because `azure.archive.ubuntu.com` timed out. A scheduled `main` run was affected as well.

## Test plan

- [x] `pre-commit run --files .github/workflows/gpu_tests.yaml`
- [x] [Manually dispatched GPU Tests from this branch](https://github.com/oumi-ai/oumi/actions/runs/32170190485)