### PR TITLE
fix(inference): salt the temp scratch path per infer() call

### DIFF
--- a/src/oumi/core/inference/base_inference_engine.py
+++ b/src/oumi/core/inference/base_inference_engine.py
@@ -278,6 +278,11 @@ class BaseInferenceEngine(ABC):
                 for c in conversations_to_process
             ]
             dataset_hash = hashlib.sha256(",".join(row_hashes).encode()).hexdigest()
+        if output_path is None:
+            # The temp scratch path is derived from content alone, so concurrent
+            # calls with identical conversations would share (and delete) one
+            # file; resume across runs only applies when output_path is set.
+            dataset_hash = f"{dataset_hash}_{uuid.uuid4().hex}"
         self._dataset_hash = dataset_hash
 
         completed_conversations = self._load_from_scratch(output_path)

--- a/tests/unit/inference/test_base_inference_engine.py
+++ b/tests/unit/inference/test_base_inference_engine.py
@@ -777,6 +777,47 @@ def test_concurrent_infer_calls_keep_separate_scratch_files(mock_engine):
     assert len(set(scratch_paths.values())) == 2
 
 
+def test_identical_content_calls_use_distinct_scratch_files(mock_engine):
+    """Identical conversations must not share (and delete) one temp scratch file."""
+    barrier = threading.Barrier(2)
+    scratch_paths: dict[int, str] = {}
+    original_save = mock_engine._save_conversation_to_scratch
+
+    def overlapping_save(conversation, output_filepath):
+        scratch_paths[threading.get_ident()] = mock_engine._get_scratch_filepath(
+            output_filepath
+        )
+        barrier.wait(timeout=5)  # hold both runs in flight at the same time
+        original_save(conversation, output_filepath)
+
+    mock_engine._save_conversation_to_scratch = overlapping_save
+    results: dict[int, list[Conversation]] = {}
+    errors: list[Exception] = []
+
+    def run(slot: int) -> None:
+        try:
+            # Same content in both threads: the id-less conversation gets the
+            # same deterministic conversation_id and content hash in each call.
+            results[slot] = mock_engine.infer(
+                input=[create_test_conversation(1)],
+                inference_config=InferenceConfig(
+                    generation=GenerationParams(max_new_tokens=10)
+                ),
+            )
+        except Exception as e:  # noqa: BLE001 - surface any thread failure
+            errors.append(e)
+
+    threads = [threading.Thread(target=run, args=(slot,)) for slot in (1, 2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert sorted(results) == [1, 2]
+    assert len(set(scratch_paths.values())) == 2
+
+
 def test_cleanup_scratch_file_tolerates_missing_file(mock_engine):
     mock_engine._dataset_hash = "abc"
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# Description

Fixes a scratch-file collision between concurrent `infer()` calls whose inputs are byte-identical.

When no `output_path` is set, the scratch file path is derived purely from the conversation content, and an id-less conversation is assigned a deterministic `conversation_id` (`uuid5(idx + content_hash)`). Two concurrent calls with identical conversations therefore share both the conversation id and the scratch file.

## Related issues

None

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
