### PR TITLE
Patch verl to sync Gemma 4 non-parameter buffers across ranks robustly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,7 +264,7 @@ ban-relative-imports = "all" # Disallow all relative imports.
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "PTH"] # Ignore docstring checks in tests
 "src/oumi/mcp/*" = ["ASYNC210", "ASYNC220", "ASYNC230", "ASYNC240"]  # fastmcp uses sync-over-async patterns
-"src/oumi/utils/verl_model_merger.*" = [
+"src/oumi/utils/verl_utils/model_merger.*" = [
     "E501", # Line too long
     "D",    # Ignore docstring checks
     "PTH",  # Ignore pathlib checks
@@ -281,7 +281,7 @@ known-third-party = ["wandb"]
 include = ["src/oumi/**", "tests/**"]
 exclude = [
     "src/oumi/core/types/proto/**",
-    "src/oumi/utils/verl_model_merger.py",
+    "src/oumi/utils/verl_utils/model_merger.py",
 ]
 typeCheckingMode = "basic"
 pythonVersion = "3.10"
@@ -293,7 +293,7 @@ reportPrivateImportUsage = "none"
 include = ["src/oumi/**"]
 exclude = [
     "src/oumi/core/types/proto/**",
-    "src/oumi/utils/verl_model_merger.py",
+    "src/oumi/utils/verl_utils/model_merger.py",
 ]
 
 [tool.ty.environment]

--- a/src/oumi/core/trainers/trl_dpo_trainer.py
+++ b/src/oumi/core/trainers/trl_dpo_trainer.py
@@ -64,7 +64,9 @@ class TrlDpoTrainer(DPOTrainer):
         """Decode serialized tool arguments immediately before rendering."""
         if isinstance(input, list):
             input = _deserialize_tool_call_arguments(input)
-        return super()._tokenize(processing_class, input, **kwargs)
+        return super()._tokenize(  # pyright: ignore[reportAttributeAccessIssue]
+            processing_class, input, **kwargs
+        )
 
     def _prepare_dataset(self, dataset, processing_class, args, dataset_name):
         """Prepare raw datasets while preserving Oumi-tokenized datasets."""

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -65,14 +65,14 @@ from oumi.core.configs import DatasetSplitParams, TrainingConfig
 from oumi.core.processors.base_processor import BaseProcessor
 from oumi.core.tokenizers import BaseTokenizer
 from oumi.core.trainers.base_trainer import BaseTrainer
-from oumi.core.trainers.verl_grpo_metrics import (
+from oumi.utils.logging import logger
+from oumi.utils.packaging import is_verl_v0_7_or_later
+from oumi.utils.verl_utils.grpo_metrics import (
     DEFAULT_REWARD_GROUP_LOW_STD_THRESHOLD,
     REWARD_GROUP_LOW_STD_CONFIG_KEY,
     install_verl_grpo_reward_group_metrics_patch,
 )
-from oumi.utils.logging import logger
-from oumi.utils.packaging import is_verl_v0_7_or_later
-from oumi.utils.verl_model_merger import FSDPModelMerger, ModelMergerConfig
+from oumi.utils.verl_utils.model_merger import FSDPModelMerger, ModelMergerConfig
 
 # Every step's metrics are mirrored to this file under the output dir so callers
 # can read reward curves.

--- a/src/oumi/utils/packaging.py
+++ b/src/oumi/utils/packaging.py
@@ -296,6 +296,20 @@ def is_verl_v0_7_or_later() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_verl_v0_8_or_later() -> bool:
+    """Checks if verl version is 0.8.0 or later.
+
+    Verl v0.8 includes the FSDP2 named-buffer broadcast fix and removes the
+    legacy worker implementation.
+    """
+    try:
+        verl_version = importlib.metadata.version("verl")
+        return version.parse(verl_version) >= version.parse("0.8.0")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+@lru_cache(maxsize=1)
 def is_trl_v0_28_or_later() -> bool:
     """Check if the installed TRL version is v0.28 or later."""
     try:

--- a/src/oumi/utils/verl_utils/__init__.py
+++ b/src/oumi/utils/verl_utils/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for Oumi's VERL integrations."""

--- a/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
+++ b/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
@@ -32,8 +32,15 @@ _BufferSpec = tuple[str, tuple[int, ...], str]
 
 def _sync_buffers_from_rank0(module: torch.nn.Module) -> tuple[int, int]:
     rank = dist.get_rank()
-    device = torch.device("cuda", torch.cuda.current_device())
-    torch.cuda.synchronize()
+    # NCCL collectives require CUDA tensors. Gloo uses CPU tensors, which also
+    # lets the synchronization contract be covered by distributed CPU tests.
+    device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if dist.get_backend() == "nccl"
+        else torch.device("cpu")
+    )
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
     local = dict(module.named_buffers(remove_duplicate=False))
     if rank == 0:
         spec: list[_BufferSpec] | None = [
@@ -57,21 +64,22 @@ def _sync_buffers_from_rank0(module: torch.nn.Module) -> tuple[int, int]:
                 and tuple(buf.shape) == tuple(shape)
                 and buf.dtype == dtype
             )
-            if usable and buf is not None and buf.is_cuda:
-                target = buf.data
-                before = target.clone() if rank != 0 else None
+            if usable and buf is not None:
+                before = buf.detach().clone() if rank != 0 else None
+                target = buf.data if buf.device == device else buf.detach().to(device)
             else:
                 target = torch.empty(
                     shape, dtype=dtype, device=device
                 )  # scratch: keep collectives aligned
                 before = None
             dist.broadcast(target, src=0)
-            if usable and buf is not None and not buf.is_cuda:
+            if usable and buf is not None and buf.device != device:
                 buf.data.copy_(target.to(buf.device))
             n_total += 1
-            if before is not None and not torch.equal(before, target):
+            if before is not None and buf is not None and not torch.equal(before, buf):
                 n_changed += 1
-    torch.cuda.synchronize()
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
     return n_total, n_changed
 
 

--- a/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
+++ b/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
@@ -20,6 +20,7 @@ log-probs. The patch wraps ``DataParallelPPOActor.__init__`` and broadcasts
 rank 0's buffers by name, shape, and dtype, including aliased buffers.
 """
 
+from importlib import import_module
 from typing import Any, cast
 
 import torch
@@ -85,7 +86,7 @@ def _sync_buffers_from_rank0(module: torch.nn.Module) -> tuple[int, int]:
 
 def _install_patch() -> None:
     # This legacy actor module was removed in verl 0.8's worker-to-engine migration.
-    from verl.workers.actor import dp_actor
+    dp_actor = cast(Any, import_module("verl.workers.actor.dp_actor"))
 
     orig_init = dp_actor.DataParallelPPOActor.__init__
 

--- a/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
+++ b/src/oumi/utils/verl_utils/fsdp1_rank_buffer_sync.py
@@ -1,0 +1,118 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synchronize VERL FSDP1 actor and reference buffers across ranks.
+
+Some models can retain different non-sharded buffers, such as RoPE tables,
+across ranks after VERL constructs an FSDP1 worker. This causes rank-dependent
+log-probs. The patch wraps ``DataParallelPPOActor.__init__`` and broadcasts
+rank 0's buffers by name, shape, and dtype, including aliased buffers.
+"""
+
+from typing import Any, cast
+
+import torch
+import torch.distributed as dist
+
+from oumi.utils.packaging import is_verl_v0_8_or_later
+
+_BufferSpec = tuple[str, tuple[int, ...], str]
+
+
+def _sync_buffers_from_rank0(module: torch.nn.Module) -> tuple[int, int]:
+    rank = dist.get_rank()
+    device = torch.device("cuda", torch.cuda.current_device())
+    torch.cuda.synchronize()
+    local = dict(module.named_buffers(remove_duplicate=False))
+    if rank == 0:
+        spec: list[_BufferSpec] | None = [
+            (n, tuple(b.shape), str(b.dtype)) for n, b in local.items() if b.numel() > 0
+        ]
+    else:
+        spec = None
+    holder: list[Any] = [spec]
+    dist.broadcast_object_list(holder, src=0)
+    received_spec = holder[0]
+    if received_spec is None:
+        raise RuntimeError("Rank 0 did not provide a module-buffer specification.")
+    spec = cast(list[_BufferSpec], received_spec)
+    n_total, n_changed = 0, 0
+    with torch.no_grad():
+        for name, shape, dtype_str in spec:
+            dtype = getattr(torch, dtype_str.split(".")[-1])
+            buf = local.get(name)
+            usable = bool(
+                buf is not None
+                and tuple(buf.shape) == tuple(shape)
+                and buf.dtype == dtype
+            )
+            if usable and buf is not None and buf.is_cuda:
+                target = buf.data
+                before = target.clone() if rank != 0 else None
+            else:
+                target = torch.empty(
+                    shape, dtype=dtype, device=device
+                )  # scratch: keep collectives aligned
+                before = None
+            dist.broadcast(target, src=0)
+            if usable and buf is not None and not buf.is_cuda:
+                buf.data.copy_(target.to(buf.device))
+            n_total += 1
+            if before is not None and not torch.equal(before, target):
+                n_changed += 1
+    torch.cuda.synchronize()
+    return n_total, n_changed
+
+
+def _install_patch() -> None:
+    # This legacy actor module was removed in verl 0.8's worker-to-engine migration.
+    from verl.workers.actor import dp_actor
+
+    orig_init = dp_actor.DataParallelPPOActor.__init__
+
+    def patched_init(
+        self: Any,
+        config: Any,
+        actor_module: torch.nn.Module,
+        actor_optimizer: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        cast(Any, orig_init)(self, config, actor_module, actor_optimizer, **kwargs)
+        if (
+            not (dist.is_available() and dist.is_initialized())
+            or dist.get_world_size() == 1
+        ):
+            return
+        n_total, n_changed = _sync_buffers_from_rank0(actor_module)
+        print(
+            f"[rank-buffer-sync] rank {dist.get_rank()}: "
+            f"{n_total} buffers broadcast from rank 0, "
+            f"{n_changed} had different content locally",
+            flush=True,
+        )
+
+    if not getattr(dp_actor.DataParallelPPOActor, "_rank_buffer_sync_patched", False):
+        setattr(dp_actor.DataParallelPPOActor, "__init__", patched_init)
+        setattr(dp_actor.DataParallelPPOActor, "_rank_buffer_sync_patched", True)
+        print("[fsdp1_rank_buffer_sync] installed", flush=True)
+
+
+if is_verl_v0_8_or_later():
+    print(
+        "[fsdp1_rank_buffer_sync] skipped for verl >= 0.8; use the FSDP2 "
+        "named-buffer synchronization path",
+        flush=True,
+    )
+else:
+    _install_patch()

--- a/src/oumi/utils/verl_utils/grpo_metrics.py
+++ b/src/oumi/utils/verl_utils/grpo_metrics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Oumi-provided reward-group metrics for the verl GRPO trainer."""
+"""Oumi-provided reward-group metrics for the VERL GRPO trainer."""
 
 import inspect
 import math

--- a/src/oumi/utils/verl_utils/model_merger.py
+++ b/src/oumi/utils/verl_utils/model_merger.py
@@ -18,7 +18,7 @@
 # with minor modifications e.g., `import verl` is wrapped into try-except block
 # and some verl-related imports are moved down to the function that uses them.
 
-"""This script is used to merge huggingface model and test verl checkpoints from FSDP and Megatron backends.
+"""Merge Hugging Face models and test VERL FSDP and Megatron checkpoints.
 
 To merge FSDP checkpoints:
 ```sh

--- a/tests/unit/core/trainers/test_trl_dpo_trainer.py
+++ b/tests/unit/core/trainers/test_trl_dpo_trainer.py
@@ -184,7 +184,9 @@ def test_prepare_dataset_preserves_disjoint_tool_argument_schemas():
     dataset = Dataset.from_list(rows)
     trainer = object.__new__(TrlDpoTrainer)
     trainer._is_vlm = False
-    trainer._tokenizer = SimpleNamespace(eos_token="</s>")
+    trainer._tokenizer = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        eos_token="</s>"
+    )
     processing_class = _CapturingProcessingClass()
     args = SimpleNamespace(dataset_num_proc=None)
 

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -16,7 +16,6 @@ from oumi.core.configs import (
 )
 from oumi.core.constants import VERL_METRICS_FILENAME
 from oumi.core.trainers import verl_grpo_trainer
-from oumi.core.trainers.verl_grpo_metrics import REWARD_GROUP_LOW_STD_CONFIG_KEY
 from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
 from oumi.core.types.conversation import (
     ContentItem,
@@ -26,6 +25,7 @@ from oumi.core.types.conversation import (
     Type,
 )
 from oumi.core.types.tool_call import FunctionCall, ToolCall
+from oumi.utils.verl_utils.grpo_metrics import REWARD_GROUP_LOW_STD_CONFIG_KEY
 
 try:
     verl_import_failed = False

--- a/tests/unit/utils/test_packaging.py
+++ b/tests/unit/utils/test_packaging.py
@@ -9,6 +9,7 @@ from oumi.utils.packaging import (
     _package_prerequisites_error_messages,
     check_package_prerequisites,
     is_trl_v1_5_or_later,
+    is_verl_v0_8_or_later,
     verify_trl_vllm_compatibility,
 )
 
@@ -215,3 +216,29 @@ def test_is_trl_v1_5_or_later_missing_package(monkeypatch):
     monkeypatch.setattr("importlib.metadata.version", mock_version)
     assert is_trl_v1_5_or_later() is False
     is_trl_v1_5_or_later.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "verl_version, expected",
+    [
+        ("0.7.1", False),
+        ("0.8.0", True),
+        ("0.9.0", True),
+    ],
+)
+def test_is_verl_v0_8_or_later(monkeypatch, verl_version, expected):
+    is_verl_v0_8_or_later.cache_clear()
+    monkeypatch.setattr("importlib.metadata.version", lambda pkg: verl_version)
+    assert is_verl_v0_8_or_later() is expected
+    is_verl_v0_8_or_later.cache_clear()
+
+
+def test_is_verl_v0_8_or_later_missing_package(monkeypatch):
+    is_verl_v0_8_or_later.cache_clear()
+
+    def mock_version(pkg):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr("importlib.metadata.version", mock_version)
+    assert is_verl_v0_8_or_later() is False
+    is_verl_v0_8_or_later.cache_clear()

--- a/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
+++ b/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
@@ -14,8 +14,14 @@
 
 import importlib
 import sys
+from datetime import timedelta
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from oumi.utils import packaging
 
@@ -25,6 +31,46 @@ _MODULE_NAME = "oumi.utils.verl_utils.fsdp1_rank_buffer_sync"
 def _import_fresh_module():
     sys.modules.pop(_MODULE_NAME, None)
     return importlib.import_module(_MODULE_NAME)
+
+
+def _run_distributed_buffer_sync(rank: int, world_size: int, init_method: str):
+    dist.init_process_group(
+        "gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=20),
+    )
+    try:
+        with patch.object(packaging, "is_verl_v0_8_or_later", return_value=True):
+            module = _import_fresh_module()
+
+        actor_module = torch.nn.Module()
+        actor_module.register_buffer(
+            "shared",
+            torch.tensor([1.0, 2.0]) if rank == 0 else torch.tensor([-1.0, -2.0]),
+        )
+        alias = torch.tensor([3.0, 4.0]) if rank == 0 else torch.tensor([-3.0, -4.0])
+        actor_module.register_buffer("alias_a", alias)
+        actor_module.register_buffer("alias_b", alias)
+        actor_module.register_buffer("already_equal", torch.tensor([5.0]))
+        if rank == 0:
+            actor_module.register_buffer("rank0_only", torch.tensor([6.0]))
+        else:
+            actor_module.register_buffer("rank1_only", torch.tensor([7.0]))
+
+        n_total, n_changed = module._sync_buffers_from_rank0(actor_module)
+
+        assert n_total == 5
+        assert n_changed == (0 if rank == 0 else 2)
+        torch.testing.assert_close(actor_module.shared, torch.tensor([1.0, 2.0]))
+        torch.testing.assert_close(actor_module.alias_a, torch.tensor([3.0, 4.0]))
+        torch.testing.assert_close(actor_module.alias_b, torch.tensor([3.0, 4.0]))
+        assert actor_module.get_buffer("alias_a") is actor_module.get_buffer("alias_b")
+        if rank == 1:
+            torch.testing.assert_close(actor_module.rank1_only, torch.tensor([7.0]))
+    finally:
+        dist.destroy_process_group()
 
 
 def test_skips_legacy_actor_import_on_verl_v0_8_or_later():
@@ -59,3 +105,15 @@ def test_installs_patch_on_legacy_verl():
         actor = FakeDataParallelPPOActor(None, object())
     assert actor.initialized is True
     sys.modules.pop(_MODULE_NAME, None)
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is unavailable")
+def test_syncs_buffers_with_unequal_lists_across_processes(tmp_path):
+    init_method = f"file://{tmp_path / 'distributed_init'}"
+
+    mp.spawn(
+        _run_distributed_buffer_sync,
+        args=(2, init_method),
+        nprocs=2,
+        join=True,
+    )

--- a/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
+++ b/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
@@ -1,0 +1,61 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from oumi.utils import packaging
+
+_MODULE_NAME = "oumi.utils.verl_utils.fsdp1_rank_buffer_sync"
+
+
+def _import_fresh_module():
+    sys.modules.pop(_MODULE_NAME, None)
+    return importlib.import_module(_MODULE_NAME)
+
+
+def test_skips_legacy_actor_import_on_verl_v0_8_or_later():
+    with patch.object(packaging, "is_verl_v0_8_or_later", return_value=True):
+        module = _import_fresh_module()
+
+    assert module.is_verl_v0_8_or_later()
+    sys.modules.pop(_MODULE_NAME, None)
+
+
+def test_installs_patch_on_legacy_verl():
+    class FakeDataParallelPPOActor:
+        def __init__(self, config, actor_module, actor_optimizer=None, **kwargs):
+            self.initialized = True
+
+    original_init = FakeDataParallelPPOActor.__init__
+    actor_module = ModuleType("verl.workers.actor")
+    actor_module.dp_actor = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        DataParallelPPOActor=FakeDataParallelPPOActor
+    )
+
+    with (
+        patch.object(packaging, "is_verl_v0_8_or_later", return_value=False),
+        patch.dict(sys.modules, {"verl.workers.actor": actor_module}),
+    ):
+        module = _import_fresh_module()
+
+    assert FakeDataParallelPPOActor.__init__ is not original_init
+    assert getattr(FakeDataParallelPPOActor, "_rank_buffer_sync_patched") is True
+
+    with patch.object(module.dist, "is_available", return_value=False):
+        actor = FakeDataParallelPPOActor(None, object())
+    assert actor.initialized is True
+    sys.modules.pop(_MODULE_NAME, None)

--- a/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
+++ b/tests/unit/utils/verl_utils/test_fsdp1_rank_buffer_sync.py
@@ -15,7 +15,7 @@
 import importlib
 import sys
 from datetime import timedelta
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -87,14 +87,13 @@ def test_installs_patch_on_legacy_verl():
             self.initialized = True
 
     original_init = FakeDataParallelPPOActor.__init__
-    actor_module = ModuleType("verl.workers.actor")
-    actor_module.dp_actor = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
-        DataParallelPPOActor=FakeDataParallelPPOActor
+    dp_actor_module = ModuleType("verl.workers.actor.dp_actor")
+    dp_actor_module.DataParallelPPOActor = (  # pyright: ignore[reportAttributeAccessIssue]
+        FakeDataParallelPPOActor
     )
-
     with (
         patch.object(packaging, "is_verl_v0_8_or_later", return_value=False),
-        patch.dict(sys.modules, {"verl.workers.actor": actor_module}),
+        patch.dict(sys.modules, {"verl.workers.actor.dp_actor": dp_actor_module}),
     ):
         module = _import_fresh_module()
 

--- a/tests/unit/utils/verl_utils/test_grpo_metrics.py
+++ b/tests/unit/utils/verl_utils/test_grpo_metrics.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from oumi.core.trainers import verl_grpo_metrics
-from oumi.core.trainers.verl_grpo_metrics import (
+from oumi.utils.verl_utils import grpo_metrics
+from oumi.utils.verl_utils.grpo_metrics import (
     compute_grpo_reward_group_metrics,
     install_verl_grpo_reward_group_metrics_patch,
 )
@@ -145,7 +145,7 @@ def test_install_patch_preserves_original_metrics_and_upstream_values(monkeypatc
 
     fake_module = SimpleNamespace(compute_data_metrics=original_collector)
     monkeypatch.setattr(
-        verl_grpo_metrics,
+        grpo_metrics,
         "import_module",
         lambda _: fake_module,
     )
@@ -168,7 +168,7 @@ def test_install_patch_is_idempotent_and_updates_threshold(monkeypatch):
 
     fake_module = SimpleNamespace(compute_data_metrics=original_collector)
     monkeypatch.setattr(
-        verl_grpo_metrics,
+        grpo_metrics,
         "import_module",
         lambda _: fake_module,
     )
@@ -192,7 +192,7 @@ def test_install_patch_warns_once_and_preserves_training_metrics(
 
     fake_module = SimpleNamespace(compute_data_metrics=original_collector)
     monkeypatch.setattr(
-        verl_grpo_metrics,
+        grpo_metrics,
         "import_module",
         lambda _: fake_module,
     )
@@ -211,7 +211,7 @@ def test_install_patch_warns_once_and_preserves_training_metrics(
 def test_install_patch_rejects_incompatible_collector(monkeypatch):
     fake_module = SimpleNamespace(compute_data_metrics=lambda data: {})
     monkeypatch.setattr(
-        verl_grpo_metrics,
+        grpo_metrics,
         "import_module",
         lambda _: fake_module,
     )
@@ -222,7 +222,7 @@ def test_install_patch_rejects_incompatible_collector(monkeypatch):
 
 def test_install_patch_rejects_missing_collector(monkeypatch):
     monkeypatch.setattr(
-        verl_grpo_metrics,
+        grpo_metrics,
         "import_module",
         lambda _: SimpleNamespace(),
     )
@@ -233,7 +233,7 @@ def test_install_patch_rejects_missing_collector(monkeypatch):
 
 def test_install_patch_rejects_invalid_threshold_before_import(monkeypatch):
     import_mock = MagicMock()
-    monkeypatch.setattr(verl_grpo_metrics, "import_module", import_mock)
+    monkeypatch.setattr(grpo_metrics, "import_module", import_mock)
 
     with pytest.raises(ValueError, match="low_std_threshold"):
         install_verl_grpo_reward_group_metrics_patch(low_std_threshold=-1.0)

--- a/tests/unit/utils/verl_utils/test_model_merger.py
+++ b/tests/unit/utils/verl_utils/test_model_merger.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 
-from oumi.utils.verl_model_merger import FSDPModelMerger
+from oumi.utils.verl_utils.model_merger import FSDPModelMerger
 
 WORLD_SIZE = 4
 


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Oumi! Before sending your PR out for review, please take a quick read through this template.

When your PR is merged, its title will appear in our release notes. Make sure your title gives a clear description of your change!

After you've updated your title, please replace this section with a detailed description of your change. Include as much context as possible so your reviewers can easily understand *what* you're changing and *why*.
The more information you provide, the faster we can review your change!
-->
<!--↓↓↓↓↓↓↓↓↓↓ Describe your change below ↓↓↓↓↓↓↓↓↓↓-->
VERL wraps independently constructed Hugging Face models with PyTorch FSDP1 using `sync_module_states=True`. In this tested combination, that synchronization has not reliably left every rank with the same Gemma 4 non-parameter buffers. The observed mismatches are the aliased rotary-embedding `inv_freq` buffers. Parameters can therefore agree while different ranks still compute different rotary embeddings and log probabilities.

The patch wraps `DataParallelPPOActor.__init__`. After VERL has constructed the actor or reference-policy wrapper, it obtains rank 0's buffer specification by name and broadcasts every buffer in a deterministic order. Each rank writes the received value to its matching local buffer.

This issue was discovered when a training run run reported a mean probability difference of 0.064–0.068 (expected 0.007) and Pearson correlation around 0.84 (expected 0.99). To investigate why agreement metrics were unhealthy, various reproductions were run and metrics from rank 0 passed. To check if the unhealthy metrics came from other ranks, per-rank dumps was conducted and it localized the failure: rank 0 had a difference of 0.0073, while ranks 1–3 had differences of 0.348–0.352 and were wrong on all 128 sequences. A four-rank state comparison then found exactly three mismatches among 2,032 parameters and buffers: Gemma 4’s sliding_attention_inv_freq, sliding_attention_original_inv_freq, and full_attention_inv_freq rotary buffers. After broadcasting rank 0’s named buffer specification and values, the same harness reported zero cross-rank mismatches, and every rank reached approximately 0.007 actor/vLLM difference and 0.999 correlation. A subsequent live VERL run independently reported that the patch replaced three differing buffers and achieved a difference of 0.00752 with correlation 0.99869.

This PR also does some housekeeping to group all verl patches under `utils/verl_utils`

The following files only have changes to fix precommit issues from an upstream PR:
- `src/oumi/core/trainers/trl_dpo_trainer.py`
- `tests/unit/core/trainers/test_trl_dpo_trainer.py`
<!--↑↑↑↑↑↑↑↑↑↑ Describe your change above ↑↑↑↑↑↑↑↑↑↑-->

## Related issues

<!--
Make sure to list any relevant related issues to your change. More often than not this will be the single issue fixed by your PR.
-->
<!--↓↓↓↓↓↓↓↓↓↓ List your related issues below ↓↓↓↓↓↓↓↓↓↓-->

Fixes # (issue)

<!--↑↑↑↑↑↑↑↑↑↑ List your related issues above ↑↑↑↑↑↑↑↑↑↑-->

## Before submitting

- [ ] This PR only changes documentation. (You can ignore the following checks in that case)
- [x] Did you read the [contributor guideline](https://github.com/oumi-ai/oumi/blob/main/CONTRIBUTING.md) Pull Request guidelines?
- [ ] Did you link the issue(s) related to this PR in the section above?
- [x] Did you add / update tests where needed?

## Reviewers

At least one review from a member of `oumi-ai/oumi-staff` is required.

<!-- Add `oumi-ai/oumi-staff` as a reviewer when your PR is ready for review.

You are also welcome to add individual members of `oumi-ai/oumi-staff` as reviewers.

If no one has reviewed your PR after several days, feel free to add a comment tagging specific reviewers.

 -->
