### PR TITLE
Forward conversation tools in Gemini/Vertex/vLLM remote inference requests

### DIFF
--- a/src/oumi/inference/bedrock_inference_engine.py
+++ b/src/oumi/inference/bedrock_inference_engine.py
@@ -114,6 +114,7 @@ class BedrockInferenceEngine(RemoteInferenceEngine):
             Dict[str, Any]: A dictionary containing the formatted input for the
                 Bedrock API, including the model, messages, and generation parameters.
         """
+        # TODO: OPE-2188 - Add tool call support
         system_messages = [
             message for message in conversation.messages if message.role == Role.SYSTEM
         ]

--- a/src/oumi/inference/gcp_inference_engine.py
+++ b/src/oumi/inference/gcp_inference_engine.py
@@ -225,6 +225,8 @@ class GoogleVertexInferenceEngine(RemoteInferenceEngine):
         if generation_params.stop_strings:
             api_input["stop"] = generation_params.stop_strings
 
+        self._add_tool_params_to_api_input(api_input, conversation, generation_params)
+
         if generation_params.guided_decoding:
             api_input["response_format"] = _convert_guided_decoding_config_to_api_input(
                 generation_params.guided_decoding
@@ -239,9 +241,11 @@ class GoogleVertexInferenceEngine(RemoteInferenceEngine):
             "guided_decoding",
             "logit_bias",
             "max_new_tokens",
+            "parallel_tool_calls",
             "seed",
             "stop_strings",
             "temperature",
+            "tool_choice",
             "top_p",
         }
 

--- a/src/oumi/inference/gemini_inference_engine.py
+++ b/src/oumi/inference/gemini_inference_engine.py
@@ -70,6 +70,8 @@ class GoogleGeminiInferenceEngine(RemoteInferenceEngine):
         if generation_params.stop_strings:
             api_input["stop"] = generation_params.stop_strings
 
+        self._add_tool_params_to_api_input(api_input, conversation, generation_params)
+
         if generation_params.guided_decoding:
             api_input["response_format"] = _convert_guided_decoding_config_to_api_input(
                 generation_params.guided_decoding
@@ -88,8 +90,10 @@ class GoogleGeminiInferenceEngine(RemoteInferenceEngine):
         return {
             "guided_decoding",
             "max_new_tokens",
+            "parallel_tool_calls",
             "stop_strings",
             "temperature",
+            "tool_choice",
             "top_p",
         }
 

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -379,6 +379,30 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             messages, group_adjacent_same_role_turns=group_adjacent_same_role_turns
         )
 
+    @staticmethod
+    def _add_tool_params_to_api_input(
+        api_input: dict[str, Any],
+        conversation: Conversation,
+        generation_params: GenerationParams,
+    ) -> None:
+        """Adds OpenAI-format tool fields to an API request, in place.
+
+        Shared by every OpenAI-compatible engine so a request builder that
+        overrides ``_convert_conversation_to_api_input`` can forward tools
+        without duplicating (and drifting from) the base logic.
+        """
+        if conversation.tools:
+            api_input["tools"] = [
+                tool.model_dump(mode="json", exclude_none=True)
+                for tool in conversation.tools
+            ]
+        if generation_params.tool_choice is not None:
+            api_input["tool_choice"] = generation_params.tool_choice
+        # Default parallel_tool_calls=True matches the OpenAI API default; only
+        # send the field when explicitly disabled.
+        if generation_params.parallel_tool_calls is False:
+            api_input["parallel_tool_calls"] = False
+
     def _convert_conversation_to_api_input(
         self,
         conversation: Conversation,
@@ -428,17 +452,7 @@ class RemoteInferenceEngine(BaseInferenceEngine):
             **generation_params_dict,
         }
 
-        if conversation.tools:
-            api_input["tools"] = [
-                tool.model_dump(mode="json", exclude_none=True)
-                for tool in conversation.tools
-            ]
-        if generation_params.tool_choice is not None:
-            api_input["tool_choice"] = generation_params.tool_choice
-        # Default parallel_tool_calls=True matches the OpenAI API default; only
-        # send the field when explicitly disabled.
-        if generation_params.parallel_tool_calls is False:
-            api_input["parallel_tool_calls"] = False
+        self._add_tool_params_to_api_input(api_input, conversation, generation_params)
 
         if generation_params.guided_decoding:
             json_schema = generation_params.guided_decoding.json

--- a/src/oumi/inference/remote_vllm_inference_engine.py
+++ b/src/oumi/inference/remote_vllm_inference_engine.py
@@ -50,6 +50,8 @@ class RemoteVLLMInferenceEngine(RemoteInferenceEngine):
             "top_p",
             "guided_decoding",
             "max_new_tokens",
+            "parallel_tool_calls",
+            "tool_choice",
         }
 
     @override
@@ -109,6 +111,8 @@ class RemoteVLLMInferenceEngine(RemoteInferenceEngine):
             api_input["stop"] = generation_params.stop_strings
         if generation_params.stop_token_ids:
             api_input["stop_token_ids"] = generation_params.stop_token_ids
+
+        self._add_tool_params_to_api_input(api_input, conversation, generation_params)
 
         return api_input
 

--- a/src/oumi/inference/sambanova_inference_engine.py
+++ b/src/oumi/inference/sambanova_inference_engine.py
@@ -64,6 +64,7 @@ class SambanovaInferenceEngine(RemoteInferenceEngine):
             Dict[str, Any]: A dictionary containing the formatted input for the
             SambaNova API, including the model, messages, and generation parameters.
         """
+        # TODO: OPE-2188 - Add tool call support
         # Build request body according to SambaNova API spec
         body = {
             "model": model_params.model_name,

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -269,6 +269,7 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
             Dict[str, Any]: A dictionary containing the formatted input for the
             SGLang server native API, including the model, messages, generation params.
         """
+        # TODO: OPE-2188 - Add tool call support
         # Chat templates loaded by SGLang server are generally different from Oumi's
         # chat templates, hence, let's apply Oumi chat template here ourselves.
         prompt = self._apply_chat_template_impl(conversation)

--- a/tests/unit/inference/test_gcp_inference_engine.py
+++ b/tests/unit/inference/test_gcp_inference_engine.py
@@ -17,10 +17,25 @@ from oumi.core.types.conversation import (
     Role,
     Type,
 )
+from oumi.core.types.tool_call import ToolDefinition
 from oumi.inference.gcp_inference_engine import GoogleVertexInferenceEngine
 from oumi.utils.image_utils import (
     create_png_bytes_from_image,
 )
+
+_WEATHER_TOOL_DICT = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+_WEATHER_TOOL = ToolDefinition.model_validate(_WEATHER_TOOL_DICT)
 
 
 def create_test_remote_params():
@@ -150,6 +165,59 @@ def test_convert_conversation_to_api_input_multimodal(gcp_engine, inference_conf
     assert api_input["max_completion_tokens"] == 100
     assert api_input["temperature"] == 0.7
     assert api_input["top_p"] == 0.9
+
+
+def test_convert_conversation_to_api_input_includes_tools(gcp_engine, inference_config):
+    """Conversation.tools is forwarded in the OpenAI wire shape."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(content="weather in Tokyo?", role=Role.USER)],
+    )
+    api_input = gcp_engine._convert_conversation_to_api_input(
+        conversation, inference_config.generation, gcp_engine._model_params
+    )
+    assert api_input["tools"] == [_WEATHER_TOOL_DICT]
+
+
+def test_convert_conversation_to_api_input_omits_tools_when_absent(
+    gcp_engine, inference_config
+):
+    """No tools key when the conversation carries no tools."""
+    conversation = create_test_text_only_conversation()
+    api_input = gcp_engine._convert_conversation_to_api_input(
+        conversation, inference_config.generation, gcp_engine._model_params
+    )
+    assert "tools" not in api_input
+
+
+def test_convert_conversation_to_api_input_forwards_tool_choice_and_parallel(
+    gcp_engine,
+):
+    """tool_choice and parallel_tool_calls=False reach the request body."""
+    generation_params = GenerationParams(
+        max_new_tokens=100,
+        tool_choice="auto",
+        parallel_tool_calls=False,
+    )
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(content="hi", role=Role.USER)],
+    )
+    api_input = gcp_engine._convert_conversation_to_api_input(
+        conversation, generation_params, gcp_engine._model_params
+    )
+    assert api_input["tool_choice"] == "auto"
+    assert api_input["parallel_tool_calls"] is False
+
+
+def test_vertex_supports_tool_params():
+    """tool_choice / parallel_tool_calls are advertised as supported."""
+    engine = GoogleVertexInferenceEngine(
+        ModelParams(model_name="gcp-model"), remote_params=create_test_remote_params()
+    )
+    supported = engine.get_supported_params()
+    assert "tool_choice" in supported
+    assert "parallel_tool_calls" in supported
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/inference/test_gemini_inference_engine.py
+++ b/tests/unit/inference/test_gemini_inference_engine.py
@@ -12,7 +12,22 @@ from oumi.core.configs import (
 )
 from oumi.core.configs.params.guided_decoding_params import GuidedDecodingParams
 from oumi.core.types.conversation import Conversation, Message, Role
+from oumi.core.types.tool_call import ToolDefinition
 from oumi.inference.gemini_inference_engine import GoogleGeminiInferenceEngine
+
+_WEATHER_TOOL_DICT = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+_WEATHER_TOOL = ToolDefinition.model_validate(_WEATHER_TOOL_DICT)
 
 
 @pytest.fixture
@@ -145,6 +160,63 @@ def test_gemini_convert_conversation_invalid_schema(gemini_engine, generation_pa
         )
 
     assert "unsupported JSON schema type" in str(exc_info.value)
+
+
+def test_gemini_convert_conversation_includes_tools(gemini_engine, generation_params):
+    """Conversation.tools is forwarded in the OpenAI wire shape."""
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(content="weather in Tokyo?", role=Role.USER)],
+    )
+
+    api_input = gemini_engine._convert_conversation_to_api_input(
+        conversation, generation_params, gemini_engine._model_params
+    )
+
+    assert api_input["tools"] == [_WEATHER_TOOL_DICT]
+
+
+def test_gemini_convert_conversation_omits_tools_when_absent(
+    gemini_engine, generation_params
+):
+    """No tools key when the conversation carries no tools."""
+    conversation = Conversation(
+        messages=[Message(content="hi", role=Role.USER)],
+    )
+
+    api_input = gemini_engine._convert_conversation_to_api_input(
+        conversation, generation_params, gemini_engine._model_params
+    )
+
+    assert "tools" not in api_input
+
+
+def test_gemini_convert_conversation_forwards_tool_choice_and_parallel(gemini_engine):
+    """tool_choice and parallel_tool_calls=False reach the request body."""
+    generation_params = GenerationParams(
+        max_new_tokens=100,
+        tool_choice="auto",
+        parallel_tool_calls=False,
+    )
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(content="hi", role=Role.USER)],
+    )
+
+    api_input = gemini_engine._convert_conversation_to_api_input(
+        conversation, generation_params, gemini_engine._model_params
+    )
+
+    assert api_input["tool_choice"] == "auto"
+    assert api_input["parallel_tool_calls"] is False
+
+
+def test_gemini_supports_tool_params():
+    """tool_choice / parallel_tool_calls are advertised as supported."""
+    engine = GoogleGeminiInferenceEngine(ModelParams(model_name="gemini-model"))
+    supported = engine.get_supported_params()
+    assert "tool_choice" in supported
+    assert "parallel_tool_calls" in supported
 
 
 @pytest.mark.asyncio

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -4463,6 +4463,55 @@ def test_response_combines_reasoning_with_tool_calls():
     assert assistant.tool_calls[0].function.name == "get_weather"
 
 
+def _openai_shape_engines() -> list[RemoteInferenceEngine]:
+    """OpenAI-compatible engines whose request builder must forward tools.
+
+    SGLang is intentionally excluded: its native ``/generate`` API takes a
+    rendered prompt plus ``sampling_params`` rather than an OpenAI ``tools``
+    array, so ``conversation.tools`` has no place in its request body.
+    """
+    from oumi.inference.gcp_inference_engine import GoogleVertexInferenceEngine
+    from oumi.inference.gemini_inference_engine import GoogleGeminiInferenceEngine
+    from oumi.inference.remote_vllm_inference_engine import (
+        RemoteVLLMInferenceEngine,
+    )
+
+    remote_params = RemoteParams(api_url=_TARGET_SERVER, api_key="dummy")
+    return [
+        RemoteInferenceEngine(_get_default_model_params(), remote_params=remote_params),
+        RemoteVLLMInferenceEngine(
+            _get_default_model_params(), remote_params=remote_params
+        ),
+        GoogleGeminiInferenceEngine(
+            _get_default_model_params(), remote_params=remote_params
+        ),
+        GoogleVertexInferenceEngine(
+            _get_default_model_params(), remote_params=remote_params
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "engine",
+    _openai_shape_engines(),
+    ids=lambda e: type(e).__name__,
+)
+def test_openai_shape_engines_forward_tools(engine):
+    """Every OpenAI-format engine forwards conversation.tools in its request body.
+
+    Guards against future ``_convert_conversation_to_api_input`` overrides that
+    silently drop tools by omitting the base class's tool-forwarding block.
+    """
+    conversation = Conversation(
+        tools=[_WEATHER_TOOL],
+        messages=[Message(role=Role.USER, content="weather in Tokyo?")],
+    )
+    api_input = engine._convert_conversation_to_api_input(
+        conversation, GenerationParams(max_new_tokens=5), engine._model_params
+    )
+    assert api_input["tools"] == [_WEATHER_TOOL_DICT]
+
+
 #
 # infer_partial
 #


### PR DESCRIPTION
# Description

Since Gemini, Vertex, and remote vLLM inference engines overrode `_convert_conversation_to_api_input`, they didn't inherit `RemoteInferenceEngine`'s tool calling capability.

- Extracted the base engine's tool-forwarding logic into a shared
  `RemoteInferenceEngine._add_tool_params_to_api_input` helper
- `GoogleGeminiInferenceEngine`, `GoogleVertexInferenceEngine`, and `RemoteVLLMInferenceEngine` now call that
  helper
- Advertise `tool_choice` / `parallel_tool_calls` in `get_supported_params()`

Tested locally for Gemini and remote vLLM

## Related issues

Fixes LOU-3655
Towards OPE-2188

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the contributor guideline Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
