### PR TITLE
feat(rollout): backend-free core for simulated-user rollouts (1/4)

### DIFF
--- a/src/oumi/core/rollout/__init__.py
+++ b/src/oumi/core/rollout/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral building blocks for RL rollouts."""

--- a/src/oumi/core/rollout/user_sim.py
+++ b/src/oumi/core/rollout/user_sim.py
@@ -1,0 +1,113 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-free core for simulated-user (conversational) rollouts."""
+
+import dataclasses
+from collections.abc import Callable
+
+from oumi.core.types.conversation import Conversation, Message, Role
+
+DEFAULT_DONE_SENTINEL = "[[END]]"
+DEFAULT_MAX_TURNS = 6
+
+
+@dataclasses.dataclass
+class RolloutState:
+    """Rollout state; ``max_turns`` is a safety cap on simulated-user replies."""
+
+    persona: str
+    max_turns: int
+    goal: str = ""
+    turn_idx: int = 0
+
+
+def build_user_turn_prompt(
+    persona: str,
+    history: list[Message],
+    current_turn: int,
+    max_turns: int,
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+    *,
+    goal: str = "",
+) -> Conversation:
+    """Builds the prompt for the next simulated-user turn."""
+    system_prompt = persona
+    if goal:
+        system_prompt += f"\n\nYour goal for this conversation: {goal}"
+
+    messages: list[Message] = [Message(role=Role.SYSTEM, content=system_prompt)]
+    messages.extend(history)
+    messages.append(
+        Message(
+            role=Role.USER,
+            content=(
+                f"You are the USER generating reply {current_turn}. You may generate "
+                f"at most {max_turns} replies; this limit is a safety cap, not a "
+                "target. Respond naturally to the assistant's latest message. Pursue "
+                "your goal without repeating yourself or inventing facts. Do not "
+                "prolong the conversation to reach the turn limit. If your goal has "
+                "been satisfied, respond naturally and append "
+                f"{done_sentinel}. Reply with ONLY your next message and stay in "
+                "character."
+            ),
+        )
+    )
+    return Conversation(messages=messages)
+
+
+def messages_to_history(messages: list[dict]) -> list[Message]:
+    """Converts backend message dicts to user and assistant history.
+
+    Only user and assistant turns survive: the simulated user is a person talking to
+    the assistant, so it never sees system prompts or tool traffic. Passing a tool
+    turn through would also be rejected by chat APIs, which require it to follow an
+    assistant message carrying structured ``tool_calls``.
+
+    Returns:
+        The conversation as the simulated user experienced it.
+    """
+    return [
+        Message(role=Role(m["role"]), content=(m.get("content") or ""))
+        for m in messages
+        if m.get("role") in (Role.USER.value, Role.ASSISTANT.value)
+    ]
+
+
+def next_user_turn(
+    state: RolloutState,
+    messages: list[dict],
+    infer_fn: Callable[[Conversation], str],
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+) -> tuple[bool, str, float]:
+    """Produces the next simulated-user turn, or ends the rollout at the cap.
+
+    Returns:
+        A tuple of whether to terminate, the simulated-user response, and its score.
+    """
+    if state.turn_idx >= state.max_turns:
+        return True, "", 0.0
+    state.turn_idx += 1
+    prompt = build_user_turn_prompt(
+        state.persona,
+        messages_to_history(messages),
+        state.turn_idx,
+        state.max_turns,
+        done_sentinel,
+        goal=state.goal,
+    )
+    text = infer_fn(prompt)
+    if done_sentinel in text:
+        return True, text.replace(done_sentinel, "").strip(), 0.0
+    return False, text.strip(), 0.0

--- a/tests/unit/core/rollout/test_user_sim.py
+++ b/tests/unit/core/rollout/test_user_sim.py
@@ -1,0 +1,129 @@
+from oumi.core.rollout.user_sim import (
+    DEFAULT_DONE_SENTINEL,
+    RolloutState,
+    build_user_turn_prompt,
+    messages_to_history,
+    next_user_turn,
+)
+from oumi.core.types.conversation import Message, Role
+
+
+def test_build_user_turn_prompt_shape():
+    history = [
+        Message(role=Role.USER, content="hi"),
+        Message(role=Role.ASSISTANT, content="hello"),
+    ]
+    conv = build_user_turn_prompt(
+        "You are Jane, a customer.",
+        history,
+        current_turn=2,
+        max_turns=6,
+        goal="Get a refund.",
+    )
+    assert conv.messages[0].role == Role.SYSTEM
+    assert conv.messages[0].content == (
+        "You are Jane, a customer.\n\nYour goal for this conversation: Get a refund."
+    )
+    assert [m.content for m in conv.messages[1:3]] == ["hi", "hello"]
+    assert conv.messages[-1].role == Role.USER
+    assert isinstance(conv.messages[-1].content, str)
+    turn_info = conv.messages[-1].content
+    assert "safety cap, not a target" in turn_info
+    assert DEFAULT_DONE_SENTINEL in turn_info
+
+
+def test_messages_to_history_maps_roles():
+    out = messages_to_history(
+        [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "a"),
+        (Role.ASSISTANT, "b"),
+    ]
+
+
+def test_next_user_turn_normal():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [{"role": "assistant", "content": "hi"}], lambda c: "  my reply  "
+    )
+    assert (done, text, score) == (False, "my reply", 0.0)
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_sentinel_ends():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [], lambda c: f"thanks {DEFAULT_DONE_SENTINEL}"
+    )
+    assert done is True
+    assert text == "thanks"
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_produces_exactly_max_turns():
+    state = RolloutState(persona="p", max_turns=1)
+
+    done, text, _ = next_user_turn(state, [], lambda c: "only turn")
+    assert (done, text) == (False, "only turn")
+
+    done, text, _ = next_user_turn(state, [], lambda c: "should not be used")
+    assert (done, text) == (True, "")
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_prompt_uses_custom_sentinel():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "bye <<STOP>>"
+
+    done, text, _ = next_user_turn(state, [], stub, done_sentinel="<<STOP>>")
+    assert "<<STOP>>" in captured["conv"].messages[-1].content
+    assert (done, text) == (True, "bye")
+
+
+def test_next_user_turn_threads_correct_turn_number():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "reply"
+
+    next_user_turn(state, [], stub)
+    turn_info = captured["conv"].messages[-1].content
+    assert "reply 1" in turn_info
+    assert "at most 5" in turn_info
+
+
+def test_messages_to_history_drops_system_turns():
+    out = messages_to_history(
+        [
+            {"role": "system", "content": "You are a support agent."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "hi"),
+        (Role.ASSISTANT, "hello"),
+    ]
+
+
+def test_messages_to_history_drops_tool_turns():
+    # Chat APIs reject a tool turn that does not follow structured `tool_calls`, and
+    # the customer would not have seen it anyway.
+    out = messages_to_history(
+        [
+            {"role": "user", "content": "where is order 4421"},
+            {"role": "tool", "content": '{"status": "delayed"}'},
+            {"role": "assistant", "content": "It is delayed."},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "where is order 4421"),
+        (Role.ASSISTANT, "It is delayed."),
+    ]


### PR DESCRIPTION
## What
Adds a backend-independent simulated user that continues a conversation from a defined persona and goal.

Resubmitted from a fork of **#2610** — I no longer have push access to the branch in this repo, so
the original cannot be updated. Rebased on current `main`, no conflicts.

## Why
Simulated-user behavior needs to be testable without initializing a trainer, GPU, or
reinforcement-learning backend. The simulator should only see the conversation a real user would
see and must stop predictably at completion or the turn limit.

## How
A lightweight conversation state turns customer-visible history into the next simulated reply and
reports whether the exchange is complete.

## Stack
| | PR | |
|---|---|---|
| 1 | #2652 | rollout core |
| 2 | #2653 | user-simulator inference engine |
| 3 | #2654 | `UserSimToolAgentLoop` |
| 4 | #2655 | `agent_name` row routing + config validation |

Each PR targets `main` because a fork cannot base a PR on another fork branch, so the diffs are
cumulative — review in order, and the commit this PR adds is the last one in its Commits tab.

Supersedes #2610. The squashed single-PR version of the whole stack, #2563, should be closed in

The squashed single-PR version of the whole stack, #2563, should be closed in favour of this stack.

## Testing
Unit tests cover prompt construction, conversation filtering, normal replies, completion signals,
and turn limits. `ruff check` and `ruff format --check` clean.
