### PR TITLE
refactor(environments): rename env types to lookup/simulated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## 🔥 News
 
 - [2026/08] Extended GRPO reinforcement learning to support tool use
-- [2026/07] Added support for tools, environments (synthetic, deterministic, database), and agentic data synthesis
+- [2026/07] Added support for tools, environments (simulated, lookup, database), and agentic data synthesis
 - [2026/06] Added support for the Gemma 4 model family
 - [2026/06] Added partial-failure support across inference, judging, and data synthesis
 - [2026/05] [Oumi v0.8 released](https://github.com/oumi-ai/oumi/releases/tag/v0.8) with `oumi deploy` CLI for dedicated inference endpoints, an `oumi-mcp` MCP server for Claude/Cursor integration, batch API support across Anthropic/Fireworks/Together, and Transformers v5 / TRL / vLLM dependency upgrades

--- a/configs/examples/synthesis/README.md
+++ b/configs/examples/synthesis/README.md
@@ -11,7 +11,7 @@ This directory contains example configurations for different data synthesis use 
 5. [Domain-specific QA](#5-domain-specific-qa-domain_qa_synthyaml) - Generate domain-focused training data
 6. [Dynamic Few-Shot Sampling](#6-dynamic-few-shot-sampling-dynamic_few_shot_synthyaml) - Randomly sample examples for diversity
 7. [Multi-turn Conversation Synthesis](#7-multi-turn-conversation-synthesis-multiturn_conversation_synthyaml) - Generate dynamic, variable-length conversations
-8. [Library Tool-Use Synthesis](#8-library-tool-use-synthesis-library_tool_use_synthyaml) - Generate tool-using assistant conversations against a deterministic environment
+8. [Library Tool-Use Synthesis](#8-library-tool-use-synthesis-library_tool_use_synthyaml) - Generate tool-using assistant conversations against a lookup environment
 
 ### 1. Question-Answer Generation (`question_answer_synth.yaml`)
 
@@ -431,13 +431,13 @@ oumi synth -c configs/examples/synthesis/multiturn_conversation_synth.yaml
 
 ### 8. Library Tool-Use Synthesis (`library_tool_use_synth.yaml`)
 
-**Purpose**: Generate multi-turn conversations where an assistant uses real tool calls against a deterministic environment, exercising the full `EnvironmentConfig` + native tool-calling stack.
+**Purpose**: Generate multi-turn conversations where an assistant uses real tool calls against a lookup environment, exercising the full `EnvironmentConfig` + native tool-calling stack.
 
-**What it does**: A library patron (one of three personas) chats with LibBot, an assistant that uses two tools — `list_book_catalog` and `lookup_book_status` — to answer questions and check borrow status. Tool calls are dispatched against a `deterministic` environment that serves them from a small lookup table, so the same call returns the same result every time.
+**What it does**: A library patron (one of three personas) chats with LibBot, an assistant that uses two tools — `list_book_catalog` and `lookup_book_status` — to answer questions and check borrow status. Tool calls are dispatched against a `lookup` environment that serves them from a small lookup table, so the same call returns the same result every time.
 
 **Key features**:
 - **Native tool calling**: assistant turns produce real `tool_calls` and the environment returns `Role.TOOL` messages — no text-format `<tool_call>` parsing.
-- **Deterministic environment**: tool outputs come from `env_kwargs.lookup_table`, not a model call. Same inputs → same outputs across runs.
+- **Lookup environment**: tool outputs come from `env_kwargs.lookup_table`, not a model call. Same inputs → same outputs across runs.
 - **Three patron personas**: `anxious_parent`, `enthusiastic_reader`, `busy_professional` — sampled per conversation.
 - **Persona-aware planner**: the conversation planner receives the persona description and matches plan length/style accordingly (terse personas get tighter plans).
 - **Catalog-grounded assistant prompt**: the assistant is explicitly forbidden from calling `lookup_book_status` with a `book_id` it hasn't seen in a recent `list_book_catalog` response — preventing fabricated lookups when patrons ask for off-catalog titles.
@@ -448,7 +448,7 @@ oumi synth -c configs/examples/synthesis/multiturn_conversation_synth.yaml
 | Feature | `multiturn_conversation_synth.yaml` | `library_tool_use_synth.yaml` |
 |---|---|---|
 | Action format | Text-format `<ACTION>` blocks | Native `tool_calls` + `Role.TOOL` |
-| State | Stateless prompt-only | Deterministic env with lookup table |
+| State | Stateless prompt-only | Lookup env with lookup table |
 | Reproducibility | Model-dependent | Lookup outputs are reproducible |
 
 **Run with**:

--- a/configs/examples/synthesis/ehr_database_agent/executors.py
+++ b/configs/examples/synthesis/ehr_database_agent/executors.py
@@ -20,7 +20,7 @@ SQL. The environment owns the transaction: executors must never commit, and
 every write is rolled back when the episode ends.
 
 For tools over small state that fits in a JSON snapshot, use
-``SyntheticEnvironment`` instead; see ``../ehr_stateful_agent/executors.py``.
+``SimulatedEnvironment`` instead; see ``../ehr_stateful_agent/executors.py``.
 """
 
 from __future__ import annotations

--- a/configs/examples/synthesis/ehr_stateful_agent/ehr_stateful_synth.yaml
+++ b/configs/examples/synthesis/ehr_stateful_agent/ehr_stateful_synth.yaml
@@ -27,7 +27,7 @@ output_path: ehr_stateful_dataset.jsonl
 environment_config:
   environments:
     - id: ehr
-      env_type: synthetic
+      env_type: simulated
       name: EHR
       description: A clinical record system with mutable patient state.
       grounding:

--- a/configs/examples/synthesis/ehr_stateful_agent/executors.py
+++ b/configs/examples/synthesis/ehr_stateful_agent/executors.py
@@ -14,7 +14,7 @@
 
 """Tool executors for the stateful EHR synthesis example.
 
-``SyntheticEnvironment`` passes each executor the complete JSON state snapshot.
+``SimulatedEnvironment`` passes each executor the complete JSON state snapshot.
 This is a functional state-transition contract: an executor reads the snapshot
 and, for a write, returns a complete candidate ``updated_state`` that the
 environment validates before committing. The snapshot is a deep copy, so an

--- a/configs/examples/synthesis/library_tool_use_synth.yaml
+++ b/configs/examples/synthesis/library_tool_use_synth.yaml
@@ -2,7 +2,7 @@
 #
 # A library patron (one of three personas) chats with LibBot, an assistant that
 # uses two tools to help: list_book_catalog and lookup_book_status. The
-# deterministic environment serves the tool calls from a small lookup table.
+# lookup environment serves the tool calls from a small lookup table.
 #
 # Requirements:
 #   - Set OPENAI_API_KEY in the environment.
@@ -31,7 +31,7 @@ environment_config:
     - id: library
       name: library
       description: A small library catalog with book lookup tools.
-      env_type: deterministic
+      env_type: lookup
       grounding:
         sample_size: 2
         seed: 13

--- a/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
+++ b/configs/examples/synthesis/mcp_docs_lookup_synth.yaml
@@ -1,4 +1,4 @@
-# MCP-style Documentation Lookup — Stateless Synthetic Tool-Use Synthesis
+# MCP-style Documentation Lookup — Stateless Simulated Tool-Use Synthesis
 #
 # Generates multi-turn conversations between a developer asking how to use a
 # library and an assistant that answers via three MCP-style stateless tools.
@@ -16,7 +16,7 @@
 #   3. `search_examples`    — returns runnable example code for a topic
 #      under a resolved `library_id`.
 #
-# This config exercises the new SyntheticEnvironment: tool outputs are
+# This config exercises the new SimulatedEnvironment: tool outputs are
 # *simulated* by the same LLM that drives planner/assistant — there are no
 # pre-declared deterministic outputs. Each tool defines an `output_schema`
 # that we use as guided-decoding JSON schema, so the simulator must produce
@@ -34,7 +34,7 @@
 #   - Config class: oumi.core.configs.SynthesisConfig
 #   - Params class: oumi.core.configs.params.synthesis_params.GeneralSynthesisParams
 #   - Env config class: oumi.core.configs.environment_config.EnvironmentConfig
-#   - SyntheticEnvironment: oumi.environments.synthetic_environment.SyntheticEnvironment
+#   - SimulatedEnvironment: oumi.environments.simulated_environment.SimulatedEnvironment
 #   - Other synthesis configs: configs/**/*synth.yaml
 
 strategy: GENERAL
@@ -44,7 +44,7 @@ output_path: mcp_docs_lookup_dataset.jsonl
 environment_config:
   environments:
     - id: docs_lookup
-      env_type: synthetic
+      env_type: simulated
       name: Docs Lookup
       description: MCP-style documentation lookup tools (LLM-simulated).
       env_kwargs:

--- a/docs/user_guides/synth.md
+++ b/docs/user_guides/synth.md
@@ -215,17 +215,17 @@ Ready to dive deeper? The sections below cover all available options in detail.
 
 Agentic synthesis now follows an environment-first model. Tools do not declare an output strategy directly. Instead, each tool is bound to an environment, and the environment type defines how tool calls are executed via its `step()` method.
 
-- **`synthetic` environments** are backed by an LLM that simulates tool execution. They can be stateless (no persistent state) or stateful (mutable JSON state across turns). Statefulness is controlled by the optional `state_params` field — when provided, the environment tracks and mutates state across calls; when absent, each call is independent.
-- **`deterministic` environments** behave like lookup tables. Each tool defines a set of input-to-output mappings, and `step()` resolves tool calls by matching arguments against those mappings. No LLM is involved.
+- **`simulated` environments** are backed by an LLM that simulates tool execution. They can be stateless (no persistent state) or stateful (mutable JSON state across turns). Statefulness is controlled by the optional `state_params` field — when provided, the environment tracks and mutates state across calls; when absent, each call is independent.
+- **`lookup` environments** behave like lookup tables. Each tool defines a set of input-to-output mappings, and `step()` resolves tool calls by matching arguments against those mappings. No LLM is involved.
 
 At the config level:
 
 - Environments own their tool definitions.
 - Reusable environment catalogs live in top-level `environment_config` or `environment_config_path`.
 - Tools do not declare an `environment` field. The parent environment owns the binding.
-- `deterministic_outputs` is only used for tools in `deterministic` environments.
-- `read_only` is only meaningful for tools in stateful `synthetic` environments.
-- `env_kwargs.use_guided_decoding` (default `true`) constrains simulated tool output to each tool's `output_schema`, and applies to every tool in the environment. Set it to `false` when a schema is too large for the provider's grammar compiler, or when constrained decoding is too slow — output is still validated against `output_schema` after generation, so an off-schema response raises a tool error instead of being silently accepted. To mix policies across tools, put them in separate `synthetic` environments.
+- `env_kwargs.lookup_table` (keyed by tool id) supplies the input-to-output rows a `lookup` environment resolves against.
+- `read_only` is only meaningful for tools in stateful `simulated` environments.
+- `env_kwargs.use_guided_decoding` (default `true`) constrains simulated tool output to each tool's `output_schema`, and applies to every tool in the environment. Set it to `false` when a schema is too large for the provider's grammar compiler, or when constrained decoding is too slow — output is still validated against `output_schema` after generation, so an off-schema response raises a tool error instead of being silently accepted. To mix policies across tools, put them in separate `simulated` environments.
 - Multiturn attributes reference environments (not individual tools) to select which tools are available.
 
 Example:
@@ -236,7 +236,7 @@ environment_config:
     - id: support_backend
       name: Support Backend
       description: Simulated support system with tickets and users
-      type: synthetic
+      type: simulated
       tool_persona: You manage a customer support system with tickets and users.
       state_params:
         state_schema:
@@ -269,7 +269,7 @@ environment_config:
     - id: faq_lookup
       name: FAQ Lookup
       description: Cached LLM-backed FAQ answers
-      type: synthetic
+      type: simulated
       tool_persona: Generate concise FAQ answers grounded in the tool contract.
       cache_by_input: true
       tools:
@@ -284,7 +284,7 @@ environment_config:
     - id: policy_table
       name: Policy Table
       description: Predefined policy responses
-      type: deterministic
+      type: lookup
       tools:
         - id: get_refund_policy
           name: GetRefundPolicy
@@ -293,7 +293,9 @@ environment_config:
             type: object
             properties:
               policy_type: { type: string }
-          deterministic_outputs:
+      env_kwargs:
+        lookup_table:
+          get_refund_policy:
             - input:
                 policy_type: standard
               output:

--- a/src/oumi/core/configs/params/environment_params.py
+++ b/src/oumi/core/configs/params/environment_params.py
@@ -40,7 +40,7 @@ class EnvironmentParams(BaseParams):
     """Optional human-readable description. Not used at runtime."""
 
     env_type: str = ""
-    """Registry key selecting the environment implementation, e.g. ``deterministic``."""
+    """Registry key selecting the environment implementation, e.g. ``lookup``."""
 
     tools: list[Any] = field(default_factory=list)
     """Tools this environment serves, coerced to ``ToolParams`` in ``__post_init__``."""

--- a/src/oumi/core/configs/params/grounding_params.py
+++ b/src/oumi/core/configs/params/grounding_params.py
@@ -24,7 +24,7 @@ from oumi.core.configs.params.base_params import BaseParams
 
 @dataclass
 class ToolGroundingConfig(BaseParams):
-    """Per-tool field whitelist for deterministic-env grounding projection."""
+    """Per-tool field whitelist for lookup-env grounding projection."""
 
     fields: list[str]
 
@@ -41,7 +41,7 @@ class ToolGroundingConfig(BaseParams):
 
 @dataclass
 class StateGroundingConfig(BaseParams):
-    """Per-state-pool grounding for stateful synthetic environments.
+    """Per-state-pool grounding for stateful simulated environments.
 
     Projects rows from ``initial_state[state_path]`` through ``fields``.
     """
@@ -66,9 +66,9 @@ class StateGroundingConfig(BaseParams):
 class GroundingConfig(BaseParams):
     """Per-environment grounding configuration.
 
-    Both sub-blocks are optional; envs read whichever applies. Deterministic
+    Both sub-blocks are optional; envs read whichever applies. Lookup
     envs project from ``tools`` (per-tool lookup-table entries); stateful
-    synthetic envs project from ``state`` (per-pool ``initial_state`` rows).
+    simulated envs project from ``state`` (per-pool ``initial_state`` rows).
     """
 
     sample_size: int = 3
@@ -81,7 +81,7 @@ class GroundingConfig(BaseParams):
     """Per-tool field whitelists, keyed by tool id."""
 
     state: list[StateGroundingConfig] = field(default_factory=list)
-    """Per-state-pool projections for stateful synthetic envs."""
+    """Per-state-pool projections for stateful simulated envs."""
 
     def __post_init__(self) -> None:
         """Validate ``sample_size`` and coerce ``tools``/``state`` entries."""

--- a/src/oumi/core/configs/params/tool_params.py
+++ b/src/oumi/core/configs/params/tool_params.py
@@ -47,7 +47,7 @@ class ToolLookupError(ToolError):
     """Raised when a tool call cannot be resolved.
 
     Covers a tool id that isn't registered in the environment
-    (``ExecutableEnvironment``) and a ``DeterministicEnvironment``
+    (``ExecutableEnvironment``) and a ``LookupEnvironment``
     ``LookupEntry`` that matches none of the provided arguments.
     """
 
@@ -74,7 +74,7 @@ class ToolParams(BaseParams):
     When set, the host env dispatches calls to it instead of LLM-simulating.
     The callable is invoked with keyword arguments — always ``arguments`` (the
     tool-call args), plus a per-env context keyword: ``state`` for a stateful
-    ``SyntheticEnvironment``, ``context`` for an ``ExecutableEnvironment`` — and
+    ``SimulatedEnvironment``, ``context`` for an ``ExecutableEnvironment`` — and
     must return a ``ToolResult``.
     """
 

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -42,7 +42,7 @@ from oumi.core.types.conversation import (
 from oumi.core.types.tool_call import ToolCall, ToolDefinition, ToolResult
 from oumi.environments import GroundingFact
 from oumi.environments.base_environment import BaseEnvironment
-from oumi.environments.synthetic_environment import SyntheticEnvironment
+from oumi.environments.simulated_environment import SimulatedEnvironment
 from oumi.environments.utils import describe_grounding_default
 from oumi.inference.native_tool_calling import (
     NATIVE_TOOL_CALLING_ENGINES,
@@ -166,8 +166,8 @@ class ConversationSynthesizer:
             raise first_error
 
     def _wire_inference(self, env: BaseEnvironment) -> None:
-        """Inject the synthesizer's engine + base config into synthetic envs."""
-        if isinstance(env, SyntheticEnvironment):
+        """Inject the synthesizer's engine + base config into simulated envs."""
+        if isinstance(env, SimulatedEnvironment):
             env.attach_inference(self._inference_engine, self._inference_config)
 
     def _resolve_available_tools(
@@ -243,7 +243,7 @@ class ConversationSynthesizer:
                 outputs = router.route_batch(calls)
             except Exception:
                 # On batch failure, re-route each call individually so per-call
-                # errors stay attributed. SyntheticEnvironment's in-batch cache
+                # errors stay attributed. SimulatedEnvironment's in-batch cache
                 # shields earlier successes from re-inference, but calls past
                 # the failing index re-infer. Acceptable for attribution today;
                 # Phase 2's corrective-retry should replace this fallback.

--- a/src/oumi/core/synthesis/tool_router.py
+++ b/src/oumi/core/synthesis/tool_router.py
@@ -104,8 +104,8 @@ class ToolRouter:
         Envs whose ``requires_isolation()`` returns ``True`` are rebuilt via
         ``build_environment`` so their mutable state stays independent across
         samples; ``on_env_built`` re-runs on those fresh instances. Envs that
-        don't require isolation (e.g. ``DeterministicEnvironment`` and
-        stateless ``SyntheticEnvironment``) are shared with the parent
+        don't require isolation (e.g. ``LookupEnvironment`` and
+        stateless ``SimulatedEnvironment``) are shared with the parent
         router to avoid the per-sample build + inference-engine attach cost.
 
         ``env_kwargs_by_env_id`` replaces ``env_kwargs`` on the rebuilt envs with

--- a/src/oumi/environments/__init__.py
+++ b/src/oumi/environments/__init__.py
@@ -35,14 +35,19 @@ from oumi.environments.base_environment import BaseEnvironment
 from oumi.environments.database_executable_environment import (
     DatabaseExecutableEnvironment,
 )
-from oumi.environments.deterministic_environment import (
-    DeterministicEnvironment,
-    DeterministicEnvironmentKwargs,
-    ToolLookupEntry,
-)
 from oumi.environments.executable_environment import ExecutableEnvironment
 from oumi.environments.executable_tool import ExecutableTool
-from oumi.environments.synthetic_environment import (
+from oumi.environments.lookup_environment import (
+    DeterministicEnvironment,
+    DeterministicEnvironmentKwargs,
+    LookupEnvironment,
+    LookupEnvironmentKwargs,
+    ToolLookupEntry,
+)
+from oumi.environments.simulated_environment import (
+    SimulatedEnvironment,
+    SimulatedEnvironmentKwargs,
+    SimulatedStateParams,
     SyntheticEnvironment,
     SyntheticEnvironmentKwargs,
     SyntheticStateParams,
@@ -51,6 +56,7 @@ from oumi.environments.synthetic_environment import (
 __all__ = [
     "BaseEnvironment",
     "DatabaseExecutableEnvironment",
+    # Deprecated aliases, kept so existing imports keep resolving.
     "DeterministicEnvironment",
     "DeterministicEnvironmentKwargs",
     "ExecutableEnvironment",
@@ -58,6 +64,11 @@ __all__ = [
     "GroundingConfig",
     "GroundingFact",
     "JSONSchema",
+    "LookupEnvironment",
+    "LookupEnvironmentKwargs",
+    "SimulatedEnvironment",
+    "SimulatedEnvironmentKwargs",
+    "SimulatedStateParams",
     "StateGroundingConfig",
     "SyntheticEnvironment",
     "SyntheticEnvironmentKwargs",

--- a/src/oumi/environments/base_environment.py
+++ b/src/oumi/environments/base_environment.py
@@ -40,7 +40,7 @@ class BaseEnvironment(ABC):
 
         Default ``False`` — the env is safe to share across samples.
         Override and return ``True`` for envs carrying mutable per-sample
-        state (e.g. stateful synthetic tool execution).
+        state (e.g. stateful simulated tool execution).
         """
         return False
 

--- a/src/oumi/environments/lookup_environment.py
+++ b/src/oumi/environments/lookup_environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Deterministic environment with fixed lookup responses."""
+"""Lookup environment with fixed lookup responses."""
 
 from __future__ import annotations
 
@@ -151,7 +151,7 @@ def _unfillable_default_paths(
 
 @dataclass
 class ToolLookupEntry(BaseParams):
-    """One (input, output) pair in a deterministic env's lookup table.
+    """One (input, output) pair in a lookup env's lookup table.
 
     ``output`` may be any JSON value (scalar, list, object, or null).
     """
@@ -169,8 +169,8 @@ class ToolLookupEntry(BaseParams):
 
 
 @dataclass
-class DeterministicEnvironmentKwargs(BaseParams):
-    """Type-specific kwargs for DeterministicEnvironment."""
+class LookupEnvironmentKwargs(BaseParams):
+    """Type-specific kwargs for LookupEnvironment."""
 
     lookup_table: dict[str, list[ToolLookupEntry]] = field(default_factory=dict)
     """Per-tool list of (input, output) entries, keyed by tool id."""
@@ -188,8 +188,9 @@ class DeterministicEnvironmentKwargs(BaseParams):
         }
 
 
-@register_environment("deterministic")
-class DeterministicEnvironment(BaseEnvironment):
+@register_environment("lookup")
+@register_environment("deterministic")  # deprecated alias, kept for back-compat
+class LookupEnvironment(BaseEnvironment):
     """Environment that resolves tools from a per-tool lookup table.
 
     The env's ``env_kwargs.lookup_table`` is the source of truth for tool
@@ -202,9 +203,9 @@ class DeterministicEnvironment(BaseEnvironment):
     def __init__(
         self,
         params: EnvironmentParams,
-        kwargs: DeterministicEnvironmentKwargs,
+        kwargs: LookupEnvironmentKwargs,
     ) -> None:
-        """Initialize a DeterministicEnvironment."""
+        """Initialize a LookupEnvironment."""
         self._params = params
         self._kwargs = kwargs
         self._tools_by_id: dict[str, ToolParams] = {
@@ -214,7 +215,7 @@ class DeterministicEnvironment(BaseEnvironment):
         self._warn_grounding_key_collisions()
 
     def step(self, calls: list[tuple[str, dict[str, Any]]]) -> list[ToolResult]:
-        """Resolve a batch of deterministic tool calls to their outputs."""
+        """Resolve a batch of lookup tool calls to their outputs."""
         return [self._resolve_one(tool_id, args) for tool_id, args in calls]
 
     def _resolve_one(self, tool_id: str, arguments: dict[str, Any]) -> ToolResult:
@@ -231,7 +232,7 @@ class DeterministicEnvironment(BaseEnvironment):
                 return ToolResult(output=entry.output)
         available = [entry.input for entry in entries]
         raise ToolLookupError(
-            f"No deterministic output matches arguments "
+            f"No lookup output matches arguments "
             f"{json.dumps(arguments, sort_keys=True)} for tool '{tool_id}'. "
             f"Configured inputs: {json.dumps(available, sort_keys=True)}"
         )
@@ -276,12 +277,12 @@ class DeterministicEnvironment(BaseEnvironment):
         return rng.sample(pool, min(n, len(pool)))
 
     @classmethod
-    def from_params(cls, params: EnvironmentParams) -> DeterministicEnvironment:
-        """Build a DeterministicEnvironment from its params object."""
+    def from_params(cls, params: EnvironmentParams) -> LookupEnvironment:
+        """Build a LookupEnvironment from its params object."""
         kwargs = parse_env_kwargs(
-            DeterministicEnvironmentKwargs,
+            LookupEnvironmentKwargs,
             params,
-            env_label="DeterministicEnvironment",
+            env_label="LookupEnvironment",
         )
         return cls(params, kwargs)
 
@@ -376,3 +377,8 @@ class DeterministicEnvironment(BaseEnvironment):
                     tool_id,
                     sorted(shadowed),
                 )
+
+
+# Deprecated aliases, kept so existing imports keep resolving.
+DeterministicEnvironment = LookupEnvironment
+DeterministicEnvironmentKwargs = LookupEnvironmentKwargs

--- a/src/oumi/environments/simulated_environment.py
+++ b/src/oumi/environments/simulated_environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Synthetic environment backed by LLM-simulated or Python-executed tools.
+"""Simulated environment backed by LLM-simulated or Python-executed tools.
 
 Stateless mode (``state_params=None``) batches LLM-simulated tool outputs
 per tool id, cached by ``(tool_id, args)``. Individual tools may still
@@ -55,8 +55,8 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class SyntheticStateParams(BaseParams):
-    """Optional state configuration for a synthetic environment.
+class SimulatedStateParams(BaseParams):
+    """Optional state configuration for a simulated environment.
 
     State grounding for these pools is declared at the env level
     via ``EnvironmentParams.grounding.state`` — each entry's
@@ -73,11 +73,11 @@ class SyntheticStateParams(BaseParams):
 
 
 @dataclass
-class SyntheticEnvironmentKwargs(BaseParams):
-    """Type-specific kwargs for SyntheticEnvironment."""
+class SimulatedEnvironmentKwargs(BaseParams):
+    """Type-specific kwargs for SimulatedEnvironment."""
 
     tool_persona: str = ""
-    state_params: SyntheticStateParams | None = None
+    state_params: SimulatedStateParams | None = None
     cache_by_input: bool = True
     use_guided_decoding: bool = True
     """Constrain simulator output to each tool's ``output_schema``.
@@ -89,23 +89,24 @@ class SyntheticEnvironmentKwargs(BaseParams):
     """
 
     def __post_init__(self) -> None:
-        """Coerce state_params dict into SyntheticStateParams if needed."""
+        """Coerce state_params dict into SimulatedStateParams if needed."""
         if isinstance(self.state_params, dict):
-            self.state_params = SyntheticStateParams(**self.state_params)
+            self.state_params = SimulatedStateParams(**self.state_params)
 
     def __finalize_and_validate__(self) -> None:
         """Finalize and validate the kwargs."""
         if not self.tool_persona:
-            raise ValueError("SyntheticEnvironmentKwargs.tool_persona cannot be empty.")
+            raise ValueError("SimulatedEnvironmentKwargs.tool_persona cannot be empty.")
         if self.state_params is not None and self.cache_by_input:
             raise ValueError(
-                "SyntheticEnvironmentKwargs.cache_by_input must be False when "
+                "SimulatedEnvironmentKwargs.cache_by_input must be False when "
                 "state_params is provided."
             )
 
 
-@register_environment("synthetic")
-class SyntheticEnvironment(BaseEnvironment):
+@register_environment("simulated")
+@register_environment("synthetic")  # deprecated alias, kept for back-compat
+class SimulatedEnvironment(BaseEnvironment):
     """LLM-simulated environment with optional mutable state.
 
     See the module docstring for the stateless vs stateful contract.
@@ -114,9 +115,9 @@ class SyntheticEnvironment(BaseEnvironment):
     def __init__(
         self,
         params: EnvironmentParams,
-        kwargs: SyntheticEnvironmentKwargs,
+        kwargs: SimulatedEnvironmentKwargs,
     ) -> None:
-        """Initialize a SyntheticEnvironment with the given params and kwargs."""
+        """Initialize a SimulatedEnvironment with the given params and kwargs."""
         self._params = params
         self._kwargs = kwargs
         self._cache: dict[str, ToolResult] = {}
@@ -136,7 +137,7 @@ class SyntheticEnvironment(BaseEnvironment):
         )
         if self._state is None and self._state_grounding:
             raise ValueError(
-                f"SyntheticEnvironment '{params.id}': grounding.state is "
+                f"SimulatedEnvironment '{params.id}': grounding.state is "
                 f"configured but the env has no state (state_params with "
                 f"initial_state is required)."
             )
@@ -149,7 +150,7 @@ class SyntheticEnvironment(BaseEnvironment):
             missing = [t.id for t in params.tools if not t.executor]
             if missing:
                 raise ValueError(
-                    "SyntheticEnvironment in stateful mode (state_params with "
+                    "SimulatedEnvironment in stateful mode (state_params with "
                     "initial_state set) requires every tool to define an executor; "
                     "LLM-simulated tools cannot mutate state. Missing executor: "
                     f"{missing}"
@@ -173,9 +174,9 @@ class SyntheticEnvironment(BaseEnvironment):
         return self._state is not None
 
     @classmethod
-    def from_params(cls, params: EnvironmentParams) -> SyntheticEnvironment:
-        """Build a SyntheticEnvironment from its params object."""
-        kwargs = SyntheticEnvironmentKwargs(**(params.env_kwargs or {}))
+    def from_params(cls, params: EnvironmentParams) -> SimulatedEnvironment:
+        """Build a SimulatedEnvironment from its params object."""
+        kwargs = SimulatedEnvironmentKwargs(**(params.env_kwargs or {}))
         kwargs.finalize_and_validate()
         return cls(params, kwargs)
 
@@ -258,7 +259,7 @@ class SyntheticEnvironment(BaseEnvironment):
         if sim_misses:
             if self._engine is None or self._base_inference_config is None:
                 raise RuntimeError(
-                    "SyntheticEnvironment.step called before "
+                    "SimulatedEnvironment.step called before "
                     "attach_inference(). Wire the synthesizer's engine via "
                     "attach_inference(engine, base_config) before invoking "
                     "step()."
@@ -380,7 +381,7 @@ class SyntheticEnvironment(BaseEnvironment):
         for cfg in self._state_grounding:
             if cfg.state_path not in self._state:
                 raise ValueError(
-                    f"SyntheticEnvironment '{self._params.id}': grounding "
+                    f"SimulatedEnvironment '{self._params.id}': grounding "
                     f"state_path '{cfg.state_path}' is not present in "
                     f"initial_state. Top-level keys: "
                     f"{sorted(self._state.keys())}."
@@ -388,7 +389,7 @@ class SyntheticEnvironment(BaseEnvironment):
             rows = self._state[cfg.state_path]
             if not isinstance(rows, list):
                 raise ValueError(
-                    f"SyntheticEnvironment '{self._params.id}': grounding "
+                    f"SimulatedEnvironment '{self._params.id}': grounding "
                     f"state_path '{cfg.state_path}' must resolve to a list, "
                     f"got {type(rows).__name__}."
                 )
@@ -481,3 +482,9 @@ class SyntheticEnvironment(BaseEnvironment):
                     f"Simulator output for '{tool.id}' failed schema validation: {e}"
                 ) from e
         return ToolResult(output=parsed)
+
+
+# Deprecated aliases, kept so existing imports keep resolving.
+SyntheticEnvironment = SimulatedEnvironment
+SyntheticEnvironmentKwargs = SimulatedEnvironmentKwargs
+SyntheticStateParams = SimulatedStateParams

--- a/tests/unit/builders/test_environments.py
+++ b/tests/unit/builders/test_environments.py
@@ -25,8 +25,8 @@ def test_build_environment_imports_without_explicit_env_package():
     params = EnvironmentParams(
         id="lookup",
         name="Lookup",
-        description="A deterministic lookup environment",
-        env_type="deterministic",
+        description="A lookup environment",
+        env_type="lookup",
         tools=[ToolParams(id="get", name="Get", description="Lookup something.")],
         env_kwargs={
             "lookup_table": {
@@ -51,9 +51,9 @@ def test_build_environment_unknown_env_type_raises():
         build_environment(params)
 
 
-def test_build_environment_dispatches_synthetic():
+def test_build_environment_dispatches_synthetic_alias():
     from oumi.builders.environments import build_environment
-    from oumi.environments.synthetic_environment import SyntheticEnvironment
+    from oumi.environments.simulated_environment import SimulatedEnvironment
 
     params = EnvironmentParams(
         id="faq",
@@ -64,12 +64,12 @@ def test_build_environment_dispatches_synthetic():
         env_kwargs={"tool_persona": "Answer FAQs."},
     )
     env = build_environment(params)
-    assert isinstance(env, SyntheticEnvironment)
+    assert isinstance(env, SimulatedEnvironment)
 
 
-def test_build_environment_dispatches_deterministic():
+def test_build_environment_dispatches_deterministic_alias():
     from oumi.builders.environments import build_environment
-    from oumi.environments.deterministic_environment import DeterministicEnvironment
+    from oumi.environments.lookup_environment import LookupEnvironment
 
     params = EnvironmentParams(
         id="lookup",
@@ -80,4 +80,36 @@ def test_build_environment_dispatches_deterministic():
         env_kwargs={"lookup_table": {"t": [{"input": {}, "output": {}}]}},
     )
     env = build_environment(params)
-    assert isinstance(env, DeterministicEnvironment)
+    assert isinstance(env, LookupEnvironment)
+
+
+def test_build_environment_dispatches_simulated():
+    from oumi.builders.environments import build_environment
+    from oumi.environments.simulated_environment import SimulatedEnvironment
+
+    params = EnvironmentParams(
+        id="faq",
+        name="FAQ",
+        description="FAQ tools",
+        env_type="simulated",
+        tools=[ToolParams(id="answer", name="Answer", description="Answer.")],
+        env_kwargs={"tool_persona": "Answer FAQs."},
+    )
+    env = build_environment(params)
+    assert isinstance(env, SimulatedEnvironment)
+
+
+def test_build_environment_dispatches_lookup():
+    from oumi.builders.environments import build_environment
+    from oumi.environments.lookup_environment import LookupEnvironment
+
+    params = EnvironmentParams(
+        id="lookup",
+        name="Lookup",
+        description="d",
+        env_type="lookup",
+        tools=[ToolParams(id="t", name="t", description="t")],
+        env_kwargs={"lookup_table": {"t": [{"input": {}, "output": {}}]}},
+    )
+    env = build_environment(params)
+    assert isinstance(env, LookupEnvironment)

--- a/tests/unit/core/configs/params/test_environment_params.py
+++ b/tests/unit/core/configs/params/test_environment_params.py
@@ -36,11 +36,11 @@ def test_constructs_with_required_fields():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
     )
     assert p.id == "e1"
-    assert p.env_type == "deterministic"
+    assert p.env_type == "lookup"
     assert len(p.tools) == 1
 
 
@@ -56,7 +56,7 @@ def test_finalize_and_validate_rejects_empty_required_field(field):
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
     )
     base[field] = ""
@@ -69,7 +69,7 @@ def test_finalize_and_validate_allows_omitted_name_and_description():
     """name and description are optional labels, not required fields."""
     p = EnvironmentParams(
         id="e1",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
     )
     p.finalize_and_validate()
@@ -82,7 +82,7 @@ def test_finalize_and_validate_rejects_duplicate_tool_ids():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool("dup"), _make_tool("dup")],
     )
     with pytest.raises(ValueError, match="duplicate tool id 'dup'"):
@@ -97,8 +97,8 @@ def test_environment_config_finalize_and_validate_descends_into_list():
 
 
 def test_environment_config_duplicate_env_ids_raises():
-    a = EnvironmentParams(id="dup", name="A", description="d", env_type="deterministic")
-    b = EnvironmentParams(id="dup", name="B", description="d", env_type="deterministic")
+    a = EnvironmentParams(id="dup", name="A", description="d", env_type="lookup")
+    b = EnvironmentParams(id="dup", name="B", description="d", env_type="lookup")
     with pytest.raises(ValueError, match="duplicate environment id 'dup'"):
         EnvironmentConfig(environments=[a, b])
 
@@ -108,7 +108,7 @@ def test_post_init_coerces_dict_tools_to_tool_params():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[{"id": "t", "name": "t", "description": "t"}],  # type: ignore[list-item]
     )
     assert type(p.tools[0]) is ToolParams
@@ -120,14 +120,14 @@ def test_environment_config_duplicate_tool_ids_across_envs_raises():
         id="env1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
     )
     b = EnvironmentParams(
         id="env2",
         name="E2",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
     )
     with pytest.raises(ValueError, match="duplicate tool id 't'"):
@@ -142,7 +142,7 @@ def test_grounding_post_init_coerces_dict_to_grounding_config():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
         grounding={"sample_size": 5, "tools": {"t": {"fields": ["a"]}}},  # type: ignore[arg-type]
     )
@@ -156,7 +156,7 @@ def test_grounding_validate_passes_with_at_least_one_tool():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
         grounding=GroundingConfig(
             sample_size=3,
@@ -173,7 +173,7 @@ def test_grounding_warns_on_stale_tool_ids(caplog):
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool("real_tool")],
         grounding=GroundingConfig(
             sample_size=3,
@@ -197,7 +197,7 @@ def test_no_grounding_does_not_validate_tools():
         id="e1",
         name="E1",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[_make_tool()],
         grounding=None,
     )

--- a/tests/unit/core/configs/params/test_tool_params.py
+++ b/tests/unit/core/configs/params/test_tool_params.py
@@ -19,7 +19,7 @@ import pytest
 
 from oumi.core.configs.params.tool_params import ToolArgumentError, ToolParams
 from oumi.core.types.tool_call import JSONSchema, ToolDefinition, ToolResult
-from oumi.environments.synthetic_environment import SyntheticStateParams
+from oumi.environments.simulated_environment import SimulatedStateParams
 
 
 def _make_state_schema() -> dict[str, Any]:
@@ -218,18 +218,18 @@ def test_validate_arguments_empty_schema_accepts_any_object():
     tool.validate_arguments({"extra": "ignored"})
 
 
-def test_synthetic_state_params_validates_initial_state_against_schema():
+def test_simulated_state_params_validates_initial_state_against_schema():
     with pytest.raises(jsonschema.ValidationError):
-        SyntheticStateParams(
+        SimulatedStateParams(
             state_schema=_make_state_schema(),
             initial_state={"files": {"count": "bad"}},
         )
 
 
-def test_synthetic_state_params_accepts_partial_inputs():
+def test_simulated_state_params_accepts_partial_inputs():
     assert (
-        SyntheticStateParams(state_schema=_make_state_schema()).state_schema is not None
+        SimulatedStateParams(state_schema=_make_state_schema()).state_schema is not None
     )
-    assert SyntheticStateParams(
+    assert SimulatedStateParams(
         initial_state={"files": {"count": 1}}
     ).initial_state == {"files": {"count": 1}}

--- a/tests/unit/core/configs/test_synthesis_config.py
+++ b/tests/unit/core/configs/test_synthesis_config.py
@@ -79,7 +79,7 @@ def _make_faq_tool() -> ToolParams:
     )
 
 
-def _synthetic_env_params(
+def _simulated_env_params(
     *,
     env_id: str = "faq",
     name: str = "FAQ",
@@ -95,7 +95,7 @@ def _synthetic_env_params(
         id=env_id,
         name=name,
         description=description,
-        env_type="synthetic",
+        env_type="simulated",
         tools=tools or [_make_faq_tool()],
         env_kwargs=env_kwargs,
     )
@@ -110,7 +110,7 @@ def test_invalid_output_path():
 
 
 def test_synthesis_config_with_top_level_environment_config():
-    env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
+    env_config = EnvironmentConfig(environments=[_simulated_env_params()])
     params = GeneralSynthesisParams()
     params.multiturn_attributes = []
 
@@ -126,7 +126,7 @@ def test_synthesis_config_with_top_level_environment_config():
 
 def test_synthesis_config_loads_environment_config_from_path(tmp_path):
     env_config_path = tmp_path / "environments.yaml"
-    env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
+    env_config = EnvironmentConfig(environments=[_simulated_env_params()])
     env_config.to_yaml(env_config_path)
 
     config = SynthesisConfig(environment_config_path=str(env_config_path))
@@ -136,7 +136,7 @@ def test_synthesis_config_loads_environment_config_from_path(tmp_path):
 
 
 def test_synthesis_config_validates_available_tools():
-    env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
+    env_config = EnvironmentConfig(environments=[_simulated_env_params()])
     params = GeneralSynthesisParams(
         multiturn_attributes=[
             MultiTurnAttribute(
@@ -185,7 +185,7 @@ def test_synthesis_config_requires_environment_config_for_available_tools():
 
 
 def test_synthesis_config_validates_available_environments():
-    env_config = EnvironmentConfig(environments=[_synthetic_env_params()])
+    env_config = EnvironmentConfig(environments=[_simulated_env_params()])
     params = GeneralSynthesisParams(
         multiturn_attributes=[
             MultiTurnAttribute(
@@ -213,8 +213,8 @@ def test_synthesis_config_restricts_tools_to_selected_environments():
     )
     env_config = EnvironmentConfig(
         environments=[
-            _synthetic_env_params(),
-            _synthetic_env_params(
+            _simulated_env_params(),
+            _simulated_env_params(
                 env_id="files",
                 name="Files",
                 description="File tools",
@@ -255,8 +255,8 @@ def test_synthesis_config_resolves_all_tools_from_selected_environments():
     )
     env_config = EnvironmentConfig(
         environments=[
-            _synthetic_env_params(),
-            _synthetic_env_params(
+            _simulated_env_params(),
+            _simulated_env_params(
                 env_id="files",
                 name="Files",
                 description="File tools",

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -48,7 +48,7 @@ from oumi.core.types.conversation import (
 )
 from oumi.core.types.tool_call import FunctionCall, ToolCall, ToolResult
 from oumi.environments.base_environment import BaseEnvironment
-from oumi.environments.synthetic_environment import SyntheticEnvironment
+from oumi.environments.simulated_environment import SimulatedEnvironment
 
 
 @pytest.fixture
@@ -1251,7 +1251,7 @@ def _grounded_env_params(
         id=env_id,
         name=env_id,
         description=f"env {env_id}",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[ToolParams(id=tool_id, name=tool_id, description="Look up an id.")],
         env_kwargs={
             "lookup_table": {
@@ -1286,7 +1286,7 @@ def _ungrounded_env_config():
                 id="env1",
                 name="env1",
                 description="ungrounded env",
-                env_type="deterministic",
+                env_type="lookup",
                 tools=[ToolParams(id="lookup", name="lookup", description="Look up.")],
                 env_kwargs={
                     "lookup_table": {
@@ -1450,7 +1450,7 @@ def test_attach_grounding_facts_filters_by_available_tools(mock_inference_config
         id="env",
         name="Env",
         description="d",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[
             ToolParams(id="lookup_a", name="A", description="d"),
             ToolParams(id="lookup_b", name="B", description="d"),
@@ -2013,7 +2013,7 @@ def test_synthesize_emits_tools_for_unlabeled_environment(
         environments=[
             EnvironmentParams(
                 id="library",
-                env_type="deterministic",
+                env_type="lookup",
                 tools=[ToolParams(id="lookup", name="lookup", description="x")],
             )
         ]
@@ -2122,7 +2122,7 @@ def _make_env_config(env_id: str, tool_id: str) -> MagicMock:
         id=env_id,
         name="x",
         description="x",
-        env_type="deterministic",
+        env_type="lookup",
         tools=[],
     )
     env_config = MagicMock(spec=EnvironmentConfig)
@@ -2418,7 +2418,7 @@ def test_dispatch_tool_calls_recovers_from_unguided_schema_drift(
 ):
     """End-to-end: guidance off → off-schema simulator output → recoverable tool error.
 
-    Drives a real ``SyntheticEnvironment`` so the assertions cover the whole path:
+    Drives a real ``SimulatedEnvironment`` so the assertions cover the whole path:
     no constraint reaches the engine, and the resulting ``ToolError`` becomes a
     ``TOOL`` message instead of killing the sample.
     """
@@ -2441,11 +2441,11 @@ def test_dispatch_tool_calls_recovers_from_unguided_schema_drift(
         id="faq",
         name="FAQ",
         description="FAQ env",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[tool],
         env_kwargs={"tool_persona": "Answer FAQs.", "use_guided_decoding": False},
     )
-    mock_build_environment.return_value = SyntheticEnvironment.from_params(env_params)
+    mock_build_environment.return_value = SimulatedEnvironment.from_params(env_params)
 
     mock_engine = Mock()
     mock_engine.infer = Mock(
@@ -2799,12 +2799,12 @@ def test_assistant_turn_dispatches_parallel_batch_unrestricted(
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
-def test_synthesizer_attaches_inference_to_synthetic_env(
+def test_synthesizer_attaches_inference_to_simulated_env(
     mock_build_inference_engine,
     mock_general_synthesis_params,
 ):
-    """SyntheticEnvironments built via _tool_dispatch get attach_inference()."""
-    from oumi.environments.synthetic_environment import SyntheticEnvironment
+    """Simulated environments built via _tool_dispatch get attach_inference()."""
+    from oumi.environments.simulated_environment import SimulatedEnvironment
 
     mock_engine = Mock()
     mock_build_inference_engine.return_value = mock_engine
@@ -2812,8 +2812,8 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
     env_params = EnvironmentParams(
         id="docs",
         name="Docs",
-        description="Synthetic docs env",
-        env_type="synthetic",
+        description="Simulated docs env",
+        env_type="simulated",
         tools=[
             ToolParams(
                 id="lookup",
@@ -2844,7 +2844,7 @@ def test_synthesizer_attaches_inference_to_synthetic_env(
 
     assert synth._router is not None
     env = synth._router.tool_to_env["lookup"]
-    assert isinstance(env, SyntheticEnvironment)
+    assert isinstance(env, SimulatedEnvironment)
     assert env._engine is mock_engine
     assert env._base_inference_config is inference_config
 
@@ -2857,7 +2857,7 @@ def test_prepare_sample_routers_builds_one_router_per_sample(
 ):
     """_prepare_sample_routers materializes a router clone per sample.
 
-    The deterministic env carries no mutable state so it is shared across
+    The lookup env carries no mutable state so it is shared across
     routers; only the router wrappers themselves are per-sample.
     """
     env_config = _grounded_env_config(n_entries=5, sample_size=2, seed=1)

--- a/tests/unit/core/synthesis/test_tool_router.py
+++ b/tests/unit/core/synthesis/test_tool_router.py
@@ -28,7 +28,7 @@ from oumi.core.configs.params.tool_params import (
 from oumi.core.synthesis.tool_router import ToolRouter
 from oumi.core.types.tool_call import ToolResult
 from oumi.environments.base_environment import BaseEnvironment
-from oumi.environments.deterministic_environment import DeterministicEnvironment
+from oumi.environments.lookup_environment import LookupEnvironment
 
 
 def _tool(tool_id: str, schema: dict[str, Any] | None = None) -> ToolParams:
@@ -45,12 +45,12 @@ def _det_env_params(
     tools: list[ToolParams],
     lookup: dict[str, list[dict]] | None = None,
 ) -> EnvironmentParams:
-    """Build a DeterministicEnvironment params block with a default identity lookup."""
+    """Build a LookupEnvironment params block with a default identity lookup."""
     return EnvironmentParams(
         id=env_id,
         name=env_id,
         description=f"Env {env_id}",
-        env_type="deterministic",
+        env_type="lookup",
         tools=tools,
         env_kwargs={
             "lookup_table": lookup
@@ -70,7 +70,7 @@ def _stateful_synth_env_params(env_id: str) -> EnvironmentParams:
         id=env_id,
         name=env_id,
         description=f"Env {env_id}",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[],
         env_kwargs={
             "tool_persona": "p",
@@ -94,7 +94,7 @@ def test_from_environment_config_builds_all_fields():
     router = ToolRouter.from_environment_config(env_config)
 
     assert set(router.env_by_id) == {"env1"}
-    assert isinstance(router.env_by_id["env1"], DeterministicEnvironment)
+    assert isinstance(router.env_by_id["env1"], LookupEnvironment)
     assert router.tool_to_env["t1"] is router.env_by_id["env1"]
     assert router.tools_by_id["t1"] is tool
     assert len(router.tool_specs) == 1
@@ -113,7 +113,7 @@ def test_from_environment_config_invokes_on_env_built_for_each_env():
     ToolRouter.from_environment_config(env_config, on_env_built=seen.append)
 
     assert len(seen) == 2
-    assert all(isinstance(env, DeterministicEnvironment) for env in seen)
+    assert all(isinstance(env, LookupEnvironment) for env in seen)
 
 
 def test_from_environment_config_routes_tools_across_envs():
@@ -145,7 +145,7 @@ def test_from_environment_config_includes_grounding_only_envs():
         id="state_only",
         name="state_only",
         description="grounding-only env",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[],
         env_kwargs={
             "tool_persona": "p",
@@ -249,7 +249,7 @@ def test_route_batch_empty_returns_empty():
 
 
 def test_route_batch_dispatches_through_real_env():
-    """End-to-end: real DeterministicEnvironment lookup via the router."""
+    """End-to-end: real LookupEnvironment lookup via the router."""
     env_params = _det_env_params(
         "env1",
         [_tool("t1")],
@@ -345,7 +345,7 @@ def test_for_sample_clones_envs_that_require_isolation():
 
 
 def test_for_sample_shares_envs_that_do_not_require_isolation():
-    """Deterministic envs carry no mutable state, so they are shared with parent."""
+    """Lookup envs carry no mutable state, so they are shared with parent."""
     env_config = EnvironmentConfig(
         environments=[
             _det_env_params("det1", [_tool("t1")]),

--- a/tests/unit/environments/test_lookup_environment.py
+++ b/tests/unit/environments/test_lookup_environment.py
@@ -25,9 +25,9 @@ from oumi.core.configs.params.grounding_params import (
 )
 from oumi.core.configs.params.tool_params import ToolLookupError, ToolParams
 from oumi.core.types.tool_call import ToolResult
-from oumi.environments.deterministic_environment import (
-    DeterministicEnvironment,
-    DeterministicEnvironmentKwargs,
+from oumi.environments.lookup_environment import (
+    LookupEnvironment,
+    LookupEnvironmentKwargs,
     ToolLookupEntry,
 )
 
@@ -62,8 +62,8 @@ def _make_params(
     defaults: dict = dict(
         id="lookup",
         name="Lookup",
-        description="A deterministic lookup environment",
-        env_type="deterministic",
+        description="A lookup environment",
+        env_type="lookup",
         tools=tools,
         env_kwargs={"lookup_table": lookup_table},
         grounding=grounding,
@@ -76,14 +76,14 @@ def _make_params(
 
 
 def test_from_params_constructs_runtime_instance():
-    env = DeterministicEnvironment.from_params(_make_params())
-    assert isinstance(env, DeterministicEnvironment)
-    assert isinstance(env._kwargs, DeterministicEnvironmentKwargs)
+    env = LookupEnvironment.from_params(_make_params())
+    assert isinstance(env, LookupEnvironment)
+    assert isinstance(env._kwargs, LookupEnvironmentKwargs)
 
 
 def test_from_params_coerces_raw_lookup_entries():
     """Raw dict entries in lookup_table are coerced to ToolLookupEntry."""
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             lookup_table={  # type: ignore[arg-type]
                 "tool1": [{"input": {"id": "1"}, "output": {"msg": "ok"}}],
@@ -98,7 +98,7 @@ def test_from_params_coerces_raw_lookup_entries():
 def test_tool_without_entries_raises():
     """Hard error: tool declared but lookup_table has no entries for it."""
     with pytest.raises(ValueError, match="has no entries in lookup_table"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[_make_tool("tool1"), _make_tool("tool2")],
                 lookup_table={
@@ -112,7 +112,7 @@ def test_tool_without_entries_raises():
 def test_stale_lookup_table_keys_warn(caplog):
     """Warning (not error) when lookup_table has entries for unknown tool."""
     with caplog.at_level(logging.WARNING, logger="oumi"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 lookup_table={
                     "tool1": [
@@ -138,12 +138,12 @@ def test_unknown_env_kwargs_raises_with_known_keys():
         "lookup_tabel": {},
     }
     with pytest.raises(ValueError, match="unknown env_kwargs.*lookup_tabel"):
-        DeterministicEnvironment.from_params(params)
+        LookupEnvironment.from_params(params)
 
 
 def test_duplicate_inputs_raises():
     with pytest.raises(ValueError, match="duplicate input"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 lookup_table={
                     "tool1": [
@@ -164,7 +164,7 @@ def test_inputs_with_omitted_and_explicit_defaults_are_duplicates():
     )
 
     with pytest.raises(ValueError, match="duplicate input"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -193,7 +193,7 @@ def test_unreachable_schema_default_raises(keyword, subschema, path_suffix):
     }
 
     with pytest.raises(ValueError, match="never applied") as excinfo:
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(tools=[_make_tool(parameters=parameters)])
         )
     assert f"parameters.properties.value.{path_suffix}" in str(excinfo.value)
@@ -208,7 +208,7 @@ def test_combinator_without_defaults_is_accepted():
         }
     )
 
-    env = DeterministicEnvironment.from_params(_make_params(tools=[tool]))
+    env = LookupEnvironment.from_params(_make_params(tools=[tool]))
 
     assert env.step([("tool1", {"id": "01"})]) == [ToolResult(output={"msg": "ok"})]
 
@@ -228,7 +228,7 @@ def test_defaults_are_filled_through_local_ref():
     )
     entry = ToolLookupEntry(input={}, output={"msg": "ok"})
 
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={"tool1": [entry]},
@@ -251,7 +251,7 @@ def test_invalid_entry_input_raises():
     )
 
     with pytest.raises(ValueError, match="invalid input.*locaton"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -288,7 +288,7 @@ def test_entry_input_is_validated_after_defaults_are_filled():
     )
 
     with pytest.raises(ValueError, match="invalid input.*fahrenheit.*not one of"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -309,7 +309,7 @@ def test_invalid_entry_output_raises():
     )
 
     with pytest.raises(ValueError, match="invalid output.*temprature"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -334,7 +334,7 @@ def test_valid_entry_output_constructs():
         }
     )
 
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={
@@ -359,7 +359,7 @@ def test_non_json_output_raises():
     tool = _make_tool(output_schema={"type": "object"})
 
     with pytest.raises(ValueError, match="non-JSON output"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -383,7 +383,7 @@ def test_non_json_output_raises():
 def test_non_dict_outputs_validate_against_schema(output_schema, output):
     tool = _make_tool(output_schema=output_schema)
 
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={"tool1": [ToolLookupEntry(input={}, output=output)]},
@@ -393,7 +393,7 @@ def test_non_dict_outputs_validate_against_schema(output_schema, output):
     assert env.step([("tool1", {})]) == [ToolResult(output=output)]
 
     with pytest.raises(ValueError, match="invalid output"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[tool],
                 lookup_table={
@@ -407,7 +407,7 @@ def test_non_dict_outputs_validate_against_schema(output_schema, output):
 
 
 def test_step_returns_matching_output():
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             lookup_table={
                 "tool1": [
@@ -431,17 +431,17 @@ def test_step_returns_matching_output():
 
 
 def test_step_no_match_raises_with_hint():
-    env = DeterministicEnvironment.from_params(_make_params())
+    env = LookupEnvironment.from_params(_make_params())
     with pytest.raises(ToolLookupError) as excinfo:
         env.step([("tool1", {"id": "99"})])
     msg = str(excinfo.value)
-    assert "No deterministic output matches" in msg
+    assert "No lookup output matches" in msg
     assert "tool1" in msg
     assert '"id": "01"' in msg  # configured inputs surfaced for self-correction
 
 
 def test_step_supports_zero_arg_tool():
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("ping")],
             lookup_table={"ping": [ToolLookupEntry(input={}, output={})]},
@@ -451,7 +451,7 @@ def test_step_supports_zero_arg_tool():
 
 
 def test_step_unknown_tool_raises():
-    env = DeterministicEnvironment.from_params(_make_params())
+    env = LookupEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
         env.step([("missing", {"id": "01"})])
 
@@ -467,7 +467,7 @@ def test_step_applies_defaults_to_calls_and_entries():
         }
     )
     entry = ToolLookupEntry(input={"location": "sf"}, output={"temperature": 18})
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={"tool1": [entry]},
@@ -491,7 +491,7 @@ def test_default_filling_deep_copies_values():
         }
     )
     entry = ToolLookupEntry(input={}, output={"ok": True})
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(tools=[tool], lookup_table={"tool1": [entry]})
     )
     arguments = {}
@@ -514,7 +514,7 @@ def test_step_does_not_create_missing_object_without_default():
             },
         }
     )
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={
@@ -541,7 +541,7 @@ def test_step_does_not_create_missing_object_without_default():
 )
 def test_step_returns_non_dict_output(output):
     """Scalars, lists, and None round-trip through step() unchanged."""
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             lookup_table={"tool1": [ToolLookupEntry(input={"id": "01"}, output=output)]}
         )
@@ -556,9 +556,9 @@ def _grounded_env(
     n_entries: int = 10,
     sample_size: int = 3,
     seed: int | None = None,
-) -> DeterministicEnvironment:
-    """Build a DeterministicEnvironment with one grounded tool."""
-    return DeterministicEnvironment.from_params(
+) -> LookupEnvironment:
+    """Build a LookupEnvironment with one grounded tool."""
+    return LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("lookup")],
             lookup_table={
@@ -588,13 +588,13 @@ def test_sample_grounding_returns_facts():
 
 
 def test_sample_grounding_no_grounding_returns_empty():
-    env = DeterministicEnvironment.from_params(_make_params())
+    env = LookupEnvironment.from_params(_make_params())
     assert env.sample_grounding(n=5, rng=random.Random(0)) == []
 
 
 def test_sample_grounding_only_grounded_tools_contribute():
     """Tools without an entry in grounding.tools contribute nothing."""
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("grounded"), _make_tool("plain")],
             lookup_table={
@@ -620,7 +620,7 @@ def test_sample_grounding_only_grounded_tools_contribute():
 
 
 def test_sample_grounding_respects_tool_ids_filter():
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("a"), _make_tool("b")],
             lookup_table={
@@ -642,7 +642,7 @@ def test_sample_grounding_respects_tool_ids_filter():
 
 
 def test_sample_grounding_field_missing_in_row_is_dropped():
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("t")],
             lookup_table={
@@ -663,7 +663,7 @@ def test_sample_grounding_field_missing_in_row_is_dropped():
 
 def test_sample_grounding_merges_input_and_output():
     """Output values win over input values on key collision."""
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("lookup")],
             lookup_table={
@@ -697,7 +697,7 @@ def test_sample_grounding_includes_filled_defaults():
             },
         },
     )
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[tool],
             lookup_table={
@@ -717,7 +717,7 @@ def test_sample_grounding_includes_filled_defaults():
 def test_grounding_key_collision_warns(caplog):
     """Warn when a whitelisted grounding field is in both input and output."""
     with caplog.at_level(logging.WARNING, logger="oumi"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[_make_tool("lookup")],
                 lookup_table={
@@ -745,7 +745,7 @@ def test_grounding_key_collision_warns(caplog):
 def test_grounding_key_collision_outside_whitelist_no_warn(caplog):
     """A collision on a non-whitelisted key never reaches a fact, so no warning."""
     with caplog.at_level(logging.WARNING, logger="oumi"):
-        DeterministicEnvironment.from_params(
+        LookupEnvironment.from_params(
             _make_params(
                 tools=[_make_tool("lookup")],
                 lookup_table={
@@ -767,7 +767,7 @@ def test_grounding_key_collision_outside_whitelist_no_warn(caplog):
 
 def test_sample_grounding_scalar_output_projects_input_only():
     """Non-dict outputs have no fields to project; ground on input alone."""
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("price")],
             lookup_table={
@@ -810,7 +810,7 @@ def test_sample_grounding_no_replacement_within_call():
 
 
 def test_sample_grounding_pools_across_tools():
-    env = DeterministicEnvironment.from_params(
+    env = LookupEnvironment.from_params(
         _make_params(
             tools=[_make_tool("a"), _make_tool("b")],
             lookup_table={

--- a/tests/unit/environments/test_simulated_environment.py
+++ b/tests/unit/environments/test_simulated_environment.py
@@ -29,10 +29,10 @@ from oumi.core.configs.params.model_params import ModelParams
 from oumi.core.configs.params.tool_params import ToolError, ToolParams
 from oumi.core.types.conversation import Conversation, Message, Role
 from oumi.core.types.tool_call import ToolResult
-from oumi.environments.synthetic_environment import (
-    SyntheticEnvironment,
-    SyntheticEnvironmentKwargs,
-    SyntheticStateParams,
+from oumi.environments.simulated_environment import (
+    SimulatedEnvironment,
+    SimulatedEnvironmentKwargs,
+    SimulatedStateParams,
 )
 
 
@@ -61,7 +61,7 @@ def _make_params(**overrides) -> EnvironmentParams:
         id="faq",
         name="FAQ",
         description="FAQ tools",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[_make_tool()],
         env_kwargs={"tool_persona": "Answer FAQs."},
     )
@@ -70,10 +70,10 @@ def _make_params(**overrides) -> EnvironmentParams:
 
 
 def test_from_params_constructs_stateless():
-    env = SyntheticEnvironment.from_params(_make_params())
-    assert isinstance(env, SyntheticEnvironment)
+    env = SimulatedEnvironment.from_params(_make_params())
+    assert isinstance(env, SimulatedEnvironment)
     assert env.current_state is None
-    assert isinstance(env._kwargs, SyntheticEnvironmentKwargs)
+    assert isinstance(env._kwargs, SimulatedEnvironmentKwargs)
 
 
 def test_from_params_constructs_stateful():
@@ -81,14 +81,14 @@ def test_from_params_constructs_stateful():
         tools=[_make_tool(executor=f"{__name__}._state_increment")],
         env_kwargs={
             "tool_persona": "You manage a filesystem.",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
         },
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     assert env.current_state == {"files": {"count": 1}}
 
 
@@ -100,36 +100,36 @@ def test_stateful_mode_requires_executor_on_every_tool():
         ],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(initial_state={"counter": 0}),
+            "state_params": SimulatedStateParams(initial_state={"counter": 0}),
             "cache_by_input": False,
         },
     )
     with pytest.raises(
         ValueError, match=r"requires every tool to define an executor.*without_exec"
     ):
-        SyntheticEnvironment.from_params(params)
+        SimulatedEnvironment.from_params(params)
 
 
 def test_empty_tool_persona_raises():
     params = _make_params(env_kwargs={"tool_persona": ""})
     with pytest.raises(ValueError, match="tool_persona cannot be empty"):
-        SyntheticEnvironment.from_params(params)
+        SimulatedEnvironment.from_params(params)
 
 
 def test_rejects_cache_when_stateful():
     params = _make_params(
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(),
+            "state_params": SimulatedStateParams(),
             "cache_by_input": True,
         }
     )
     with pytest.raises(ValueError, match="cache_by_input must be False"):
-        SyntheticEnvironment.from_params(params)
+        SimulatedEnvironment.from_params(params)
 
 
 def test_cache_round_trip_stateless_caching():
-    env = SyntheticEnvironment.from_params(_make_params())
+    env = SimulatedEnvironment.from_params(_make_params())
     result = ToolResult(output={"temp": 72})
     env._cache_result("answer", {"city": "SF"}, result)
     cached = env._resolve_cached("answer", {"city": "SF"})
@@ -138,13 +138,13 @@ def test_cache_round_trip_stateless_caching():
 
 
 def test_step_unknown_tool_raises():
-    env = SyntheticEnvironment.from_params(_make_params())
+    env = SimulatedEnvironment.from_params(_make_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
         env.step([("missing", {})])
 
 
 def test_step_without_attach_inference_raises():
-    env = SyntheticEnvironment.from_params(_make_params())
+    env = SimulatedEnvironment.from_params(_make_params())
     with pytest.raises(RuntimeError, match="attach_inference"):
         env.step([("answer", {})])
 
@@ -177,7 +177,7 @@ def _typed_params() -> EnvironmentParams:
         id="faq",
         name="FAQ",
         description="FAQ env",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[_typed_tool()],
         env_kwargs={"tool_persona": "Answer FAQs as a JSON tool."},
     )
@@ -187,7 +187,7 @@ def _attached_env(
     infer_returns: list[str],
     params: EnvironmentParams | None = None,
     **kwargs_overrides,
-) -> tuple[SyntheticEnvironment, Mock]:
+) -> tuple[SimulatedEnvironment, Mock]:
     """Build an env with a mock engine that drains ``infer_returns`` in order.
 
     Each call consumed by the simulator pops the next element from the queue,
@@ -197,7 +197,7 @@ def _attached_env(
     """
     params = params or _typed_params()
     params.env_kwargs = {**(params.env_kwargs or {}), **kwargs_overrides}
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     mock_engine = Mock()
     queue = list(infer_returns)
 
@@ -230,7 +230,7 @@ def test_step_zero_calls_returns_empty():
 
 def test_step_unknown_tool_raises_before_engine_check():
     """Unknown tool id raises ValueError even when no engine is attached."""
-    env = SyntheticEnvironment.from_params(_typed_params())
+    env = SimulatedEnvironment.from_params(_typed_params())
     with pytest.raises(ValueError, match="Tool 'missing' not found"):
         env.step([("missing", {})])
 
@@ -308,11 +308,11 @@ def test_step_no_output_schema_accepts_any_object():
         id="faq",
         name="FAQ",
         description="FAQ env",
-        env_type="synthetic",
+        env_type="simulated",
         tools=[tool],
         env_kwargs={"tool_persona": "Answer FAQs."},
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     mock_engine = Mock()
     mock_engine.infer = Mock(
         return_value=[
@@ -427,7 +427,7 @@ def test_stateless_executor_dispatches_callable_no_state():
         executor=f"{__name__}._ok_stateless_exec",
     )
     params = _make_params(tools=[tool])
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     results = env.step([("echo", {"x": 1})])
     assert results == [ToolResult(output={"echo": {"x": 1}})]
 
@@ -444,14 +444,14 @@ def test_stateful_executor_threads_state_and_mutates():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
         },
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     out = env.step([("bump", {}), ("bump", {})])
     assert out[0].output == {"new_count": 2}
     assert out[1].output == {"new_count": 3}
@@ -470,14 +470,14 @@ def test_read_only_tool_rejected_when_executor_returns_state():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
         },
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     with pytest.raises(ToolError, match="read_only"):
         env.step([("bump", {})])
 
@@ -494,14 +494,14 @@ def test_updated_state_validated_against_schema():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
         },
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     with pytest.raises(ToolError, match="state_schema"):
         env.step([("bad", {})])
 
@@ -514,7 +514,7 @@ def test_stateless_executor_rejecting_state_return():
         executor=f"{__name__}._stateless_returns_state",
     )
     params = _make_params(tools=[tool])
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     with pytest.raises(ToolError, match="stateless"):
         env.step([("oops", {})])
 
@@ -530,14 +530,14 @@ def test_executor_returning_non_toolresult_raises():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema=_make_state_schema(),
                 initial_state={"files": {"count": 1}},
             ),
             "cache_by_input": False,
         },
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     with pytest.raises(ToolError, match="must return ToolResult"):
         env.step([("x", {})])
 
@@ -554,7 +554,7 @@ def test_state_grounding_projects_from_state_path():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema={"type": "object"},
                 initial_state={
                     "books": [
@@ -575,7 +575,7 @@ def test_state_grounding_projects_from_state_path():
             ],
         ),
     )
-    env = SyntheticEnvironment.from_params(params)
+    env = SimulatedEnvironment.from_params(params)
     facts = env.sample_grounding(n=10, rng=random.Random(0))
     assert len(facts) == 3
     assert {f.data["book_id"] for f in facts} == {"B1", "B2", "B3"}
@@ -593,7 +593,7 @@ def test_state_grounding_state_path_missing_raises_at_init():
         tools=[tool],
         env_kwargs={
             "tool_persona": "p",
-            "state_params": SyntheticStateParams(
+            "state_params": SimulatedStateParams(
                 state_schema={"type": "object"},
                 initial_state={"files": {"count": 0}},
             ),
@@ -609,15 +609,15 @@ def test_state_grounding_state_path_missing_raises_at_init():
         ),
     )
     with pytest.raises(ValueError, match="state_path"):
-        SyntheticEnvironment.from_params(params)
+        SimulatedEnvironment.from_params(params)
 
 
 def test_state_grounding_without_state_raises():
-    """grounding.state on a stateless synthetic env is a config error."""
+    """grounding.state on a stateless simulated env is a config error."""
     params = _make_params(
         grounding=GroundingConfig(
             state=[StateGroundingConfig(state_path="books", fields=["book_id"])],
         ),
     )
     with pytest.raises(ValueError, match="grounding.state is configured"):
-        SyntheticEnvironment.from_params(params)
+        SimulatedEnvironment.from_params(params)


### PR DESCRIPTION
# Description

- Rename DeterministicEnvironment to LookupEnvironment, since it's more indicative of how the env works. Also, other envs can be deterministic too (ex. synthetic envs with caching)
- Rename SyntheticEnvironment to SimulatedEnvironment, to avoid conflicting with our synthesis feature
- Rename all related classes/comments throughout
- Keep the `deterministic`/`synthetic` registry aliases, and `*Environment`/`*EnvironmentKwargs`/`*StateParams` for backwards compatibility

## Related issues

Fixes LOU-3513

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
