### PR TITLE
fix(inference): keep the scratch-file hash per infer() call

### DIFF
--- a/src/oumi/core/async_utils.py
+++ b/src/oumi/core/async_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import contextvars
 from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, TypeVar
@@ -35,6 +36,9 @@ def safe_asyncio_run(main: Coroutine[Any, Any, T]) -> T:
     Returns:
         The result of the Coroutine.
     """
+    # Carry the caller's context variables into the helper thread so per-call
+    # state (e.g. the inference scratch-file hash) survives the thread hop.
+    context = contextvars.copy_context()
     with ThreadPoolExecutor(max_workers=1) as executor:
-        task = executor.submit(asyncio.run, main)
+        task = executor.submit(context.run, asyncio.run, main)
         return task.result()

--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextvars
 import copy
 import dataclasses
 import hashlib
@@ -36,6 +37,11 @@ from oumi.core.inference.progress_reporter import ProgressFileReporter
 from oumi.core.types.conversation import Conversation
 from oumi.utils.logging import logger
 from oumi.utils.math_utils import is_power_of_two
+
+# Per-call, not per-engine: concurrent infer() calls must not share a scratch file.
+_dataset_hash_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "oumi_inference_dataset_hash", default=None
+)
 
 
 @dataclass
@@ -172,7 +178,15 @@ class BaseInferenceEngine(ABC):
 
         self._latency_histogram_online = HdrHistogram(1, 60 * 1000, 1)
         self._latency_histogram_from_file = HdrHistogram(20, 180 * 1000, 1)
-        self._dataset_hash = None
+
+    @property
+    def _dataset_hash(self) -> str | None:
+        """Dataset hash of the ``infer()`` call running in this execution context."""
+        return _dataset_hash_var.get()
+
+    @_dataset_hash.setter
+    def _dataset_hash(self, value: str | None) -> None:
+        _dataset_hash_var.set(value)
 
     def _prepare_inference_run(
         self,
@@ -680,9 +694,9 @@ class BaseInferenceEngine(ABC):
             output_filepath: The path to the output file. This is used to determine the
                 location of the scratch file.
         """
-        scratch_filepath = self._get_scratch_filepath(output_filepath)
-        if Path(scratch_filepath).exists():
-            Path(scratch_filepath).unlink()
+        # missing_ok: a concurrent run with an identical dataset shares the path
+        # and may have removed it already.
+        Path(self._get_scratch_filepath(output_filepath)).unlink(missing_ok=True)
 
     def _save_conversations(
         self, conversations: list[Conversation], output_filepath: str

--- a/tests/unit/core/test_async_utils.py
+++ b/tests/unit/core/test_async_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import re
 from unittest.mock import Mock
 
@@ -69,3 +70,13 @@ def test_safe_asyncio_run_nested_fails():
         match=re.escape("asyncio.run() cannot be called from a running event loop"),
     ):
         _ = safe_asyncio_run(main())
+
+
+def test_safe_asyncio_run_propagates_context_variables():
+    var: contextvars.ContextVar[str] = contextvars.ContextVar("probe", default="unset")
+    var.set("from-caller")
+
+    async def read_var():
+        return var.get()
+
+    assert safe_asyncio_run(read_var()) == "from-caller"

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -1,4 +1,5 @@
 import tempfile
+import threading
 from pathlib import Path
 from unittest import mock
 from unittest.mock import patch
@@ -734,3 +735,49 @@ def test_existing_infer_tests_unaffected_by_partial_run(mock_engine):
 
     assert len(partial.successful) == 2
     assert len(results) == 2
+
+
+def test_concurrent_infer_calls_keep_separate_scratch_files(mock_engine):
+    """Two threads sharing one engine must each keep their own scratch file."""
+    barrier = threading.Barrier(2)
+    scratch_paths: dict[int, str] = {}
+    original_save = mock_engine._save_conversation_to_scratch
+
+    def overlapping_save(conversation, output_filepath):
+        scratch_paths[threading.get_ident()] = mock_engine._get_scratch_filepath(
+            output_filepath
+        )
+        barrier.wait(timeout=5)  # hold both runs in flight at the same time
+        original_save(conversation, output_filepath)
+
+    mock_engine._save_conversation_to_scratch = overlapping_save
+    results: dict[int, list[Conversation]] = {}
+    errors: list[Exception] = []
+
+    def run(idx: int) -> None:
+        try:
+            results[idx] = mock_engine.infer(
+                input=[create_test_conversation(idx)],
+                inference_config=InferenceConfig(
+                    generation=GenerationParams(max_new_tokens=10)
+                ),
+            )
+        except Exception as e:  # noqa: BLE001 - surface any thread failure
+            errors.append(e)
+
+    threads = [threading.Thread(target=run, args=(idx,)) for idx in (1, 2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert sorted(results) == [1, 2]
+    assert results[1][0].messages[-1].content == "Mock response 0"
+    assert len(set(scratch_paths.values())) == 2
+
+
+def test_cleanup_scratch_file_tolerates_missing_file(mock_engine):
+    mock_engine._dataset_hash = "abc"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mock_engine._cleanup_scratch_file(str(Path(temp_dir) / "output.jsonl"))


### PR DESCRIPTION
## Description

`BaseInferenceEngine` keeps the current run's dataset hash on the engine instance (`self._dataset_hash`, set in `_prepare_inference_run`) and derives the scratch-file path from it. Two `infer()` calls in flight on the same engine — e.g. one `SimpleJudge` scored from a thread pool — overwrite each other's hash, resolve to the same scratch file, and race in `_cleanup_scratch_file` (`if exists: unlink`), which then fails with `FileNotFoundError` on `~/.cache/oumi/tmp/temp_inference_output_<hash>.jsonl`.

### Changes

- `base_inference_engine.py`: the dataset hash lives in a `contextvars.ContextVar` instead of on the instance, exposed through the same `_dataset_hash` property/setter so existing callers and tests are unchanged. Concurrent calls (threads, or tasks on one loop) each see their own hash and scratch path.
- `async_utils.safe_asyncio_run`: copies the caller's context into the helper thread (`contextvars.copy_context().run(...)`) so the hash survives the thread hop into `_infer`.
- `_cleanup_scratch_file`: `unlink(missing_ok=True)` — two runs with an identical dataset legitimately share a path, and either may clean up first.

### Tests

- `test_concurrent_infer_calls_keep_separate_scratch_files`: two threads share one engine with an overlapping save; both complete and resolve distinct scratch paths. Fails on `main` (paths collapse to one).
- `test_cleanup_scratch_file_tolerates_missing_file`.
- `test_safe_asyncio_run_propagates_context_variables`.

## Related issues

Towards https://linear.app/oumi/issue/LOU-3735

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
