### PR TITLE
feat(verl): process-wide user-simulator inference engine (2/4)

### DIFF
--- a/configs/examples/verl_conversational/user_sim_engine.yaml
+++ b/configs/examples/verl_conversational/user_sim_engine.yaml
@@ -1,0 +1,18 @@
+# Inference config for the simulated user.
+#
+# Must be a REMOTE-backed engine. One engine is cached per worker process and shared by
+# every concurrent rollout in it, so an in-process engine (NATIVE / VLLM / LLAMACPP) would
+# need a lock that serializes them all. See user_sim_provider.user_sim_engine.
+#
+# Settings match the validated job-273 run so rollouts stay comparable.
+#
+# Requirements:
+#   - export OPENAI_API_KEY=your_key_here
+model:
+  model_name: "gpt-4o-mini"
+
+engine: OPENAI
+
+generation:
+  max_new_tokens: 256
+  temperature: 1.0

--- a/src/oumi/core/rollout/__init__.py
+++ b/src/oumi/core/rollout/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral building blocks for RL rollouts."""

--- a/src/oumi/core/rollout/user_sim.py
+++ b/src/oumi/core/rollout/user_sim.py
@@ -1,0 +1,113 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-free core for simulated-user (conversational) rollouts."""
+
+import dataclasses
+from collections.abc import Callable
+
+from oumi.core.types.conversation import Conversation, Message, Role
+
+DEFAULT_DONE_SENTINEL = "[[END]]"
+DEFAULT_MAX_TURNS = 6
+
+
+@dataclasses.dataclass
+class RolloutState:
+    """Rollout state; ``max_turns`` is a safety cap on simulated-user replies."""
+
+    persona: str
+    max_turns: int
+    goal: str = ""
+    turn_idx: int = 0
+
+
+def build_user_turn_prompt(
+    persona: str,
+    history: list[Message],
+    current_turn: int,
+    max_turns: int,
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+    *,
+    goal: str = "",
+) -> Conversation:
+    """Builds the prompt for the next simulated-user turn."""
+    system_prompt = persona
+    if goal:
+        system_prompt += f"\n\nYour goal for this conversation: {goal}"
+
+    messages: list[Message] = [Message(role=Role.SYSTEM, content=system_prompt)]
+    messages.extend(history)
+    messages.append(
+        Message(
+            role=Role.USER,
+            content=(
+                f"You are the USER generating reply {current_turn}. You may generate "
+                f"at most {max_turns} replies; this limit is a safety cap, not a "
+                "target. Respond naturally to the assistant's latest message. Pursue "
+                "your goal without repeating yourself or inventing facts. Do not "
+                "prolong the conversation to reach the turn limit. If your goal has "
+                "been satisfied, respond naturally and append "
+                f"{done_sentinel}. Reply with ONLY your next message and stay in "
+                "character."
+            ),
+        )
+    )
+    return Conversation(messages=messages)
+
+
+def messages_to_history(messages: list[dict]) -> list[Message]:
+    """Converts backend message dicts to user and assistant history.
+
+    Only user and assistant turns survive: the simulated user is a person talking to
+    the assistant, so it never sees system prompts or tool traffic. Passing a tool
+    turn through would also be rejected by chat APIs, which require it to follow an
+    assistant message carrying structured ``tool_calls``.
+
+    Returns:
+        The conversation as the simulated user experienced it.
+    """
+    return [
+        Message(role=Role(m["role"]), content=(m.get("content") or ""))
+        for m in messages
+        if m.get("role") in (Role.USER.value, Role.ASSISTANT.value)
+    ]
+
+
+def next_user_turn(
+    state: RolloutState,
+    messages: list[dict],
+    infer_fn: Callable[[Conversation], str],
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+) -> tuple[bool, str, float]:
+    """Produces the next simulated-user turn, or ends the rollout at the cap.
+
+    Returns:
+        A tuple of whether to terminate, the simulated-user response, and its score.
+    """
+    if state.turn_idx >= state.max_turns:
+        return True, "", 0.0
+    state.turn_idx += 1
+    prompt = build_user_turn_prompt(
+        state.persona,
+        messages_to_history(messages),
+        state.turn_idx,
+        state.max_turns,
+        done_sentinel,
+        goal=state.goal,
+    )
+    text = infer_fn(prompt)
+    if done_sentinel in text:
+        return True, text.replace(done_sentinel, "").strip(), 0.0
+    return False, text.strip(), 0.0

--- a/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
@@ -1,0 +1,88 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-wide user-simulator inference engine for the verl agent-loop adapter."""
+
+from __future__ import annotations
+
+from functools import cache
+
+from oumi.builders.inference_engines import build_inference_engine
+from oumi.core.configs.inference_config import InferenceConfig
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.types.conversation import Conversation
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+# Engines that hold a model in-process. Rejected before `build_inference_engine` so we
+# never pay to load weights just to refuse them.
+_IN_PROCESS_ENGINES = frozenset(
+    {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }
+)
+
+
+@cache
+def user_sim_engine(config_path: str) -> tuple[RemoteInferenceEngine, InferenceConfig]:
+    """Builds the user-sim engine once per process.
+
+    Agent loops are instantiated per trajectory, so building the engine in the loop's
+    `__init__` would construct one per rollout.
+
+    Returns:
+        The engine and the config it was built from.
+    """
+    cfg = InferenceConfig.from_yaml(config_path)
+    if cfg.engine is None:
+        raise ValueError(f"No inference engine set in {config_path}.")
+    if cfg.engine in _IN_PROCESS_ENGINES:
+        raise ValueError(
+            f"The user simulator requires a remote inference engine; got "
+            f"{cfg.engine} from {config_path}. One engine is shared by every "
+            "concurrent rollout in a worker, so an in-process engine would need a "
+            "lock that serializes them all. "
+            "Use REMOTE_VLLM, SGLANG, or a hosted provider."
+        )
+    engine = build_inference_engine(
+        engine_type=cfg.engine,
+        model_params=cfg.model,
+        remote_params=cfg.remote_params,
+    )
+    # Free: every engine that loads weights was already rejected above, so nothing
+    # expensive reaches this. Catches a new engine type added between releases.
+    if not isinstance(engine, RemoteInferenceEngine):
+        raise ValueError(
+            f"User-sim engine {type(engine).__name__} is not remote-backed; "
+            f"got {cfg.engine} from {config_path}."
+        )
+    return engine, cfg
+
+
+def infer_one(
+    engine: RemoteInferenceEngine, cfg: InferenceConfig, conversation: Conversation
+) -> str:
+    """Runs one blocking user-sim generation.
+
+    Returns:
+        The simulated user's reply text.
+    """
+    results = engine.infer([conversation], inference_config=cfg)
+    content = results[0].messages[-1].content
+    if not isinstance(content, str):
+        raise RuntimeError(
+            f"user-sim engine returned non-text content: {type(content)}"
+        )
+    return content

--- a/tests/unit/core/rollout/test_user_sim.py
+++ b/tests/unit/core/rollout/test_user_sim.py
@@ -1,0 +1,129 @@
+from oumi.core.rollout.user_sim import (
+    DEFAULT_DONE_SENTINEL,
+    RolloutState,
+    build_user_turn_prompt,
+    messages_to_history,
+    next_user_turn,
+)
+from oumi.core.types.conversation import Message, Role
+
+
+def test_build_user_turn_prompt_shape():
+    history = [
+        Message(role=Role.USER, content="hi"),
+        Message(role=Role.ASSISTANT, content="hello"),
+    ]
+    conv = build_user_turn_prompt(
+        "You are Jane, a customer.",
+        history,
+        current_turn=2,
+        max_turns=6,
+        goal="Get a refund.",
+    )
+    assert conv.messages[0].role == Role.SYSTEM
+    assert conv.messages[0].content == (
+        "You are Jane, a customer.\n\nYour goal for this conversation: Get a refund."
+    )
+    assert [m.content for m in conv.messages[1:3]] == ["hi", "hello"]
+    assert conv.messages[-1].role == Role.USER
+    assert isinstance(conv.messages[-1].content, str)
+    turn_info = conv.messages[-1].content
+    assert "safety cap, not a target" in turn_info
+    assert DEFAULT_DONE_SENTINEL in turn_info
+
+
+def test_messages_to_history_maps_roles():
+    out = messages_to_history(
+        [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "a"),
+        (Role.ASSISTANT, "b"),
+    ]
+
+
+def test_next_user_turn_normal():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [{"role": "assistant", "content": "hi"}], lambda c: "  my reply  "
+    )
+    assert (done, text, score) == (False, "my reply", 0.0)
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_sentinel_ends():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [], lambda c: f"thanks {DEFAULT_DONE_SENTINEL}"
+    )
+    assert done is True
+    assert text == "thanks"
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_produces_exactly_max_turns():
+    state = RolloutState(persona="p", max_turns=1)
+
+    done, text, _ = next_user_turn(state, [], lambda c: "only turn")
+    assert (done, text) == (False, "only turn")
+
+    done, text, _ = next_user_turn(state, [], lambda c: "should not be used")
+    assert (done, text) == (True, "")
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_prompt_uses_custom_sentinel():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "bye <<STOP>>"
+
+    done, text, _ = next_user_turn(state, [], stub, done_sentinel="<<STOP>>")
+    assert "<<STOP>>" in captured["conv"].messages[-1].content
+    assert (done, text) == (True, "bye")
+
+
+def test_next_user_turn_threads_correct_turn_number():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "reply"
+
+    next_user_turn(state, [], stub)
+    turn_info = captured["conv"].messages[-1].content
+    assert "reply 1" in turn_info
+    assert "at most 5" in turn_info
+
+
+def test_messages_to_history_drops_system_turns():
+    out = messages_to_history(
+        [
+            {"role": "system", "content": "You are a support agent."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "hi"),
+        (Role.ASSISTANT, "hello"),
+    ]
+
+
+def test_messages_to_history_drops_tool_turns():
+    # Chat APIs reject a tool turn that does not follow structured `tool_calls`, and
+    # the customer would not have seen it anyway.
+    out = messages_to_history(
+        [
+            {"role": "user", "content": "where is order 4421"},
+            {"role": "tool", "content": '{"status": "delayed"}'},
+            {"role": "assistant", "content": "It is delayed."},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "where is order 4421"),
+        (Role.ASSISTANT, "It is delayed."),
+    ]

--- a/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oumi.builders.inference_engines import ENGINE_MAP
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.inference.base_inference_engine import BaseInferenceEngine
+from oumi.core.trainers.verl_agentic.user_sim_provider import (
+    _IN_PROCESS_ENGINES,
+    user_sim_engine,
+)
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+_BUILD = "oumi.core.trainers.verl_agentic.user_sim_provider.build_inference_engine"
+
+
+def _write_config(tmp_path, engine: str) -> str:
+    path = tmp_path / f"user_sim_{engine.lower()}.yaml"
+    path.write_text(
+        f"model:\n  model_name: 'gpt-4o-mini'\nengine: {engine}\n"
+        "remote_params:\n  api_url: 'http://localhost:8000/v1/chat/completions'\n"
+    )
+    return str(path)
+
+
+@pytest.mark.parametrize("engine", ["NATIVE", "VLLM", "LLAMACPP"])
+def test_in_process_engine_rejected_before_build(tmp_path, engine):
+    config_path = _write_config(tmp_path, engine)
+    with patch(_BUILD) as build:
+        with pytest.raises(ValueError, match="remote inference engine"):
+            user_sim_engine(config_path)
+    build.assert_not_called()
+
+
+def test_missing_engine_rejected(tmp_path):
+    path = tmp_path / "no_engine.yaml"
+    path.write_text("model:\n  model_name: 'gpt-4o-mini'\n")
+    with pytest.raises(ValueError, match="No inference engine"):
+        user_sim_engine(str(path))
+
+
+def test_remote_engine_built_once(tmp_path):
+    config_path = _write_config(tmp_path, "REMOTE_VLLM")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=RemoteInferenceEngine)
+        first = user_sim_engine(config_path)
+        second = user_sim_engine(config_path)
+    assert first is second
+    assert build.call_count == 1
+
+
+def test_non_remote_engine_rejected(tmp_path):
+    """A newly-added engine type that isn't remote-backed must not slip through."""
+    config_path = _write_config(tmp_path, "REMOTE")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=BaseInferenceEngine)
+        with pytest.raises(ValueError, match="not remote-backed"):
+            user_sim_engine(config_path)
+
+
+@pytest.mark.parametrize("engine_type,engine_cls", sorted(ENGINE_MAP.items(), key=str))
+def test_every_engine_is_classified(engine_type, engine_cls):
+    """A new engine type must be either in-process or remote-backed, never neither."""
+    assert (engine_type in _IN_PROCESS_ENGINES) ^ issubclass(
+        engine_cls, RemoteInferenceEngine
+    ), f"{engine_type} is classified neither in-process nor remote"
+
+
+def test_in_process_set_matches_expected_members():
+    assert _IN_PROCESS_ENGINES == {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }


### PR DESCRIPTION
## What
Adds one shared remote inference engine per worker process for generating simulated-user replies.

Resubmitted from a fork of **#2611** — I no longer have push access to the branch in this repo.
Rebased on current `main`, no conflicts.

## Why
Creating a new inference engine for every conversation wastes resources, while sharing an
in-process model would force concurrent conversations to run one at a time. The simulator
therefore needs a reusable remote engine with early validation for unsupported configurations.

## How
The simulator loads its configuration once per worker, reuses the resulting remote engine, and
rejects local model engines before they load weights.

## Stack
| | PR | |
|---|---|---|
| 1 | #2652 | rollout core |
| 2 | #2653 | user-simulator inference engine |
| 3 | #2654 | `UserSimToolAgentLoop` |
| 4 | #2655 | `agent_name` row routing + config validation |

Each PR targets `main` because a fork cannot base a PR on another fork branch, so the diffs are
cumulative — review in order, and the commit this PR adds is the last one in its Commits tab.

Supersedes #2611.

## Testing
Unit tests verify remote-engine reuse and confirm that missing, local, or otherwise non-remote
engines are rejected before use. `ruff check` and `ruff format --check` clean.
