### PR TITLE
fix(inference): fold Anthropic cache tokens into prompt_tokens

### DIFF
--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -457,9 +457,7 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
             return None
         cached_tokens = usage.get("cache_read_input_tokens", 0)
         cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
-        # Anthropic excludes cache read/write from input_tokens; every other
-        # provider counts them inside prompt_tokens. Fold them in so prompt_tokens
-        # means total prompt tokens uniformly across engines.
+        # Anthropic excludes cache read/write from input, unlike other providers.
         prompt_tokens = (
             usage.get("input_tokens", 0) + cached_tokens + cache_creation_tokens
         )

--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -455,18 +455,22 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         usage = response.get("usage")
         if not usage:
             return None
-        prompt_tokens = usage.get("input_tokens", 0)
+        cached_tokens = usage.get("cache_read_input_tokens", 0)
+        cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
+        # Anthropic excludes cache read/write from input_tokens; every other
+        # provider counts them inside prompt_tokens. Fold them in so prompt_tokens
+        # means total prompt tokens uniformly across engines.
+        prompt_tokens = (
+            usage.get("input_tokens", 0) + cached_tokens + cache_creation_tokens
+        )
         completion_tokens = usage.get("output_tokens", 0)
         result = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
         }
-        # Extract cached tokens from Anthropic's flat format
-        cached_tokens = usage.get("cache_read_input_tokens", 0)
         if cached_tokens:
             result["cached_tokens"] = cached_tokens
-        cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
         if cache_creation_tokens:
             result["cache_creation_tokens"] = cache_creation_tokens
         return result

--- a/tests/unit/inference/test_anthropic_inference_engine.py
+++ b/tests/unit/inference/test_anthropic_inference_engine.py
@@ -339,17 +339,17 @@ def test_convert_api_output_missing_content_key(anthropic_engine):
             {"input_tokens": 12, "output_tokens": 8},
             {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20},
         ),
-        # With cache read tokens
+        # Cache read tokens fold into prompt_tokens (12 + 5).
         (
             {"input_tokens": 12, "output_tokens": 8, "cache_read_input_tokens": 5},
             {
-                "prompt_tokens": 12,
+                "prompt_tokens": 17,
                 "completion_tokens": 8,
-                "total_tokens": 20,
+                "total_tokens": 25,
                 "cached_tokens": 5,
             },
         ),
-        # With cache read + creation tokens
+        # Cache read + creation both fold into prompt_tokens (12 + 5 + 3).
         (
             {
                 "input_tokens": 12,
@@ -358,9 +358,9 @@ def test_convert_api_output_missing_content_key(anthropic_engine):
                 "cache_creation_input_tokens": 3,
             },
             {
-                "prompt_tokens": 12,
+                "prompt_tokens": 20,
                 "completion_tokens": 8,
-                "total_tokens": 20,
+                "total_tokens": 28,
                 "cached_tokens": 5,
                 "cache_creation_tokens": 3,
             },


### PR DESCRIPTION
# Description

Anthropic excludes cache read/write from input_tokens, while every other inference engine counts cached tokens inside prompt_tokens. Fold cache read and creation tokens into the normalized prompt_tokens so it means total prompt tokens uniformly across engines, keeping cached_tokens and cache_creation_tokens as a separate breakdown.

## Related issues

Fixes [LOU-3658](https://linear.app/oumi/issue/LOU-3658)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
