### PR TITLE
fix(evals): pin lm_eval<0.4.12 to keep group-task evals working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,11 @@ dependencies = [
     "httpx>=0.27,<1.0",           # Used by deploy module (async HTTP client)
     "jsonlines",
     "jsonschema>=4.0,<5.0",       # Used for tool argument validation
-    "lm_eval[wandb]>=0.4,<0.5.0",
+    # <0.4.12: 0.4.12+ stopped recursively flattening multi-level task groups
+    # (e.g. mmlu, which nests group->subgroups->subjects), so lm_harness group
+    # evals fail with `'dict' object has no attribute build_all_requests`. 0.4.11
+    # is the last version that handles them (single-subject tasks are unaffected).
+    "lm_eval[wandb]>=0.4,<0.4.12",
     "mlflow>=3.1",                # >=3.1.4 requires Python3.10>=
     "numpy>=1.26,<2.4",           # verl==0.5.0 depends on numpy<2.0.0
     # The latest stable version, 2.3.0, is two years old and is causing dependency


### PR DESCRIPTION
lm_eval 0.4.12 stopped recursively flattening multi-level task groups (mmlu nests group->subgroups->subjects), so lm_harness group evals fail with `'dict' object has no attribute build_all_requests`. 0.4.11 (2026-02-13) is the last version that handles them; single-subject tasks are unaffected, so CI's single-task GPU test stayed green while e2e group evals broke since ~May 2026. Verified locally on CPU: 0.4.11 runs nested mmlu + emits the group aggregate; 0.4.12/0.4.13 raise the AttributeError.