### PR TITLE
Fix preprocessing for raw conversational DPO datasets

### DIFF
--- a/src/oumi/core/trainers/trl_dpo_trainer.py
+++ b/src/oumi/core/trainers/trl_dpo_trainer.py
@@ -14,9 +14,16 @@
 
 from trl import DPOTrainer
 
+_TOKENIZED_DPO_COLUMN_SETS = (
+    frozenset(("prompt_ids", "chosen_ids", "rejected_ids")),
+    frozenset(("prompt_input_ids", "chosen_input_ids", "rejected_input_ids")),
+)
+_OUMI_PROMPT_COLUMN = "messages"
+_TRL_PROMPT_COLUMN = "prompt"
+
 
 class TrlDpoTrainer(DPOTrainer):
-    """Light wrapper around the DPOTrainer to handle vision models."""
+    """Light wrapper supporting raw and Oumi-tokenized DPO datasets."""
 
     def __init__(
         self,
@@ -27,6 +34,18 @@ class TrlDpoTrainer(DPOTrainer):
         super().__init__(*args, **kwargs)
 
     def _prepare_dataset(self, dataset, processing_class, args, dataset_name):
-        """Prepare the dataset for training."""
-        # Skip the dataset preparation since the dataset is already prepared.
-        return dataset
+        """Prepare raw datasets while preserving Oumi-tokenized datasets."""
+        column_names = frozenset(dataset.column_names or ())
+        if any(
+            tokenized_columns <= column_names
+            for tokenized_columns in _TOKENIZED_DPO_COLUMN_SETS
+        ):
+            return dataset
+
+        if (
+            _OUMI_PROMPT_COLUMN in column_names
+            and _TRL_PROMPT_COLUMN not in column_names
+        ):
+            dataset = dataset.rename_column(_OUMI_PROMPT_COLUMN, _TRL_PROMPT_COLUMN)
+
+        return super()._prepare_dataset(dataset, processing_class, args, dataset_name)

--- a/tests/integration/train/test_train.py
+++ b/tests/integration/train/test_train.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import tempfile
 
@@ -250,6 +251,60 @@ def test_train_dpo(temp_hf_datasets_cache):
                 output_dir=output_training_dir,
                 try_resume_from_last_checkpoint=False,
                 save_final_model=True,
+            ),
+        )
+
+        train(config)
+
+
+def test_train_dpo_from_raw_json(temp_hf_datasets_cache):
+    with tempfile.TemporaryDirectory() as output_temp_dir:
+        output_training_dir = str(pathlib.Path(output_temp_dir) / "train")
+        dataset_path = pathlib.Path(output_temp_dir) / "preferences.jsonl"
+        rows = [
+            {
+                "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+                "chosen": [{"role": "assistant", "content": "4"}],
+                "rejected": [{"role": "assistant", "content": "5"}],
+            },
+            {
+                "messages": [{"role": "user", "content": "What is 3 + 3?"}],
+                "chosen": [{"role": "assistant", "content": "6"}],
+                "rejected": [{"role": "assistant", "content": "7"}],
+            },
+        ]
+        dataset_path.write_text(
+            "".join(f"{json.dumps(row)}\n" for row in rows), encoding="utf-8"
+        )
+
+        config = TrainingConfig(
+            data=DataParams(
+                train=DatasetSplitParams(
+                    datasets=[
+                        DatasetParams(
+                            dataset_name="json",
+                            dataset_kwargs={"data_files": str(dataset_path)},
+                        )
+                    ],
+                ),
+            ),
+            model=ModelParams(
+                model_name="openai-community/gpt2",
+                model_max_length=128,
+                trust_remote_code=True,
+                tokenizer_pad_token="<|endoftext|>",
+            ),
+            training=TrainingParams(
+                per_device_train_batch_size=1,
+                trainer_type=TrainerType.TRL_DPO,
+                max_steps=1,
+                logging_steps=1,
+                enable_wandb=False,
+                enable_tensorboard=False,
+                enable_mlflow=False,
+                output_dir=output_training_dir,
+                try_resume_from_last_checkpoint=False,
+                save_final_model=False,
             ),
         )
 

--- a/tests/unit/core/trainers/test_trl_dpo_trainer.py
+++ b/tests/unit/core/trainers/test_trl_dpo_trainer.py
@@ -1,0 +1,79 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from transformers import PreTrainedTokenizerBase
+from trl import DPOConfig, DPOTrainer
+
+from oumi.core.trainers.trl_dpo_trainer import TrlDpoTrainer
+
+
+def _mock_prepare_inputs() -> tuple[PreTrainedTokenizerBase, DPOConfig]:
+    return cast(PreTrainedTokenizerBase, MagicMock()), cast(DPOConfig, MagicMock())
+
+
+@pytest.mark.parametrize(
+    "column_names",
+    [
+        ["prompt_ids", "chosen_ids", "rejected_ids"],
+        ["prompt_input_ids", "chosen_input_ids", "rejected_input_ids"],
+    ],
+)
+def test_prepare_dataset_preserves_tokenized_datasets(column_names):
+    trainer = object.__new__(TrlDpoTrainer)
+    dataset = MagicMock(column_names=column_names)
+    processing_class, args = _mock_prepare_inputs()
+
+    with patch.object(DPOTrainer, "_prepare_dataset", autospec=True) as prepare:
+        result = trainer._prepare_dataset(dataset, processing_class, args, "train")
+
+    assert result is dataset
+    prepare.assert_not_called()
+
+
+def test_prepare_dataset_delegates_raw_datasets_to_trl():
+    trainer = object.__new__(TrlDpoTrainer)
+    dataset = MagicMock(column_names=["prompt", "chosen", "rejected"])
+    prepared_dataset = MagicMock()
+    processing_class, args = _mock_prepare_inputs()
+
+    with patch.object(
+        DPOTrainer,
+        "_prepare_dataset",
+        autospec=True,
+        return_value=prepared_dataset,
+    ) as prepare:
+        result = trainer._prepare_dataset(dataset, processing_class, args, "train")
+
+    assert result is prepared_dataset
+    prepare.assert_called_once_with(trainer, dataset, processing_class, args, "train")
+
+
+def test_prepare_dataset_maps_oumi_prompt_column_to_trl():
+    trainer = object.__new__(TrlDpoTrainer)
+    dataset = MagicMock(column_names=["messages", "chosen", "rejected"])
+    renamed_dataset = MagicMock()
+    dataset.rename_column.return_value = renamed_dataset
+    processing_class, args = _mock_prepare_inputs()
+
+    with patch.object(DPOTrainer, "_prepare_dataset", autospec=True) as prepare:
+        trainer._prepare_dataset(dataset, processing_class, args, "train")
+
+    dataset.rename_column.assert_called_once_with("messages", "prompt")
+    prepare.assert_called_once_with(
+        trainer, renamed_dataset, processing_class, args, "train"
+    )


### PR DESCRIPTION
## Description

Oumi's TRL DPO wrapper currently bypasses `DPOTrainer._prepare_dataset` for every dataset, assuming that all inputs are already tokenized. This prevents raw conversational preference datasets from being chat-templated and tokenized by TRL.

This change:

- Preserves Oumi-tokenized datasets using either supported column convention.
- Maps Oumi's `messages` prompt column to TRL's `prompt` column.
- Delegates raw dataset preprocessing to TRL.
- Adds unit coverage and a one-step training integration test using raw JSONL.

During an end-to-end DPO experiment using Qwen3.5-0.8B, raw conversational JSONL reached the trainer but could not be optimized because input IDs were never produced. Applying this preprocessing behavior allowed the job to run end to end and complete optimizer steps.

After this PR, DPO training accepts the following dataset row formats. Each object represents one line in a JSONL dataset.

Raw conversational data using TRL's conventional `prompt` field (see https://huggingface.co/docs/trl/dpo_trainer):

```json
{
  "prompt": [{"role": "user", "content": "What is 2 + 2?"}],
  "chosen": [{"role": "assistant", "content": "4"}],
  "rejected": [{"role": "assistant", "content": "5"}]
}
```

Raw conversational data using Oumi's `messages` alias:

```json
{
  "messages": [{"role": "user", "content": "What is 2 + 2?"}],
  "chosen": [{"role": "assistant", "content": "4"}],
  "rejected": [{"role": "assistant", "content": "5"}]
}
```

Existing pre-tokenized datasets remain supported using either `prompt_ids` / `chosen_ids` / `rejected_ids` or their legacy `*_input_ids` equivalents. Raw rows are chat-templated and tokenized by TRL, while pre-tokenized rows bypass that processing.

## Testing

- Full-parameter DPO experiment with `Qwen/Qwen3.5-0.8B` using raw conversational JSONL; the end-to-end optimizer run completed and moved a deterministic preference score from 0/500 before training to 494/500 afterward.
- Unit tests for raw and tokenized preprocessing dispatch.
- One-step raw-JSON DPO integration test with GPT-2.
- Existing pre-tokenized DPO integration test.
- Ruff formatting and lint checks.
- Targeted Pyright check.

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation.
- [x] Read the contributor guidelines.
- [x] Added tests where needed.
