### PR TITLE
[GRPO] Mirror verl step metrics to verl_metrics.jsonl via the file tracker

### DIFF
--- a/src/oumi/core/constants.py
+++ b/src/oumi/core/constants.py
@@ -21,3 +21,6 @@ from typing import Final
 # Refer to the `ignore_index` parameter of `torch.nn.CrossEntropyLoss()`
 # for more details.
 LABEL_IGNORE_INDEX: Final[int] = -100
+
+# FileLogger output produced by verl-backed trainers.
+VERL_METRICS_FILENAME: Final[str] = "verl_metrics.jsonl"

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
+from oumi.core.constants import VERL_METRICS_FILENAME
 from oumi.core.types.conversation import Conversation
 from oumi.core.types.conversation import Role as ConversationRole
 from oumi.utils.conversation_utils import create_list_of_message_json_dicts
@@ -53,6 +54,12 @@ except ModuleNotFoundError:
     verl = None
     ray = None
 
+try:
+    from verl.utils.tracking import (  # pyright: ignore[reportMissingImports]
+        Tracking as VerlTracking,
+    )
+except ModuleNotFoundError:
+    VerlTracking = None
 
 from oumi.core.configs import DatasetSplitParams, TrainingConfig
 from oumi.core.processors.base_processor import BaseProcessor
@@ -61,6 +68,11 @@ from oumi.core.trainers.base_trainer import BaseTrainer
 from oumi.utils.logging import logger
 from oumi.utils.packaging import is_verl_v0_7_or_later
 from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
+
+# Every step's metrics are mirrored to this file under the output dir so callers
+# can read reward curves without a wandb account.
+_VERL_FILE_LOGGER_BACKEND = "file"
+_VERL_FILE_LOGGER_PATH_ENV = "VERL_FILE_LOGGER_PATH"
 
 # Dataset processing function type. This function takes the following arguments:
 # 1. a dataset sample.
@@ -76,6 +88,13 @@ _PROMPT_JSON_EXTRA_INFO_KEY = "prompt_json"
 # Passes verl's `save_freq > 0` check (which enables its last-step save) while
 # being too large for `step % save_freq` to ever match: final checkpoint only.
 _SAVE_FINAL_STEP_ONLY_FREQ = 10**9
+
+
+def _verl_supports_file_logger() -> bool:
+    """Whether the installed verl has the ``file`` tracking backend (>=0.6)."""
+    if VerlTracking is None:
+        return False
+    return _VERL_FILE_LOGGER_BACKEND in getattr(VerlTracking, "supported_backend", ())
 
 
 class VerlGrpoTrainer(BaseTrainer):
@@ -498,6 +517,13 @@ class VerlGrpoTrainer(BaseTrainer):
             config.trainer.logger.append("console")
         if training_params.enable_wandb:
             config.trainer.logger.append("wandb")
+        if self._final_output_dir is not None and _verl_supports_file_logger():
+            # verl's FileLogger reads its destination from this env var.
+            os.environ.setdefault(
+                _VERL_FILE_LOGGER_PATH_ENV,
+                str(self._final_output_dir / VERL_METRICS_FILENAME),
+            )
+            config.trainer.logger.append(_VERL_FILE_LOGGER_BACKEND)
         config.trainer.project_name = os.environ.get("WANDB_PROJECT", "oumi_verl")
         config.trainer.experiment_name = training_params.run_name
         config.trainer.default_local_dir = str(self._temp_output_dir or "")

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -70,7 +70,7 @@ from oumi.utils.packaging import is_verl_v0_7_or_later
 from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
 
 # Every step's metrics are mirrored to this file under the output dir so callers
-# can read reward curves without a wandb account.
+# can read reward curves.
 _VERL_FILE_LOGGER_BACKEND = "file"
 _VERL_FILE_LOGGER_PATH_ENV = "VERL_FILE_LOGGER_PATH"
 

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -518,7 +518,6 @@ class VerlGrpoTrainer(BaseTrainer):
         if training_params.enable_wandb:
             config.trainer.logger.append("wandb")
         if self._final_output_dir is not None and _verl_supports_file_logger():
-            # verl's FileLogger reads its destination from this env var.
             os.environ.setdefault(
                 _VERL_FILE_LOGGER_PATH_ENV,
                 str(self._final_output_dir / VERL_METRICS_FILENAME),

--- a/tests/integration/train/test_verl_train.py
+++ b/tests/integration/train/test_verl_train.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import pathlib
 import tempfile
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from oumi.core.configs import (
     TrainingParams,
 )
 from oumi.core.configs.params.grpo_params import GrpoParams
+from oumi.core.constants import VERL_METRICS_FILENAME
 from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
 from oumi.utils.packaging import is_verl_v0_7_or_later
 from tests.markers import requires_gpus
@@ -338,3 +340,20 @@ def test_verl_grpo_train_1_step():
         verl_output = pathlib.Path(output_dir) / "verl_output"
         assert verl_output.exists(), f"verl_output dir not created: {verl_output}"
         assert any(verl_output.iterdir()), f"verl_output dir is empty: {verl_output}"
+
+        # verl's file tracker mirrors every step's metrics next to the output.
+        metrics_file = pathlib.Path(output_dir) / VERL_METRICS_FILENAME
+        assert metrics_file.exists(), f"verl metrics not written: {metrics_file}"
+        steps = [json.loads(line) for line in metrics_file.read_text().splitlines()]
+        assert len(steps) >= 1
+        first_step = steps[0]
+        assert first_step["step"] == 1
+        logged_keys = set(first_step["data"])
+        for expected_key in (
+            "critic/score/mean",
+            "actor/pg_loss",
+            "actor/entropy",
+            "response_length/mean",
+            "training/global_step",
+        ):
+            assert expected_key in logged_keys, f"{expected_key} missing: {logged_keys}"

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -13,6 +14,8 @@ from oumi.core.configs import (
     TrainingConfig,
     TrainingParams,
 )
+from oumi.core.constants import VERL_METRICS_FILENAME
+from oumi.core.trainers import verl_grpo_trainer
 from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
 from oumi.core.types.conversation import (
     ContentItem,
@@ -280,6 +283,59 @@ def _make_trainer_for_config(
     trainer._final_output_dir = Path(output_dir)
     trainer._temp_output_dir = Path(output_dir) / "verl_output"
     return trainer
+
+
+class _TrackingWithFileBackend:
+    supported_backend = ["console", "wandb", "file"]
+
+
+class _TrackingWithoutFileBackend:
+    supported_backend = ["console", "wandb"]
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_file_logger_mirrors_metrics_under_output_dir(monkeypatch, tmp_path):
+    """Metrics are written to verl_metrics.jsonl in the output dir by default."""
+    monkeypatch.delenv("VERL_FILE_LOGGER_PATH", raising=False)
+    trainer = _make_trainer_for_config(
+        save_steps=5, save_final_model=True, output_dir=str(tmp_path)
+    )
+
+    with patch.object(verl_grpo_trainer, "VerlTracking", _TrackingWithFileBackend):
+        config = trainer._create_config()
+
+    assert "file" in config.trainer.logger
+    assert os.environ["VERL_FILE_LOGGER_PATH"] == str(tmp_path / VERL_METRICS_FILENAME)
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_file_logger_respects_preset_path(monkeypatch, tmp_path):
+    """A caller-provided VERL_FILE_LOGGER_PATH wins over the default."""
+    monkeypatch.setenv("VERL_FILE_LOGGER_PATH", "/elsewhere/metrics.jsonl")
+    trainer = _make_trainer_for_config(
+        save_steps=5, save_final_model=True, output_dir=str(tmp_path)
+    )
+
+    with patch.object(verl_grpo_trainer, "VerlTracking", _TrackingWithFileBackend):
+        config = trainer._create_config()
+
+    assert "file" in config.trainer.logger
+    assert os.environ["VERL_FILE_LOGGER_PATH"] == "/elsewhere/metrics.jsonl"
+
+
+@pytest.mark.skipif(verl_import_failed, reason="verl not available")
+def test_file_logger_skipped_when_verl_lacks_backend(monkeypatch, tmp_path):
+    """Older verl without the ``file`` backend keeps the plain logger list."""
+    monkeypatch.delenv("VERL_FILE_LOGGER_PATH", raising=False)
+    trainer = _make_trainer_for_config(
+        save_steps=5, save_final_model=True, output_dir=str(tmp_path)
+    )
+
+    with patch.object(verl_grpo_trainer, "VerlTracking", _TrackingWithoutFileBackend):
+        config = trainer._create_config()
+
+    assert "file" not in config.trainer.logger
+    assert "VERL_FILE_LOGGER_PATH" not in os.environ
 
 
 @pytest.mark.skipif(verl_import_failed, reason="verl not available")


### PR DESCRIPTION
# Description

`VerlGrpoTrainer.train()` hands off to verl's `RayPPOTrainer.fit()`, so oumi's `MetricsLoggerCallback` never runs and a GRPO run leaves no `metrics_rank*.jsonl` behind. The only per-step metrics went to verl's `console` and `wandb` trackers, which callers without a wandb account cannot read back.

verl ships a `file` tracking backend (`FileLogger`, verl >= 0.6) that appends one JSON line per step, `{"step": N, "data": {...}}`, to the path in `VERL_FILE_LOGGER_PATH`. This change enables it whenever the installed verl supports it and an output dir is configured:

- `_create_config` appends `"file"` to `trainer.logger` and sets `VERL_FILE_LOGGER_PATH` to `<output_dir>/verl_metrics.jsonl` if the caller has not already set it. A caller-provided path wins.
- The check is `"file" in Tracking.supported_backend`, so verl 0.5 (no `file` backend) keeps today's behavior.
- `VERL_METRICS_FILENAME` lives in `oumi.core.constants` so downstream readers can import the filename instead of hardcoding it.

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [x] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.
