### PR TITLE
Fix parsed inference content without tool calls

### DIFF
--- a/src/oumi/inference/vllm_inference_engine.py
+++ b/src/oumi/inference/vllm_inference_engine.py
@@ -668,8 +668,7 @@ class VLLMInferenceEngine(BaseInferenceEngine):
     ) -> tuple[list[Message], FinishReason | None]:
         """Builds assistant messages from a vLLM chat response.
 
-        When ``self._tool_parser`` is set, runs it over each completion's
-        text and populates ``Message.tool_calls`` with the extracted payload.
+        When ``self._tool_parser`` is set, uses its parsed content and tool calls.
         On parser failure, falls back to raw text.
         """
         new_messages: list[Message] = []
@@ -708,15 +707,15 @@ class VLLMInferenceEngine(BaseInferenceEngine):
                     )
                     extracted = None
 
-                if extracted is not None and getattr(extracted, "tools_called", False):
-                    tool_calls_payload = [
-                        ToolCall.model_validate(tc.model_dump())
-                        for tc in extracted.tool_calls
-                    ]
-                    # Empty leading content is rendered as `None` to match
-                    # the OpenAI wire format for tool-only assistant turns.
-                    content = extracted.content or None
-                    finish_reason_override = FinishReason.TOOL_CALLS
+                if extracted is not None:
+                    tools_called = bool(getattr(extracted, "tools_called", False))
+                    content = extracted.content or (None if tools_called else "")
+                    if tools_called:
+                        tool_calls_payload = [
+                            ToolCall.model_validate(tc.model_dump())
+                            for tc in extracted.tool_calls
+                        ]
+                        finish_reason_override = FinishReason.TOOL_CALLS
 
             new_messages.append(
                 Message(

--- a/tests/unit/inference/test_vllm_inference_engine.py
+++ b/tests/unit/inference/test_vllm_inference_engine.py
@@ -885,6 +885,35 @@ def test_infer_input_preserves_tool_calls_and_tool_call_id(mock_vllm):
     assert sent[2]["tool_call_id"] == "call_abc"
 
 
+@pytest.mark.parametrize(
+    ("parsed_content", "expected_content"),
+    [("clean answer", "clean answer"), (None, "")],
+)
+def test_tool_call_parser_uses_content_without_tool_calls(
+    parsed_content, expected_content
+):
+    parser_instance = Mock()
+    parser_instance.extract_tool_calls.return_value = SimpleNamespace(
+        tools_called=False,
+        tool_calls=[],
+        content=parsed_content,
+    )
+    engine = object.__new__(VLLMInferenceEngine)
+    engine._tool_parser = parser_instance
+    conv = Conversation(
+        messages=[Message(role=Role.USER, content="hi")], conversation_id="1"
+    )
+    chat_response = SimpleNamespace(outputs=[SimpleNamespace(text="raw protocol text")])
+    messages, finish_reason_override = engine._build_response_messages(
+        conv, chat_response
+    )
+
+    assistant = messages[-1]
+    assert assistant.tool_calls is None
+    assert assistant.content == expected_content
+    assert finish_reason_override is None
+
+
 @pytest.mark.skipif(vllm_import_failed, reason="vLLM not available")
 def test_tool_call_parser_populates_message_tool_calls(mock_vllm):
     """When tool_call_parser is set, parsed tool calls land on Message.tool_calls."""


### PR DESCRIPTION
## Summary

- Use a vLLM tool parser’s parsed content even when no tool call was detected.
- Preserve the existing tool-call payload, finish-reason, and parser-error fallback behavior.
- Convert parser-returned `None` content to an empty assistant message when there is no tool call.

This lets parsers that own model-specific response framing, such as `muse_glimmer`, remove protocol markers from ordinary assistant responses before Oumi serializes them. Previously Oumi only used parser output when `tools_called=True` and otherwise kept the raw model text. This also matches vLLM’s OpenAI serving path, which uses parser-returned content independently of whether a tool call was found.

## Reasoning behavior

Muse Glimmer natively emits private `to=self` reasoning before its user-visible `to=user` answer. The `muse_glimmer` tool parser returns only the latter as parsed content, so with this change the model still generates its reasoning but Oumi serializes only the clean final answer; the reasoning and its ATEM protocol markers are discarded.

Preserving that reasoning separately would require local vLLM reasoning-parser integration and consistent end-to-end handling of `Message.reasoning_content` by downstream consumers. That should be addressed as a broader reasoning-output feature rather than placing private reasoning or model-specific protocol tokens back into ordinary assistant `content`.

## Compatibility check

Reviewed representative non-tool response paths in the current vLLM parsers:

- **Qwen3.5 (`hermes`)**: returns the original model output as `content` when no `<tool_call>` tag is present, so ordinary answers are unchanged.
- **Llama 3.1–3.3 (`llama3_json`)**: returns the original model output as `content` when no tool-call payload is found, so ordinary answers are unchanged.
- **Muse Glimmer (`muse_glimmer`)**: returns only the visible user-channel content, or `None` when the response has no user-visible content; this is the behavior the fix is intended to preserve.
- Models that do not configure `tool_call_parser` are unaffected.

For both Qwen and Llama parsers, valid tool calls continue through the existing `tools_called=True` path; parsed content, tool-call payloads, and finish reasons are unchanged.

The remaining compatibility risk is limited to a custom parser that incorrectly returns `content=None` for a response that actually has visible content.

## Testing

- `ruff format` and `ruff check` on changed files
- focused parser-content unit tests (`2 passed`)
- targeted `pyright` on changed files (`0 errors`)
