### PR TITLE
training(feat): Support fractional eval steps for Hugging Face trainers

### DIFF
--- a/src/oumi/core/configs/params/training_params.py
+++ b/src/oumi/core/configs/params/training_params.py
@@ -481,8 +481,13 @@ class TrainingParams(BaseParams):
     - "epoch": Evaluation is done at the end of each epoch.
     """
 
-    eval_steps: int = 500
-    """Number of update steps between two evaluations if eval_strategy="steps".
+    eval_steps: int | float = 500
+    """Interval between evaluations if eval_strategy="steps".
+
+    If int, run validation every `eval_steps` update steps. If float in (0, 1),
+    HF and TRL trainers run validation every `ceil(eval_steps * max_steps)` update
+    steps. For example, with `eval_steps=0.2` and `max_steps=100`, validation
+    runs every 20 steps, five times in total.
 
     Ignored if eval_strategy is not "steps".
     """
@@ -1033,6 +1038,18 @@ class TrainingParams(BaseParams):
                 f"Actual: max_steps: {self.max_steps}, "
                 f"num_train_epochs: {self.num_train_epochs}."
             )
+
+        if isinstance(self.eval_steps, float):
+            if not 0 < self.eval_steps < 1:
+                raise OumiConfigError(
+                    "Fractional eval_steps must be greater than 0 and less than 1. "
+                    "Use an integer for a fixed number of steps."
+                )
+            if self.trainer_type in (TrainerType.OUMI, TrainerType.VERL_GRPO):
+                raise OumiConfigError(
+                    "Fractional eval_steps are only supported by Hugging Face and "
+                    f"TRL trainers. Actual trainer_type: {self.trainer_type}."
+                )
 
         if self.reward_functions is not None:
             function_names = [name for name in self.reward_functions if name]

--- a/tests/unit/core/configs/params/test_training_params.py
+++ b/tests/unit/core/configs/params/test_training_params.py
@@ -14,7 +14,44 @@
 
 from unittest.mock import patch
 
-from oumi.core.configs.params.training_params import TrainingParams
+import pytest
+
+from oumi.core.configs.params.training_params import TrainerType, TrainingParams
+from oumi.exceptions import OumiConfigError
+
+
+def test_fractional_eval_steps_passed_to_trl_config():
+    params = TrainingParams(
+        trainer_type=TrainerType.TRL_SFT,
+        eval_strategy="steps",
+        eval_steps=0.1,
+    )
+
+    assert params.to_hf().eval_steps == 0.1
+
+
+@pytest.mark.parametrize("trainer_type", [TrainerType.OUMI, TrainerType.VERL_GRPO])
+def test_fractional_eval_steps_rejected_for_non_hf_trainers(trainer_type):
+    with pytest.raises(
+        OumiConfigError,
+        match="Fractional eval_steps are only supported by Hugging Face and TRL",
+    ):
+        TrainingParams(trainer_type=trainer_type, eval_steps=0.1)
+
+
+@pytest.mark.parametrize("eval_steps", [-0.1, 0.0, 1.0, 1.5, float("inf")])
+def test_fractional_eval_steps_must_be_ratio(eval_steps):
+    with pytest.raises(
+        OumiConfigError,
+        match="Fractional eval_steps must be greater than 0 and less than 1",
+    ):
+        TrainingParams(eval_steps=eval_steps)
+
+
+def test_integer_eval_steps_supported_for_oumi_trainer():
+    params = TrainingParams(trainer_type=TrainerType.OUMI, eval_steps=20)
+
+    assert params.eval_steps == 20
 
 
 @patch("oumi.utils.packaging.is_transformers_v5", return_value=True)

--- a/tests/unit/core/configs/test_config.py
+++ b/tests/unit/core/configs/test_config.py
@@ -52,6 +52,23 @@ def test_config_loading_from_str():
     assert loaded_config.data.train.datasets[0].dataset_name == "my_test_dataset"
 
 
+@pytest.mark.parametrize("eval_steps", [20, 0.1])
+def test_config_loading_eval_steps_from_str(eval_steps):
+    loaded_config = TrainingConfig.from_str(
+        f"""
+        model:
+            model_name: test-model
+        training:
+            trainer_type: TRL_SFT
+            eval_strategy: steps
+            eval_steps: {eval_steps}
+        """
+    )
+
+    assert loaded_config.training.eval_steps == eval_steps
+    assert type(loaded_config.training.eval_steps) is type(eval_steps)
+
+
 def test_config_equality():
     config_a = TrainingConfig()
     config_b = TrainingConfig()


### PR DESCRIPTION
# Description

Let `TrainingParams.eval_steps` accept either an integer step interval (current behavior) or a float in `(0, 1)` representing a proportion of total training steps for HF and TRL trainers (new behavior).

Integer behavior is unchanged. Floats are rejected for OUMI and VERL_GRPO trainers because their scheduling implementations require fixed integer step counts.

Tests cover YAML parsing, TRL forwarding, invalid ratios, unsupported trainers, and integer compatibility.

## Related issues

Toward [LOU-3597](https://linear.app/oumi/issue/LOU-3597/agent-suggested-lack-of-validation-metrics-while-training)

See also [PRD-243](https://linear.app/oumi/issue/PRD-243/miscellaneous-sft-training-pipeline-improvements)

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
