### PR TITLE
fix(verl): scope the verl dataset cache to the run's output dir

### DIFF
--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -137,11 +137,15 @@ class VerlGrpoTrainer(BaseTrainer):
             raise ValueError("We only support up to one reward function.")
         self._reward_funcs = reward_funcs
 
-        self._cache_dir: Path = (
-            Path(cache_dir)
-            if cache_dir
-            else Path.home() / ".cache" / "oumi" / "verl_datasets"
-        )
+        if cache_dir:
+            self._cache_dir = Path(cache_dir)
+        elif self._final_output_dir:
+            # Keep dataset files private to this run: a shared default location
+            # lets concurrent verl runs overwrite each other's Parquet files.
+            self._cache_dir = self._final_output_dir / "verl_datasets"
+        else:
+            self._cache_dir = Path.home() / ".cache" / "oumi" / "verl_datasets"
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._train_dataset = train_dataset
         self._eval_dataset = eval_dataset
         # verl trainer uses private methods and properties of `transformers`

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -366,7 +366,7 @@ class VerlGrpoTrainer(BaseTrainer):
     ) -> None:
         """Creates dataset files for verl in Parquet format.
 
-        The Parquet files are saved to the Oumi cache directory.
+        The Parquet files are saved to the output directory.
 
         Args:
             process_fn: Optional function to convert the dataset samples to verl format.


### PR DESCRIPTION


# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
The verl Parquet files defaulted to a single shared path (~/.cache/oumi/verl_datasets), so two concurrent verl GRPO runs overwrote each other's train.parquet/val.parquet. Default to <output_dir>/verl_datasets when an output dir is configured, keeping the shared cache only as the fallback, and create the directory up front since `to_parquet` does not create parent dirs.

An explicit `cache_dir` argument still wins.
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [ ] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
