### PR TITLE
chore(deps): bump transformers ceiling from 5.9 to 5.16

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -79,7 +79,11 @@ jobs:
 
       - name: Override PyTorch ${{ matrix.torch-version }}
         run: |
-          uv pip install --system torch==${{ matrix.torch-version }} torchvision torchaudio
+          # torchaudio declares no dependency on torch, so leaving it unpinned lets it
+          # float to a build compiled against a different CUDA major version. transformers
+          # >=5.12 imports torchaudio on every `import transformers`, which turns that
+          # mismatch into an OSError on a missing libcudart. Versions track torch 1:1.
+          uv pip install --system torch==${{ matrix.torch-version }} torchvision torchaudio==${{ matrix.torch-version }}
 
       - name: Verify installation
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ oumi = ["LICENSE", "README.md", "*.jinja"]
 # ships beta versions on PyPI).
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
-override-dependencies = ["transformers>=5.5,<5.8"]
+override-dependencies = ["transformers>=5.5,<5.17"]
 
 [project]
 name = "oumi"
@@ -73,7 +73,7 @@ dependencies = [
     "pydantic>=2.11,<2.14",
     "requests>=2.31,<3.0",        # Used by deploy module (GCS upload)
     "responses>=0.25,<0.27",
-    "safetensors>=0.6,<0.8",
+    "safetensors>=0.6,<0.9",
     "skypilot>=0.12,<0.13", # 0.12 adds Slurm cloud support
     "tensorboard>=2.20,<2.21", # Optional, for monitoring training
     "tiktoken>=0.7,<1.0",
@@ -81,7 +81,7 @@ dependencies = [
     "torchao>=0.16,<0.17",     # Used by transformers; >=0.16 required by peft>=0.19
     "torchvision>=0.21,<0.26", # Used by some VLM-s (multimodal)
     "tqdm",
-    "transformers>=4.57,<5.10",
+    "transformers>=4.57,<5.17",
     "trl>=0.24,<1.7",
     "typer<0.25.2",             # Used by CLI. Pinned due to sphinxcontrib-typer compatibility. OPE-1806
     "typing_extensions",        # Backports of typing updates


### PR DESCRIPTION
# Description

Raises the transformers ceiling from <5.10 to <5.17 (latest 5.16.1). Requires bumping safetensors to <0.9 since transformers>=5.16 requires safetensors>=0.8.

Pins torchaudio to the torch version in install_test.yaml: transformers>=5.12 imports torchaudio on every import, and an unpinned torchaudio can pull a build compiled against a different CUDA major, causing an OSError on missing libcudart.

Tested E2E

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?
