### PR TITLE
Add default pad token for Nemotron 3 Nano 4B

### DIFF
--- a/src/oumi/core/tokenizers/special_tokens.py
+++ b/src/oumi/core/tokenizers/special_tokens.py
@@ -36,6 +36,10 @@ class SpecialTokensConfig:
 # Llama 3.1/3.2 models already have `<|finetune_right_pad_id|>` token in their vocab.
 LLAMA_SPECIAL_TOKENS = SpecialTokensConfig(pad_token="<|finetune_right_pad_id|>")
 
+# Nemotron 3 defines no pad token, but its config.json sets pad_token_id=0, which
+# is `<unk>` — distinct from eos (`<|im_end|>`), so padding can't mask a real stop.
+NEMOTRON_3_SPECIAL_TOKENS = SpecialTokensConfig(pad_token="<unk>")
+
 special_tokens = {
     "meta-llama/Llama-3.1-8B": LLAMA_SPECIAL_TOKENS,
     "meta-llama/Llama-3.1-8B-Instruct": LLAMA_SPECIAL_TOKENS,
@@ -57,6 +61,7 @@ special_tokens = {
     "meta-llama/Llama-3.2-1B-Instruct": LLAMA_SPECIAL_TOKENS,
     "meta-llama/Llama-3.2-3B": LLAMA_SPECIAL_TOKENS,
     "meta-llama/Llama-3.2-3B-Instruct": LLAMA_SPECIAL_TOKENS,
+    "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16": NEMOTRON_3_SPECIAL_TOKENS,
 }
 
 # Lowercase all keys for case-insensitive lookup.

--- a/tests/unit/core/tokenizers/test_special_tokens.py
+++ b/tests/unit/core/tokenizers/test_special_tokens.py
@@ -1,0 +1,52 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from oumi.core.tokenizers.special_tokens import get_default_special_tokens
+
+
+def _tokenizer(name_or_path: str) -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.name_or_path = name_or_path
+    return tokenizer
+
+
+@pytest.mark.parametrize(
+    "name_or_path,expected_pad_token",
+    [
+        ("meta-llama/Llama-3.1-8B-Instruct", "<|finetune_right_pad_id|>"),
+        ("nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16", "<unk>"),
+        # Lookup is case-insensitive.
+        ("nvidia/nvidia-nemotron-3-nano-4b-bf16", "<unk>"),
+    ],
+)
+def test_known_tokenizers_have_a_pad_token(name_or_path, expected_pad_token):
+    special_tokens = get_default_special_tokens(_tokenizer(name_or_path))
+
+    assert special_tokens.pad_token == expected_pad_token
+
+
+def test_unknown_tokenizer_returns_empty_config():
+    special_tokens = get_default_special_tokens(_tokenizer("some/unknown-model"))
+
+    assert special_tokens.pad_token is None
+
+
+def test_missing_tokenizer_returns_empty_config():
+    special_tokens = get_default_special_tokens(None)
+
+    assert special_tokens.pad_token is None


### PR DESCRIPTION
## Description

`nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` cannot be used for training or inference: its tokenizer defines no `pad_token`, so `build_tokenizer` reaches the final guard and raises before the model loads.

```
ValueError: Tokenizer does not have a pad token. This is expected for older
models, but you need to set it manually in your model config as:
tokenizer_kwargs={'pad_token': 'user_defined_pad_token'}
```

The guard only raises after `get_default_special_tokens` finds nothing, and that lookup table currently covers Llama 3.1/3.2 only. This adds a Nemotron 3 entry so the fallback resolves.

`<unk>` is the right pad token here: the model's own `config.json` sets `pad_token_id=0`, which is `<unk>`. It is distinct from eos (`<|im_end|>`), so padding cannot mask a real stop signal during training, and it is already in the vocab, so the embedding table does not have to grow.

## Tests

New `tests/unit/core/tokenizers/test_special_tokens.py` covers `get_default_special_tokens`, which had no direct unit test:

- Nemotron 3 Nano and an existing Llama entry both resolve their pad token
- the lookup is case-insensitive
- an unrecognised tokenizer and `None` both return an empty config

Confirmed the Nemotron cases fail without the table entry and pass with it.
