### PR TITLE
RubricJudge - part 2

### DIFF
--- a/src/oumi/core/configs/params/judge_params.py
+++ b/src/oumi/core/configs/params/judge_params.py
@@ -120,6 +120,9 @@ class JudgeParams(BaseParams):
     include_explanation: bool = field(default=False)
     """Whether the judge should provide an explanation before the judgment."""
 
+    use_guided_decoding: bool = field(default=True)
+    """Whether to constrain the judge's response (JSON only) to the expected schema."""
+
     examples: list[dict[str, str]] = field(default_factory=list)
     """Few-shot examples for the judge as a list of field value dictionaries.
 

--- a/src/oumi/core/configs/params/rubric_judge_params.py
+++ b/src/oumi/core/configs/params/rubric_judge_params.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -19,6 +20,8 @@ from enum import Enum
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.core.configs.params.judge_params import JudgeOutputType
 from oumi.exceptions import OumiConfigError
+
+logger = logging.getLogger(__name__)
 
 # Suffix appended to a criterion id to name its per-criterion explanation field.
 EXPLANATION_SUFFIX = "_explanation"
@@ -57,7 +60,6 @@ class JudgeCriterion(BaseParams):
         ...     id="groundedness",
         ...     description="Every claim is supported by the provided context.",
         ...     judgment_type=JudgeOutputType.BOOL,
-        ...     include_explanation=True,
         ...     weight=2.0,
         ... )
     """
@@ -78,11 +80,23 @@ class JudgeCriterion(BaseParams):
         {"excellent": 1.0, "good": 0.7, "poor": 0.3, "not_applicable": None}
     """
 
-    include_explanation: bool = field(default=False)
+    include_explanation: bool = field(default=True)
     """Whether the judge should explain this criterion before judging it."""
 
     weight: float = field(default=1.0)
     """Relative weight of this criterion under WEIGHTED_MEAN aggregation."""
+
+    @property
+    def is_scoreable(self) -> bool:
+        """Whether this criterion can ever contribute a numeric score.
+
+        BOOL criteria are scored 1.0/0.0 automatically. Anything else needs a
+        `judgment_scores` mapping with at least one label that carries a score --
+        a mapping whose labels all map to None only constrains the allowed values.
+        """
+        if self.judgment_scores:
+            return any(score is not None for score in self.judgment_scores.values())
+        return self.judgment_type == JudgeOutputType.BOOL
 
     @property
     def explanation_id(self) -> str:
@@ -182,8 +196,11 @@ class RubricJudgeParams(BaseParams):
         ...             include_explanation=True,
         ...         ),
         ...         JudgeCriterion(
-        ...             id="tone",
-        ...             description="The register of the response.",
+        ...             id="formality",
+        ...             description=(
+        ...                 "How formal the response's register is. 'formal' for "
+        ...                 "professional prose, 'casual' for slang or contractions."
+        ...             ),
         ...             judgment_type=JudgeOutputType.ENUM,
         ...             judgment_scores={"formal": 1.0, "neutral": 0.5, "casual": 0.0},
         ...         ),
@@ -201,6 +218,42 @@ class RubricJudgeParams(BaseParams):
     def __post_init__(self):
         """Validate the parameters after initialization."""
         self._validate_params()
+        self._warn_about_aggregation_gaps()
+
+    def _warn_about_aggregation_gaps(self) -> None:
+        """Warn about config that silently has no effect on the aggregate score."""
+        self._warn_about_ignored_weights()
+        self._warn_about_unscored_criteria()
+
+    def _warn_about_ignored_weights(self) -> None:
+        """Warn when weights are set under an aggregation that does not read them.
+
+        Only WEIGHTED_MEAN consults `weight`; MIN and ALL are order statistics and
+        NONE aggregates nothing, so a weight set under those is a silent no-op.
+        """
+        if self.aggregation == JudgeAggregation.WEIGHTED_MEAN:
+            return
+
+        weighted = [c.id for c in self.criteria if c.weight != 1.0]
+        if weighted:
+            logger.warning(
+                f"Criteria {sorted(weighted)} set a non-default `weight`, but "
+                f"'{self.aggregation.value}' aggregation ignores weights. The weights "
+                "have no effect. Use 'weighted_mean' aggregation, or remove them."
+            )
+
+    def _warn_about_unscored_criteria(self) -> None:
+        """Warn about criteria that cannot contribute to the aggregate score."""
+        if self.aggregation == JudgeAggregation.NONE:
+            return
+
+        unscored = [c.id for c in self.criteria if not c.is_scoreable]
+        if unscored:
+            logger.warning(
+                f"Criteria {sorted(unscored)} produce no numeric score and will be "
+                f"excluded from the '{self.aggregation.value}' aggregate score. "
+                "Add `judgment_scores` to include them."
+            )
 
     def _validate_params(self):
         """Validate the parameters for consistency and completeness.

--- a/src/oumi/judges/base_judge.py
+++ b/src/oumi/judges/base_judge.py
@@ -215,6 +215,14 @@ class JudgeOutput(pydantic.BaseModel):
         Returns:
             Dictionary of field names to values, empty dict if parsing fails
         """
+
+        def _loads_json_object(text: str) -> dict | None:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                return None
+            return parsed if isinstance(parsed, dict) else None
+
         if not json_output:
             return {}
 
@@ -224,12 +232,19 @@ class JudgeOutput(pydantic.BaseModel):
         if json_output.endswith("```"):
             json_output = json_output[:-3].rstrip()
 
-        try:
-            parsed = json.loads(json_output)
-            # Ensure all values are strings for consistent processing
-            return {k: str(v) for k, v in parsed.items()}
-        except json.JSONDecodeError:
-            return {}
+        parsed = _loads_json_object(json_output)
+        if parsed is None:
+            # Models that are not schema-constrained often wrap the object in
+            # prose; retry on the outermost {...} span before giving up.
+            start, end = json_output.find("{"), json_output.rfind("}")
+            if start == -1 or end <= start:
+                return {}
+            parsed = _loads_json_object(json_output[start : end + 1])
+            if parsed is None:
+                return {}
+
+        # Ensure all values are strings for consistent processing
+        return {k: str(v) for k, v in parsed.items()}
 
     def generate_raw_output(self, field_values: dict[str, str]) -> str:
         """Generate raw output string from field values in the specified format.

--- a/src/oumi/judges/rubric_judge.py
+++ b/src/oumi/judges/rubric_judge.py
@@ -106,15 +106,18 @@ class RubricJudge(BaseJudge):
                 "inference_config must be provided in JudgeConfig for RubricJudge. "
                 "Please ensure your JudgeConfig includes a valid inference_config."
             )
-        json_format = self._judge_params.response_format == JudgeResponseFormat.JSON
+
+        use_schema = (
+            self._judge_params.response_format == JudgeResponseFormat.JSON
+            and self._judge_params.use_guided_decoding
+        )
         inference_engine = self._create_inference_engine(
             inference_config=self._inference_config,
-            response_schema=self._build_response_schema() if json_format else None,
+            response_schema=self._build_response_schema() if use_schema else None,
         )
 
         output_fields = self._create_output_fields()
         self._rubric_suffix = self._build_rubric_suffix(output_fields)
-        self._warn_about_aggregation_gaps()
 
         # Append the rubric and format suffix to the system instruction if it exists
         system_instruction = self._judge_params.system_instruction
@@ -338,53 +341,3 @@ class RubricJudge(BaseJudge):
                 "`rubric_judge_params.criteria`. Please move them there and remove "
                 "them from `judge_params`."
             )
-
-    def _warn_about_aggregation_gaps(self) -> None:
-        """Warn about config that silently has no effect on the aggregate score."""
-        self._warn_about_ignored_weights()
-        self._warn_about_unscored_criteria()
-
-    def _warn_about_ignored_weights(self) -> None:
-        """Warn when weights are set under an aggregation that does not read them.
-
-        Only WEIGHTED_MEAN consults `weight`; MIN and ALL are order statistics and
-        NONE aggregates nothing, so a weight set under those is a silent no-op.
-        """
-        aggregation = self._rubric_params.aggregation
-        if aggregation == JudgeAggregation.WEIGHTED_MEAN:
-            return
-
-        weighted = [c.id for c in self.criteria if c.weight != 1.0]
-        if weighted:
-            logger.warning(
-                f"Criteria {sorted(weighted)} set a non-default `weight`, but "
-                f"'{aggregation.value}' aggregation ignores weights. The weights "
-                "have no effect. Use 'weighted_mean' aggregation, or remove them."
-            )
-
-    def _warn_about_unscored_criteria(self) -> None:
-        """Warn about criteria that cannot contribute to the aggregate score."""
-        if self._rubric_params.aggregation == JudgeAggregation.NONE:
-            return
-
-        unscored = [c.id for c in self.criteria if not self._is_scoreable(c)]
-        if unscored:
-            logger.warning(
-                f"Criteria {sorted(unscored)} produce no numeric score and will be "
-                f"excluded from the '{self._rubric_params.aggregation.value}' "
-                "aggregate score. Add `judgment_scores` to include them."
-            )
-
-    @staticmethod
-    def _is_scoreable(criterion: JudgeCriterion) -> bool:
-        """Return True if a criterion can ever contribute a numeric score.
-
-        BOOL criteria are scored 1.0/0.0 automatically. Anything else needs a
-        `judgment_scores` mapping with at least one label that carries a score --
-        a mapping whose labels all map to None only constrains the allowed values.
-        """
-        if criterion.judgment_scores:
-            return any(
-                score is not None for score in criterion.judgment_scores.values()
-            )
-        return criterion.judgment_type == JudgeOutputType.BOOL

--- a/src/oumi/judges/simple_judge.py
+++ b/src/oumi/judges/simple_judge.py
@@ -97,10 +97,14 @@ class SimpleJudge(BaseJudge):
                 "inference_config must be provided in JudgeConfig for SimpleJudge. "
                 "Please ensure your JudgeConfig includes a valid inference_config."
             )
-        json_format = self._judge_params.response_format == JudgeResponseFormat.JSON
+
+        use_schema = (
+            self._judge_params.response_format == JudgeResponseFormat.JSON
+            and self._judge_params.use_guided_decoding
+        )
         inference_engine = self._create_inference_engine(
             inference_config=self._inference_config,
-            response_schema=self._build_response_schema() if json_format else None,
+            response_schema=self._build_response_schema() if use_schema else None,
         )
 
         # Append format suffix to system instruction if it exists

--- a/tests/unit/judges/test_base_judge.py
+++ b/tests/unit/judges/test_base_judge.py
@@ -1467,3 +1467,29 @@ class TestJudgePartial:
 
         call_kwargs = mock_engine.infer_partial.call_args.kwargs
         assert call_kwargs["progress_path"] == "/tmp/progress.json"
+
+
+class TestJsonOutputParsing:
+    """`_parse_json_output` must be tolerant, and must never raise."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ('{"a": 1}', {"a": "1"}),
+            ('```json\n{"a": 1}\n```', {"a": "1"}),
+            # Unconstrained models often wrap the object in prose.
+            ('Sure! Here you go: {"a": 1}', {"a": "1"}),
+            ('prose {"a": 1} more prose', {"a": "1"}),
+            # Valid JSON that is not an object yields no fields rather than raising.
+            ("[1, 2]", {}),
+            ('"just a string"', {}),
+            ("42", {}),
+            ("null", {}),
+            ("not json at all", {}),
+            ("", {}),
+        ],
+    )
+    def test_parse_json_output(self, raw, expected):
+        from oumi.judges.base_judge import JudgeOutput
+
+        assert JudgeOutput._parse_json_output(raw) == expected

--- a/tests/unit/judges/test_rubric_judge.py
+++ b/tests/unit/judges/test_rubric_judge.py
@@ -113,6 +113,26 @@ class TestJudgeOutputFields:
             "clarity",
         ]
 
+    def test_explanations_are_on_by_default(self):
+        """Explanations default to on: the judge reasons before it commits.
+
+        This matters most under guided decoding, where a schema-constrained
+        response leaves no other room to think.
+        """
+        criterion = JudgeCriterion(id="a", description="A.")
+        assert criterion.include_explanation is True
+
+        judge = _build_judge(criteria=[JudgeCriterion(id="a", description="A.")])
+        assert [f.field_key for f in judge.output_fields] == ["a_explanation", "a"]
+
+    def test_explanations_can_be_turned_off(self):
+        judge = _build_judge(
+            criteria=[
+                JudgeCriterion(id="a", description="A.", include_explanation=False)
+            ]
+        )
+        assert [f.field_key for f in judge.output_fields] == ["a"]
+
     def test_explanation_is_opt_in_per_criterion(self):
         judge = _build_judge(
             criteria=[
@@ -243,6 +263,49 @@ class TestRubricJudgeResponseSchema:
             assert (schema is not None) == expects_schema
 
 
+class TestGuidedDecoding:
+    """`use_guided_decoding` controls whether the response is schema-constrained."""
+
+    def _schema_sent(
+        self, response_format=JudgeResponseFormat.JSON, **overrides
+    ) -> bool:
+        with patch(
+            "oumi.judges.base_judge.BaseJudge._create_inference_engine"
+        ) as mock_create:
+            RubricJudge(
+                judge_config=_build_config(
+                    response_format=response_format, judge_params_overrides=overrides
+                )
+            )
+        return mock_create.call_args.kwargs["response_schema"] is not None
+
+    def test_on_by_default_for_json(self):
+        assert self._schema_sent() is True
+
+    def test_can_be_turned_off(self):
+        assert self._schema_sent(use_guided_decoding=False) is False
+
+    def test_never_applies_to_xml(self):
+        """XML has no JSON schema to constrain against, so the flag is a no-op."""
+        assert self._schema_sent(response_format=JudgeResponseFormat.XML) is False
+        assert (
+            self._schema_sent(
+                response_format=JudgeResponseFormat.XML, use_guided_decoding=True
+            )
+            is False
+        )
+
+    def test_unconstrained_output_still_parses(self):
+        """Without a schema the model may wrap the object in prose."""
+        judge = _build_judge(judge_params_overrides={"use_guided_decoding": False})
+        output = judge._transform_judge_output(
+            "Here is my assessment:\n"
+            '{"correctness": "Yes", "clarity": "good"}\n'
+            "Hope that helps!"
+        )
+        assert output.field_values == {"correctness": True, "clarity": "good"}
+
+
 class TestRubricJudgeParsing:
     """Parsing model responses into per-criterion judgments."""
 
@@ -276,18 +339,26 @@ class TestRubricJudgeParsing:
         assert output.field_scores == {"correctness": 0.0, "clarity": 0.0}
 
     def test_parse_mixed_types(self):
+        # Explanations off, so the assertions below stay focused on type parsing.
         judge = _build_judge(
             criteria=[
                 JudgeCriterion(
-                    id="rating", description="R.", judgment_type=JudgeOutputType.INT
+                    id="rating",
+                    description="R.",
+                    judgment_type=JudgeOutputType.INT,
+                    include_explanation=False,
                 ),
                 JudgeCriterion(
                     id="confidence",
                     description="C.",
                     judgment_type=JudgeOutputType.FLOAT,
+                    include_explanation=False,
                 ),
                 JudgeCriterion(
-                    id="notes", description="N.", judgment_type=JudgeOutputType.TEXT
+                    id="notes",
+                    description="N.",
+                    judgment_type=JudgeOutputType.TEXT,
+                    include_explanation=False,
                 ),
             ],
             aggregation=JudgeAggregation.NONE,


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
Follow up on Rubric Judge
1. Addressing Will's feedback on #2626 
2. Making guided decoding configurable

Specifically
- `include_explanation` now defaults to True. The explanation is emitted before the judgment, so the judge reasons before committing to an answer, which matters most under guided decoding where a schema-constrained response otherwise leaves no room to think.
- Guided decoding is now configurable via `judge_params.use_guided_decoding` (default True, JSON only), for callers who would rather let the model generate freely.
- The judge's JSON parser no longer raises on valid JSON that is not an object, and now tolerates prose around the object. Both cases become reachable once guided decoding can be turned off.
- Aggregation warnings moved from RubricJudge into RubricJudgeParams, next to the existing aggregation/weight validation. They now fire once at config load rather than once per judge.
- Docstring example: renamed `tone` to `formality`, since its scores reward formality, and made its description concrete.

Follow up:  Documentation for RubricJudge will follows in a separate PR (by EOD)

<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Towards LOU-3713

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
