### PR TITLE
Fix FSDP merge handling of dim 0 tensors

### DIFF
--- a/src/oumi/utils/verl_model_merger.py
+++ b/src/oumi/utils/verl_model_merger.py
@@ -346,9 +346,103 @@ class FSDPModelMerger(BaseModelMerger):
                     # 2-D list, FSDP + TP
                     raise NotImplementedError("FSDP + TP is not supported yet")
             else:
-                state_dict[key] = torch.cat(state_dict[key], dim=0)
+                # Expected shapes are only needed for plain (non-DTensor) entries,
+                # which carry no placement metadata.
+                if any(key not in param_placements for key in state_dict):
+                    expected_shapes = self._get_expected_shapes()
+
+                state_dict[key] = self._merge_unsharded_shards(
+                    key, state_dict[key], expected_shapes
+                )
 
         return state_dict
+
+    def _get_expected_shapes(self) -> dict[str, torch.Size] | None:
+        """Returns the target architecture's tensor shapes, keyed by name.
+
+        The model is instantiated on the meta device (shape/dtype metadata
+        only, no weight storage), so this is cheap even for large models.
+        Returns None if the architecture cannot be instantiated.
+        """
+        try:
+            auto_model_class = self.get_transformers_auto_model_class()
+            with init_empty_weights():
+                model = auto_model_class.from_config(self.model_config)
+            return {key: value.shape for key, value in model.state_dict().items()}
+        except Exception as e:
+            logger.warning(
+                "Could not build the target model on the meta device to look up "
+                f"expected tensor shapes ({e}); falling back to heuristics for "
+                "non-DTensor checkpoint entries."
+            )
+            return None
+
+    def _merge_unsharded_shards(
+        self,
+        key: str,
+        shards: list[torch.Tensor],
+        expected_shapes: dict[str, torch.Size] | None,
+    ) -> torch.Tensor:
+        """Merges per-rank copies of a tensor saved without placement metadata.
+
+        FSDP saves the tensors it does not shard (e.g. 0-dim learned scalars
+        and buffers) as plain tensors, so every rank's checkpoint holds a full
+        replicated copy. Genuinely dim-0-sharded plain tensors also exist in
+        older checkpoint formats. The target model's expected shape decides
+        between the two; when it is unavailable, identical rank copies are
+        treated as replicated.
+        """
+        # Ground truth is unavailable in two distinct cases; both fall back to
+        # the value-based heuristic.
+        if expected_shapes is None:
+            # Case 1: the target model could not be instantiated at all.
+            # (_get_expected_shapes already warned once for the whole merge.)
+            return self._merge_shards_heuristically(shards)
+        if key not in expected_shapes:
+            # Case 2: the model was instantiated, but its architecture does
+            # not declare this tensor (e.g. a custom head).
+            logger.warning(
+                f"Tensor '{key}' is not part of the target model architecture; "
+                "merging heuristically."
+            )
+            return self._merge_shards_heuristically(shards)
+
+        expected = expected_shapes[key]
+        if shards[0].shape == expected:
+            # Replicated: every rank saved a full copy; keep one.
+            if any(not torch.equal(s, shards[0]) for s in shards[1:]):
+                logger.warning(
+                    f"Replicated tensor '{key}' differs across ranks; "
+                    "keeping the rank-0 copy."
+                )
+            return shards[0]
+        dim0_concat_shape = None
+        if shards[0].ndim > 0:
+            dim0_concat_shape = torch.Size(
+                (sum(s.shape[0] for s in shards), *shards[0].shape[1:])
+            )
+        if dim0_concat_shape == expected:
+            return torch.cat(shards, dim=0)
+        raise ValueError(
+            f"Cannot merge tensor '{key}': the per-rank shape "
+            f"{tuple(shards[0].shape)} matches neither the expected shape "
+            f"{tuple(expected)} nor its dim-0 concatenation."
+        )
+
+    @staticmethod
+    def _merge_shards_heuristically(shards: list[torch.Tensor]) -> torch.Tensor:
+        """Merges per-rank shards without knowing the expected final shape.
+
+        0-dim tensors cannot be sharded along dim 0, and identical rank copies
+        indicate replication: either way, every rank holds a full copy, so
+        keep one instead of concatenating world_size copies. Otherwise assume
+        dim-0 shards and concatenate.
+        """
+        if shards[0].ndim == 0 or all(
+            s.shape == shards[0].shape and torch.equal(s, shards[0]) for s in shards[1:]
+        ):
+            return shards[0]
+        return torch.cat(shards, dim=0)
 
     def merge_and_save(self):
         world_size = self._get_world_size()

--- a/src/oumi/utils/verl_model_merger.py
+++ b/src/oumi/utils/verl_model_merger.py
@@ -383,14 +383,34 @@ class FSDPModelMerger(BaseModelMerger):
         shards: list[torch.Tensor],
         expected_shapes: dict[str, torch.Size] | None,
     ) -> torch.Tensor:
-        """Merges per-rank copies of a tensor saved without placement metadata.
+        """Merges the per-rank copies of a tensor saved without placement metadata.
 
-        FSDP saves the tensors it does not shard (e.g. 0-dim learned scalars
-        and buffers) as plain tensors, so every rank's checkpoint holds a full
-        replicated copy. Genuinely dim-0-sharded plain tensors also exist in
-        older checkpoint formats. The target model's expected shape decides
-        between the two; when it is unavailable, identical rank copies are
-        treated as replicated.
+        Tensors FSDP leaves unsharded (e.g. 0-dim scalars and buffers) arrive
+        as one full copy per rank, while older checkpoint formats may store
+        genuine dim-0 slices. The two look identical in the checkpoint, so the
+        target architecture's expected shape decides: 4 copies of shape [1]
+        with expected shape [1] are replicas (keep one); 4 slices of [2, 6]
+        with expected shape [8, 6] are shards (concatenate). Without an
+        expected shape, a value-based heuristic decides instead.
+
+        Args:
+            key: Tensor name in the model state dict, e.g.
+                ``"model.language_model.layers.0.layer_scalar"``.
+            shards: The tensor's per-rank entries, in rank order — one per
+                checkpoint shard file (``model_world_size_4_rank_0.pt``, ...).
+            expected_shapes: Tensor name -> final shape in the target
+                architecture, from ``_get_expected_shapes()``. ``None`` if the
+                model could not be built; ``key`` may also be absent (e.g. a
+                custom head). Both cases fall back to
+                ``_merge_shards_heuristically()``.
+
+        Returns:
+            The merged tensor: ``shards[0]`` if replicated (warns if the
+            copies differ across ranks), otherwise the dim-0 concatenation.
+
+        Raises:
+            ValueError: Neither one per-rank copy nor the dim-0 concatenation
+                matches the expected shape.
         """
         # Ground truth is unavailable in two distinct cases; both fall back to
         # the value-based heuristic.

--- a/src/oumi/utils/verl_model_merger.py
+++ b/src/oumi/utils/verl_model_merger.py
@@ -329,6 +329,12 @@ class FSDPModelMerger(BaseModelMerger):
 
         del model_state_dict_lst
 
+        # Expected shapes are only needed for plain (non-DTensor) entries,
+        # which carry no placement metadata; build them once for the merge.
+        expected_shapes = None
+        if any(key not in param_placements for key in state_dict):
+            expected_shapes = self._get_expected_shapes()
+
         # Merge tensors
         for key in sorted(state_dict):
             if not isinstance(state_dict[key], list):
@@ -346,13 +352,11 @@ class FSDPModelMerger(BaseModelMerger):
                     # 2-D list, FSDP + TP
                     raise NotImplementedError("FSDP + TP is not supported yet")
             else:
-                # Expected shapes are only needed for plain (non-DTensor) entries,
-                # which carry no placement metadata.
-                if any(key not in param_placements for key in state_dict):
-                    expected_shapes = self._get_expected_shapes()
-
                 state_dict[key] = self._merge_unsharded_shards(
-                    key, state_dict[key], expected_shapes
+                    key,
+                    state_dict[key],
+                    expected_shapes,
+                    checkpoint_has_dtensors=bool(param_placements),
                 )
 
         return state_dict
@@ -360,13 +364,14 @@ class FSDPModelMerger(BaseModelMerger):
     def _get_expected_shapes(self) -> dict[str, torch.Size] | None:
         """Returns the target architecture's tensor shapes, keyed by name.
 
-        The model is instantiated on the meta device (shape/dtype metadata
-        only, no weight storage), so this is cheap even for large models.
-        Returns None if the architecture cannot be instantiated.
+        The model is instantiated on the meta device — parameters and buffers
+        alike carry shape/dtype metadata but no storage — so this is cheap
+        even for large models. Returns None if the architecture cannot be
+        instantiated.
         """
         try:
             auto_model_class = self.get_transformers_auto_model_class()
-            with init_empty_weights():
+            with init_empty_weights(include_buffers=True):
                 model = auto_model_class.from_config(self.model_config)
             return {key: value.shape for key, value in model.state_dict().items()}
         except Exception as e:
@@ -382,16 +387,14 @@ class FSDPModelMerger(BaseModelMerger):
         key: str,
         shards: list[torch.Tensor],
         expected_shapes: dict[str, torch.Size] | None,
+        checkpoint_has_dtensors: bool,
     ) -> torch.Tensor:
         """Merges the per-rank copies of a tensor saved without placement metadata.
 
-        Tensors FSDP leaves unsharded (e.g. 0-dim scalars and buffers) arrive
-        as one full copy per rank, while older checkpoint formats may store
-        genuine dim-0 slices. The two look identical in the checkpoint, so the
-        target architecture's expected shape decides: 4 copies of shape [1]
-        with expected shape [1] are replicas (keep one); 4 slices of [2, 6]
-        with expected shape [8, 6] are shards (concatenate). Without an
-        expected shape, a value-based heuristic decides instead.
+        Each rank's copy is either a full replica (tensors FSDP leaves
+        unsharded, e.g. gemma-4's 0-dim min/max buffers and shape-[1]
+        ``layer_scalar``s) or a dim-0 shard (legacy checkpoint formats).
+        ``_is_replicated()`` decides which; this method applies the verdict.
 
         Args:
             key: Tensor name in the model state dict, e.g.
@@ -399,10 +402,10 @@ class FSDPModelMerger(BaseModelMerger):
             shards: The tensor's per-rank entries, in rank order — one per
                 checkpoint shard file (``model_world_size_4_rank_0.pt``, ...).
             expected_shapes: Tensor name -> final shape in the target
-                architecture, from ``_get_expected_shapes()``. ``None`` if the
-                model could not be built; ``key`` may also be absent (e.g. a
-                custom head). Both cases fall back to
-                ``_merge_shards_heuristically()``.
+                architecture, from ``_get_expected_shapes()``; ``None`` if the
+                model could not be built.
+            checkpoint_has_dtensors: Whether the checkpoint stores its sharded
+                tensors as DTensors (see ``_is_replicated()``).
 
         Returns:
             The merged tensor: ``shards[0]`` if replicated (warns if the
@@ -410,59 +413,70 @@ class FSDPModelMerger(BaseModelMerger):
 
         Raises:
             ValueError: Neither one per-rank copy nor the dim-0 concatenation
-                matches the expected shape.
+                matches the tensor's expected shape.
         """
-        # Ground truth is unavailable in two distinct cases; both fall back to
-        # the value-based heuristic.
-        if expected_shapes is None:
-            # Case 1: the target model could not be instantiated at all.
-            # (_get_expected_shapes already warned once for the whole merge.)
-            return self._merge_shards_heuristically(shards)
-        if key not in expected_shapes:
-            # Case 2: the model was instantiated, but its architecture does
-            # not declare this tensor (e.g. a custom head).
-            logger.warning(
-                f"Tensor '{key}' is not part of the target model architecture; "
-                "merging heuristically."
-            )
-            return self._merge_shards_heuristically(shards)
-
-        expected = expected_shapes[key]
-        if shards[0].shape == expected:
-            # Replicated: every rank saved a full copy; keep one.
-            if any(not torch.equal(s, shards[0]) for s in shards[1:]):
+        if self._is_replicated(key, shards, expected_shapes, checkpoint_has_dtensors):
+            if any(
+                s.shape != shards[0].shape or not torch.equal(s, shards[0])
+                for s in shards[1:]
+            ):
                 logger.warning(
                     f"Replicated tensor '{key}' differs across ranks; "
                     "keeping the rank-0 copy."
                 )
             return shards[0]
-        dim0_concat_shape = None
-        if shards[0].ndim > 0:
-            dim0_concat_shape = torch.Size(
-                (sum(s.shape[0] for s in shards), *shards[0].shape[1:])
+        return torch.cat(shards, dim=0)
+
+    def _is_replicated(
+        self,
+        key: str,
+        shards: list[torch.Tensor],
+        expected_shapes: dict[str, torch.Size] | None,
+        checkpoint_has_dtensors: bool,
+    ) -> bool:
+        """Decides whether the per-rank copies are replicas or dim-0 shards.
+
+        Evidence is consulted strongest first:
+
+        1. The tensor's expected shape in the target architecture — decisive:
+           one rank's copy already having the final shape means replicas; the
+           dim-0 concatenation having the final shape means shards; neither
+           raises ValueError rather than guessing.
+        2. Structure: a 0-dim tensor has no dim 0 and cannot be a shard.
+        3. Checkpoint format: a checkpoint that stores its sharded tensors as
+           DTensors saves plain tensors only for replicated buffers, while a
+           legacy DTensor-free checkpoint saves plain dim-0 shards.
+        """
+        expected = expected_shapes.get(key) if expected_shapes is not None else None
+        if expected is not None:
+            if shards[0].shape == expected:
+                return True
+            if self._dim0_concat_shape(shards) == expected:
+                return False
+            raise ValueError(
+                f"Cannot merge tensor '{key}': the per-rank shape "
+                f"{tuple(shards[0].shape)} matches neither the expected shape "
+                f"{tuple(expected)} nor its dim-0 concatenation."
             )
-        if dim0_concat_shape == expected:
-            return torch.cat(shards, dim=0)
-        raise ValueError(
-            f"Cannot merge tensor '{key}': the per-rank shape "
-            f"{tuple(shards[0].shape)} matches neither the expected shape "
-            f"{tuple(expected)} nor its dim-0 concatenation."
-        )
+        if expected_shapes is not None:
+            # The architecture was built but does not declare this tensor
+            # (e.g. a custom head). A failed build was already warned about
+            # once, in _get_expected_shapes.
+            logger.warning(
+                f"Tensor '{key}' is not part of the target model architecture; "
+                "inferring from the checkpoint format."
+            )
+        return shards[0].ndim == 0 or checkpoint_has_dtensors
 
     @staticmethod
-    def _merge_shards_heuristically(shards: list[torch.Tensor]) -> torch.Tensor:
-        """Merges per-rank shards without knowing the expected final shape.
+    def _dim0_concat_shape(shards: list[torch.Tensor]) -> torch.Size | None:
+        """The shape a dim-0 concatenation of ``shards`` would produce.
 
-        0-dim tensors cannot be sharded along dim 0, and identical rank copies
-        indicate replication: either way, every rank holds a full copy, so
-        keep one instead of concatenating world_size copies. Otherwise assume
-        dim-0 shards and concatenate.
+        ``None`` for 0-dim tensors, which have no dim 0 to concatenate along.
         """
-        if shards[0].ndim == 0 or all(
-            s.shape == shards[0].shape and torch.equal(s, shards[0]) for s in shards[1:]
-        ):
-            return shards[0]
-        return torch.cat(shards, dim=0)
+        if shards[0].ndim == 0:
+            return None
+        return torch.Size((sum(s.shape[0] for s in shards), *shards[0].shape[1:]))
 
     def merge_and_save(self):
         world_size = self._get_world_size()

--- a/src/oumi/utils/verl_model_merger.py
+++ b/src/oumi/utils/verl_model_merger.py
@@ -364,10 +364,10 @@ class FSDPModelMerger(BaseModelMerger):
     def _get_expected_shapes(self) -> dict[str, torch.Size] | None:
         """Returns the target architecture's tensor shapes, keyed by name.
 
-        The model is instantiated on the meta device — parameters and buffers
-        alike carry shape/dtype metadata but no storage — so this is cheap
-        even for large models. Returns None if the architecture cannot be
-        instantiated.
+        The model is instantiated on the meta device, where parameters and
+        buffers carry shape and dtype metadata but occupy no storage, so this
+        is cheap even for large models. Returns None if the architecture
+        cannot be instantiated.
         """
         try:
             auto_model_class = self.get_transformers_auto_model_class()
@@ -377,8 +377,8 @@ class FSDPModelMerger(BaseModelMerger):
         except Exception as e:
             logger.warning(
                 "Could not build the target model on the meta device to look up "
-                f"expected tensor shapes ({e}); falling back to heuristics for "
-                "non-DTensor checkpoint entries."
+                f"expected tensor shapes ({e}). Plain checkpoint entries will be "
+                "merged based on the checkpoint format instead."
             )
             return None
 
@@ -391,29 +391,35 @@ class FSDPModelMerger(BaseModelMerger):
     ) -> torch.Tensor:
         """Merges the per-rank copies of a tensor saved without placement metadata.
 
-        Each rank's copy is either a full replica (tensors FSDP leaves
-        unsharded, e.g. gemma-4's 0-dim min/max buffers and shape-[1]
-        ``layer_scalar``s) or a dim-0 shard (legacy checkpoint formats).
-        ``_is_replicated()`` decides which; this method applies the verdict.
+        Each rank's copy is either a full replica of the tensor (FSDP leaves
+        buffers unsharded, such as gemma-4's 0-dim min/max trackers and its
+        shape-[1] ``layer_scalar`` buffers) or a dim-0 slice of it (as in
+        legacy checkpoint formats). ``_is_replicated()`` decides which one it
+        is, and this method then either keeps a single copy or concatenates
+        the slices.
 
         Args:
             key: Tensor name in the model state dict, e.g.
                 ``"model.language_model.layers.0.layer_scalar"``.
-            shards: The tensor's per-rank entries, in rank order — one per
-                checkpoint shard file (``model_world_size_4_rank_0.pt``, ...).
-            expected_shapes: Tensor name -> final shape in the target
-                architecture, from ``_get_expected_shapes()``; ``None`` if the
-                model could not be built.
+            shards: The tensor's per-rank entries in rank order, one per
+                checkpoint shard file (``model_world_size_4_rank_0.pt`` and
+                so on).
+            expected_shapes: Mapping from tensor name to its final shape in
+                the target architecture, produced by
+                ``_get_expected_shapes()``. ``None`` if the model could not
+                be built.
             checkpoint_has_dtensors: Whether the checkpoint stores its sharded
-                tensors as DTensors (see ``_is_replicated()``).
+                tensors as DTensors. See ``_is_replicated()`` for how this is
+                used.
 
         Returns:
-            The merged tensor: ``shards[0]`` if replicated (warns if the
-            copies differ across ranks), otherwise the dim-0 concatenation.
+            The merged tensor: ``shards[0]`` if the copies are replicas (with
+            a warning if they differ across ranks), otherwise their dim-0
+            concatenation.
 
         Raises:
-            ValueError: Neither one per-rank copy nor the dim-0 concatenation
-                matches the tensor's expected shape.
+            ValueError: Neither a single per-rank copy nor the dim-0
+                concatenation matches the tensor's expected shape.
         """
         if self._is_replicated(key, shards, expected_shapes, checkpoint_has_dtensors):
             if any(
@@ -436,16 +442,18 @@ class FSDPModelMerger(BaseModelMerger):
     ) -> bool:
         """Decides whether the per-rank copies are replicas or dim-0 shards.
 
-        Evidence is consulted strongest first:
+        The strongest available evidence wins:
 
-        1. The tensor's expected shape in the target architecture — decisive:
-           one rank's copy already having the final shape means replicas; the
-           dim-0 concatenation having the final shape means shards; neither
-           raises ValueError rather than guessing.
-        2. Structure: a 0-dim tensor has no dim 0 and cannot be a shard.
-        3. Checkpoint format: a checkpoint that stores its sharded tensors as
+        1. The tensor's expected shape in the target architecture. If one
+           rank's copy already has the final shape, the copies are replicas.
+           If concatenating them along dim 0 would produce the final shape,
+           they are shards. If neither is true, the checkpoint contradicts
+           the architecture and a ValueError is raised instead of guessing.
+        2. Tensor structure. A 0-dim tensor has no dim 0, so it cannot be a
+           shard and must be a replica.
+        3. Checkpoint format. A checkpoint that stores its sharded tensors as
            DTensors saves plain tensors only for replicated buffers, while a
-           legacy DTensor-free checkpoint saves plain dim-0 shards.
+           legacy checkpoint with no DTensors saves plain dim-0 shards.
         """
         expected = expected_shapes.get(key) if expected_shapes is not None else None
         if expected is not None:
@@ -460,8 +468,8 @@ class FSDPModelMerger(BaseModelMerger):
             )
         if expected_shapes is not None:
             # The architecture was built but does not declare this tensor
-            # (e.g. a custom head). A failed build was already warned about
-            # once, in _get_expected_shapes.
+            # (e.g. a custom head). If the build itself had failed,
+            # _get_expected_shapes would already have warned once.
             logger.warning(
                 f"Tensor '{key}' is not part of the target model architecture; "
                 "inferring from the checkpoint format."
@@ -470,9 +478,10 @@ class FSDPModelMerger(BaseModelMerger):
 
     @staticmethod
     def _dim0_concat_shape(shards: list[torch.Tensor]) -> torch.Size | None:
-        """The shape a dim-0 concatenation of ``shards`` would produce.
+        """Returns the shape that concatenating ``shards`` on dim 0 would produce.
 
-        ``None`` for 0-dim tensors, which have no dim 0 to concatenate along.
+        Returns None for 0-dim tensors, which have no dim 0 to concatenate
+        along.
         """
         if shards[0].ndim == 0:
             return None

--- a/tests/unit/utils/test_verl_model_merger.py
+++ b/tests/unit/utils/test_verl_model_merger.py
@@ -46,7 +46,9 @@ def test_replicated_zero_dim_keeps_single_copy(merger):
     concatenated").
     """
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
-    merged = merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([])})
+    merged = merger._merge_unsharded_shards(
+        "buf", shards, {"buf": torch.Size([])}, checkpoint_has_dtensors=True
+    )
     assert merged.shape == torch.Size([])
     assert merged.item() == 0.5
 
@@ -61,7 +63,7 @@ def test_replicated_shape1_keeps_single_copy_without_warning(merger, caplog):
     shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
         merged = merger._merge_unsharded_shards(
-            "scalar", shards, {"scalar": torch.Size([1])}
+            "scalar", shards, {"scalar": torch.Size([1])}, checkpoint_has_dtensors=True
         )
     assert merged.shape == torch.Size([1])
     assert not caplog.records
@@ -71,7 +73,9 @@ def test_sharded_tensor_is_concatenated_in_rank_order(merger):
     """Includes FSDP's smaller last slice: 7 rows over 4 ranks is 2+2+2+1."""
     full = torch.arange(42.0).reshape(7, 6)
     shards = list(full.chunk(WORLD_SIZE, dim=0))
-    merged = merger._merge_unsharded_shards("w", shards, {"w": full.shape})
+    merged = merger._merge_unsharded_shards(
+        "w", shards, {"w": full.shape}, checkpoint_has_dtensors=False
+    )
     assert torch.equal(merged, full)
 
 
@@ -79,12 +83,13 @@ def test_frozen_constant_shards_are_still_concatenated(merger):
     """All-identical shards of a genuinely sharded tensor must be
     concatenated, not collapsed to one copy.
 
-    This is the case a purely value-based heuristic gets wrong (e.g. a
-    frozen all-ones norm weight): identical values do not imply
-    replication. Only the expected shape can tell the difference.
+    Identical values do not imply replication (e.g. a frozen all-ones norm
+    weight); only the expected shape can tell the difference.
     """
     shards = [torch.ones(2, 6) for _ in range(WORLD_SIZE)]
-    merged = merger._merge_unsharded_shards("w", shards, {"w": torch.Size([8, 6])})
+    merged = merger._merge_unsharded_shards(
+        "w", shards, {"w": torch.Size([8, 6])}, checkpoint_has_dtensors=False
+    )
     assert merged.shape == torch.Size([8, 6])
 
 
@@ -93,7 +98,9 @@ def test_divergent_replicas_warn_and_keep_rank_zero(merger, caplog):
     keep the rank-0 copy and emit a warning."""
     shards = [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])]
     with caplog.at_level("WARNING"):
-        merged = merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([1])})
+        merged = merger._merge_unsharded_shards(
+            "buf", shards, {"buf": torch.Size([1])}, checkpoint_has_dtensors=True
+        )
     assert merged.item() == 1.0
     assert any("differs across ranks" in r.message for r in caplog.records)
 
@@ -103,7 +110,9 @@ def test_impossible_shape_raises_naming_the_key(merger):
     shape: hard error instead of a silent guess."""
     shards = [torch.ones(3, 5) for _ in range(WORLD_SIZE)]
     with pytest.raises(ValueError, match="'w'"):
-        merger._merge_unsharded_shards("w", shards, {"w": torch.Size([8, 6])})
+        merger._merge_unsharded_shards(
+            "w", shards, {"w": torch.Size([8, 6])}, checkpoint_has_dtensors=True
+        )
 
 
 def test_zero_dim_with_mismatched_expected_shape_raises(merger):
@@ -112,21 +121,28 @@ def test_zero_dim_with_mismatched_expected_shape_raises(merger):
     unreachable for it."""
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     with pytest.raises(ValueError, match="'buf'"):
-        merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([1])})
+        merger._merge_unsharded_shards(
+            "buf", shards, {"buf": torch.Size([1])}, checkpoint_has_dtensors=True
+        )
 
 
 #
-# Ground truth unavailable: warned fallback to the value-based heuristic.
+# Ground truth unavailable: fallback inferring from the checkpoint format
+# (DTensors present => plain tensors are replicated buffers; no DTensors =>
+# legacy format where plain tensors are dim-0 shards).
 #
 
 
-def test_unknown_key_falls_back_with_warning(merger, caplog):
+def test_unknown_key_modern_format_keeps_one_copy(merger, caplog):
     """Case 2: the architecture does not declare this tensor (e.g. a custom
-    head). Identical copies are treated as replicated."""
+    head). In a DTensor-bearing checkpoint, plain tensors are replicated."""
     shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
         merged = merger._merge_unsharded_shards(
-            "custom_head.weight", shards, {"other": torch.Size([1])}
+            "custom_head.weight",
+            shards,
+            {"other": torch.Size([1])},
+            checkpoint_has_dtensors=True,
         )
     assert merged.shape == torch.Size([1])
     assert any(
@@ -140,25 +156,55 @@ def test_no_expected_shapes_falls_back_silently_per_key(merger, caplog):
     whole merge, so no additional per-key warning is emitted here."""
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
-        merged = merger._merge_unsharded_shards("buf", shards, None)
+        merged = merger._merge_unsharded_shards(
+            "buf", shards, None, checkpoint_has_dtensors=True
+        )
     assert merged.shape == torch.Size([])
     assert not caplog.records
 
 
 #
-# The heuristic itself (used only by the fallbacks above).
+# The format-based fallback (no expected shapes at all).
 #
 
 
-def test_heuristic_zero_dim_short_circuits_even_when_divergent():
+def test_fallback_zero_dim_collapses_in_any_format(merger):
     """ndim == 0 alone proves replication (a scalar cannot be dim-0
-    sharded), so divergent values still collapse to the rank-0 copy
-    instead of hitting torch.cat."""
-    shards = [torch.tensor(1.0), torch.tensor(2.0)]
-    merged = FSDPModelMerger._merge_shards_heuristically(shards)
+    sharded), regardless of checkpoint format."""
+    shards = [torch.tensor(0.5), torch.tensor(0.5)]
+    merged = merger._merge_unsharded_shards(
+        "buf", shards, None, checkpoint_has_dtensors=False
+    )
+    assert merged.shape == torch.Size([])
+
+
+def test_fallback_modern_format_divergent_replicas_warn(merger, caplog):
+    """DTensor-bearing checkpoint: plain tensors are replicated buffers;
+    divergent copies keep rank 0 with a warning."""
+    shards = [torch.tensor([1.0]), torch.tensor([2.0])]
+    with caplog.at_level("WARNING"):
+        merged = merger._merge_unsharded_shards(
+            "buf", shards, None, checkpoint_has_dtensors=True
+        )
     assert merged.item() == 1.0
+    assert any("differs across ranks" in r.message for r in caplog.records)
 
 
-def test_heuristic_distinct_shards_concatenate():
-    full, shards = _sharded_rows()
-    assert torch.equal(FSDPModelMerger._merge_shards_heuristically(shards), full)
+def test_fallback_legacy_format_concatenates_even_identical_shards(merger):
+    """Legacy (DTensor-free) checkpoint: plain tensors are dim-0 shards and
+    are always concatenated — even bit-identical ones (frozen constants) —
+    matching the pre-fix behavior exactly. Value equality is never used to
+    decide, so the fallback cannot corrupt a legacy checkpoint the old code
+    handled correctly.
+    """
+    identical = [torch.ones(2, 6) for _ in range(WORLD_SIZE)]
+    merged = merger._merge_unsharded_shards(
+        "w", identical, None, checkpoint_has_dtensors=False
+    )
+    assert merged.shape == torch.Size([8, 6])
+
+    full, distinct = _sharded_rows()
+    merged = merger._merge_unsharded_shards(
+        "w", distinct, None, checkpoint_has_dtensors=False
+    )
+    assert torch.equal(merged, full)

--- a/tests/unit/utils/test_verl_model_merger.py
+++ b/tests/unit/utils/test_verl_model_merger.py
@@ -39,11 +39,12 @@ def _sharded_rows(rows: int = 8, cols: int = 6) -> tuple[torch.Tensor, list]:
 
 
 def test_replicated_zero_dim_keeps_single_copy(merger):
-    """gemma-4's min/max buffers: shape-() copies on every rank.
+    """A 0-dim buffer, like gemma-4's min/max trackers, has a full copy on
+    every rank, and the merger keeps a single one.
 
-    The pre-fix code crashed here: torch.cat cannot concatenate 0-dim
-    tensors ("zero-dimensional tensor (at position 0) cannot be
-    concatenated").
+    The pre-fix code crashed on these tensors, because torch.cat cannot
+    concatenate 0-dim tensors ("zero-dimensional tensor (at position 0)
+    cannot be concatenated").
     """
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     merged = merger._merge_unsharded_shards(
@@ -54,11 +55,12 @@ def test_replicated_zero_dim_keeps_single_copy(merger):
 
 
 def test_replicated_shape1_keeps_single_copy_without_warning(merger, caplog):
-    """gemma-4's layer_scalar: identical shape-[1] copies on every rank.
+    """A shape-[1] buffer, like gemma-4's layer_scalar, has an identical copy
+    on every rank, and the merger keeps a single one without warning.
 
     The pre-fix code silently concatenated these into shape [WORLD_SIZE],
-    corrupting the export (caught later by from_pretrained as
-    "ckpt: [4] vs model: [1]").
+    corrupting the export. The corruption only surfaced later, when
+    from_pretrained rejected the file with "ckpt: [4] vs model: [1]".
     """
     shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
@@ -70,7 +72,11 @@ def test_replicated_shape1_keeps_single_copy_without_warning(merger, caplog):
 
 
 def test_sharded_tensor_is_concatenated_in_rank_order(merger):
-    """Includes FSDP's smaller last slice: 7 rows over 4 ranks is 2+2+2+1."""
+    """Genuine dim-0 shards are concatenated back in rank order.
+
+    This also covers FSDP giving the last rank a smaller slice when sizes
+    do not divide evenly: 7 rows over 4 ranks splits as 2+2+2+1.
+    """
     full = torch.arange(42.0).reshape(7, 6)
     shards = list(full.chunk(WORLD_SIZE, dim=0))
     merged = merger._merge_unsharded_shards(
@@ -83,8 +89,9 @@ def test_frozen_constant_shards_are_still_concatenated(merger):
     """All-identical shards of a genuinely sharded tensor must be
     concatenated, not collapsed to one copy.
 
-    Identical values do not imply replication (e.g. a frozen all-ones norm
-    weight); only the expected shape can tell the difference.
+    Identical values do not imply replication. A frozen all-ones norm
+    weight, e.g. produces bit-identical shards on every rank, and
+    only the expected shape can tell it apart from a replicated buffer.
     """
     shards = [torch.ones(2, 6) for _ in range(WORLD_SIZE)]
     merged = merger._merge_unsharded_shards(
@@ -94,8 +101,8 @@ def test_frozen_constant_shards_are_still_concatenated(merger):
 
 
 def test_divergent_replicas_warn_and_keep_rank_zero(merger, caplog):
-    """Replicas that differ across ranks (e.g. unsynced statistics buffers)
-    keep the rank-0 copy and emit a warning."""
+    """Replicas that differ across ranks, such as unsynced statistics
+    buffers, keep the rank-0 copy and emit a warning."""
     shards = [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])]
     with caplog.at_level("WARNING"):
         merged = merger._merge_unsharded_shards(
@@ -106,8 +113,9 @@ def test_divergent_replicas_warn_and_keep_rank_zero(merger, caplog):
 
 
 def test_impossible_shape_raises_naming_the_key(merger):
-    """Neither one shard nor the dim-0 concatenation matches the expected
-    shape: hard error instead of a silent guess."""
+    """When neither one shard nor the dim-0 concatenation matches the
+    expected shape, the merger raises an error naming the tensor instead of
+    guessing silently."""
     shards = [torch.ones(3, 5) for _ in range(WORLD_SIZE)]
     with pytest.raises(ValueError, match="'w'"):
         merger._merge_unsharded_shards(
@@ -116,9 +124,9 @@ def test_impossible_shape_raises_naming_the_key(merger):
 
 
 def test_zero_dim_with_mismatched_expected_shape_raises(merger):
-    """A 0-dim tensor can never be treated as a dim-0 shard: if it does not
-    match the expected shape, the only outcome is an error — torch.cat is
-    unreachable for it."""
+    """A 0-dim tensor can never be treated as a dim-0 shard. If it does not
+    match the expected shape, the merger raises an error, and torch.cat is
+    never reached for it."""
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     with pytest.raises(ValueError, match="'buf'"):
         merger._merge_unsharded_shards(
@@ -127,15 +135,18 @@ def test_zero_dim_with_mismatched_expected_shape_raises(merger):
 
 
 #
-# Ground truth unavailable: fallback inferring from the checkpoint format
-# (DTensors present => plain tensors are replicated buffers; no DTensors =>
-# legacy format where plain tensors are dim-0 shards).
+# No expected shape for the tensor: the merger infers from the checkpoint
+# format. A checkpoint that contains DTensors saves plain tensors only for
+# replicated buffers, while a legacy checkpoint with no DTensors saves
+# plain dim-0 shards.
 #
 
 
 def test_unknown_key_modern_format_keeps_one_copy(merger, caplog):
-    """Case 2: the architecture does not declare this tensor (e.g. a custom
-    head). In a DTensor-bearing checkpoint, plain tensors are replicated."""
+    """A key the architecture does not declare, such as a custom head, is
+    warned about and then merged by checkpoint format. Since this checkpoint
+    contains DTensors, its plain tensors are replicated buffers, so one copy
+    is kept."""
     shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
         merged = merger._merge_unsharded_shards(
@@ -151,8 +162,8 @@ def test_unknown_key_modern_format_keeps_one_copy(merger, caplog):
 
 
 def test_no_expected_shapes_falls_back_silently_per_key(merger, caplog):
-    """Case 1: the target model could not be instantiated at all
-    (expected_shapes is None). _get_expected_shapes warns once for the
+    """When expected_shapes is None, the target model could not be
+    instantiated at all. _get_expected_shapes already warned once for the
     whole merge, so no additional per-key warning is emitted here."""
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     with caplog.at_level("WARNING"):
@@ -163,14 +174,9 @@ def test_no_expected_shapes_falls_back_silently_per_key(merger, caplog):
     assert not caplog.records
 
 
-#
-# The format-based fallback (no expected shapes at all).
-#
-
-
 def test_fallback_zero_dim_collapses_in_any_format(merger):
-    """ndim == 0 alone proves replication (a scalar cannot be dim-0
-    sharded), regardless of checkpoint format."""
+    """A 0-dim tensor collapses to one copy in either checkpoint format,
+    because a scalar cannot be sharded along dim 0."""
     shards = [torch.tensor(0.5), torch.tensor(0.5)]
     merged = merger._merge_unsharded_shards(
         "buf", shards, None, checkpoint_has_dtensors=False
@@ -179,8 +185,8 @@ def test_fallback_zero_dim_collapses_in_any_format(merger):
 
 
 def test_fallback_modern_format_divergent_replicas_warn(merger, caplog):
-    """DTensor-bearing checkpoint: plain tensors are replicated buffers;
-    divergent copies keep rank 0 with a warning."""
+    """In a checkpoint that contains DTensors, plain tensors are replicated
+    buffers. When the copies diverge, the merger keeps rank 0's and warns."""
     shards = [torch.tensor([1.0]), torch.tensor([2.0])]
     with caplog.at_level("WARNING"):
         merged = merger._merge_unsharded_shards(
@@ -191,11 +197,11 @@ def test_fallback_modern_format_divergent_replicas_warn(merger, caplog):
 
 
 def test_fallback_legacy_format_concatenates_even_identical_shards(merger):
-    """Legacy (DTensor-free) checkpoint: plain tensors are dim-0 shards and
-    are always concatenated — even bit-identical ones (frozen constants) —
-    matching the pre-fix behavior exactly. Value equality is never used to
-    decide, so the fallback cannot corrupt a legacy checkpoint the old code
-    handled correctly.
+    """In a legacy checkpoint with no DTensors, plain tensors are dim-0
+    shards and are always concatenated, exactly as the pre-fix code did.
+    That includes bit-identical shards such as frozen constants: value
+    equality plays no part in the decision, so the fallback cannot corrupt
+    a legacy checkpoint that the old code handled correctly.
     """
     identical = [torch.ones(2, 6) for _ in range(WORLD_SIZE)]
     merged = merger._merge_unsharded_shards(

--- a/tests/unit/utils/test_verl_model_merger.py
+++ b/tests/unit/utils/test_verl_model_merger.py
@@ -51,29 +51,25 @@ def test_replicated_zero_dim_keeps_single_copy(merger):
     assert merged.item() == 0.5
 
 
-def test_replicated_shape1_keeps_single_copy(merger):
-    """gemma-4's layer_scalar: shape-[1] copies on every rank.
+def test_replicated_shape1_keeps_single_copy_without_warning(merger, caplog):
+    """gemma-4's layer_scalar: identical shape-[1] copies on every rank.
 
     The pre-fix code silently concatenated these into shape [WORLD_SIZE],
     corrupting the export (caught later by from_pretrained as
     "ckpt: [4] vs model: [1]").
     """
     shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
-    merged = merger._merge_unsharded_shards(
-        "scalar", shards, {"scalar": torch.Size([1])}
-    )
+    with caplog.at_level("WARNING"):
+        merged = merger._merge_unsharded_shards(
+            "scalar", shards, {"scalar": torch.Size([1])}
+        )
     assert merged.shape == torch.Size([1])
+    assert not caplog.records
 
 
 def test_sharded_tensor_is_concatenated_in_rank_order(merger):
-    full, shards = _sharded_rows()
-    merged = merger._merge_unsharded_shards("w", shards, {"w": full.shape})
-    assert torch.equal(merged, full)
-
-
-def test_sharded_tensor_with_uneven_last_shard(merger):
-    """FSDP gives the last rank a smaller slice when sizes don't divide."""
-    full = torch.arange(42.0).reshape(7, 6)  # 7 rows over 4 ranks: 2+2+2+1
+    """Includes FSDP's smaller last slice: 7 rows over 4 ranks is 2+2+2+1."""
+    full = torch.arange(42.0).reshape(7, 6)
     shards = list(full.chunk(WORLD_SIZE, dim=0))
     merged = merger._merge_unsharded_shards("w", shards, {"w": full.shape})
     assert torch.equal(merged, full)
@@ -102,13 +98,6 @@ def test_divergent_replicas_warn_and_keep_rank_zero(merger, caplog):
     assert any("differs across ranks" in r.message for r in caplog.records)
 
 
-def test_identical_replicas_do_not_warn(merger, caplog):
-    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
-    with caplog.at_level("WARNING"):
-        merger._merge_unsharded_shards("scalar", shards, {"scalar": torch.Size([1])})
-    assert not caplog.records
-
-
 def test_impossible_shape_raises_naming_the_key(merger):
     """Neither one shard nor the dim-0 concatenation matches the expected
     shape: hard error instead of a silent guess."""
@@ -124,14 +113,6 @@ def test_zero_dim_with_mismatched_expected_shape_raises(merger):
     shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
     with pytest.raises(ValueError, match="'buf'"):
         merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([1])})
-
-
-def test_single_rank_world(merger):
-    """world_size=1: the lone shard already has the final shape."""
-    merged = merger._merge_unsharded_shards(
-        "w", [torch.ones(8, 6)], {"w": torch.Size([8, 6])}
-    )
-    assert merged.shape == torch.Size([8, 6])
 
 
 #
@@ -151,14 +132,6 @@ def test_unknown_key_falls_back_with_warning(merger, caplog):
     assert any(
         "not part of the target model architecture" in r.message for r in caplog.records
     )
-
-
-def test_unknown_key_with_distinct_shards_concatenates(merger):
-    full, shards = _sharded_rows()
-    merged = merger._merge_unsharded_shards(
-        "custom_head.weight", shards, {"other": torch.Size([1])}
-    )
-    assert torch.equal(merged, full)
 
 
 def test_no_expected_shapes_falls_back_silently_per_key(merger, caplog):
@@ -184,11 +157,6 @@ def test_heuristic_zero_dim_short_circuits_even_when_divergent():
     shards = [torch.tensor(1.0), torch.tensor(2.0)]
     merged = FSDPModelMerger._merge_shards_heuristically(shards)
     assert merged.item() == 1.0
-
-
-def test_heuristic_identical_copies_collapse():
-    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
-    assert FSDPModelMerger._merge_shards_heuristically(shards).shape == (1,)
 
 
 def test_heuristic_distinct_shards_concatenate():

--- a/tests/unit/utils/test_verl_model_merger.py
+++ b/tests/unit/utils/test_verl_model_merger.py
@@ -1,0 +1,196 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from oumi.utils.verl_model_merger import FSDPModelMerger
+
+WORLD_SIZE = 4
+
+
+@pytest.fixture
+def merger() -> FSDPModelMerger:
+    # _merge_unsharded_shards uses no instance state, so skip __init__
+    # (which loads a HF model config from disk).
+    return FSDPModelMerger.__new__(FSDPModelMerger)
+
+
+def _sharded_rows(rows: int = 8, cols: int = 6) -> tuple[torch.Tensor, list]:
+    """A full [rows, cols] tensor and its dim-0 shards, one per rank."""
+    full = torch.arange(float(rows * cols)).reshape(rows, cols)
+    return full, list(full.chunk(WORLD_SIZE, dim=0))
+
+
+#
+# Ground truth available: the expected shape decides.
+#
+
+
+def test_replicated_zero_dim_keeps_single_copy(merger):
+    """gemma-4's min/max buffers: shape-() copies on every rank.
+
+    The pre-fix code crashed here: torch.cat cannot concatenate 0-dim
+    tensors ("zero-dimensional tensor (at position 0) cannot be
+    concatenated").
+    """
+    shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
+    merged = merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([])})
+    assert merged.shape == torch.Size([])
+    assert merged.item() == 0.5
+
+
+def test_replicated_shape1_keeps_single_copy(merger):
+    """gemma-4's layer_scalar: shape-[1] copies on every rank.
+
+    The pre-fix code silently concatenated these into shape [WORLD_SIZE],
+    corrupting the export (caught later by from_pretrained as
+    "ckpt: [4] vs model: [1]").
+    """
+    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
+    merged = merger._merge_unsharded_shards(
+        "scalar", shards, {"scalar": torch.Size([1])}
+    )
+    assert merged.shape == torch.Size([1])
+
+
+def test_sharded_tensor_is_concatenated_in_rank_order(merger):
+    full, shards = _sharded_rows()
+    merged = merger._merge_unsharded_shards("w", shards, {"w": full.shape})
+    assert torch.equal(merged, full)
+
+
+def test_sharded_tensor_with_uneven_last_shard(merger):
+    """FSDP gives the last rank a smaller slice when sizes don't divide."""
+    full = torch.arange(42.0).reshape(7, 6)  # 7 rows over 4 ranks: 2+2+2+1
+    shards = list(full.chunk(WORLD_SIZE, dim=0))
+    merged = merger._merge_unsharded_shards("w", shards, {"w": full.shape})
+    assert torch.equal(merged, full)
+
+
+def test_frozen_constant_shards_are_still_concatenated(merger):
+    """All-identical shards of a genuinely sharded tensor must be
+    concatenated, not collapsed to one copy.
+
+    This is the case a purely value-based heuristic gets wrong (e.g. a
+    frozen all-ones norm weight): identical values do not imply
+    replication. Only the expected shape can tell the difference.
+    """
+    shards = [torch.ones(2, 6) for _ in range(WORLD_SIZE)]
+    merged = merger._merge_unsharded_shards("w", shards, {"w": torch.Size([8, 6])})
+    assert merged.shape == torch.Size([8, 6])
+
+
+def test_divergent_replicas_warn_and_keep_rank_zero(merger, caplog):
+    """Replicas that differ across ranks (e.g. unsynced statistics buffers)
+    keep the rank-0 copy and emit a warning."""
+    shards = [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])]
+    with caplog.at_level("WARNING"):
+        merged = merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([1])})
+    assert merged.item() == 1.0
+    assert any("differs across ranks" in r.message for r in caplog.records)
+
+
+def test_identical_replicas_do_not_warn(merger, caplog):
+    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
+    with caplog.at_level("WARNING"):
+        merger._merge_unsharded_shards("scalar", shards, {"scalar": torch.Size([1])})
+    assert not caplog.records
+
+
+def test_impossible_shape_raises_naming_the_key(merger):
+    """Neither one shard nor the dim-0 concatenation matches the expected
+    shape: hard error instead of a silent guess."""
+    shards = [torch.ones(3, 5) for _ in range(WORLD_SIZE)]
+    with pytest.raises(ValueError, match="'w'"):
+        merger._merge_unsharded_shards("w", shards, {"w": torch.Size([8, 6])})
+
+
+def test_zero_dim_with_mismatched_expected_shape_raises(merger):
+    """A 0-dim tensor can never be treated as a dim-0 shard: if it does not
+    match the expected shape, the only outcome is an error — torch.cat is
+    unreachable for it."""
+    shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
+    with pytest.raises(ValueError, match="'buf'"):
+        merger._merge_unsharded_shards("buf", shards, {"buf": torch.Size([1])})
+
+
+def test_single_rank_world(merger):
+    """world_size=1: the lone shard already has the final shape."""
+    merged = merger._merge_unsharded_shards(
+        "w", [torch.ones(8, 6)], {"w": torch.Size([8, 6])}
+    )
+    assert merged.shape == torch.Size([8, 6])
+
+
+#
+# Ground truth unavailable: warned fallback to the value-based heuristic.
+#
+
+
+def test_unknown_key_falls_back_with_warning(merger, caplog):
+    """Case 2: the architecture does not declare this tensor (e.g. a custom
+    head). Identical copies are treated as replicated."""
+    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
+    with caplog.at_level("WARNING"):
+        merged = merger._merge_unsharded_shards(
+            "custom_head.weight", shards, {"other": torch.Size([1])}
+        )
+    assert merged.shape == torch.Size([1])
+    assert any(
+        "not part of the target model architecture" in r.message for r in caplog.records
+    )
+
+
+def test_unknown_key_with_distinct_shards_concatenates(merger):
+    full, shards = _sharded_rows()
+    merged = merger._merge_unsharded_shards(
+        "custom_head.weight", shards, {"other": torch.Size([1])}
+    )
+    assert torch.equal(merged, full)
+
+
+def test_no_expected_shapes_falls_back_silently_per_key(merger, caplog):
+    """Case 1: the target model could not be instantiated at all
+    (expected_shapes is None). _get_expected_shapes warns once for the
+    whole merge, so no additional per-key warning is emitted here."""
+    shards = [torch.tensor(0.5) for _ in range(WORLD_SIZE)]
+    with caplog.at_level("WARNING"):
+        merged = merger._merge_unsharded_shards("buf", shards, None)
+    assert merged.shape == torch.Size([])
+    assert not caplog.records
+
+
+#
+# The heuristic itself (used only by the fallbacks above).
+#
+
+
+def test_heuristic_zero_dim_short_circuits_even_when_divergent():
+    """ndim == 0 alone proves replication (a scalar cannot be dim-0
+    sharded), so divergent values still collapse to the rank-0 copy
+    instead of hitting torch.cat."""
+    shards = [torch.tensor(1.0), torch.tensor(2.0)]
+    merged = FSDPModelMerger._merge_shards_heuristically(shards)
+    assert merged.item() == 1.0
+
+
+def test_heuristic_identical_copies_collapse():
+    shards = [torch.tensor([0.73]) for _ in range(WORLD_SIZE)]
+    assert FSDPModelMerger._merge_shards_heuristically(shards).shape == (1,)
+
+
+def test_heuristic_distinct_shards_concatenate():
+    full, shards = _sharded_rows()
+    assert torch.equal(FSDPModelMerger._merge_shards_heuristically(shards), full)


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
GRPO training run launched in enterprise with Gemma 4 e2b trained successfully but failed at saving stage with the following error:

```
_run_verl_train
    _save_final_model(trainer, config)
  File "/usr/local/lib/python3.11/site-packages/oumi/train.py", line 254, in 
_save_final_model
    trainer.save_model(config=config)
  File 
"/usr/local/lib/python3.11/site-packages/oumi/core/trainers/verl_grpo_trainer.py
", line 621, in save_model
    self._export_hf_model()
  File 
"/usr/local/lib/python3.11/site-packages/oumi/core/trainers/verl_grpo_trainer.py
", line 676, in _export_hf_model
    merger.merge_and_save()
  File 
"/usr/local/lib/python3.11/site-packages/oumi/utils/verl_model_merger.py", line 
369, in merge_and_save
    merged_state_dict = self._load_and_merge_state_dicts(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File 
"/usr/local/lib/python3.11/site-packages/oumi/utils/verl_model_merger.py", line 
349, in _load_and_merge_state_dicts
    state_dict = torch.cat(state_dict, dim=0)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: zero-dimensional tensor (at position 0) cannot be concatenated
```

The merging mechanism assumes every plain (non-DTensor) tensor in the rank checkpoints is dim-0-sharded and thus concatenates the pieces rankwise. Gemma-4 has parameters that are not stored as dim-0-sharded tensors and are too small to be sharded. FSDP replicates them across ranks. This causes two problems: 

- 0-dim scalars crash `torch.cat` -> results in the error
- `[1]`-shaped ones concatenate "successfully" into garbage (eg 35 `layer_scalar` params) -> silent error

This PR aims to handle the edge case of non-dim-0-sharded tensors via the following approach:
1. Build the target model architecture on the meta device and read the expected shape of every tensor in its state dict.
2. For each plain (non-DTensor) checkpoint entry, compare against the expected shape:
     - rank-0 shard shape == expected -> the copies are replicas, keep rank 0's (warn if copies differ across ranks)
     - dim-0-concatenated shape == expected -> the copies are shards, concatenate
     - neither -> raise ValueError naming the tensor.
3. If no expected shape is available (architecture couldn't be instantiated, or the key isn't part of it, e.g. a custom head), fall back with a warning to a value-based heuristic: keep rank 0's copy if the tensor is 0-dim or all rank copies are identical, otherwise concatenate along dim 0 (the previous behavior).

Gemma 4 has 963 of such plain tensors (non D tensor)
 - 928 zero-dim buffers — the input_min / input_max / output_min / output_max activation-range trackers on gemma-4's "clipped linear" layers in the vision and audio towers.
  - 35 shape-[1] parameters — the per-layer layer_scalars.

Most models (like qwen/llama) don't have these so they don't encounter this saving issue

| model | state-dict keys | 0-dim | shape-[1] | persistent buffers | min ndim |
  |---|---|---|---|---|---|
  | Llama-3.2-3B *(this yaml's original model)* | 255 | 0 | 0 | 0 | 1 |
  | Qwen2.5-3B-Instruct | 435 | 0 | 0 | 0 | 1 |
  | gemma-4-E2B-it | 1,952 | **928** | **35** | **963** | 0 |

## Tests
1. Added unit test to showcase and validate `_merge_unsharded_shards` behavior
3. Ran `/oumi/configs/examples/grpo_verl_countdown/train.yaml` for 3 steps. Training and saving finished successfully 

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
