### PR TITLE
Carry the synthesized user persona on conversation metadata

### DIFF
--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -75,7 +75,12 @@ class OpeningTurnPrompt:
 
 @dataclasses.dataclass
 class SeedConversation:
-    """A seed conversation plus the ``generation_state`` a turn driver needs."""
+    """A seed conversation plus the ``generation_state`` a turn driver needs.
+
+    The user persona rides the conversation itself, on
+    ``conversation.metadata["user_persona"]``; ``generation_state`` holds the
+    remaining turn-driving fields (target turns, turn plans, output system prompt).
+    """
 
     conversation: Conversation
     generation_state: dict
@@ -495,7 +500,12 @@ class ConversationSynthesizer:
                         sample_with_turn, assistant_persona, Role.ASSISTANT
                     ),
                     Message(role=Role.USER, content=opening),
-                ]
+                ],
+                metadata={
+                    "user_persona": self._formatter.format(
+                        sample_with_turn, user_persona, missing_values_allowed=False
+                    )
+                },
             )
             output_message = self._format_output_system_message(
                 sample, multiturn_attribute.output_system_prompt
@@ -506,9 +516,6 @@ class ConversationSynthesizer:
             generation_state = {
                 "target_turns": sample["target_turns"],
                 "turn_plans": sample.get("parsed_turn_plans", []),
-                "user_persona": self._formatter.format(
-                    sample_with_turn, user_persona, missing_values_allowed=False
-                ),
                 "output_system_prompt": output_system_prompt,
             }
             seeds.append(

--- a/src/oumi/core/synthesis/conversation_synthesizer.py
+++ b/src/oumi/core/synthesis/conversation_synthesizer.py
@@ -77,9 +77,8 @@ class OpeningTurnPrompt:
 class SeedConversation:
     """A seed conversation plus the ``generation_state`` a turn driver needs.
 
-    The user persona rides the conversation itself, on
-    ``conversation.metadata["user_persona"]``; ``generation_state`` holds the
-    remaining turn-driving fields (target turns, turn plans, output system prompt).
+    The user persona, which drives user message synthesis, is at 
+    ``conversation.metadata["user_persona"]``.
     """
 
     conversation: Conversation

--- a/tests/unit/core/synthesis/test_conversation_synthesizer.py
+++ b/tests/unit/core/synthesis/test_conversation_synthesizer.py
@@ -301,9 +301,11 @@ def test_build_seed_conversations_assembles_seed_and_state(
     state = seed.generation_state
     assert state["target_turns"] == 3
     assert state["turn_plans"] == ["open", "answer", "close"]
-    assert "billing" in state["user_persona"]
     assert state["output_system_prompt"] is not None
     assert "billing" in state["output_system_prompt"]
+    # The user persona rides the conversation's metadata, not the generation state.
+    assert "user_persona" not in state
+    assert "billing" in seed.conversation.metadata["user_persona"]
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")
@@ -341,7 +343,9 @@ def test_build_seed_conversations_renders_current_turn_personas(
     assert seeds[0].conversation.messages[0].content == (
         "You are the assistant on turn 1."
     )
-    assert seeds[0].generation_state["user_persona"] == "You are the user on turn 1."
+    assert (
+        seeds[0].conversation.metadata["user_persona"] == "You are the user on turn 1."
+    )
 
 
 @patch("oumi.core.synthesis.conversation_synthesizer.build_inference_engine")


### PR DESCRIPTION
# Description

User persona is now an important concept throughout our repo for agentic inference, not just specific to synthesis. The standard is it lives top-level under `metadata["user_persona"]`, so for agentic synthesis, this PR moves it there

## Related issues

Towards LOU-3712

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed