### PR TITLE
chore(deps): Update trl ceiling from 1.4 to 1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
     "transformers>=4.57,<5.10",
-    "trl>=0.24,<1.5",
+    "trl>=0.24,<1.7",
     "typer<0.25.2",             # Used by CLI. Pinned due to sphinxcontrib-typer compatibility. OPE-1806
     "typing_extensions",        # Backports of typing updates
     "uvicorn<0.49.0",           # TODO: Remove on resolution of https://github.com/skypilot-org/skypilot/issues/7303

--- a/src/oumi/core/configs/params/gold_params.py
+++ b/src/oumi/core/configs/params/gold_params.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from oumi.core.configs.params.base_params import BaseParams
 from oumi.exceptions import OumiConfigError
+from oumi.utils.packaging import is_trl_v1_5_or_later
 
 
 @dataclass
@@ -477,11 +478,18 @@ class GoldParams(BaseParams):
             result["vllm_guided_decoding_regex"] = self.vllm_guided_decoding_regex
 
         if len(self.teacher_model_init_kwargs) > 0:
-            result["teacher_model_init_kwargs"] = self.teacher_model_init_kwargs
+            result["teacher_model_init_kwargs"] = dict(self.teacher_model_init_kwargs)
         else:
             result["teacher_model_init_kwargs"] = {}
 
-        if "torch_dtype" not in result["teacher_model_init_kwargs"]:
-            result["teacher_model_init_kwargs"]["torch_dtype"] = "auto"
+        # trl 1.5 renamed the teacher dtype key from `torch_dtype` to `dtype` and
+        # dropped the alias, so emit whichever key the installed version reads.
+        init_kwargs = result["teacher_model_init_kwargs"]
+        dtype_key = "dtype" if is_trl_v1_5_or_later() else "torch_dtype"
+        stale_key = "torch_dtype" if dtype_key == "dtype" else "dtype"
+        if stale_key in init_kwargs and dtype_key not in init_kwargs:
+            init_kwargs[dtype_key] = init_kwargs.pop(stale_key)
+        if dtype_key not in init_kwargs:
+            init_kwargs[dtype_key] = "auto"
 
         return result

--- a/src/oumi/utils/packaging.py
+++ b/src/oumi/utils/packaging.py
@@ -305,6 +305,21 @@ def is_trl_v0_28_or_later() -> bool:
         return False
 
 
+@lru_cache(maxsize=1)
+def is_trl_v1_5_or_later() -> bool:
+    """Check if the installed TRL version is v1.5 or later.
+
+    trl 1.5 renamed the ``teacher_model_init_kwargs`` dtype key from
+    ``torch_dtype`` to ``dtype`` in GOLDTrainer and dropped the back-compat
+    alias, so the correct key to emit depends on the installed version.
+    """
+    try:
+        trl_version = importlib.metadata.version("trl")
+        return version.parse(trl_version) >= version.parse("1.5.0")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
 def verify_trl_vllm_compatibility(feature_name: str) -> None:
     """Checks TRL/vLLM compatibility before importing TRL trainers.
 

--- a/tests/unit/core/configs/params/test_gold_params.py
+++ b/tests/unit/core/configs/params/test_gold_params.py
@@ -1,0 +1,83 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from oumi.core.configs.params.gold_params import GoldParams
+
+
+def _to_kwargs_with_trl(is_v1_5_or_later: bool, **params_kwargs) -> dict:
+    params = GoldParams(teacher_model_name_or_path="teacher", **params_kwargs)
+    with patch(
+        "oumi.core.configs.params.gold_params.is_trl_v1_5_or_later",
+        return_value=is_v1_5_or_later,
+    ):
+        return params.to_hf_trainer_kwargs()["teacher_model_init_kwargs"]
+
+
+def test_default_emits_torch_dtype_for_trl_below_1_5():
+    """trl < 1.5 GOLDTrainer reads teacher_model_init_kwargs['torch_dtype']."""
+    init_kwargs = _to_kwargs_with_trl(False)
+    assert init_kwargs.get("torch_dtype") == "auto"
+    assert "dtype" not in init_kwargs
+
+
+def test_default_emits_dtype_for_trl_1_5_or_later():
+    """trl >= 1.5 renamed the key to 'dtype' and dropped the alias."""
+    init_kwargs = _to_kwargs_with_trl(True)
+    assert init_kwargs.get("dtype") == "auto"
+    assert "torch_dtype" not in init_kwargs
+
+
+def test_user_torch_dtype_normalized_to_dtype_on_trl_1_5():
+    """A user-supplied torch_dtype is renamed to dtype under trl >= 1.5."""
+    init_kwargs = _to_kwargs_with_trl(
+        True, teacher_model_init_kwargs={"torch_dtype": "bfloat16"}
+    )
+    assert init_kwargs.get("dtype") == "bfloat16"
+    assert "torch_dtype" not in init_kwargs
+
+
+def test_user_dtype_normalized_to_torch_dtype_below_trl_1_5():
+    """A user-supplied dtype is renamed to torch_dtype under trl < 1.5."""
+    init_kwargs = _to_kwargs_with_trl(
+        False, teacher_model_init_kwargs={"dtype": "bfloat16"}
+    )
+    assert init_kwargs.get("torch_dtype") == "bfloat16"
+    assert "dtype" not in init_kwargs
+
+
+def test_extra_init_kwargs_preserved():
+    """Non-dtype kwargs pass through untouched."""
+    init_kwargs = _to_kwargs_with_trl(
+        True,
+        teacher_model_init_kwargs={"attn_implementation": "sdpa"},
+    )
+    assert init_kwargs["attn_implementation"] == "sdpa"
+    assert init_kwargs.get("dtype") == "auto"
+
+
+def test_does_not_mutate_original_params():
+    """to_hf_trainer_kwargs must not mutate the caller's dict."""
+    original = {"torch_dtype": "bfloat16"}
+    params = GoldParams(
+        teacher_model_name_or_path="teacher",
+        teacher_model_init_kwargs=original,
+    )
+    with patch(
+        "oumi.core.configs.params.gold_params.is_trl_v1_5_or_later",
+        return_value=True,
+    ):
+        params.to_hf_trainer_kwargs()
+    assert original == {"torch_dtype": "bfloat16"}

--- a/tests/unit/utils/test_packaging.py
+++ b/tests/unit/utils/test_packaging.py
@@ -8,6 +8,7 @@ from oumi.utils.packaging import (
     _package_error_message,
     _package_prerequisites_error_messages,
     check_package_prerequisites,
+    is_trl_v1_5_or_later,
     verify_trl_vllm_compatibility,
 )
 
@@ -187,3 +188,30 @@ def test_verify_trl_vllm_compatibility_fails_new_trl_old_vllm(monkeypatch):
     monkeypatch.setattr("importlib.metadata.version", mock_version)
     with pytest.raises(RuntimeError, match="vLLM >= 0.11.0"):
         verify_trl_vllm_compatibility("test")
+
+
+@pytest.mark.parametrize(
+    "trl_version, expected",
+    [
+        ("1.4.0", False),
+        ("1.5.0", True),
+        ("1.5.1", True),
+        ("1.6.0", True),
+    ],
+)
+def test_is_trl_v1_5_or_later(monkeypatch, trl_version, expected):
+    is_trl_v1_5_or_later.cache_clear()
+    monkeypatch.setattr("importlib.metadata.version", lambda pkg: trl_version)
+    assert is_trl_v1_5_or_later() is expected
+    is_trl_v1_5_or_later.cache_clear()
+
+
+def test_is_trl_v1_5_or_later_missing_package(monkeypatch):
+    is_trl_v1_5_or_later.cache_clear()
+
+    def mock_version(pkg):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr("importlib.metadata.version", mock_version)
+    assert is_trl_v1_5_or_later() is False
+    is_trl_v1_5_or_later.cache_clear()


### PR DESCRIPTION
# Description

trl 1.5.0 renamed the GOLDTrainer teacher_model_init_kwargs dtype key from torch_dtype to dtype and dropped the back-compat alias, so GoldParams emitting torch_dtype raised KeyError: 'dtype' on trl>=1.5. Emit the version-correct key via a new is_trl_v1_5_or_later() helper, normalizing whichever key the user supplied, and raise the trl ceiling to <1.7.

Extended from dependabot #2512.

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
