### PR TITLE
[Inference] Preserve Accept-Encoding across engine header overrides

### DIFF
--- a/src/oumi/inference/anthropic_inference_engine.py
+++ b/src/oumi/inference/anthropic_inference_engine.py
@@ -548,7 +548,7 @@ class AnthropicInferenceEngine(RemoteInferenceEngine):
         )
 
     @override
-    def _get_request_headers(self, remote_params: RemoteParams) -> dict[str, str]:
+    def _get_auth_headers(self, remote_params: RemoteParams) -> dict[str, str]:
         return {
             "Content-Type": "application/json",
             "anthropic-version": self.anthropic_version,

--- a/src/oumi/inference/fireworks_inference_engine.py
+++ b/src/oumi/inference/fireworks_inference_engine.py
@@ -108,10 +108,8 @@ class FireworksInferenceEngine(RemoteInferenceEngine):
         return f"https://api.fireworks.ai/v1/accounts/{account_id}"
 
     @override
-    def _get_request_headers(
-        self, remote_params: RemoteParams | None
-    ) -> dict[str, str]:
-        """Get request headers for Fireworks API calls."""
+    def _get_auth_headers(self, remote_params: RemoteParams | None) -> dict[str, str]:
+        """Get auth headers for Fireworks API calls."""
         api_key = self._get_api_key(remote_params or self._remote_params)
         return {
             "Authorization": f"Bearer {api_key}",

--- a/src/oumi/inference/gcp_inference_engine.py
+++ b/src/oumi/inference/gcp_inference_engine.py
@@ -156,10 +156,8 @@ class GoogleVertexInferenceEngine(RemoteInferenceEngine):
         return credentials.token  # type: ignore
 
     @override
-    def _get_request_headers(
-        self, remote_params: RemoteParams | None
-    ) -> dict[str, str]:
-        """Gets the request headers for GCP."""
+    def _get_auth_headers(self, remote_params: RemoteParams | None) -> dict[str, str]:
+        """Gets the auth headers for GCP."""
         if not remote_params:
             raise ValueError("Remote params are required for GCP inference.")
 

--- a/src/oumi/inference/remote_inference_engine.py
+++ b/src/oumi/inference/remote_inference_engine.py
@@ -25,7 +25,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, TypeVar, final
 
 import aiofiles
 import aiofiles.os
@@ -71,7 +71,14 @@ from oumi.utils.http import (
 from oumi.utils.logging import logger
 
 _AUTHORIZATION_KEY: str = "Authorization"
+_ACCEPT_ENCODING_KEY: str = "Accept-Encoding"
 _RETRY_AFTER_HEADER: str = "Retry-After"
+
+# Advertise only the codecs the standard library can always decode. aiohttp
+# otherwise adds `br`/`zstd` whenever their decoders happen to be importable,
+# which makes every response depend on a package we don't declare and can't
+# version-check at runtime.
+_ACCEPT_ENCODING: str = "gzip, deflate"
 _BATCH_PURPOSE = "batch"
 _BATCH_ENDPOINT = "/v1/chat/completions"
 _MAX_CONNECTION_LIMIT = 200
@@ -633,21 +640,25 @@ class RemoteInferenceEngine(BaseInferenceEngine):
 
         return None
 
+    @final
     def _get_request_headers(
         self, remote_params: RemoteParams | None
     ) -> dict[str, str]:
-        # Exclude brotli (br) from Accept-Encoding since this will fail on systems
-        # without brotli installed
-        headers = {"Accept-Encoding": "gzip, deflate"}
+        """Returns the full header set. Override `_get_auth_headers` instead."""
+        headers = {_ACCEPT_ENCODING_KEY: _ACCEPT_ENCODING}
+        headers.update(self._get_auth_headers(remote_params))
+        return headers
 
+    def _get_auth_headers(self, remote_params: RemoteParams | None) -> dict[str, str]:
+        """Returns the engine's auth and content headers."""
         if not remote_params:
-            return headers
+            return {}
 
         api_key = self._get_api_key(remote_params)
         if api_key:
-            headers[_AUTHORIZATION_KEY] = f"Bearer {api_key}"
+            return {_AUTHORIZATION_KEY: f"Bearer {api_key}"}
 
-        return headers
+        return {}
 
     @staticmethod
     def _parse_iso_timestamp(timestamp: str | None) -> datetime | None:

--- a/src/oumi/inference/sambanova_inference_engine.py
+++ b/src/oumi/inference/sambanova_inference_engine.py
@@ -121,8 +121,8 @@ class SambanovaInferenceEngine(RemoteInferenceEngine):
         )
 
     @override
-    def _get_request_headers(self, remote_params: RemoteParams) -> dict[str, str]:
-        """Get headers for the API request.
+    def _get_auth_headers(self, remote_params: RemoteParams) -> dict[str, str]:
+        """Get auth headers for the API request.
 
         Args:
             remote_params: Remote server parameters.

--- a/src/oumi/inference/sglang_inference_engine.py
+++ b/src/oumi/inference/sglang_inference_engine.py
@@ -333,7 +333,7 @@ class SGLangInferenceEngine(RemoteInferenceEngine):
         )
 
     @override
-    def _get_request_headers(self, remote_params: RemoteParams) -> dict[str, str]:
+    def _get_auth_headers(self, remote_params: RemoteParams) -> dict[str, str]:
         return {
             "Content-Type": "application/json",
         }

--- a/tests/unit/inference/test_gcp_inference_engine.py
+++ b/tests/unit/inference/test_gcp_inference_engine.py
@@ -114,6 +114,7 @@ def test_get_request_headers(gcp_engine, remote_params):
     with patch.object(gcp_engine, "_get_api_key", return_value="fake_token"):
         headers = gcp_engine._get_request_headers(remote_params)
         assert headers == {
+            "Accept-Encoding": "gzip, deflate",
             "Authorization": "Bearer fake_token",
             "Content-Type": "application/json",
         }

--- a/tests/unit/inference/test_remote_inference_engine.py
+++ b/tests/unit/inference/test_remote_inference_engine.py
@@ -4759,3 +4759,57 @@ def test_infer_partial_retriable_400_pattern_retried_and_retryable(mock_asyncio_
     detail = result.failures[0]
     assert detail.status_code == 400
     assert detail.is_retryable
+
+
+def _all_remote_engine_subclasses() -> list[type]:
+    """Every RemoteInferenceEngine subclass, at any depth."""
+    import oumi.inference  # noqa: F401  (registers every engine subclass)
+
+    found: list[type] = []
+    pending = [RemoteInferenceEngine]
+    while pending:
+        for subclass in pending.pop().__subclasses__():
+            found.append(subclass)
+            pending.append(subclass)
+    return found
+
+
+def test_no_engine_overrides_get_request_headers():
+    """`_get_request_headers` is @final; engines override `_get_auth_headers`.
+
+    A subclass that overrides `_get_request_headers` returns a fresh dict and
+    silently drops `Accept-Encoding`, which makes aiohttp advertise whatever
+    codecs happen to be importable in the runtime environment. @final is only a
+    type-checker hint, so this test is the enforcement.
+    """
+    offenders = [
+        subclass.__name__
+        for subclass in _all_remote_engine_subclasses()
+        if "_get_request_headers" in subclass.__dict__
+    ]
+    assert offenders == [], (
+        f"{offenders} override _get_request_headers. Override "
+        "_get_auth_headers instead so the transport headers survive."
+    )
+
+
+def test_get_request_headers_excludes_optional_codecs():
+    engine = RemoteInferenceEngine(_get_default_model_params())
+
+    headers = engine._get_request_headers(RemoteParams(api_key="key"))
+
+    assert headers["Accept-Encoding"] == "gzip, deflate"
+    assert headers["Authorization"] == "Bearer key"
+
+
+def test_get_request_headers_merges_subclass_auth_headers():
+    """A subclass's own headers and the transport headers both survive."""
+    from oumi.inference import AnthropicInferenceEngine
+
+    engine = AnthropicInferenceEngine(ModelParams(model_name="some_model"))
+
+    headers = engine._get_request_headers(RemoteParams(api_key="key"))
+
+    assert headers["Accept-Encoding"] == "gzip, deflate"
+    assert headers["X-API-Key"] == "key"
+    assert headers["Content-Type"] == "application/json"


### PR DESCRIPTION
# Description

Five engines override `_get_request_headers` and return a new dict, so they drop the
base `Accept-Encoding: gzip, deflate`. aiohttp then advertises `br`, and every
request fails on a host with Brotli older than 1.2.

`_get_request_headers` is now `@final`. The five engines override `_get_auth_headers`
instead, with unchanged bodies. 

## Related issues

Towards LOU-3687

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
