### PR TITLE
feat(verl): route agent-loop rows via agent_name and validate the config (4/4)

### DIFF
--- a/configs/examples/verl_conversational/user_sim_agent_loop.yaml
+++ b/configs/examples/verl_conversational/user_sim_agent_loop.yaml
@@ -1,0 +1,12 @@
+# verl agent-loop registry entry. Must be a LIST -- verl iterates it
+# (verl/experimental/agent_loop/agent_loop.py:444-449). Keys beyond `name` and `_target_`
+# are passed to the loop's constructor by hydra.
+#
+# Wire it up in training.verl_config_overrides alongside:
+#   actor_rollout_ref.rollout.mode: async
+#   actor_rollout_ref.rollout.multi_turn.enable: true
+#   actor_rollout_ref.rollout.agent.agent_loop_config_path: <this file>
+# VerlGrpoTrainer._validate_agent_loop_config fails loudly if any is missing.
+- name: oumi_user_sim_tool_agent
+  _target_: oumi.core.trainers.verl_agentic.user_sim_agent_loop.UserSimToolAgentLoop
+  user_sim_inference: configs/examples/verl_conversational/user_sim_engine.yaml

--- a/configs/examples/verl_conversational/user_sim_engine.yaml
+++ b/configs/examples/verl_conversational/user_sim_engine.yaml
@@ -1,0 +1,18 @@
+# Inference config for the simulated user.
+#
+# Must be a REMOTE-backed engine. One engine is cached per worker process and shared by
+# every concurrent rollout in it, so an in-process engine (NATIVE / VLLM / LLAMACPP) would
+# need a lock that serializes them all. See user_sim_provider.user_sim_engine.
+#
+# Settings match the validated job-273 run so rollouts stay comparable.
+#
+# Requirements:
+#   - export OPENAI_API_KEY=your_key_here
+model:
+  model_name: "gpt-4o-mini"
+
+engine: OPENAI
+
+generation:
+  max_new_tokens: 256
+  temperature: 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,11 @@ gpu = [
     "bitsandbytes>=0.47,<0.50",     # Used for QLora, and PagedAdam implementation
     # When updating verl version, make sure to also update the default config:
     # src/oumi/core/trainers/verl_trainer_config.yaml.
-    "verl>=0.5,<0.8; python_version >= '3.10'", # Used for the VERL_GRPO trainer
+    # The agent loop works on 0.7 and 0.8 alike, but VerlGrpoTrainer's worker imports
+    # are still 0.7-only: 0.8 removed verl.workers.fsdp_workers, and
+    # AsyncActorRolloutRefWorker / CriticWorker have no counterpart in engine_workers.
+    # >=0.7: UserSimToolAgentLoop needs AgentLoopBase.apply_chat_template, which 0.6 lacks.
+    "verl>=0.7,<0.8; python_version >= '3.10'", # Used for the VERL_GRPO trainer
     "vllm>=0.14,<0.24",                         # For VLLMInferenceEngine, and vLLM-powered GRPO training.
     "kernels>=0.11,<0.15",                      # For compute kernel implementations (e.g., attn_implementation in gold trainer)
 ]

--- a/src/oumi/core/rollout/__init__.py
+++ b/src/oumi/core/rollout/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral building blocks for RL rollouts."""

--- a/src/oumi/core/rollout/user_sim.py
+++ b/src/oumi/core/rollout/user_sim.py
@@ -1,0 +1,113 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-free core for simulated-user (conversational) rollouts."""
+
+import dataclasses
+from collections.abc import Callable
+
+from oumi.core.types.conversation import Conversation, Message, Role
+
+DEFAULT_DONE_SENTINEL = "[[END]]"
+DEFAULT_MAX_TURNS = 6
+
+
+@dataclasses.dataclass
+class RolloutState:
+    """Rollout state; ``max_turns`` is a safety cap on simulated-user replies."""
+
+    persona: str
+    max_turns: int
+    goal: str = ""
+    turn_idx: int = 0
+
+
+def build_user_turn_prompt(
+    persona: str,
+    history: list[Message],
+    current_turn: int,
+    max_turns: int,
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+    *,
+    goal: str = "",
+) -> Conversation:
+    """Builds the prompt for the next simulated-user turn."""
+    system_prompt = persona
+    if goal:
+        system_prompt += f"\n\nYour goal for this conversation: {goal}"
+
+    messages: list[Message] = [Message(role=Role.SYSTEM, content=system_prompt)]
+    messages.extend(history)
+    messages.append(
+        Message(
+            role=Role.USER,
+            content=(
+                f"You are the USER generating reply {current_turn}. You may generate "
+                f"at most {max_turns} replies; this limit is a safety cap, not a "
+                "target. Respond naturally to the assistant's latest message. Pursue "
+                "your goal without repeating yourself or inventing facts. Do not "
+                "prolong the conversation to reach the turn limit. If your goal has "
+                "been satisfied, respond naturally and append "
+                f"{done_sentinel}. Reply with ONLY your next message and stay in "
+                "character."
+            ),
+        )
+    )
+    return Conversation(messages=messages)
+
+
+def messages_to_history(messages: list[dict]) -> list[Message]:
+    """Converts backend message dicts to user and assistant history.
+
+    Only user and assistant turns survive: the simulated user is a person talking to
+    the assistant, so it never sees system prompts or tool traffic. Passing a tool
+    turn through would also be rejected by chat APIs, which require it to follow an
+    assistant message carrying structured ``tool_calls``.
+
+    Returns:
+        The conversation as the simulated user experienced it.
+    """
+    return [
+        Message(role=Role(m["role"]), content=(m.get("content") or ""))
+        for m in messages
+        if m.get("role") in (Role.USER.value, Role.ASSISTANT.value)
+    ]
+
+
+def next_user_turn(
+    state: RolloutState,
+    messages: list[dict],
+    infer_fn: Callable[[Conversation], str],
+    done_sentinel: str = DEFAULT_DONE_SENTINEL,
+) -> tuple[bool, str, float]:
+    """Produces the next simulated-user turn, or ends the rollout at the cap.
+
+    Returns:
+        A tuple of whether to terminate, the simulated-user response, and its score.
+    """
+    if state.turn_idx >= state.max_turns:
+        return True, "", 0.0
+    state.turn_idx += 1
+    prompt = build_user_turn_prompt(
+        state.persona,
+        messages_to_history(messages),
+        state.turn_idx,
+        state.max_turns,
+        done_sentinel,
+        goal=state.goal,
+    )
+    text = infer_fn(prompt)
+    if done_sentinel in text:
+        return True, text.replace(done_sentinel, "").strip(), 0.0
+    return False, text.strip(), 0.0

--- a/src/oumi/core/trainers/verl_agentic/user_sim_agent_loop.py
+++ b/src/oumi/core/trainers/verl_agentic/user_sim_agent_loop.py
@@ -1,0 +1,195 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""verl agent loop adding persona-driven simulated-user turns to ToolAgentLoop."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from verl.experimental.agent_loop.tool_agent_loop import (  # pyright: ignore[reportMissingImports]
+    AgentState,
+    ToolAgentLoop,
+)
+
+from oumi.core.rollout.user_sim import (
+    DEFAULT_DONE_SENTINEL,
+    DEFAULT_MAX_TURNS,
+    RolloutState,
+    next_user_turn,
+)
+from oumi.core.trainers.verl_agentic.user_sim_provider import infer_one, user_sim_engine
+
+
+# Deliberately NOT decorated with verl's @register. That decorator does
+# `_agent_loop_registry[name] = {"_target_": fqdn}` — an unconditional overwrite that
+# drops every other key. Since importing this module is what resolves `_target_`, the
+# decorator would wipe the `user_sim_inference` path the agent-loop YAML supplies.
+# Registration comes from `agent_loop_config_path`; see user_sim_agent_loop.yaml.
+class UserSimToolAgentLoop(ToolAgentLoop):
+    """ToolAgentLoop plus a simulated user that speaks when the assistant stops."""
+
+    def __init__(
+        self, *args: Any, user_sim_inference: str | None = None, **kwargs: Any
+    ):
+        """Stores the user-sim config path; the engine itself is cached per process."""
+        super().__init__(*args, **kwargs)
+        self._sim_config_path = user_sim_inference
+        self._sim: RolloutState | None = None
+        # verl instantiates one loop per rollout, so this is per-conversation state.
+        self._sim_history: list[dict[str, Any]] = []
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs: Any):
+        """Runs the rollout.
+
+        Returns:
+            verl's `AgentLoopOutput`, with `sim_user_turns` in `extra_fields` when
+            a simulated user took part.
+        """
+        sim_kwargs = (kwargs.get("extra_info") or {}).get("interaction_kwargs") or {}
+        if sim_kwargs:
+            if not self._sim_config_path:
+                raise ValueError(
+                    "Row carries interaction_kwargs but the agent-loop config has no "
+                    "'user_sim_inference' path. Add it to the YAML that "
+                    "agent_loop_config_path points at."
+                )
+            self._sim = RolloutState(
+                persona=sim_kwargs["user_persona"],
+                goal=sim_kwargs.get("goal", ""),
+                max_turns=sim_kwargs.get("max_turns") or DEFAULT_MAX_TURNS,
+            )
+            # Tracked separately from verl's `messages`, which holds tool results with
+            # no assistant turn requesting them -- a shape chat APIs reject outright.
+            # `messages_to_history` drops everything the customer would not have seen.
+            self._sim_history = [dict(message) for message in kwargs["raw_prompt"]]
+        output = await super().run(sampling_params, **kwargs)
+        # Written once, after the rollout: incremental writes to extra_fields make the
+        # dict truthy, which stops verl copying engine telemetry into it.
+        if self._sim is not None:
+            output.extra_fields["sim_user_turns"] = self._sim.turn_idx
+        return output
+
+    async def _handle_generating_state(
+        self,
+        agent_data: Any,
+        sampling_params: dict[str, Any],
+        ignore_termination: bool = False,
+    ) -> AgentState:
+        """Adds a simulated-user turn when the assistant stops without calling a tool.
+
+        Returns:
+            The next agent state.
+        """
+        state = await super()._handle_generating_state(
+            agent_data, sampling_params, ignore_termination
+        )
+        # `_sim` and `_sim_config_path` are set together in `run()`; both are absent
+        # for tool-only rows, which take the stock ToolAgentLoop path.
+        if self._sim is None:
+            return state
+        if state is not AgentState.TERMINATED:
+            # Heading to tools, so the assistant has not addressed the customer yet.
+            return state
+        self._sim_history.append(
+            {"role": "assistant", "content": await self._decode_response(agent_data)}
+        )
+        if self._hard_cap_hit(agent_data, ignore_termination):
+            return state
+        return await self._run_simulated_user_turn(
+            agent_data, self._sim, str(self._sim_config_path)
+        )
+
+    def _hard_cap_hit(self, agent_data: Any, ignore_termination: bool = False) -> bool:
+        """Mirrors ToolAgentLoop._handle_generating_state's termination checks.
+
+        Returns:
+            Whether the parent terminated because a hard cap was reached.
+        """
+        if (
+            not ignore_termination
+            and len(agent_data.response_mask) >= self.response_length
+        ):
+            return True
+        if (
+            self.max_assistant_turns
+            and agent_data.assistant_turns >= self.max_assistant_turns
+        ):
+            return True
+        if self.max_user_turns and agent_data.user_turns >= self.max_user_turns:
+            return True
+        return False
+
+    async def _run_simulated_user_turn(
+        self, agent_data: Any, sim: RolloutState, config_path: str
+    ) -> AgentState:
+        """Generates one simulated-user turn and appends it as environment text.
+
+        Returns:
+            `GENERATING` if the conversation continues, else `TERMINATED`.
+        """
+        engine, cfg = user_sim_engine(config_path)
+        done, text, score = await asyncio.to_thread(
+            next_user_turn,
+            sim,
+            self._sim_history,
+            lambda conversation: infer_one(engine, cfg, conversation),
+            DEFAULT_DONE_SENTINEL,
+        )
+        agent_data.user_turns += 1
+        agent_data.turn_scores.append(score)
+        if done:
+            return AgentState.TERMINATED
+        self._sim_history.append({"role": "user", "content": text})
+        fits = await self._append_environment_turn(
+            agent_data, [{"role": "user", "content": text}]
+        )
+        return AgentState.GENERATING if fits else AgentState.TERMINATED
+
+    async def _append_environment_turn(
+        self, agent_data: Any, messages: list[dict[str, Any]]
+    ) -> bool:
+        """Appends environment-authored messages, which never carry gradient.
+
+        Mirrors `_handle_processing_tools_state`: the mask is 0 because the policy did
+        not produce these tokens, and the length check precedes any mutation.
+
+        Returns:
+            Whether the turn fit within the response budget.
+        """
+        agent_data.messages.extend(messages)
+        response_ids = await self.apply_chat_template(
+            messages, remove_system_prompt=True
+        )
+        if len(agent_data.response_mask) + len(response_ids) >= self.response_length:
+            return False
+        agent_data.prompt_ids += response_ids
+        agent_data.response_mask += [0] * len(response_ids)
+        if agent_data.response_logprobs:
+            agent_data.response_logprobs += [0.0] * len(response_ids)
+        return True
+
+    async def _decode_response(self, agent_data: Any) -> str:
+        """Decodes the assistant's latest turn.
+
+        Returns:
+            The assistant's text, as the simulated user would read it.
+        """
+        return await self.loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(
+                agent_data.response_ids, skip_special_tokens=True
+            ),
+        )

--- a/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
+++ b/src/oumi/core/trainers/verl_agentic/user_sim_provider.py
@@ -1,0 +1,88 @@
+# Copyright 2025 - Oumi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-wide user-simulator inference engine for the verl agent-loop adapter."""
+
+from __future__ import annotations
+
+from functools import cache
+
+from oumi.builders.inference_engines import build_inference_engine
+from oumi.core.configs.inference_config import InferenceConfig
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.types.conversation import Conversation
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+# Engines that hold a model in-process. Rejected before `build_inference_engine` so we
+# never pay to load weights just to refuse them.
+_IN_PROCESS_ENGINES = frozenset(
+    {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }
+)
+
+
+@cache
+def user_sim_engine(config_path: str) -> tuple[RemoteInferenceEngine, InferenceConfig]:
+    """Builds the user-sim engine once per process.
+
+    Agent loops are instantiated per trajectory, so building the engine in the loop's
+    `__init__` would construct one per rollout.
+
+    Returns:
+        The engine and the config it was built from.
+    """
+    cfg = InferenceConfig.from_yaml(config_path)
+    if cfg.engine is None:
+        raise ValueError(f"No inference engine set in {config_path}.")
+    if cfg.engine in _IN_PROCESS_ENGINES:
+        raise ValueError(
+            f"The user simulator requires a remote inference engine; got "
+            f"{cfg.engine} from {config_path}. One engine is shared by every "
+            "concurrent rollout in a worker, so an in-process engine would need a "
+            "lock that serializes them all. "
+            "Use REMOTE_VLLM, SGLANG, or a hosted provider."
+        )
+    engine = build_inference_engine(
+        engine_type=cfg.engine,
+        model_params=cfg.model,
+        remote_params=cfg.remote_params,
+    )
+    # Free: every engine that loads weights was already rejected above, so nothing
+    # expensive reaches this. Catches a new engine type added between releases.
+    if not isinstance(engine, RemoteInferenceEngine):
+        raise ValueError(
+            f"User-sim engine {type(engine).__name__} is not remote-backed; "
+            f"got {cfg.engine} from {config_path}."
+        )
+    return engine, cfg
+
+
+def infer_one(
+    engine: RemoteInferenceEngine, cfg: InferenceConfig, conversation: Conversation
+) -> str:
+    """Runs one blocking user-sim generation.
+
+    Returns:
+        The simulated user's reply text.
+    """
+    results = engine.infer([conversation], inference_config=cfg)
+    content = results[0].messages[-1].content
+    if not isinstance(content, str):
+        raise RuntimeError(
+            f"user-sim engine returned non-text content: {type(content)}"
+        )
+    return content

--- a/src/oumi/core/trainers/verl_grpo_trainer.py
+++ b/src/oumi/core/trainers/verl_grpo_trainer.py
@@ -27,6 +27,7 @@ from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
 
 from oumi.core.constants import VERL_METRICS_FILENAME
+from oumi.core.rollout.user_sim import DEFAULT_MAX_TURNS
 from oumi.core.types.conversation import Conversation
 from oumi.core.types.conversation import Role as ConversationRole
 from oumi.utils.conversation_utils import create_list_of_message_json_dicts
@@ -112,6 +113,15 @@ class VerlGrpoTrainer(BaseTrainer):
     https://verl.readthedocs.io/en/latest/examples/config.html.
     """
 
+    # Must match the `name` in the agent-loop YAML and the @register decorator on
+    # UserSimToolAgentLoop; verl looks the row's `agent_name` up in its registry.
+    OUMI_AGENT_LOOP_NAME = "oumi_user_sim_tool_agent"
+    # verl's own fallback. Plain rows must still carry the key: `Dataset.map` fixes
+    # the output schema from the first row, so a mix of rows with and without
+    # `agent_name` either raises or silently drops the column, which would route
+    # agent-loop rows to single-turn generation with no error.
+    VERL_DEFAULT_AGENT_LOOP_NAME = "single_turn_agent"
+
     def __init__(
         self,
         processing_class: BaseTokenizer | None,
@@ -178,9 +188,11 @@ class VerlGrpoTrainer(BaseTrainer):
         # verl trainer uses private methods and properties of `transformers`
         # processor, so we need to pass the raw processor here.
         self._processor = processor.raw_processor if processor is not None else None
+        self._uses_agent_loop = False
         # Detect what dataset post-processing function to use (if any).
         process_fn = self._detect_dataset_process_fn()
         # Generate files and set self._train_filepath and self._val_filepath.
+        # Also sets self._uses_agent_loop, which _create_config validates against.
         self._create_dataset_files(process_fn)
         self._setup_verl_trainer()
 
@@ -288,47 +300,100 @@ class VerlGrpoTrainer(BaseTrainer):
         return (prompt_messages, images, answer)
 
     @staticmethod
-    def _create_verl_data_entry_from_tool_agent_conversation(
+    def _create_verl_agent_loop_entry(
         conversation: Conversation,
         ground_truth: str,
         tools_kwargs: dict[str, Any],
+        interaction_kwargs: dict[str, Any] | None,
         ability: str,
         idx: int,
         data_source: str,
         split: str,
     ) -> dict:
-        """Build a verl row from a structured tool-agent prompt."""
+        """Build a verl row routed to Oumi's agent loop (tools, user sim, or both)."""
         if any(
             message.count_content_items().image_items
             for message in conversation.messages
         ):
-            raise ValueError("Tool-agent conversations do not support images.")
+            raise ValueError("Agent-loop conversations do not support images.")
         if not conversation.messages or conversation.messages[-1].role not in (
             ConversationRole.USER,
             ConversationRole.TOOL,
         ):
             raise ValueError(
-                "Tool-agent conversation prompts must end with a user or tool message."
+                "Agent-loop conversation prompts must end with a user or tool message."
             )
 
         prompt_messages = create_list_of_message_json_dicts(
             conversation.messages,
             group_adjacent_same_role_turns=False,
         )
+        extra_info: dict[str, Any] = {
+            "split": split,
+            "index": idx,
+            _PROMPT_JSON_EXTRA_INFO_KEY: json.dumps(prompt_messages),
+            "need_tools_kwargs": bool(tools_kwargs),
+            "tools_kwargs": tools_kwargs,
+        }
+        if interaction_kwargs:
+            extra_info["interaction_kwargs"] = interaction_kwargs
         return {
             "data_source": data_source,
             "prompt": prompt_messages,
             "images": [],
             "ability": ability,
-            "agent_name": "tool_agent",
+            "agent_name": VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME,
             "reward_model": {"style": "rule", "ground_truth": ground_truth},
-            "extra_info": {
-                "split": split,
-                "index": idx,
-                _PROMPT_JSON_EXTRA_INFO_KEY: json.dumps(prompt_messages),
-                "need_tools_kwargs": True,
-                "tools_kwargs": tools_kwargs,
-            },
+            "extra_info": extra_info,
+        }
+
+    @staticmethod
+    def _parse_tools_kwargs(metadata: dict) -> dict[str, Any]:
+        """Validates and returns the row's per-tool kwargs.
+
+        Returns:
+            A mapping of tool name to that tool's kwargs.
+        """
+        tools_kwargs = metadata.get("tools_kwargs")
+        tools_kwargs_error = (
+            "Tool-agent conversation metadata 'tools_kwargs' must be a "
+            "mapping of tool names to dictionaries."
+        )
+        if not isinstance(tools_kwargs, dict):
+            raise ValueError(f"{tools_kwargs_error} Got {type(tools_kwargs).__name__}.")
+        for tool_name, tool_kwargs in tools_kwargs.items():
+            if not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict):
+                raise ValueError(
+                    f"{tools_kwargs_error} Got {tool_name!r}: "
+                    f"{type(tool_kwargs).__name__}."
+                )
+        return tools_kwargs
+
+    @staticmethod
+    def _parse_interaction_kwargs(
+        conversation: Conversation, interaction_kwargs: dict
+    ) -> dict[str, Any]:
+        """Validates and normalizes the row's simulated-user settings.
+
+        Returns:
+            The persona, goal and turn cap the agent loop needs.
+        """
+        if (
+            not conversation.messages
+            or conversation.messages[-1].role != ConversationRole.USER
+        ):
+            raise ValueError(
+                "interaction rows must end on a user turn (the opening "
+                "customer message)."
+            )
+        # `.get(k, default)` returns None when the key is present but null.
+        max_turns = interaction_kwargs.get("max_turns")
+        if max_turns is None:
+            max_turns = DEFAULT_MAX_TURNS
+        return {
+            "user_persona": interaction_kwargs["user_persona"],
+            "goal": interaction_kwargs.get("goal", ""),
+            "max_turns": max_turns,
         }
 
     @staticmethod
@@ -337,40 +402,48 @@ class VerlGrpoTrainer(BaseTrainer):
     ) -> dict:
         # Peek at metadata off the raw JSON so only the branch that needs a
         # `Conversation` pays for building one.
-        raw_conversation = example["conversation_json"]
+        raw_conversation = example.get("conversation_json") or "{}"
         metadata = json.loads(raw_conversation).get("metadata") or {}
-        if metadata.get("agent_name") == "tool_agent":
+        wants_tools = metadata.get("agent_name") == "tool_agent"
+        interaction_kwargs = metadata.get("interaction_kwargs")
+        # Both are optional and compose: the loop runs tools until the assistant stops
+        # calling them, then hands over to the simulated user. Either alone is valid.
+        if wants_tools or interaction_kwargs:
             conversation = Conversation.from_json(raw_conversation)
-            ground_truth = metadata.get("ground_truth")
-            if not isinstance(ground_truth, str) or not ground_truth:
-                raise ValueError(
-                    "Tool-agent conversation metadata must include a non-empty "
-                    "string 'ground_truth'."
-                )
-            tools_kwargs = metadata.get("tools_kwargs")
-            tools_kwargs_error = (
-                "Tool-agent conversation metadata 'tools_kwargs' must be a "
-                "mapping of tool names to dictionaries."
+            tools_kwargs = (
+                VerlGrpoTrainer._parse_tools_kwargs(metadata) if wants_tools else {}
             )
-            if not isinstance(tools_kwargs, dict):
-                raise ValueError(
-                    f"{tools_kwargs_error} Got {type(tools_kwargs).__name__}."
+            resolved_interaction = (
+                VerlGrpoTrainer._parse_interaction_kwargs(
+                    conversation, interaction_kwargs
                 )
-            for tool_name, tool_kwargs in tools_kwargs.items():
-                if not isinstance(tool_name, str) or not isinstance(tool_kwargs, dict):
+                if interaction_kwargs
+                else None
+            )
+            ground_truth: str = ""
+            if wants_tools:
+                declared = metadata.get("ground_truth")
+                if not isinstance(declared, str) or not declared:
                     raise ValueError(
-                        f"{tools_kwargs_error} Got {tool_name!r}: "
-                        f"{type(tool_kwargs).__name__}."
+                        "Tool-agent conversation metadata must include a non-empty "
+                        "string 'ground_truth'."
                     )
-            ability = metadata.get("ability", "tool_agent")
+                ground_truth = declared
+            elif resolved_interaction is not None:
+                # Simulator-only rows are graded against the customer's goal.
+                ground_truth = resolved_interaction["goal"]
+            ability = metadata.get(
+                "ability", "tool_agent" if wants_tools else "conversation"
+            )
             if not isinstance(ability, str):
                 raise ValueError(
-                    "Tool-agent conversation metadata 'ability' must be a string."
+                    "Agent-loop conversation metadata 'ability' must be a string."
                 )
-            return VerlGrpoTrainer._create_verl_data_entry_from_tool_agent_conversation(
+            return VerlGrpoTrainer._create_verl_agent_loop_entry(
                 conversation,
                 ground_truth,
                 tools_kwargs,
+                resolved_interaction,
                 ability,
                 idx,
                 data_source,
@@ -384,6 +457,7 @@ class VerlGrpoTrainer(BaseTrainer):
             "prompt": prompt_messages,
             "images": images,
             "ability": "math",
+            "agent_name": VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME,
             "reward_model": {"style": "rule", "ground_truth": answer},
             "extra_info": {
                 "split": split,
@@ -425,6 +499,9 @@ class VerlGrpoTrainer(BaseTrainer):
                 with_indices=True,
                 num_proc=num_proc,
             )
+            # Read this off the mapped dataset, not from inside process_fn: the map
+            # runs in subprocesses, so a flag set there never reaches us.
+            self._uses_agent_loop = "agent_name" in train_dataset.column_names
 
         train_dataset.to_parquet(train_file)
         self._train_filepath = str(train_file)
@@ -573,7 +650,35 @@ class VerlGrpoTrainer(BaseTrainer):
             raise ValueError(
                 "Actor and critic must use the same strategy when using FSDP."
             )
+        if self._uses_agent_loop:
+            self._validate_agent_loop_config(config.actor_rollout_ref.rollout)
         return config
+
+    @staticmethod
+    def _validate_agent_loop_config(rollout: DictConfig) -> None:
+        """Fails loudly when agent-loop rows would silently fall back to plain gen.
+
+        verl only consults a row's `agent_name` on the async agent-loop path; without
+        these settings it runs `single_turn_agent`, skipping tools and the simulated
+        user with no error.
+        """
+        if rollout.mode != "async" or not rollout.multi_turn.enable:
+            raise ValueError(
+                "Dataset rows route to Oumi's agent loop, but "
+                f"rollout.mode={rollout.mode!r} and "
+                f"multi_turn.enable={rollout.multi_turn.enable}. verl would fall back "
+                "to single_turn_agent and silently skip tools and the simulated user. "
+                "Set actor_rollout_ref.rollout.mode=async and "
+                "actor_rollout_ref.rollout.multi_turn.enable=true in "
+                "training.verl_config_overrides."
+            )
+        if not rollout.agent.agent_loop_config_path:
+            raise ValueError(
+                "Dataset rows route to Oumi's agent loop, but "
+                "actor_rollout_ref.rollout.agent.agent_loop_config_path is unset. "
+                "Point it at the agent-loop YAML registering "
+                f"{VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME!r}."
+            )
 
     def _setup_verl_trainer(self):
         """Sets up verl's RayPPOTrainer."""

--- a/src/oumi/core/trainers/verl_trainer_config.yaml
+++ b/src/oumi/core/trainers/verl_trainer_config.yaml
@@ -88,6 +88,23 @@ actor_rollout_ref:
     entropy_checkpointing: false
   rollout:
     name: vllm
+    # `sync` runs plain single-turn generation. Tools and the simulated user both
+    # need verl's async agent-loop path, which reads each row's `agent_name`.
+    # Enable it per-recipe via `training.verl_config_overrides` -- these defaults are
+    # shared with the single-turn recipes:
+    #
+    #   actor_rollout_ref:
+    #     rollout:
+    #       mode: async
+    #       multi_turn:
+    #         enable: true
+    #         max_assistant_turns: 6        # generation safety rail; null = unbounded
+    #         tool_config_path: <verl tool config>   # only when tools are used
+    #       agent:
+    #         agent_loop_config_path: <yaml registering oumi_user_sim_tool_agent>
+    #
+    # VerlGrpoTrainer._validate_agent_loop_config raises at config time if rows route
+    # to the agent loop without these, so a missing override fails before any GPU work.
     mode: sync
     temperature: 1.0
     top_k: -1

--- a/tests/unit/core/configs/test_parse_configs.py
+++ b/tests/unit/core/configs/test_parse_configs.py
@@ -52,6 +52,8 @@ def _get_all_config_paths(exclude_yaml_suffixes: set[str] | None) -> list[str]:
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            # verl's agent-loop registry format: a bare list, not an Oumi config.
+            "user_sim_agent_loop.yaml",
         }
     ),
 )
@@ -88,6 +90,8 @@ def test_parse_configs(config_path: str):
             "accelerate.yaml",
             "_deploy.yaml",  # Deploy configs use a different schema
             "analyze/analyze.yaml",  # Uses TypedAnalyzeConfig (v2) format
+            # verl's agent-loop registry format: a bare list, not an Oumi config.
+            "user_sim_agent_loop.yaml",
         }
     ),
 )

--- a/tests/unit/core/rollout/test_user_sim.py
+++ b/tests/unit/core/rollout/test_user_sim.py
@@ -1,0 +1,129 @@
+from oumi.core.rollout.user_sim import (
+    DEFAULT_DONE_SENTINEL,
+    RolloutState,
+    build_user_turn_prompt,
+    messages_to_history,
+    next_user_turn,
+)
+from oumi.core.types.conversation import Message, Role
+
+
+def test_build_user_turn_prompt_shape():
+    history = [
+        Message(role=Role.USER, content="hi"),
+        Message(role=Role.ASSISTANT, content="hello"),
+    ]
+    conv = build_user_turn_prompt(
+        "You are Jane, a customer.",
+        history,
+        current_turn=2,
+        max_turns=6,
+        goal="Get a refund.",
+    )
+    assert conv.messages[0].role == Role.SYSTEM
+    assert conv.messages[0].content == (
+        "You are Jane, a customer.\n\nYour goal for this conversation: Get a refund."
+    )
+    assert [m.content for m in conv.messages[1:3]] == ["hi", "hello"]
+    assert conv.messages[-1].role == Role.USER
+    assert isinstance(conv.messages[-1].content, str)
+    turn_info = conv.messages[-1].content
+    assert "safety cap, not a target" in turn_info
+    assert DEFAULT_DONE_SENTINEL in turn_info
+
+
+def test_messages_to_history_maps_roles():
+    out = messages_to_history(
+        [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "a"),
+        (Role.ASSISTANT, "b"),
+    ]
+
+
+def test_next_user_turn_normal():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [{"role": "assistant", "content": "hi"}], lambda c: "  my reply  "
+    )
+    assert (done, text, score) == (False, "my reply", 0.0)
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_sentinel_ends():
+    state = RolloutState(persona="p", max_turns=5)
+    done, text, score = next_user_turn(
+        state, [], lambda c: f"thanks {DEFAULT_DONE_SENTINEL}"
+    )
+    assert done is True
+    assert text == "thanks"
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_produces_exactly_max_turns():
+    state = RolloutState(persona="p", max_turns=1)
+
+    done, text, _ = next_user_turn(state, [], lambda c: "only turn")
+    assert (done, text) == (False, "only turn")
+
+    done, text, _ = next_user_turn(state, [], lambda c: "should not be used")
+    assert (done, text) == (True, "")
+    assert state.turn_idx == 1
+
+
+def test_next_user_turn_prompt_uses_custom_sentinel():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "bye <<STOP>>"
+
+    done, text, _ = next_user_turn(state, [], stub, done_sentinel="<<STOP>>")
+    assert "<<STOP>>" in captured["conv"].messages[-1].content
+    assert (done, text) == (True, "bye")
+
+
+def test_next_user_turn_threads_correct_turn_number():
+    state = RolloutState(persona="p", max_turns=5)
+    captured = {}
+
+    def stub(conv):
+        captured["conv"] = conv
+        return "reply"
+
+    next_user_turn(state, [], stub)
+    turn_info = captured["conv"].messages[-1].content
+    assert "reply 1" in turn_info
+    assert "at most 5" in turn_info
+
+
+def test_messages_to_history_drops_system_turns():
+    out = messages_to_history(
+        [
+            {"role": "system", "content": "You are a support agent."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "hi"),
+        (Role.ASSISTANT, "hello"),
+    ]
+
+
+def test_messages_to_history_drops_tool_turns():
+    # Chat APIs reject a tool turn that does not follow structured `tool_calls`, and
+    # the customer would not have seen it anyway.
+    out = messages_to_history(
+        [
+            {"role": "user", "content": "where is order 4421"},
+            {"role": "tool", "content": '{"status": "delayed"}'},
+            {"role": "assistant", "content": "It is delayed."},
+        ]
+    )
+    assert [(m.role, m.content) for m in out] == [
+        (Role.USER, "where is order 4421"),
+        (Role.ASSISTANT, "It is delayed."),
+    ]

--- a/tests/unit/core/trainers/test_verl_grpo_interaction_entry.py
+++ b/tests/unit/core/trainers/test_verl_grpo_interaction_entry.py
@@ -1,0 +1,280 @@
+import json
+
+import pytest
+
+from oumi.core.trainers.verl_grpo_trainer import VerlGrpoTrainer
+
+
+def _conv_json(messages, metadata=None):
+    d = {"messages": messages}
+    if metadata is not None:
+        d["metadata"] = metadata
+    return json.dumps(d)
+
+
+def _interaction_example():
+    return {
+        "conversation_json": _conv_json(
+            [
+                {"role": "system", "content": "You are a support agent."},
+                {"role": "user", "content": "My order #4421 is late."},
+            ],
+            metadata={
+                "interaction_kwargs": {
+                    "user_persona": "You are Jane, a customer whose order #4421 "
+                    "is late.",
+                    "goal": "get a refund or delivery date",
+                    "max_turns": 6,
+                }
+            },
+        ),
+    }
+
+
+def test_interaction_branch_shape():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=3, data_source="support", split="train"
+    )
+    assert len(entry["prompt"]) == 2
+    assert entry["prompt"][0]["role"] == "system"
+    assert entry["prompt"][-1]["role"] == "user"
+    assert entry["reward_model"]["ground_truth"] == "get a refund or delivery date"
+    ik = entry["extra_info"]["interaction_kwargs"]
+    assert ik["max_turns"] == 6
+    assert ik["goal"] == "get a refund or delivery date"
+    assert ik["user_persona"].startswith("You are Jane")
+
+
+def test_interaction_row_must_end_on_user():
+    bad = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "resolved"},
+            ],
+            metadata={"interaction_kwargs": {"user_persona": "p", "goal": "g"}},
+        )
+    }
+    with pytest.raises(ValueError):
+        VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            bad, idx=0, data_source="s", split="train"
+        )
+
+
+def test_missing_conversation_json_raises_with_context():
+    with pytest.raises(ValueError, match="conversation_json"):
+        VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            {}, idx=0, data_source="s", split="train"
+        )
+
+
+def test_non_interaction_row_uses_final_turn_path():
+    example = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "2+2?"}, {"role": "assistant", "content": "4"}]
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="math", split="train"
+    )
+    assert entry["reward_model"]["ground_truth"] == "4"
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+AGENT_NAME = "oumi_user_sim_tool_agent"
+
+
+def test_interaction_row_routes_to_agent_loop():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=3, data_source="support", split="train"
+    )
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["reward_model"]["style"] == "rule"
+    assert entry["reward_model"]["ground_truth"] == "get a refund or delivery date"
+    assert entry["extra_info"]["tools_kwargs"] == {}
+    assert entry["extra_info"]["need_tools_kwargs"] is False
+    kwargs = entry["extra_info"]["interaction_kwargs"]
+    assert kwargs["user_persona"].startswith("You are Jane")
+    assert kwargs["max_turns"] == 6
+    assert "name" not in kwargs
+
+
+def test_tool_agent_row_routes_to_same_loop():
+    example = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "How many orders?"}],
+            metadata={
+                "agent_name": "tool_agent",
+                "ground_truth": "SELECT count(*) FROM orders",
+                "tools_kwargs": {"run_sql": {"create_kwargs": {}}},
+            },
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="spider", split="train"
+    )
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["extra_info"]["need_tools_kwargs"] is True
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+def test_plain_row_carries_verl_default_agent_name():
+    """Plain rows still need the key so a mixed dataset keeps a uniform schema."""
+    example = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        )
+    }
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        example, idx=0, data_source="math", split="train"
+    )
+    assert entry["agent_name"] == VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME
+
+
+def _mapped(rows):
+    from datasets import Dataset
+
+    return Dataset.from_list(rows).map(
+        lambda ex, i: VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+            ex, i, "src", "train"
+        ),
+        with_indices=True,
+    )
+
+
+@pytest.mark.parametrize("plain_first", [True, False])
+def test_mixed_rows_keep_agent_name_in_both_orders(plain_first):
+    """`Dataset.map` fixes the schema from row 0, so every row must carry agent_name.
+
+    Without it, plain-first silently drops the column and agent-loop rows fall back to
+    single-turn generation with no error.
+    """
+    interaction = {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "late order"}],
+            metadata={"interaction_kwargs": {"user_persona": "Jane", "goal": "refund"}},
+        )
+    }
+    plain = {
+        "conversation_json": _conv_json(
+            [
+                {"role": "user", "content": "2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        )
+    }
+    rows = [plain, interaction] if plain_first else [interaction, plain]
+
+    mapped = _mapped(rows)
+
+    assert "agent_name" in mapped.column_names
+    assert set(mapped["agent_name"]) == {
+        VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME,
+        VerlGrpoTrainer.VERL_DEFAULT_AGENT_LOOP_NAME,
+    }
+
+
+def test_interaction_only_dataset_writes_parquet(tmp_path):
+    """Simulator-only rows carry `tools_kwargs={}`; the schema must still serialize."""
+    rows = [
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "late order"}],
+                metadata={"interaction_kwargs": {"user_persona": "Jane"}},
+            )
+        }
+    ]
+    out = tmp_path / "train.parquet"
+
+    _mapped(rows).to_parquet(str(out))
+
+    assert out.stat().st_size > 0
+
+
+def test_explicit_null_max_turns_falls_back_to_default():
+    """`.get(key, default)` returns None when the key is present but null."""
+    from oumi.core.rollout.user_sim import DEFAULT_MAX_TURNS
+
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "hi"}],
+                metadata={
+                    "interaction_kwargs": {"user_persona": "Jane", "max_turns": None}
+                },
+            )
+        },
+        idx=0,
+        data_source="src",
+        split="train",
+    )
+
+    assert entry["extra_info"]["interaction_kwargs"]["max_turns"] == DEFAULT_MAX_TURNS
+
+
+def _tools_and_sim_example():
+    return {
+        "conversation_json": _conv_json(
+            [{"role": "user", "content": "where is order #4421?"}],
+            metadata={
+                "agent_name": "tool_agent",
+                "ground_truth": "SELECT status FROM orders WHERE id=4421",
+                "tools_kwargs": {"run_sql": {"create_kwargs": {}}},
+                "interaction_kwargs": {
+                    "user_persona": "You are Jane, chasing order #4421.",
+                    "goal": "get a delivery date",
+                    "max_turns": 4,
+                },
+            },
+        )
+    }
+
+
+def test_row_can_carry_both_tools_and_simulated_user():
+    """The loop runs tools then hands over to the simulator; the row must say so."""
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _tools_and_sim_example(), idx=0, data_source="support", split="train"
+    )
+
+    assert entry["agent_name"] == AGENT_NAME
+    assert entry["extra_info"]["tools_kwargs"] == {"run_sql": {"create_kwargs": {}}}
+    assert entry["extra_info"]["need_tools_kwargs"] is True
+    assert entry["extra_info"]["interaction_kwargs"]["user_persona"].startswith(
+        "You are Jane"
+    )
+    assert entry["extra_info"]["interaction_kwargs"]["max_turns"] == 4
+    assert entry["reward_model"]["ground_truth"] == (
+        "SELECT status FROM orders WHERE id=4421"
+    )
+
+
+def test_tools_only_row_has_no_simulator():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        {
+            "conversation_json": _conv_json(
+                [{"role": "user", "content": "how many orders?"}],
+                metadata={
+                    "agent_name": "tool_agent",
+                    "ground_truth": "SELECT count(*) FROM orders",
+                    "tools_kwargs": {"run_sql": {}},
+                },
+            )
+        },
+        idx=0,
+        data_source="spider",
+        split="train",
+    )
+
+    assert "interaction_kwargs" not in entry["extra_info"]
+
+
+def test_simulator_only_row_has_no_tools():
+    entry = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
+        _interaction_example(), idx=0, data_source="support", split="train"
+    )
+
+    assert entry["extra_info"]["tools_kwargs"] == {}
+    assert entry["extra_info"]["need_tools_kwargs"] is False

--- a/tests/unit/core/trainers/test_verl_grpo_trainer.py
+++ b/tests/unit/core/trainers/test_verl_grpo_trainer.py
@@ -190,7 +190,7 @@ def test_create_verl_data_entry_tool_agent_carries_metadata():
     row = VerlGrpoTrainer._create_verl_data_entry_from_conversation(
         _example(convo), 0, "nl2sql", "train"
     )
-    assert row["agent_name"] == "tool_agent"
+    assert row["agent_name"] == VerlGrpoTrainer.OUMI_AGENT_LOOP_NAME
     assert row["reward_model"]["ground_truth"] == "SELECT count(*) FROM t"
     assert row["extra_info"]["need_tools_kwargs"] is True
     assert "run_sql" in row["extra_info"]["tools_kwargs"]

--- a/tests/unit/core/trainers/verl_agentic/test_user_sim_agent_loop.py
+++ b/tests/unit/core/trainers/verl_agentic/test_user_sim_agent_loop.py
@@ -1,0 +1,374 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("verl")
+
+from verl.experimental.agent_loop.tool_agent_loop import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    AgentState,
+    ToolAgentLoop,
+)
+
+from oumi.core.rollout.user_sim import RolloutState  # noqa: E402
+from oumi.core.trainers.verl_agentic.user_sim_agent_loop import (  # noqa: E402
+    UserSimToolAgentLoop,
+)
+
+_MODULE = "oumi.core.trainers.verl_agentic.user_sim_agent_loop"
+PROMPT_LEN = 10
+# 4 token ids per appended message, from the stub apply_chat_template below.
+TOKENS_PER_MESSAGE = 4
+SEED_TURN = {"role": "user", "content": "my order is late"}
+
+
+def _agent_data(policy_tokens: int = 3):
+    """Rollout state after the policy has generated `policy_tokens` tokens."""
+    return SimpleNamespace(
+        messages=[dict(SEED_TURN)],
+        prompt_ids=list(range(PROMPT_LEN)) + [900 + i for i in range(policy_tokens)],
+        response_ids=[900 + i for i in range(policy_tokens)],
+        response_mask=[1] * policy_tokens,
+        response_logprobs=[],
+        turn_scores=[],
+        user_turns=0,
+        assistant_turns=1,
+        extra_fields={},
+    )
+
+
+def _loop(response_length: int = 1000, max_turns: int = 4):
+    loop = UserSimToolAgentLoop.__new__(UserSimToolAgentLoop)
+    loop.response_length = response_length
+    loop.max_assistant_turns = None
+    loop.max_user_turns = None
+    loop.loop = asyncio.new_event_loop()
+    loop.tokenizer = SimpleNamespace(decode=lambda ids, **kw: "let me check on that")
+    loop._sim_config_path = "unused.yaml"
+    loop._sim = RolloutState(persona="Jane", max_turns=max_turns)
+    # `run()` seeds this from `raw_prompt`; these tests enter below `run()`.
+    loop._sim_history = [dict(SEED_TURN)]
+
+    async def _apply_chat_template(messages, **kwargs):
+        return [100 + i for i in range(TOKENS_PER_MESSAGE * len(messages))]
+
+    loop.apply_chat_template = _apply_chat_template
+    return loop
+
+
+def _run_sim_turn(loop, data, turn_result):
+    with (
+        patch(f"{_MODULE}.next_user_turn", return_value=turn_result),
+        patch(f"{_MODULE}.user_sim_engine", return_value=(object(), object())),
+        patch.object(
+            ToolAgentLoop,
+            "_handle_generating_state",
+            return_value=AgentState.TERMINATED,
+        ),
+    ):
+        return loop.loop.run_until_complete(
+            loop._handle_generating_state(data, {}, False)
+        )
+
+
+def test_simulated_user_tokens_are_masked_zero():
+    loop, data = _loop(), _agent_data()
+    state = _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert state is AgentState.GENERATING
+    assert data.response_mask[:3] == [1, 1, 1], "policy tokens must stay mask 1"
+    assert set(data.response_mask[3:]) == {0}, "simulated-user tokens must be mask 0"
+    assert len(data.response_mask) == 3 + TOKENS_PER_MESSAGE
+
+
+def test_boundary_invariant_holds_after_append():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert len(data.prompt_ids) - len(data.response_mask) == PROMPT_LEN
+
+
+def test_assistant_turn_reaches_simulator_without_duplicating_tokens():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.0))
+
+    assert [m["role"] for m in loop._sim_history] == ["user", "assistant", "user"]
+    assert loop._sim_history[1]["content"] == "let me check on that"
+    # Only the simulated-user turn adds tokens; the assistant's are already there.
+    assert len(data.prompt_ids) == PROMPT_LEN + 3 + TOKENS_PER_MESSAGE
+
+
+def test_user_turn_counted_and_score_recorded():
+    loop, data = _loop(), _agent_data()
+    _run_sim_turn(loop, data, (False, "and my refund?", 0.5))
+
+    assert data.user_turns == 1
+    assert data.turn_scores == [0.5]
+
+
+def test_done_sentinel_terminates_without_tokenizing():
+    loop, data = _loop(), _agent_data()
+    before = list(data.prompt_ids)
+    state = _run_sim_turn(loop, data, (True, "", 0.0))
+
+    assert state is AgentState.TERMINATED
+    assert data.prompt_ids == before, "a finished turn must not be tokenized"
+
+
+def test_overlong_turn_terminates_without_mutating():
+    loop, data = _loop(response_length=4), _agent_data()
+    before_ids, before_mask = list(data.prompt_ids), list(data.response_mask)
+    state = _run_sim_turn(loop, data, (False, "x", 0.0))
+
+    assert state is AgentState.TERMINATED
+    assert data.prompt_ids == before_ids
+    assert data.response_mask == before_mask
+
+
+@pytest.mark.parametrize(
+    "cap_attr,counter_attr",
+    [("max_assistant_turns", "assistant_turns"), ("max_user_turns", "user_turns")],
+)
+def test_turn_caps_prevent_simulated_user_turn(cap_attr, counter_attr):
+    loop, data = _loop(), _agent_data()
+    setattr(loop, cap_attr, 1)
+    setattr(data, counter_attr, 1)
+
+    assert loop._hard_cap_hit(data) is True
+
+
+def test_response_length_cap_prevents_simulated_user_turn():
+    loop, data = _loop(response_length=3), _agent_data()
+
+    assert loop._hard_cap_hit(data) is True
+    assert loop._hard_cap_hit(data, ignore_termination=True) is False
+
+
+def test_no_caps_hit_allows_simulated_user_turn():
+    loop, data = _loop(), _agent_data()
+
+    assert loop._hard_cap_hit(data) is False
+
+
+def test_importing_this_module_does_not_clobber_yaml_registry_entry():
+    """verl's @register overwrites the registry entry with {_target_} alone.
+
+    Importing this module is what resolves `_target_`, so decorating the loop would
+    drop the `user_sim_inference` key that agent_loop_config_path supplies.
+    """
+    import importlib
+
+    from verl.experimental.agent_loop.agent_loop import (  # pyright: ignore[reportMissingImports]
+        _agent_loop_registry,
+    )
+
+    name = "oumi_user_sim_tool_agent"
+    target = "oumi.core.trainers.verl_agentic.user_sim_agent_loop.UserSimToolAgentLoop"
+    saved = _agent_loop_registry.get(name)
+    try:
+        _agent_loop_registry[name] = {
+            "_target_": target,
+            "user_sim_inference": "configs/user_sim_engine.yaml",
+        }
+        importlib.reload(importlib.import_module(_MODULE))
+        assert (
+            _agent_loop_registry[name].get("user_sim_inference")
+            == "configs/user_sim_engine.yaml"
+        ), "module import stripped the YAML-supplied constructor kwargs"
+    finally:
+        if saved is None:
+            _agent_loop_registry.pop(name, None)
+        else:
+            _agent_loop_registry[name] = saved
+
+
+# --- Verification item 9: tools and the simulator compose ---------------------
+
+
+def _generating_state(loop, data, parent_returns):
+    """Runs our override with the parent's decision stubbed to `parent_returns`."""
+    with patch.object(
+        ToolAgentLoop, "_handle_generating_state", return_value=parent_returns
+    ):
+        return loop.loop.run_until_complete(
+            loop._handle_generating_state(data, {}, False)
+        )
+
+
+def test_tool_path_is_never_intercepted():
+    """A pending tool call belongs to the parent; the simulator must stay out of it."""
+    loop, data = _loop(), _agent_data()
+
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        state = _generating_state(loop, data, AgentState.PROCESSING_TOOLS)
+
+    assert state is AgentState.PROCESSING_TOOLS
+    sim.assert_not_called()
+    assert data.user_turns == 0
+
+
+def test_simulator_skipped_entirely_when_not_configured():
+    """Tool-only rows must behave exactly like stock ToolAgentLoop."""
+    loop, data = _loop(), _agent_data()
+    loop._sim = None
+
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        state = _generating_state(loop, data, AgentState.TERMINATED)
+
+    assert state is AgentState.TERMINATED
+    sim.assert_not_called()
+
+
+def test_tool_turn_then_simulated_user_turn_interleave():
+    """user -> assistant(tool_call) -> tool -> assistant(text) -> sim_user -> assistant.
+
+    The tool result and the simulated-user turn are both environment text, so the
+    mask must read 1,0,1,0 across the four spans.
+    """
+    loop, data = _loop(), _agent_data(policy_tokens=3)
+
+    # The assistant calls a tool: the parent routes to PROCESSING_TOOLS, and the
+    # simulator stays out of it -- the customer was not addressed by a tool call.
+    with patch(f"{_MODULE}.next_user_turn") as sim:
+        assert (
+            _generating_state(loop, data, AgentState.PROCESSING_TOOLS)
+            is AgentState.PROCESSING_TOOLS
+        )
+    sim.assert_not_called()
+
+    # verl's tool path appends the tool result exactly as we append environment text.
+    loop.loop.run_until_complete(
+        loop._append_environment_turn(
+            data, [{"role": "tool", "content": "status=late"}]
+        )
+    )
+    tool_span = len(data.response_mask)
+
+    # The policy generates again, this time with no tool call.
+    data.response_ids = [950, 951]
+    data.prompt_ids += data.response_ids
+    data.response_mask += [1, 1]
+    data.assistant_turns += 1
+
+    state = _run_sim_turn(loop, data, (False, "when will it arrive?", 0.0))
+
+    assert state is AgentState.GENERATING
+    # verl's own bookkeeping: environment turns only, never assistant turns.
+    assert [m["role"] for m in data.messages] == ["user", "tool", "user"]
+    # What the persona sees: no tool traffic, and no tool-calling assistant turn,
+    # which carried no text for the customer to read.
+    assert [m["role"] for m in loop._sim_history] == ["user", "assistant", "user"]
+    assert loop._sim_history[1]["content"] == "let me check on that"
+    assert data.response_mask[:3] == [1, 1, 1], "first assistant turn"
+    assert set(data.response_mask[3:tool_span]) == {0}, "tool result is environment"
+    assert data.response_mask[tool_span : tool_span + 2] == [1, 1], "second assistant"
+    assert set(data.response_mask[tool_span + 2 :]) == {0}, "simulated user"
+    assert len(data.prompt_ids) - len(data.response_mask) == PROMPT_LEN
+
+
+# --- rollout output shape -----------------------------------------------------
+
+SIM_KWARGS = {"user_persona": "Jane", "goal": "get a refund", "max_turns": 3}
+
+
+def _fresh_loop(config_path: str | None = "unused.yaml"):
+    """A loop as `__init__` leaves it: configured, but with no rollout state yet."""
+    loop = _loop()
+    loop._sim = None
+    loop._sim_history = []
+    loop._sim_config_path = config_path
+    return loop
+
+
+def _run_rollout(loop, extra_info, sim_turns_taken=0, engine_telemetry=None):
+    """Runs `run()` with the parent stubbed to take `sim_turns_taken` user turns."""
+    output = SimpleNamespace(extra_fields=dict(engine_telemetry or {}))
+
+    async def _parent(_self, sampling_params, **kwargs):
+        if loop._sim is not None:
+            loop._sim.turn_idx = sim_turns_taken
+        return output
+
+    with patch.object(ToolAgentLoop, "run", _parent):
+        return loop.loop.run_until_complete(
+            loop.run({}, extra_info=extra_info, raw_prompt=[SEED_TURN])
+        )
+
+
+def test_rollout_output_reports_simulated_user_turns():
+    loop = _fresh_loop()
+
+    output = _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS}, sim_turns_taken=2)
+
+    assert output.extra_fields["sim_user_turns"] == 2
+
+
+def test_tool_only_rollout_output_carries_no_simulator_field():
+    """Rows without a persona must produce stock ToolAgentLoop output."""
+    loop = _fresh_loop()
+
+    output = _run_rollout(loop, {"tools_kwargs": {"run_sql": {}}})
+
+    assert loop._sim is None
+    assert "sim_user_turns" not in output.extra_fields
+
+
+def test_rollout_output_keeps_engine_telemetry():
+    """`sim_user_turns` is written after the parent returns, so it must not clobber."""
+    loop = _fresh_loop()
+
+    output = _run_rollout(
+        loop,
+        {"interaction_kwargs": SIM_KWARGS},
+        sim_turns_taken=1,
+        engine_telemetry={"num_turns": 12},
+    )
+
+    assert output.extra_fields == {"num_turns": 12, "sim_user_turns": 1}
+
+
+def test_persona_row_without_engine_config_fails_loudly():
+    """Silently dropping the persona would train on single-turn rollouts instead."""
+    loop = _fresh_loop(config_path=None)
+
+    with pytest.raises(ValueError, match="user_sim_inference"):
+        _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS})
+
+
+def test_simulator_history_starts_as_a_copy_of_the_prompt():
+    loop = _fresh_loop()
+
+    _run_rollout(loop, {"interaction_kwargs": SIM_KWARGS})
+
+    assert loop._sim_history == [SEED_TURN]
+    loop._sim_history[0]["content"] = "mutated"
+    assert SEED_TURN["content"] == "my order is late", "prompt rows must not alias"
+
+
+# --- Verification item 7: drift guards ----------------------------------------
+
+
+def test_parent_generating_state_signature_is_unchanged():
+    """Our override must keep matching ToolAgentLoop's, which we delegate to."""
+    import inspect
+
+    assert list(
+        inspect.signature(ToolAgentLoop._handle_generating_state).parameters
+    ) == ["self", "agent_data", "sampling_params", "ignore_termination"]
+
+
+def test_agent_state_members_are_known():
+    """An unrecognized state upstream may need handling in _handle_generating_state.
+
+    INTERACTING exists in 0.7 and was removed in 0.8; it is inert for us either way,
+    since we never set `interaction_config_path`.
+    """
+    required = {"PENDING", "GENERATING", "PROCESSING_TOOLS", "TERMINATED"}
+    tolerated = required | {"INTERACTING"}
+    members = set(AgentState.__members__)
+
+    assert required <= members, (
+        f"upstream dropped a state we rely on: {required - members}"
+    )
+    assert members <= tolerated, f"unhandled new AgentState: {members - tolerated}"

--- a/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
+++ b/tests/unit/core/trainers/verl_agentic/test_user_sim_provider.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oumi.builders.inference_engines import ENGINE_MAP
+from oumi.core.configs.inference_engine_type import InferenceEngineType
+from oumi.core.inference.base_inference_engine import BaseInferenceEngine
+from oumi.core.trainers.verl_agentic.user_sim_provider import (
+    _IN_PROCESS_ENGINES,
+    user_sim_engine,
+)
+from oumi.inference.remote_inference_engine import RemoteInferenceEngine
+
+_BUILD = "oumi.core.trainers.verl_agentic.user_sim_provider.build_inference_engine"
+
+
+def _write_config(tmp_path, engine: str) -> str:
+    path = tmp_path / f"user_sim_{engine.lower()}.yaml"
+    path.write_text(
+        f"model:\n  model_name: 'gpt-4o-mini'\nengine: {engine}\n"
+        "remote_params:\n  api_url: 'http://localhost:8000/v1/chat/completions'\n"
+    )
+    return str(path)
+
+
+@pytest.mark.parametrize("engine", ["NATIVE", "VLLM", "LLAMACPP"])
+def test_in_process_engine_rejected_before_build(tmp_path, engine):
+    config_path = _write_config(tmp_path, engine)
+    with patch(_BUILD) as build:
+        with pytest.raises(ValueError, match="remote inference engine"):
+            user_sim_engine(config_path)
+    build.assert_not_called()
+
+
+def test_missing_engine_rejected(tmp_path):
+    path = tmp_path / "no_engine.yaml"
+    path.write_text("model:\n  model_name: 'gpt-4o-mini'\n")
+    with pytest.raises(ValueError, match="No inference engine"):
+        user_sim_engine(str(path))
+
+
+def test_remote_engine_built_once(tmp_path):
+    config_path = _write_config(tmp_path, "REMOTE_VLLM")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=RemoteInferenceEngine)
+        first = user_sim_engine(config_path)
+        second = user_sim_engine(config_path)
+    assert first is second
+    assert build.call_count == 1
+
+
+def test_non_remote_engine_rejected(tmp_path):
+    """A newly-added engine type that isn't remote-backed must not slip through."""
+    config_path = _write_config(tmp_path, "REMOTE")
+    with patch(_BUILD) as build:
+        build.return_value = MagicMock(spec=BaseInferenceEngine)
+        with pytest.raises(ValueError, match="not remote-backed"):
+            user_sim_engine(config_path)
+
+
+@pytest.mark.parametrize("engine_type,engine_cls", sorted(ENGINE_MAP.items(), key=str))
+def test_every_engine_is_classified(engine_type, engine_cls):
+    """A new engine type must be either in-process or remote-backed, never neither."""
+    assert (engine_type in _IN_PROCESS_ENGINES) ^ issubclass(
+        engine_cls, RemoteInferenceEngine
+    ), f"{engine_type} is classified neither in-process nor remote"
+
+
+def test_in_process_set_matches_expected_members():
+    assert _IN_PROCESS_ENGINES == {
+        InferenceEngineType.NATIVE,
+        InferenceEngineType.VLLM,
+        InferenceEngineType.LLAMACPP,
+    }


### PR DESCRIPTION
## What
Routes simulator and tool conversations through multi-turn generation while keeping ordinary
examples on the default single-turn path.

Resubmitted from a fork of **#2613** — I no longer have push access to the branch in this repo.
Rebased on current `main`.

## Why
Mixed datasets can silently discard per-row generation choices when the first example is ordinary,
causing interactive examples to run as single-turn generation. Misconfigured training should fail
before GPU allocation instead of quietly skipping tools or simulated users.

## How
Every dataset row now identifies its generation path, with simulator and tool settings allowed
together. Configuration validation requires asynchronous multi-turn generation whenever any row
needs interactive behavior.

## Rebase note
`src/oumi/core/trainers/verl_grpo_trainer.py` moved a lot since this was written (#2607, #2624,
#2627, #2643, #2644, #2646, #2647). Two conflicts, both resolved to keep `main`'s behaviour:

- **Imports.** `VERL_METRICS_FILENAME` (#2643) and `DEFAULT_MAX_TURNS` (this PR) — kept both.
- **`extra_info` construction.** This PR refactors the inline `extra_info` dict in the agent-loop
  row builder into a local variable so the simulated-user keys can be added conditionally. #2624
  had meanwhile added `_PROMPT_JSON_EXTRA_INFO_KEY: json.dumps(prompt_messages)` to that same dict.
  Resolved by carrying #2624's key into the refactored variable, so agent-loop rows still emit
  `prompt_json`. The single-turn row builder keeps #2624's `prompt_json` and `metadata` untouched.

Worth a close look from a reviewer who knows #2624 — that resolution is the one judgement call in
this rebase.

## Stack
| | PR | |
|---|---|---|
| 1 | #2652 | rollout core |
| 2 | #2653 | user-simulator inference engine |
| 3 | #2654 | `UserSimToolAgentLoop` |
| 4 | #2655 | `agent_name` row routing + config validation |

Each PR targets `main` because a fork cannot base a PR on another fork branch, so the diffs are
cumulative — review in order, and the commit this PR adds is the last one in its Commits tab.

Supersedes #2613.

## Testing
Unit tests cover mixed-row ordering, simulator-only and tool-only rows, combined behavior,
serialization, and invalid configurations. `ruff check` and `ruff format --check` clean.

I could not run the suite locally for this resubmission — `verl` and `vllm` have no macOS ARM
wheels and I no longer have access to the cluster the original run used. Relying on CI here.
