### PR TITLE
[GRPO] Preserve conversation metadata in GRPO datasets

### DIFF
--- a/src/oumi/core/datasets/base_grpo_dataset.py
+++ b/src/oumi/core/datasets/base_grpo_dataset.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from typing import Literal
+
 import pandas as pd
 from typing_extensions import override
 
@@ -36,6 +38,8 @@ class BaseExperimentalGrpoDataset(BaseMapDataset):
         dataset_name: str | None = None,
         dataset_path: str | None = None,
         split: str | None = None,
+        return_conversations: bool = False,
+        return_conversations_format: Literal["dict", "json"] = "json",
         **kwargs,
     ) -> None:
         """Initializes a new instance of the BaseExperimentalGrpoDataset class."""
@@ -46,7 +50,21 @@ class BaseExperimentalGrpoDataset(BaseMapDataset):
             **kwargs,
         )
 
+        self._return_conversations = return_conversations
+        self._return_conversations_format = return_conversations_format
         self._data = self._load_data()
+
+    @override
+    def __getitem__(self, idx: int) -> dict:
+        """Gets a GRPO row, optionally preserving its Conversation structure."""
+        sample = self.raw(idx)
+        if not self._return_conversations:
+            return self.transform(sample)
+
+        conversation = self.transform_conversation(sample)
+        return self._format_conversation(
+            conversation, self._return_conversations_format
+        )
 
     @staticmethod
     def _process_text_value(s: str) -> str:

--- a/src/oumi/core/datasets/base_grpo_dataset.py
+++ b/src/oumi/core/datasets/base_grpo_dataset.py
@@ -51,7 +51,9 @@ class BaseExperimentalGrpoDataset(BaseMapDataset):
         )
 
         self._return_conversations = return_conversations
-        self._return_conversations_format = return_conversations_format
+        self._return_conversations_format: Literal["dict", "json"] = (
+            return_conversations_format
+        )
         self._data = self._load_data()
 
     @override

--- a/src/oumi/core/datasets/base_map_dataset.py
+++ b/src/oumi/core/datasets/base_map_dataset.py
@@ -19,12 +19,13 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Sized
 from pathlib import Path
-from typing import Any, NamedTuple, cast
+from typing import Any, Literal, NamedTuple, cast
 
 import datasets
 import pandas as pd
 from torch.utils.data import MapDataPipe
 
+from oumi.core.types.conversation import Conversation
 from oumi.utils.hf_utils import is_cached_to_disk_hf_dataset
 from oumi.utils.io_utils import load_xlsx_all_sheets
 from oumi.utils.logging import logger
@@ -131,6 +132,30 @@ class BaseMapDataset(MapDataPipe, Sized, ABC):
             int: The number of items in the dataset.
         """
         return len(self._data)
+
+    @staticmethod
+    def _format_conversation(
+        conversation: Conversation,
+        output_format: Literal["dict", "json"],
+    ) -> dict:
+        """Formats a Conversation for a stable Hugging Face dataset schema.
+
+        HF Datasets infers one Arrow struct schema across rows. Dict output
+        therefore keeps optional top-level fields present even when unset.
+        JSON output avoids schema inference by storing the whole Conversation
+        in a single string column.
+        """
+        if output_format == "json":
+            return {"conversation_json": conversation.to_json()}
+        if output_format == "dict":
+            data = conversation.to_dict()
+            # HF Datasets requires every row to have the same top-level keys.
+            data.setdefault("tools", None)
+            return data
+        raise ValueError(
+            f"Invalid return_conversations_format: '{output_format}'. "
+            "Supported formats are 'json' and 'dict'."
+        )
 
     @property
     def data(self) -> pd.DataFrame:

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -158,37 +158,10 @@ class BaseSftDataset(BaseMapDataset, ABC):
         if self._return_conversations:
             # This may require `use_torchdata=True` for TRL_SFT trainer,
             # but compatible with TRL_GRPO trainer.
-            if self._return_conversations_format == "json":
-                conversation_json = conversation.to_json()
-                return {"conversation_json": conversation_json}
-            elif self._return_conversations_format == "dict":
-                return self._conversation_to_hf_compatible_dict(conversation)
-            else:
-                raise ValueError(
-                    f"Invalid return_conversations_format: "
-                    f"'{self._return_conversations_format}'."
-                    "Supported formats are 'json' and 'dict'."
-                )
+            return self._format_conversation(
+                conversation, self._return_conversations_format
+            )
         return self.tokenize(conversation)
-
-    def _conversation_to_hf_compatible_dict(self, conversation: Conversation) -> dict:
-        """Convert a Conversation to a dict with an HF-Datasets-stable schema.
-
-        HF Datasets infers a single arrow struct schema across rows and
-        requires every top-level key to exist on every row with the same
-        type. Without forcing `tools` to be present, rows whose Conversation
-        has no tools end up missing the key (`exclude_none=True` strips it),
-        and `datasets.Dataset.from_generator` fails with KeyError when mixing
-        tool and non-tool rows.
-
-        This rule applies at the column level only — inside a list-of-dicts
-        column like `messages`, items can have heterogeneous keys (e.g.,
-        assistant messages with `tool_calls`, tool messages with
-        `tool_call_id`, plain messages with neither), and that's fine.
-        """
-        data = conversation.to_dict()
-        data.setdefault("tools", None)
-        return data
 
     def tokenize(
         self,

--- a/src/oumi/core/datasets/base_sft_dataset.py
+++ b/src/oumi/core/datasets/base_sft_dataset.py
@@ -69,7 +69,9 @@ class BaseSftDataset(BaseMapDataset, ABC):
         self._response_template = response_template
         self._instruction_template = instruction_template
         self._return_conversations = return_conversations
-        self._return_conversations_format = return_conversations_format
+        self._return_conversations_format: Literal["dict", "json"] = (
+            return_conversations_format
+        )
 
         if self._assistant_only:
             self._verify_assistant_only_compatibility()

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -247,6 +247,8 @@ class VerlGrpoTrainer(BaseTrainer):
         Supports both single-turn and multi-turn conversations. The prompt is
         returned in verl's chat format (a list of ``{"role", "content"}`` dicts)
         and the answer is the final assistant message's text (the ground truth).
+        Prompt-only conversations use an empty ground truth for reward functions
+        that score without a reference answer.
 
         Args:
             example: A dictionary containing the conversation JSON.
@@ -260,7 +262,9 @@ class VerlGrpoTrainer(BaseTrainer):
                 Images are only supported for single-turn conversations.
         """
         prompt_messages, images, answer = (
-            extract_prompt_images_completion_from_conversation(example)
+            extract_prompt_images_completion_from_conversation(
+                example, allow_prompt_only=True
+            )
         )
 
         if len(images) > 0:

--- a/src/oumi/datasets/grpo/letter_count.py
+++ b/src/oumi/datasets/grpo/letter_count.py
@@ -80,11 +80,6 @@ class LetterCountGrpoDataset(BaseExperimentalGrpoDataset):
         sample_dict = sample.to_dict()
         # Add system prompt before user prompt.
         system_message = {"content": _SYSTEM_PROMPT, "role": "system"}
-        expected_answer = sample["metadata"]["letter_count_integer"]
-        assistant_message = {
-            "content": rf"\boxed{{{expected_answer}}}",
-            "role": "assistant",
-        }
-        messages = [system_message, sample["messages"][0], assistant_message]
+        messages = [system_message, sample["messages"][0]]
         sample_dict["messages"] = messages
         return Conversation.from_dict(sample_dict)

--- a/src/oumi/datasets/grpo/letter_count.py
+++ b/src/oumi/datasets/grpo/letter_count.py
@@ -80,6 +80,11 @@ class LetterCountGrpoDataset(BaseExperimentalGrpoDataset):
         sample_dict = sample.to_dict()
         # Add system prompt before user prompt.
         system_message = {"content": _SYSTEM_PROMPT, "role": "system"}
-        messages = [system_message, sample["messages"][0]]
+        expected_answer = sample["metadata"]["letter_count_integer"]
+        assistant_message = {
+            "content": rf"\boxed{{{expected_answer}}}",
+            "role": "assistant",
+        }
+        messages = [system_message, sample["messages"][0], assistant_message]
         sample_dict["messages"] = messages
         return Conversation.from_dict(sample_dict)

--- a/src/oumi/utils/grpo_utils.py
+++ b/src/oumi/utils/grpo_utils.py
@@ -62,16 +62,20 @@ def extract_prompt_images_completion_from_single_turn_conversation(
 
 def extract_prompt_images_completion_from_conversation(
     example: dict,
+    *,
+    allow_prompt_only: bool = False,
 ) -> tuple[list[dict], list, str]:
     """Splits a (possibly multi-turn) conversation into prompt, images, completion.
 
-    The final message must be an assistant message; its text becomes the
-    completion (ground truth). All preceding messages form the prompt, in
-    verl's chat format. A single-turn conversation (one user + one assistant
-    message) is just the two-message special case.
+    By default, the final message must be an assistant message; its text becomes
+    the completion (ground truth), and all preceding messages form the prompt.
+    When ``allow_prompt_only`` is true, a conversation without a final assistant
+    message is returned entirely as the prompt with an empty completion.
 
     Args:
         example: A dictionary containing the conversation JSON.
+        allow_prompt_only: Whether to accept a conversation with no reference
+            assistant response.
 
     Returns:
         A tuple ``(prompt_messages, images, completion)``: the prompt as a list of
@@ -79,10 +83,8 @@ def extract_prompt_images_completion_from_conversation(
         and the completion text.
 
     Raises:
-        ValueError: If ``conversation_json`` is missing, the conversation has
-            fewer than 2 messages, the prompt starts with an assistant message,
-            the prompt or completion is empty, or the final message is not an
-            assistant message.
+        ValueError: If ``conversation_json`` is missing, the conversation has an
+            invalid message sequence, or the prompt or required completion is empty.
     """
     if "conversation_json" not in example:
         raise ValueError(
@@ -93,18 +95,19 @@ def extract_prompt_images_completion_from_conversation(
     conversation = Conversation.from_json(example["conversation_json"])
     messages = conversation.messages
 
-    if len(messages) < 2:
+    has_completion = bool(messages and messages[-1].role == Role.ASSISTANT)
+    if not messages or (has_completion and len(messages) < 2):
         raise ValueError(
             f"Conversation must have at least 2 messages (a prompt and a "
             f"final assistant message), but got {len(messages)}."
         )
-    if messages[-1].role != Role.ASSISTANT:
+    if not has_completion and not allow_prompt_only:
         raise ValueError(
             f"The final message of a conversation must be an assistant message "
             f"(used as the ground truth), but got role '{messages[-1].role}'."
         )
 
-    prompt_source_messages = messages[:-1]
+    prompt_source_messages = messages[:-1] if has_completion else messages
     if prompt_source_messages[0].role == Role.ASSISTANT:
         raise ValueError("Conversation prompt cannot start with an assistant message.")
 
@@ -115,8 +118,8 @@ def extract_prompt_images_completion_from_conversation(
     if not prompt_has_content:
         raise ValueError("Conversation prompt must not be empty.")
 
-    completion = messages[-1].compute_flattened_text_content()
-    if not completion.strip():
+    completion = messages[-1].compute_flattened_text_content() if has_completion else ""
+    if has_completion and not completion.strip():
         raise ValueError("Conversation completion must not be empty.")
 
     prompt_messages: list[dict] = []

--- a/tests/unit/datasets/grpo/test_letter_count.py
+++ b/tests/unit/datasets/grpo/test_letter_count.py
@@ -59,15 +59,18 @@ def test_return_conversations_preserves_metadata_for_verl():
             return_conversations=True,
         )
 
-    hf_dataset = dataset.to_hf()
-    assert hf_dataset.column_names == ["conversation_json"]
-    row = hf_dataset[0]
+    hf_dataset = dataset.to_hf(return_iterable=True)
+    row = next(iter(hf_dataset))
+    assert set(row) == {"conversation_json"}
     conversation = Conversation.from_json(row["conversation_json"])
     assert conversation.metadata["letter_count_integer"] == 3
-    assert conversation.messages[-1].role == Role.ASSISTANT
-    assert conversation.messages[-1].content == "\\boxed{3}"
+    assert [message.role for message in conversation.messages] == [
+        Role.SYSTEM,
+        Role.USER,
+    ]
 
     verl_row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
         row, 0, dataset.dataset_name, "train"
     )
+    assert verl_row["reward_model"]["ground_truth"] == ""
     assert json.loads(verl_row["extra_info"]["metadata"])["letter_count_integer"] == 3

--- a/tests/unit/datasets/grpo/test_letter_count.py
+++ b/tests/unit/datasets/grpo/test_letter_count.py
@@ -1,0 +1,73 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import patch
+
+import pandas as pd
+
+from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
+from oumi.core.types.conversation import Conversation, Role
+from oumi.datasets.grpo.letter_count import LetterCountGrpoDataset
+
+
+def _raw_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "conversation_id": "oumi_letter_count_0",
+                "messages": [
+                    {
+                        "content": "How many 'r's are in 'strawberry'?",
+                        "role": "user",
+                    }
+                ],
+                "metadata": {
+                    "letter": "r",
+                    "letter_count_integer": 3,
+                    "word": "strawberry",
+                },
+            }
+        ]
+    )
+
+
+def test_default_output_remains_native_grpo_format():
+    with patch.object(LetterCountGrpoDataset, "_load_data", return_value=_raw_data()):
+        dataset = LetterCountGrpoDataset(split="train")
+
+    row = dataset[0]
+    assert set(row) == {"prompt", "letter_count"}
+    assert row["letter_count"] == 3
+
+
+def test_return_conversations_preserves_metadata_for_verl():
+    with patch.object(LetterCountGrpoDataset, "_load_data", return_value=_raw_data()):
+        dataset = LetterCountGrpoDataset(
+            split="train",
+            return_conversations=True,
+        )
+
+    hf_dataset = dataset.to_hf()
+    assert hf_dataset.column_names == ["conversation_json"]
+    row = hf_dataset[0]
+    conversation = Conversation.from_json(row["conversation_json"])
+    assert conversation.metadata["letter_count_integer"] == 3
+    assert conversation.messages[-1].role == Role.ASSISTANT
+    assert conversation.messages[-1].content == "\\boxed{3}"
+
+    verl_row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        row, 0, dataset.dataset_name, "train"
+    )
+    assert json.loads(verl_row["extra_info"]["metadata"])["letter_count_integer"] == 3

--- a/tests/unit/utils/test_grpo_utils.py
+++ b/tests/unit/utils/test_grpo_utils.py
@@ -80,6 +80,26 @@ def test_raises_when_last_message_not_assistant():
         extract_prompt_images_completion_from_conversation(_example(convo))
 
 
+def test_prompt_only_conversation_when_allowed():
+    convo = Conversation(
+        messages=[
+            Message(role=Role.SYSTEM, content="You are helpful."),
+            Message(role=Role.USER, content="What is 2+2?"),
+        ]
+    )
+
+    prompt, images, completion = extract_prompt_images_completion_from_conversation(
+        _example(convo), allow_prompt_only=True
+    )
+
+    assert prompt == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    assert images == []
+    assert completion == ""
+
+
 def test_raises_when_fewer_than_two_messages():
     convo = Conversation(
         messages=[


### PR DESCRIPTION
# Description

`BaseExperimentalGrpoDataset` accepted `return_conversations` through `**kwargs` but ignored it, unlike `BaseSftDataset`. Registered GRPO datasets therefore continued emitting flattened rows when callers requested `conversation_json`, dropping metadata needed by custom reward functions.

This change:

- moves shared `Conversation` output formatting to `BaseMapDataset`;
- makes `BaseExperimentalGrpoDataset` honor `return_conversations` and `return_conversations_format`;
- allows verl-backed GRPO to consume prompt-only conversations for reference-free reward functions without fabricating assistant ground truth;
- verifies that `letter_count_integer` survives Hugging Face conversion and reaches verl's `extra_info.metadata`.

The default native GRPO output remains unchanged when conversation output is disabled.

## Related issues

N/A

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.