### PR TITLE
Decode serialized tool arguments during DPO tokenization

### DIFF
--- a/src/oumi/core/trainers/trl_dpo_trainer.py
+++ b/src/oumi/core/trainers/trl_dpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import importlib.metadata
 import json
 from typing import Any
 
@@ -78,7 +79,9 @@ class TrlDpoTrainer(DPOTrainer):
             getattr(DPOTrainer, "_tokenize", None)
         ):
             raise RuntimeError(
-                "Structured DPO datasets with tools require TRL 1.0 or newer."
+                "Structured DPO datasets with tools require TRL 1.0 or newer "
+                f"(installed: {importlib.metadata.version('trl')}). "
+                "Upgrade with: pip install --upgrade 'trl>=1.0'"
             )
 
         if (

--- a/src/oumi/core/trainers/trl_dpo_trainer.py
+++ b/src/oumi/core/trainers/trl_dpo_trainer.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import json
+from typing import Any
+
 from trl import DPOTrainer
 
 _TOKENIZED_DPO_COLUMN_SETS = (
@@ -20,6 +24,28 @@ _TOKENIZED_DPO_COLUMN_SETS = (
 )
 _OUMI_PROMPT_COLUMN = "messages"
 _TRL_PROMPT_COLUMN = "prompt"
+_TOOLS_COLUMN = "tools"
+
+
+def _deserialize_tool_call_arguments(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Decode JSON tool arguments without mutating the source messages."""
+    has_serialized_arguments = any(
+        isinstance((tool_call.get("function") or {}).get("arguments"), str)
+        for message in messages
+        for tool_call in message.get("tool_calls") or []
+    )
+    if not has_serialized_arguments:
+        return messages
+
+    decoded_messages = copy.deepcopy(messages)
+    for message in decoded_messages:
+        for tool_call in message.get("tool_calls") or []:
+            function = tool_call.get("function") or {}
+            if isinstance(function.get("arguments"), str):
+                function["arguments"] = json.loads(function["arguments"])
+    return decoded_messages
 
 
 class TrlDpoTrainer(DPOTrainer):
@@ -33,6 +59,12 @@ class TrlDpoTrainer(DPOTrainer):
         """Initializes the TrlDpoTrainer."""
         super().__init__(*args, **kwargs)
 
+    def _tokenize(self, processing_class, input, **kwargs):
+        """Decode serialized tool arguments immediately before rendering."""
+        if isinstance(input, list):
+            input = _deserialize_tool_call_arguments(input)
+        return super()._tokenize(processing_class, input, **kwargs)
+
     def _prepare_dataset(self, dataset, processing_class, args, dataset_name):
         """Prepare raw datasets while preserving Oumi-tokenized datasets."""
         column_names = frozenset(dataset.column_names or ())
@@ -41,6 +73,13 @@ class TrlDpoTrainer(DPOTrainer):
             for tokenized_columns in _TOKENIZED_DPO_COLUMN_SETS
         ):
             return dataset
+
+        if _TOOLS_COLUMN in column_names and not callable(
+            getattr(DPOTrainer, "_tokenize", None)
+        ):
+            raise RuntimeError(
+                "Structured DPO datasets with tools require TRL 1.0 or newer."
+            )
 
         if (
             _OUMI_PROMPT_COLUMN in column_names

--- a/tests/unit/core/trainers/test_trl_dpo_trainer.py
+++ b/tests/unit/core/trainers/test_trl_dpo_trainer.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
+import copy
+import json
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from datasets import Dataset
 from transformers import PreTrainedTokenizerBase
 from trl import DPOConfig, DPOTrainer
 
@@ -24,6 +28,29 @@ from oumi.core.trainers.trl_dpo_trainer import TrlDpoTrainer
 
 def _mock_prepare_inputs() -> tuple[PreTrainedTokenizerBase, DPOConfig]:
     return cast(PreTrainedTokenizerBase, MagicMock()), cast(DPOConfig, MagicMock())
+
+
+def _tool_call(arguments: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "arguments": json.dumps(arguments),
+        },
+    }
+
+
+class _CapturingProcessingClass:
+    eos_token = "</s>"
+
+    def __init__(self):
+        self.rendered_messages: list[list[dict[str, Any]]] = []
+
+    def apply_chat_template(
+        self, messages: list[dict[str, Any]], **kwargs
+    ) -> dict[str, list[int]]:
+        self.rendered_messages.append(copy.deepcopy(messages))
+        return {"input_ids": list(range(len(messages) + 1))}
 
 
 @pytest.mark.parametrize(
@@ -76,4 +103,108 @@ def test_prepare_dataset_maps_oumi_prompt_column_to_trl():
     dataset.rename_column.assert_called_once_with("messages", "prompt")
     prepare.assert_called_once_with(
         trainer, renamed_dataset, processing_class, args, "train"
+    )
+
+
+def test_prepare_dataset_rejects_tools_when_trl_lacks_tokenize_hook():
+    trainer = object.__new__(TrlDpoTrainer)
+    dataset = MagicMock(column_names=["prompt", "chosen", "rejected", "tools"])
+    processing_class, args = _mock_prepare_inputs()
+
+    with (
+        patch.object(DPOTrainer, "_tokenize", None),
+        pytest.raises(RuntimeError, match="require TRL 1.0 or newer"),
+    ):
+        trainer._prepare_dataset(dataset, processing_class, args, "train")
+
+
+def test_tokenize_decodes_tool_arguments_without_mutating_input():
+    trainer = object.__new__(TrlDpoTrainer)
+    trainer._is_vlm = False
+    processing_class = MagicMock()
+    processing_class.apply_chat_template.return_value = {"input_ids": [1]}
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [_tool_call({"case_id": "X"})],
+        }
+    ]
+    original_messages = copy.deepcopy(messages)
+
+    trainer._tokenize(processing_class, messages)
+
+    assert messages == original_messages
+    rendered_messages = processing_class.apply_chat_template.call_args.args[0]
+    assert rendered_messages[0]["tool_calls"][0]["function"]["arguments"] == {
+        "case_id": "X"
+    }
+
+
+def test_tokenize_preserves_text_only_messages():
+    trainer = object.__new__(TrlDpoTrainer)
+    messages = [{"role": "assistant", "content": "Done."}]
+    processing_class = MagicMock()
+
+    with patch.object(DPOTrainer, "_tokenize", autospec=True) as tokenize:
+        trainer._tokenize(processing_class, messages)
+
+    assert tokenize.call_args.args[2] is messages
+
+
+def test_prepare_dataset_preserves_disjoint_tool_argument_schemas():
+    rows = [
+        {
+            "prompt": [{"role": "user", "content": "Find my record."}],
+            "chosen": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [_tool_call({"case_id": "X"})],
+                }
+            ],
+            "rejected": [{"role": "assistant", "content": "I cannot help."}],
+            "tools": json.dumps([{"type": "function", "function": {}}]),
+        },
+        {
+            "prompt": [{"role": "user", "content": "Find my flight."}],
+            "chosen": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        _tool_call({"flight": "AA1", "seats": 2}),
+                    ],
+                }
+            ],
+            "rejected": [{"role": "assistant", "content": "I cannot help."}],
+            "tools": json.dumps([{"type": "function", "function": {}}]),
+        },
+    ]
+    dataset = Dataset.from_list(rows)
+    trainer = object.__new__(TrlDpoTrainer)
+    trainer._is_vlm = False
+    trainer._tokenizer = SimpleNamespace(eos_token="</s>")
+    processing_class = _CapturingProcessingClass()
+    args = SimpleNamespace(dataset_num_proc=None)
+
+    trainer._prepare_dataset(
+        dataset,
+        cast(PreTrainedTokenizerBase, processing_class),
+        cast(DPOConfig, args),
+        "train",
+    )
+
+    rendered_tool_arguments = [
+        message["tool_calls"][0]["function"]["arguments"]
+        for messages in processing_class.rendered_messages
+        for message in messages
+        if message.get("tool_calls")
+    ]
+    assert rendered_tool_arguments == [
+        {"case_id": "X"},
+        {"flight": "AA1", "seats": 2},
+    ]
+    assert dataset[0]["chosen"][0]["tool_calls"][0]["function"]["arguments"] == (
+        '{"case_id": "X"}'
     )


### PR DESCRIPTION
## Summary

- Decode JSON-serialized `function.arguments` immediately before TRL's DPO trainer applies the chat template.
- Deep-copy tool-bearing messages so tokenization does not mutate the source examples.
- Fail fast when a raw DPO dataset contains `tools` but the installed TRL version lacks the required tokenization hook.

Serializing each tool call's arguments while data passes through Arrow prevents heterogeneous argument objects from being widened into a shared schema with unrelated nullable keys. Text-only DPO inputs and non-DPO trainers are unchanged.

The tokenization hook used here was introduced in TRL 1.0. Tool-bearing raw DPO datasets therefore require TRL 1.0 or newer. Older supported TRL versions receive an explicit error instead of silently rendering incorrect input.

## Testing

- `pytest -q tests/unit/core/trainers/test_trl_dpo_trainer.py`
- `pyright src/oumi/core/trainers/trl_dpo_trainer.py tests/unit/core/trainers/test_trl_dpo_trainer.py`
- Oumi pre-commit hooks for both changed files

Coverage includes heterogeneous/disjoint tool-argument keys passing through a Hugging Face `Dataset`, source-message immutability, text-only messages, and the TRL compatibility guard.
